### PR TITLE
🧪 Add test coverage for Category toEntity mapper

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -21,4 +21,8 @@ dependencies {
     implementation(libs.workmanager.ktx)
     implementation(libs.hilt.work)
     ksp(libs.hilt.compiler)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/data/src/test/java/app/komikku/data/repository/CategoryRepositoryImplTest.kt
+++ b/data/src/test/java/app/komikku/data/repository/CategoryRepositoryImplTest.kt
@@ -1,0 +1,90 @@
+package app.komikku.data.repository
+
+import app.komikku.core.database.dao.CategoryDao
+import app.komikku.core.database.dao.MangaCategoryDao
+import app.komikku.core.database.entity.CategoryEntity
+import app.komikku.core.database.entity.MangaCategoryEntity
+import app.komikku.domain.model.Category
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class CategoryRepositoryImplTest {
+
+    private lateinit var categoryDao: CategoryDao
+    private lateinit var mangaCategoryDao: MangaCategoryDao
+    private lateinit var repository: CategoryRepositoryImpl
+
+    @Before
+    fun setup() {
+        categoryDao = mockk()
+        mangaCategoryDao = mockk()
+        repository = CategoryRepositoryImpl(categoryDao, mangaCategoryDao)
+    }
+
+    @Test
+    fun `toEntity maps Category to CategoryEntity correctly`() = runTest {
+        // Arrange
+        val category = Category(
+            id = 1L,
+            name = "Test Category",
+            order = 2,
+            flags = 3L
+        )
+        val expectedEntity = CategoryEntity(
+            id = 1L,
+            name = "Test Category",
+            order = 2,
+            flags = 3L
+        )
+
+        coEvery { categoryDao.upsert(any()) } returns 1L
+
+        // Act
+        repository.upsertCategory(category)
+
+        // Assert
+        coVerify { categoryDao.upsert(expectedEntity) }
+    }
+
+    @Test
+    fun `reorderCategories uses toEntity correctly`() = runTest {
+        // Arrange
+        val categories = listOf(
+            Category(id = 1L, name = "Cat 1", order = 5, flags = 0L),
+            Category(id = 2L, name = "Cat 2", order = 2, flags = 1L)
+        )
+
+        val expectedEntity1 = CategoryEntity(id = 1L, name = "Cat 1", order = 0, flags = 0L)
+        val expectedEntity2 = CategoryEntity(id = 2L, name = "Cat 2", order = 1, flags = 1L)
+
+        coEvery { categoryDao.upsert(any()) } returns 1L
+
+        // Act
+        repository.reorderCategories(categories)
+
+        // Assert
+        coVerify(exactly = 1) { categoryDao.upsert(expectedEntity1) }
+        coVerify(exactly = 1) { categoryDao.upsert(expectedEntity2) }
+    }
+
+    @Test
+    fun `deleteCategory passes correct id to DAO`() = runTest {
+        // Arrange
+        val categoryId = 42L
+        coEvery { categoryDao.delete(categoryId) } returns Unit
+
+        // Act
+        repository.deleteCategory(categoryId)
+
+        // Assert
+        coVerify(exactly = 1) { categoryDao.delete(categoryId) }
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing unit test coverage for the private `CategoryEntity.toEntity()` mapper in `CategoryRepositoryImpl`. It does so implicitly by testing the public repository methods that rely on this mapping (such as upserting, reordering, and deleting categories).

📊 **Coverage:** What scenarios are now tested
1. `upsertCategory`: Verifies that domain categories are correctly mapped to Room `CategoryEntity` before being inserted/updated via `CategoryDao.upsert()`.
2. `reorderCategories`: Verifies that a list of domain categories is properly mapped and updated with their new order indices via `CategoryDao.upsert()`.
3. `deleteCategory`: Verifies that the correct category ID is passed directly to the `CategoryDao.delete()` method.

✨ **Result:** The improvement in test coverage
The logic connecting the domain `Category` model and the Room `CategoryEntity` is now robustly covered, improving the maintainability and safety of the `CategoryRepositoryImpl`. This allows for future refactoring with confidence. In addition, JUnit, MockK, and Coroutines testing libraries were added to the `data` module dependencies to facilitate these tests.

---
*PR created automatically by Jules for task [9586337025773481371](https://jules.google.com/task/9586337025773481371) started by @HeartlessVeteran2*