### PR TITLE
fix: Address CodeAnt-AI review issues #352, #360, #363

### DIFF
--- a/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/repository/SourceRepositoryImpl.kt
+++ b/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/repository/SourceRepositoryImpl.kt
@@ -12,6 +12,7 @@ import app.otakureader.sourceapi.MangaPage
 import app.otakureader.sourceapi.MangaSource
 import app.otakureader.sourceapi.SourceChapter
 import app.otakureader.sourceapi.SourceManga
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -22,6 +23,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.io.InterruptedIOException
 import java.net.URL
 import java.util.concurrent.ConcurrentHashMap
 
@@ -54,9 +56,6 @@ class SourceRepositoryImpl(
         context,
         LocalSourcePreferences.ofDirectory(localDirectory),
         healthMonitor
-    )
-        context.packageManager,
-        context.cacheDir
     )
 
     /**
@@ -100,6 +99,16 @@ class SourceRepositoryImpl(
         return null
     }
 
+    /**
+     * Determines if an exception should be recorded as a source failure.
+     * Cancellation and interruption exceptions are expected and should not
+     * mark a source as unhealthy.
+     */
+    private fun shouldRecordFailure(e: Throwable): Boolean {
+        return e !is CancellationException &&
+               e !is InterruptedIOException
+    }
+
     override suspend fun getPopularManga(sourceId: String, page: Int): Result<MangaPage> {
         return withContext(Dispatchers.IO) {
             // Check source health before attempting request; still allow cached data
@@ -129,11 +138,13 @@ class SourceRepositoryImpl(
                 healthMonitor.recordSuccess(sourceId)
 
                 Result.success(mangaPage)
-            } catch (e: kotlinx.coroutines.CancellationException) {
+            } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                // Record failure for health monitoring
-                healthMonitor.recordFailure(sourceId, e)
+                // Record failure for health monitoring (but not for cancellations/interruptions)
+                if (shouldRecordFailure(e)) {
+                    healthMonitor.recordFailure(sourceId, e)
+                }
                 Result.failure(e)
             }
         }
@@ -169,8 +180,10 @@ class SourceRepositoryImpl(
 
                 Result.success(mangaPage)
             } catch (e: Exception) {
-                // Record failure for health monitoring
-                healthMonitor.recordFailure(sourceId, e)
+                // Record failure for health monitoring (but not for cancellations/interruptions)
+                if (shouldRecordFailure(e)) {
+                    healthMonitor.recordFailure(sourceId, e)
+                }
                 Result.failure(e)
             }
         }
@@ -224,8 +237,10 @@ class SourceRepositoryImpl(
 
                 Result.success(mangaPage)
             } catch (e: Exception) {
-                // Record failure for health monitoring
-                healthMonitor.recordFailure(sourceId, e)
+                // Record failure for health monitoring (but not for cancellations/interruptions)
+                if (shouldRecordFailure(e)) {
+                    healthMonitor.recordFailure(sourceId, e)
+                }
                 Result.failure(e)
             }
         }
@@ -255,8 +270,10 @@ class SourceRepositoryImpl(
 
                 Result.success(details)
             } catch (e: Exception) {
-                // Record failure for health monitoring
-                healthMonitor.recordFailure(sourceId, e)
+                // Record failure for health monitoring (but not for cancellations/interruptions)
+                if (shouldRecordFailure(e)) {
+                    healthMonitor.recordFailure(sourceId, e)
+                }
                 Result.failure(e)
             }
         }

