### PR TITLE
fix: Address Aura issue #418 - Session timing and monotonic clock fixes

### DIFF
--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/BatteryTimeOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/BatteryTimeOverlay.kt
@@ -103,7 +103,12 @@ fun BatteryTimeOverlay(
         }
 
         onDispose {
-            context.unregisterReceiver(batteryReceiver)
+            // Guard against IllegalArgumentException if registration failed or receiver already unregistered
+            try {
+                context.unregisterReceiver(batteryReceiver)
+            } catch (_: IllegalArgumentException) {
+                // Receiver was not registered or already unregistered - safe to ignore
+            }
         }
     }
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReadingTimerOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReadingTimerOverlay.kt
@@ -40,10 +40,12 @@ fun ReadingTimerOverlay(
     var currentTimeMs by remember { mutableLongStateOf(SystemClock.elapsedRealtime()) }
 
     // Update current time every second
-    LaunchedEffect(Unit) {
+    // Restart the effect if sessionStartMs changes (e.g., new reading session)
+    LaunchedEffect(sessionStartMs) {
+        currentTimeMs = SystemClock.elapsedRealtime()
         while (true) {
-            currentTimeMs = SystemClock.elapsedRealtime()
             delay(1000)
+            currentTimeMs = SystemClock.elapsedRealtime()
         }
     }
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/UltimateReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/UltimateReaderViewModel.kt
@@ -473,6 +473,10 @@ class UltimateReaderViewModel @Inject constructor(
                 val pageDuration = nowElapsed - lastPageChangeMs
                 lastPageChangeMs = nowElapsed
 
+                // Derive epoch timestamp consistently from sessionReadAt + monotonic offset
+                // This ensures timestamp and duration use consistent time bases
+                val epochTimestamp = sessionReadAt + (nowElapsed - sessionStartMs)
+
                 val event = PageNavigationEvent(
                     mangaId = mangaId,
                     chapterId = chapterId,
@@ -480,7 +484,7 @@ class UltimateReaderViewModel @Inject constructor(
                     toPage = validPage,
                     pageDurationMs = pageDuration,
                     readerMode = _state.value.mode.ordinal,
-                    timestamp = System.currentTimeMillis()
+                    timestamp = epochTimestamp
                 )
                 behaviorTracker.recordNavigation(event)
             }


### PR DESCRIPTION
## **User description**
- ReadingTimerOverlay: Use LaunchedEffect(sessionStartMs) to restart timer when session changes while overlay is visible
- UltimateReaderViewModel: Derive epoch timestamp from sessionReadAt + monotonic offset to ensure consistent time bases for telemetry
- BatteryTimeOverlay: Add try-catch around unregisterReceiver to prevent crashes during composition disposal (Issue #415)

Fixes #418

## 📋 Description
Brief description of changes.

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation
- [ ] 🎨 UI/UX
- [ ] ♻️ Refactoring
- [ ] 🚀 Performance
- [ ] 🧪 Tests

## 🧪 Testing
How has this been tested?

## 📸 Screenshots
If UI changes, add screenshots.

## ✅ Checklist
- [ ] Code follows style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [ ] No new warnings
- [ ] Tests pass

## 🔗 Related Issues
Fixes #(issue number)


___

## **CodeAnt-AI Description**
**Fix reader session timing, telemetry timestamps, and battery overlay crash**

### What Changed
- On-screen reading timer now resets when a new session starts so displayed session duration matches the current session
- Telemetry navigation events use a consistent epoch timestamp derived from the reading session start plus monotonic offset, removing mismatches between timestamps and durations
- Closing the battery overlay no longer causes crashes by safely ignoring unregister errors for the system receiver

### Impact
`✅ Accurate reader session timers`
`✅ Consistent telemetry timestamps for navigation events`
`✅ Fewer crashes when closing the battery overlay`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved stability of the battery indicator overlay to prevent crashes during disposal
* Fixed reading timer to properly reset when starting a new reading session
* Corrected timestamp consistency for reading session tracking to ensure accurate data logging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->