### PR TITLE
fix: Address Aura issue #408 - Image quality enum migration

### DIFF
--- a/feature/reader/src/main/java/app/otakureader/feature/reader/repository/ReaderSettingsRepository.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/repository/ReaderSettingsRepository.kt
@@ -14,8 +14,11 @@ import app.otakureader.feature.reader.model.ImageQuality
 import app.otakureader.feature.reader.model.ReaderMode
 import app.otakureader.feature.reader.model.ReadingDirection
 import app.otakureader.feature.reader.model.TapZoneConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -269,10 +272,10 @@ class ReaderSettingsRepository @Inject constructor(
      * storage would break if entries were reordered or inserted.
      *
      * Migration: users who previously had an ordinal stored under the old int key
-     * ([Keys.IMAGE_QUALITY_LEGACY], name "reader_image_quality") are migrated transparently
-     * on the first read.  The new key uses a distinct name ("reader_image_quality_name") to
-     * avoid a ClassCastException — DataStore key equality is name-only, so two keys with the
-     * same name but different types would collide.
+     * ([Keys.IMAGE_QUALITY_LEGACY], name "reader_image_quality") are migrated proactively:
+     * on first read the ordinal is converted to the enum name and persisted to the new key,
+     * and the legacy key is removed. This ensures the migration happens once and future reads
+     * use the stable string key.
      */
     val imageQuality: Flow<ImageQuality> = dataStore.data.map { prefs ->
         val name = prefs[Keys.IMAGE_QUALITY]
@@ -281,7 +284,21 @@ class ReaderSettingsRepository @Inject constructor(
         } else {
             // Migrate from legacy ordinal stored under the old int key.
             val legacyOrdinal = prefs[Keys.IMAGE_QUALITY_LEGACY]
-            ImageQuality.entries.getOrNull(legacyOrdinal ?: 0) ?: ImageQuality.ORIGINAL
+            val migratedQuality = ImageQuality.entries.getOrNull(legacyOrdinal ?: 0) ?: ImageQuality.ORIGINAL
+            
+            // Proactively persist the migrated value (fire-and-forget)
+            CoroutineScope(Dispatchers.IO).launch {
+                try {
+                    dataStore.edit { editPrefs ->
+                        editPrefs[Keys.IMAGE_QUALITY] = migratedQuality.name
+                        editPrefs.remove(Keys.IMAGE_QUALITY_LEGACY)
+                    }
+                } catch (_: Exception) {
+                    // Migration failure is non-critical; the in-memory value is still correct
+                }
+            }
+            
+            migratedQuality
         }
     }
 

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
@@ -5,6 +5,7 @@ import app.otakureader.core.common.mvi.UiEvent
 import app.otakureader.core.common.mvi.UiState
 import app.otakureader.core.preferences.AiTier
 import app.otakureader.core.preferences.LocalSourcePreferences
+import app.otakureader.feature.reader.model.ImageQuality
 
 data class TrackerInfo(
     val id: Int,
@@ -35,7 +36,7 @@ data class SettingsState(
     val preloadPagesAfter: Int = 3,    // Pages to preload after current (0–10)
     val cropBordersEnabled: Boolean = false, // Automatically crop white/black borders from page images
     /** ImageQuality stored as enum entry name (e.g. "ORIGINAL", "HIGH", "MEDIUM", "LOW") for stability. */
-    val imageQuality: String = "ORIGINAL",
+    val imageQuality: String = ImageQuality.ORIGINAL.name,
     val dataSaverEnabled: Boolean = false,   // Data saver mode - reduce image quality for bandwidth savings
     val deleteAfterReading: Boolean = false,
     val saveAsCbz: Boolean = false,    // Save downloaded chapters as CBZ archives

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
@@ -202,8 +202,18 @@ class SettingsViewModel @Inject constructor(
                 is SettingsEvent.SetPreloadPagesAfter -> readerSettingsRepository.setPreloadPagesAfter(event.count)
                 is SettingsEvent.SetCropBordersEnabled -> readerSettingsRepository.setCropBordersEnabled(event.enabled)
                 is SettingsEvent.SetImageQuality -> {
-                    val quality = ImageQuality.entries.firstOrNull { it.name == event.quality }
-                        ?: ImageQuality.ORIGINAL
+                    // Validate and normalize the incoming quality string with case-insensitive matching
+                    val normalizedInput = event.quality.trim().uppercase()
+                    val quality = ImageQuality.entries.firstOrNull { 
+                        it.name.equals(normalizedInput, ignoreCase = true) 
+                    } ?: run {
+                        // Log invalid value for debugging (non-fatal)
+                        android.util.Log.w(
+                            "SettingsViewModel",
+                            "Invalid image quality value '${event.quality}', falling back to ORIGINAL"
+                        )
+                        ImageQuality.ORIGINAL
+                    }
                     readerSettingsRepository.setImageQuality(quality)
                 }
                 is SettingsEvent.SetDataSaverEnabled -> readerSettingsRepository.setDataSaverEnabled(event.enabled)


### PR DESCRIPTION
## **User description**
## 📋 Description

Fixes #408 - CodeAnt-AI review feedback on PR #405.

### Changes
- Proactively migrate legacy ordinal to new string key on first read (fire-and-forget)
- Use enum constant (`ImageQuality.ORIGINAL.name`) instead of hardcoded string in `SettingsState`
- Add case-insensitive validation for `SetImageQuality` event with logging for invalid values
- Remove legacy key after successful migration

### Migration Strategy
1. On first read, detect legacy ordinal key
2. Convert to enum name
3. Fire-and-forget write to new key + remove legacy key
4. Subsequent reads use new key directly

### Validation
- Case-insensitive enum name matching
- Invalid values log warning and fall back to ORIGINAL
- Whitespace is trimmed before validation

## 🔗 Related Issues
Fixes #408


___

## **CodeAnt-AI Description**
**Migrate image quality preference to enum names and validate incoming values**

### What Changed
- Preference now stores image quality as the enum name (string) instead of an ordinal; on first read any legacy ordinal is converted to the enum name, written back, and the legacy key removed.
- The settings default is set to the enum constant for ORIGINAL so new installs and fallbacks use the stable name.
- When user-facing events set image quality, the input is trimmed and matched case-insensitively; invalid values log a warning and fall back to ORIGINAL.

### Impact
`✅ No crashes from legacy numeric image-quality storage`
`✅ Image quality preference preserved and migrated during app upgrade`
`✅ Clearer fallback behavior and logged warnings for invalid quality values`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
