### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Heartless-Veteran/Otaku-Reader/security/code-scanning/10](https://github.com/Heartless-Veteran/Otaku-Reader/security/code-scanning/10)

To fix the problem, explicitly declare `GITHUB_TOKEN` permissions in the workflow and restrict them to the minimal scopes required. Since this CI workflow only checks out code, builds, tests, uploads artifacts, and sends results to an external service using a separate secret token, it does not need to write to repository contents or manage PRs. Therefore, a root‑level `permissions` block with `contents: read` is an appropriate minimal setting, which all jobs will inherit unless they override it.

Concretely, in `.github/workflows/ci.yml`, add a `permissions:` block near the top of the file, alongside `name:` and `on:`, before the `jobs:` section. Set `contents: read` so that CodeQL sees that the workflow limits `GITHUB_TOKEN` to read‑only access to repository contents. No other code changes, imports, or additional methods are necessary, and existing functionality (build, tests, artifact upload, CI Insights reporting) will continue to work as before.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance security permissions management for continuous integration processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->