--- a/domain/src/test/java/app/otakureader/domain/ArchitectureTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/ArchitectureTest.kt
@@ -15,6 +15,41 @@ import java.io.File
 class ArchitectureTest {
 
     /**
+     * Resolves the domain module root directory.
+     * Handles different working directories (CI, IDE, command line).
+     */
+    private fun resolveDomainModuleRoot(): File {
+        // Try to locate from current working directory
+        val cwd = File(".").canonicalFile
+
+        // If we're already in the domain module
+        if (cwd.name == "domain" && File(cwd, "build.gradle.kts").exists()) {
+            return cwd
+        }
+
+        // If we're in the project root
+        val domainFromRoot = File(cwd, "domain")
+        if (domainFromRoot.exists() && File(domainFromRoot, "build.gradle.kts").exists()) {
+            return domainFromRoot
+        }
+
+        // Try parent directories (for IDE test runs from nested directories)
+        var parent = cwd.parentFile
+        while (parent != null) {
+            val domainFromParent = File(parent, "domain")
+            if (domainFromParent.exists() && File(domainFromParent, "build.gradle.kts").exists()) {
+                return domainFromParent
+            }
+            parent = parent.parentFile
+        }
+
+        // Fallback to current directory - test will fail with clear message if wrong
+        return cwd
+    }
+
+    private val domainModuleRoot by lazy { resolveDomainModuleRoot() }
+
+    /**
      * Verifies that the domain layer contains no Android framework imports.
      *
      * This is critical for Clean Architecture - the domain layer must be pure Kotlin
@@ -23,8 +58,11 @@ class ArchitectureTest {
      */
     @Test
     fun `domain layer must not import Android framework classes`() {
-        val domainSourceDir = File("src/main/java")
-        assertTrue("Domain source directory should exist", domainSourceDir.exists())
+        val domainSourceDir = File(domainModuleRoot, "src/main/java")
+        assertTrue(
+            "Domain source directory should exist at ${domainSourceDir.absolutePath}",
+            domainSourceDir.exists()
+        )
 
         val androidImports = mutableListOf<String>()
         val bannedPrefixes = listOf(
@@ -62,15 +100,15 @@ class ArchitectureTest {
      */
     @Test
     fun `domain models should be in model package`() {
-        val modelDir = File("src/main/java/app/otakureader/domain/model")
+        val modelDir = File(domainModuleRoot, "src/main/java/app/otakureader/domain/model")
         assertTrue(
-            "Domain model package should exist",
+            "Domain model package should exist at ${modelDir.absolutePath}",
             modelDir.exists() && modelDir.isDirectory
         )
 
-        val domainDir = File("src/main/java/app/otakureader/domain")
+        val domainDir = File(domainModuleRoot, "src/main/java/app/otakureader/domain")
         assertTrue(
-            "Domain source directory should exist",
+            "Domain source directory should exist at ${domainDir.absolutePath}",
             domainDir.exists() && domainDir.isDirectory
         )
 
@@ -81,7 +119,14 @@ class ArchitectureTest {
             .forEach { file ->
                 val lines = file.readLines()
                 lines.forEachIndexed { index, line ->
-                    if (line.startsWith("data class ")) {
+                    // Match data class declarations with optional modifiers/annotations
+                    // Handles: data class, internal data class, @Serializable data class, etc.
+                    // Excludes: line comments (//), block comments (/*, */), and KDoc (*)
+                    val trimmed = line.trimStart()
+                    if (Regex("""\bdata\s+class\s+\w+""").containsMatchIn(trimmed) &&
+                        !trimmed.startsWith("//") &&
+                        !trimmed.startsWith("/*") &&
+                        !trimmed.startsWith("*")) {
                         nonModelDataClasses += "${file.path}:${index + 1}: ${line.trim()}"
                     }
                 }
@@ -106,9 +151,9 @@ class ArchitectureTest {
      */
     @Test
     fun `repository interfaces should be in domain repository package`() {
-        val repoDir = File("src/main/java/app/otakureader/domain/repository")
+        val repoDir = File(domainModuleRoot, "src/main/java/app/otakureader/domain/repository")
         assertTrue(
-            "Domain repository package should exist",
+            "Domain repository package should exist at ${repoDir.absolutePath}",
             repoDir.exists() && repoDir.isDirectory
         )
 
@@ -132,9 +177,9 @@ class ArchitectureTest {
      */
     @Test
     fun `use cases should exist in domain usecase package`() {
-        val useCaseDir = File("src/main/java/app/otakureader/domain/usecase")
+        val useCaseDir = File(domainModuleRoot, "src/main/java/app/otakureader/domain/usecase")
         assertTrue(
-            "Domain usecase package should exist",
+            "Domain usecase package should exist at ${useCaseDir.absolutePath}",
             useCaseDir.exists() && useCaseDir.isDirectory
         )
 
@@ -154,8 +199,11 @@ class ArchitectureTest {
      */
     @Test
     fun `domain build file should only declare allowed dependencies`() {
-        val buildFile = File("build.gradle.kts")
-        assertTrue("Domain build.gradle.kts should exist", buildFile.exists())
+        val buildFile = File(domainModuleRoot, "build.gradle.kts")
+        assertTrue(
+            "Domain build.gradle.kts should exist at ${buildFile.absolutePath}",
+            buildFile.exists()
+        )
 
         val buildContent = buildFile.readText()
 
@@ -166,19 +214,17 @@ class ArchitectureTest {
             buildContent.contains("kotlin(\"jvm\")")
         )
 
-        // Verify no Android dependencies
+        // Verify no Android dependencies (using literal string checks, not regex)
         val androidDependencyPatterns = listOf(
             "androidx.",
             "android.arch.",
-            "com.google.android.",
-            "implementation.*androidx",
-            "api.*androidx"
+            "com.google.android."
         )
 
         androidDependencyPatterns.forEach { pattern ->
             assertTrue(
                 "Domain build.gradle.kts should not contain Android dependency: $pattern",
-                !buildContent.contains(Regex(pattern))
+                !buildContent.contains(pattern)
             )
         }
     }

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/BatteryTimeOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/BatteryTimeOverlay.kt
@@ -57,26 +57,35 @@ fun BatteryTimeOverlay(
     var currentTime by remember { mutableStateOf("") }
     val timeFormatter = remember { SimpleDateFormat("HH:mm", Locale.getDefault()) }
 
-    // Register battery status receiver
+    // Helper function to update battery state from intent
+    fun updateBatteryFromIntent(intent: Intent) {
+        val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, 0)
+        val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, 100)
+        batteryLevel = if (scale > 0) (level / scale.toFloat()) * 100 else 0f
+
+        val status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
+        isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                     status == BatteryManager.BATTERY_STATUS_FULL
+    }
+
+    // Register battery status receiver and capture sticky intent for initial value
     DisposableEffect(Unit) {
         val batteryReceiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context, intent: Intent) {
-                val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, 0)
-                val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, 100)
-                batteryLevel = if (scale > 0) (level / scale.toFloat()) * 100 else 0f
-
-                val status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
-                isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING ||
-                             status == BatteryManager.BATTERY_STATUS_FULL
+                updateBatteryFromIntent(intent)
             }
         }
 
-        ContextCompat.registerReceiver(
+        // Register receiver and capture the sticky intent for initial battery state
+        val stickyIntent = ContextCompat.registerReceiver(
             context,
             batteryReceiver,
             IntentFilter(Intent.ACTION_BATTERY_CHANGED),
             ContextCompat.RECEIVER_NOT_EXPORTED
         )
+
+        // Process the sticky intent immediately to set initial values
+        stickyIntent?.let { updateBatteryFromIntent(it) }
 
         onDispose {
             context.unregisterReceiver(batteryReceiver)


### PR DESCRIPTION
## **User description**
- SourceRepositoryImpl: Filter CancellationException and InterruptedIOException from health monitor failure recording (Issue #352)
- SourceRepositoryImpl: Fix constructor syntax error
- BatteryTimeOverlay: Capture sticky intent for initial battery value (Issue #363)
- ArchitectureTest: Fix regex misuse (use literal string checks) (Issue #360)
- ArchitectureTest: Fix data class detection to handle modifiers/annotations
- ArchitectureTest: Fix hard-coded paths by dynamically resolving module root

## 📋 Description
Brief description of changes.

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation
- [ ] 🎨 UI/UX
- [ ] ♻️ Refactoring
- [ ] 🚀 Performance
- [ ] 🧪 Tests

## 🧪 Testing
How has this been tested?

## 📸 Screenshots
If UI changes, add screenshots.

## ✅ Checklist
- [ ] Code follows style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [ ] No new warnings
- [ ] Tests pass

## 🔗 Related Issues
Fixes #(issue number)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception handling so user-cancelled actions no longer generate failure reports, reducing false failure alerts and improving stability.
  * Battery overlay now reads system battery status on startup, ensuring correct battery level and charging indicator immediately.

* **Tests**
  * Strengthened test discovery and path resolution to make tests more reliable across CI, IDEs, and local environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Avoid false source health failures, initialize battery overlay from sticky intent, and stabilize architecture tests**

### What Changed
- Source requests no longer mark a source as unhealthy when they fail due to coroutine cancellations or interrupted IO; those exceptions are ignored for health monitoring so canceled/aborted requests won't produce failure records.
- Reader battery overlay now reads the system's sticky battery intent on registration and shows the initial battery level and charging state immediately, instead of waiting for the next broadcast.
- Architecture tests now locate the domain module root reliably across CI/IDE runs, use literal string checks for prohibited Android dependencies, detect data classes that include modifiers/annotations, and report clearer file paths when assertions fail.

### Impact
`✅ Fewer false source health alerts`
`✅ Correct initial battery level shown in reader overlay`
`✅ More reliable architecture tests across CI and developer environments`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
