### PR TITLE
fix: Address Aura issue #409 - Test improvements

### DIFF
--- a/data/src/test/java/app/otakureader/data/worker/UpdateNotifierTest.kt
+++ b/data/src/test/java/app/otakureader/data/worker/UpdateNotifierTest.kt
@@ -24,6 +24,14 @@ import org.junit.Test
 import org.junit.Assert.*
 
 /**
+ * Fully-qualified class name for Coil's SingletonImageLoader extension file.
+ * This is a generated Kotlin class name that maps to the file where `Context.imageLoader`
+ * is defined. If Coil changes its internal structure, this may need updating.
+ * Consider using a test utility or DI to avoid this brittleness.
+ */
+private const val COIL_IMAGE_LOADER_CLASS = "coil3.SingletonImageLoader_androidKt"
+
+/**
  * Unit tests for UpdateNotifier notification grouping and cover image loading.
  * Tests notification creation, grouping logic, and image timeout handling.
  */
@@ -69,19 +77,28 @@ class UpdateNotifierTest {
         mockkStatic(NotificationManagerCompat::class)
         every { NotificationManagerCompat.from(context) } returns notificationManager
 
-        // Mock static PendingIntent.getActivity()
+        // Mock static PendingIntent.getActivity() with specific flag matching for Android 12+ compatibility.
+        // Production code uses FLAG_UPDATE_CURRENT | FLAG_IMMUTABLE, so we match that exact combination.
         mockkStatic(PendingIntent::class)
-        every { PendingIntent.getActivity(any(), any(), any(), any()) } returns mockk(relaxed = true)
+        every { 
+            PendingIntent.getActivity(
+                any<Context>(), 
+                any<Int>(), 
+                any(), 
+                eq(PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            ) 
+        } returns mockk(relaxed = true)
 
         // Mock context services
         every { context.packageName } returns "app.otakureader"
         every { context.packageManager } returns packageManager
 
         // Mock Coil's Context.imageLoader extension property.
-        // This requires mocking the file where the extension is defined (SingletonImageLoader.android.kt in Coil3).
-        // While the generated class name could change with library updates, this is the standard approach
-        // for mocking extension properties from external libraries.
-        mockkStatic("coil3.SingletonImageLoader_androidKt")
+        // This mocks the file where the extension is defined (SingletonImageLoader.android.kt in Coil3).
+        // Note: This is a generated class name that could change with Coil library updates.
+        // If tests fail after updating Coil, verify the actual class name in the Coil artifact.
+        // Centralizing this in a test utility or using dependency injection would be more robust.
+        mockkStatic(COIL_IMAGE_LOADER_CLASS)
         every { context.imageLoader } returns imageLoader
 
         every { context.getSystemService(NotificationManager::class.java) } returns systemNotificationManager
@@ -259,7 +276,14 @@ class UpdateNotifierTest {
     @Test
     fun `notify continues when image loading times out`() = runTest {
         // Given - image loading takes too long (simulated with timeout)
-        // Use a generic exception instead of CancellationException to avoid canceling the test scope
+        // We use TimeoutException instead of CancellationException because throwing
+        // CancellationException would cancel the test scope itself (runTest uses a
+        // TestScope that treats CancellationException specially).
+        // 
+        // PRODUCTION NOTE: The production code catches Exception, so TimeoutException
+        // is handled the same way as any other failure - the notification proceeds
+        // without the cover image. If production code specifically handles cancellation
+        // differently, that should be tested separately with a different mocking approach.
         coEvery { imageLoader.execute(any()) } throws java.util.concurrent.TimeoutException("simulated timeout")
 
         val mangaList = listOf(testManga1)


### PR DESCRIPTION
## **User description**
## 📋 Description

Fixes #409 - CodeAnt-AI review feedback on PR #406.

### Changes
- Add explicit FLAG_IMMUTABLE to PendingIntent mock for Android 12+ compatibility
- Extract Coil class name to constant with documentation about brittleness
- Document why TimeoutException is used instead of CancellationException in tests
- Explain production code exception handling in test comments

### Test Robustness
- PendingIntent.getActivity() mock now targets specific overload with correct flags
- Coil class name is centralized as COIL_IMAGE_LOADER_CLASS constant
- Added documentation about potential Coil internal changes

### Documentation
- Added PRODUCTION NOTE explaining exception handling behavior
- Clarified why CancellationException cannot be used in tests
- Documented the trade-offs of mocking external library internals

## 🔗 Related Issues
Fixes #409


___

## **CodeAnt-AI Description**
**Fix UpdateNotifier tests for Android 12+ and Coil mocking; use TimeoutException in image timeout test**

### What Changed
- PendingIntent.getActivity() mock now requires FLAG_IMMUTABLE so tests run on Android 12+ without failing
- Coil extension class name extracted to a constant and used when mocking Context.imageLoader, with a note that the generated class name may change
- Image-loading timeout test now throws TimeoutException (instead of CancellationException) so the test scope is not cancelled and notifications proceed without a cover image

### Impact
`✅ Fewer CI test failures on Android 12+`
`✅ More stable image-loading timeout tests`
`✅ Clearer guidance when Coil upgrades break mocks`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
