### PR TITLE
fix: apply audit fixes — download selection, update checker, stability annotations

### DIFF
--- a/data/src/main/java/app/otakureader/data/updater/AppUpdateChecker.kt
+++ b/data/src/main/java/app/otakureader/data/updater/AppUpdateChecker.kt
@@ -183,11 +183,22 @@ class AppUpdateChecker @Inject constructor(
 
     /**
      * Returns true if [candidate] is strictly newer than [current].
+     *
      * Compares each dot-separated numeric component in order.
+     * All components must be valid integers; an invalid segment causes this
+     * method to throw [IllegalArgumentException] rather than silently
+     * dropping or altering components.
      */
     private fun isNewerVersion(candidate: String, current: String): Boolean {
-        val candidateParts = candidate.split(".").mapNotNull { it.toIntOrNull() }
-        val currentParts = current.split(".").mapNotNull { it.toIntOrNull() }
+        val candidateParts = candidate.split(".").map { part ->
+            part.toIntOrNull()
+                ?: throw IllegalArgumentException("Invalid version segment '$part' in candidate version '$candidate'")
+        }
+        val currentParts = current.split(".").map { part ->
+            part.toIntOrNull()
+                ?: throw IllegalArgumentException("Invalid version segment '$part' in current version '$current'")
+        }
+
         val maxLen = maxOf(candidateParts.size, currentParts.size)
         for (i in 0 until maxLen) {
             val c = candidateParts.getOrElse(i) { 0 }

--- a/data/src/main/java/app/otakureader/data/updater/AppUpdateChecker.kt
+++ b/data/src/main/java/app/otakureader/data/updater/AppUpdateChecker.kt
@@ -152,10 +152,10 @@ class AppUpdateChecker @Inject constructor(
                 .header("Accept", "application/vnd.github+json")
                 .build()
 
-            val response = okHttpClient.newCall(request).execute()
-            if (!response.isSuccessful) return@withContext null
-
-            val body = response.body?.string() ?: return@withContext null
+            val body = okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@withContext null
+                response.body?.string()
+            } ?: return@withContext null
             val json = Json { ignoreUnknownKeys = true }
                 .parseToJsonElement(body)
                 .jsonObject

--- a/data/src/main/java/app/otakureader/data/updater/AppUpdateChecker.kt
+++ b/data/src/main/java/app/otakureader/data/updater/AppUpdateChecker.kt
@@ -19,6 +19,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -44,25 +50,22 @@ data class VersionInfo(
 class AppUpdateWorker @AssistedInject constructor(
     @Assisted context: Context,
     @Assisted params: WorkerParameters,
-    private val generalPreferences: GeneralPreferences
+    private val generalPreferences: GeneralPreferences,
+    private val appUpdateChecker: AppUpdateChecker
 ) : CoroutineWorker(context, params) {
 
     override suspend fun doWork(): Result {
-        // Check if update checking is enabled
         val isEnabled = generalPreferences.appUpdateCheckEnabled.first()
         if (!isEnabled) {
             return Result.success()
         }
 
         return try {
-            // TODO: Implement actual GitHub API check
-            // In production, this would:
-            // 1. Query GitHub API for latest release
-            // 2. Compare version code with current version
-            // 3. Save version info if newer version available
-            // 4. Show notification if update available
+            val versionInfo = appUpdateChecker.checkForUpdate()
             generalPreferences.setLastAppUpdateCheck(System.currentTimeMillis())
-
+            if (versionInfo != null) {
+                generalPreferences.setLatestVersionInfo(Json.encodeToString(versionInfo))
+            }
             Result.success()
         } catch (e: Exception) {
             Result.retry()
@@ -117,7 +120,7 @@ class AppUpdateWorker @AssistedInject constructor(
             WorkManager.getInstance(context)
                 .enqueueUniqueWork(
                     "${WORK_NAME}_once",
-                    androidx.work.ExistingWorkPolicy.REPLACE,
+                    ExistingWorkPolicy.REPLACE,
                     request
                 )
         }
@@ -125,24 +128,101 @@ class AppUpdateWorker @AssistedInject constructor(
 }
 
 /**
- * Singleton class to manage app update checking.
+ * Singleton class to manage app update checking against GitHub Releases.
  */
 @Singleton
 class AppUpdateChecker @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val generalPreferences: GeneralPreferences
+    private val generalPreferences: GeneralPreferences,
+    private val okHttpClient: OkHttpClient
 ) {
+    companion object {
+        private const val GITHUB_RELEASES_URL =
+            "https://api.github.com/repos/HeartlessVeteran2/Otaku-Reader/releases/latest"
+    }
+
     /**
-     * Check if an update is available.
-     * Returns the VersionInfo if an update is available, null otherwise.
+     * Check if an update is available by querying the GitHub Releases API.
+     * Returns [VersionInfo] if a newer version exists, null if up to date or on error.
      */
     suspend fun checkForUpdate(): VersionInfo? = withContext(Dispatchers.IO) {
-        // TODO: Implement actual GitHub API call
-        // 1. Get current version from preferences
-        // 2. Query GitHub API for latest release
-        // 3. Compare versions
-        // 4. Return VersionInfo if newer, null if up to date
-        null
+        try {
+            val request = Request.Builder()
+                .url(GITHUB_RELEASES_URL)
+                .header("Accept", "application/vnd.github+json")
+                .build()
+
+            val response = okHttpClient.newCall(request).execute()
+            if (!response.isSuccessful) return@withContext null
+
+            val body = response.body?.string() ?: return@withContext null
+            val json = Json { ignoreUnknownKeys = true }
+                .parseToJsonElement(body)
+                .jsonObject
+
+            val tagName = json["tag_name"]?.jsonPrimitive?.content ?: return@withContext null
+            val latestVersion = tagName.trimStart('v')
+            val currentVersion = getCurrentVersionName()
+
+            if (isNewerVersion(latestVersion, currentVersion)) {
+                val publishedAt = json["published_at"]?.jsonPrimitive?.content
+                VersionInfo(
+                    versionCode = versionNameToCode(latestVersion),
+                    versionName = latestVersion,
+                    downloadUrl = json["html_url"]?.jsonPrimitive?.content ?: "",
+                    releaseNotes = json["body"]?.jsonPrimitive?.content ?: "",
+                    releaseDate = parseIso8601ToEpochMillis(publishedAt)
+                )
+            } else {
+                null
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Returns true if [candidate] is strictly newer than [current].
+     * Compares each dot-separated numeric component in order.
+     */
+    private fun isNewerVersion(candidate: String, current: String): Boolean {
+        val candidateParts = candidate.split(".").mapNotNull { it.toIntOrNull() }
+        val currentParts = current.split(".").mapNotNull { it.toIntOrNull() }
+        val maxLen = maxOf(candidateParts.size, currentParts.size)
+        for (i in 0 until maxLen) {
+            val c = candidateParts.getOrElse(i) { 0 }
+            val cur = currentParts.getOrElse(i) { 0 }
+            if (c > cur) return true
+            if (c < cur) return false
+        }
+        return false
+    }
+
+    /** Converts a semver string like "1.2.3" to a comparable int (e.g. 10203). */
+    private fun versionNameToCode(version: String): Int {
+        val parts = version.split(".").mapNotNull { it.toIntOrNull() }
+        return (parts.getOrElse(0) { 0 } * 10000) +
+            (parts.getOrElse(1) { 0 } * 100) +
+            parts.getOrElse(2) { 0 }
+    }
+
+    /** Parses an ISO-8601 date string to epoch millis; returns 0 on failure. */
+    private fun parseIso8601ToEpochMillis(dateStr: String?): Long {
+        if (dateStr.isNullOrEmpty()) return 0L
+        return try {
+            java.time.Instant.parse(dateStr).toEpochMilli()
+        } catch (e: Exception) {
+            0L
+        }
+    }
+
+    private fun getCurrentVersionName(): String {
+        return try {
+            val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+            pInfo.versionName ?: "0.0.0"
+        } catch (e: Exception) {
+            "0.0.0"
+        }
     }
 
     /**

--- a/domain/src/main/java/app/otakureader/domain/model/SourceInfo.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/SourceInfo.kt
@@ -1,5 +1,7 @@
 package app.otakureader.domain.model
 
+import androidx.compose.runtime.Immutable
+
 /**
  * Input model describing a single source candidate for evaluation.
  *
@@ -9,6 +11,7 @@ package app.otakureader.domain.model
  * @property latestChapterName Name of the most recently updated chapter, or `null`.
  * @property language Primary language of the source.
  */
+@Immutable
 data class SourceInfo(
     val sourceId: String,
     val sourceName: String,

--- a/domain/src/main/java/app/otakureader/domain/model/search/SearchIntent.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/search/SearchIntent.kt
@@ -1,5 +1,6 @@
 package app.otakureader.domain.model.search
 
+import androidx.compose.runtime.Immutable
 import app.otakureader.domain.model.MangaStatus
 
 /**
@@ -17,6 +18,7 @@ enum class MatchMode {
 /**
  * Sealed class representing different search intents extracted from natural language queries.
  */
+@Immutable
 sealed interface SearchIntent {
     /**
      * Search by manga title.
@@ -120,6 +122,7 @@ sealed interface SearchIntent {
 /**
  * Data class representing the result of parsing a natural language query.
  */
+@Immutable
 data class ParsedSearchQuery(
     val originalQuery: String,
     val intents: List<SearchIntent>,
@@ -132,6 +135,7 @@ data class ParsedSearchQuery(
 /**
  * Data class representing a cached smart search.
  */
+@Immutable
 data class CachedSmartSearch(
     val queryHash: String,
     val originalQuery: String,

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -388,10 +388,24 @@ class LibraryViewModel @Inject constructor(
     }
 
     private fun downloadSelected() {
-        // TODO: Wire up DownloadRepository to enqueue selected manga chapters.
-        // Currently left as a no-op to avoid silently doing nothing after clearing
-        // the selection — callers should wait until this is implemented before exposing it.
-        clearSelection()
+        val mangaIds = _state.value.selectedManga
+        if (mangaIds.isEmpty()) return
+        viewModelScope.launch {
+            val mangaById = _allItems.value.associateBy { it.id }
+            mangaIds.forEach { mangaId ->
+                val manga = mangaById[mangaId] ?: return@forEach
+                val chapters = chapterRepository.getChaptersByMangaIdSync(mangaId)
+                chapters.filter { !it.read }.forEach { chapter ->
+                    downloadRepository.enqueueChapter(
+                        mangaId = mangaId,
+                        chapterId = chapter.id,
+                        mangaTitle = manga.title,
+                        chapterTitle = chapter.name
+                    )
+                }
+            }
+            clearSelection()
+        }
     }
 
     private fun toggleFavorite(mangaId: Long) {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -394,7 +394,7 @@ class LibraryViewModel @Inject constructor(
             val mangaById = _allItems.value.associateBy { it.id }
             mangaIds.forEach { mangaId ->
                 val manga = mangaById[mangaId] ?: return@forEach
-                val chapters = chapterRepository.getChaptersByMangaIdSync(mangaId)
+                val chapters = chapterRepository.getChaptersByMangaId(mangaId).first()
                 chapters.filter { !it.read }.forEach { chapter ->
                     downloadRepository.enqueueChapter(
                         mangaId = mangaId,

--- a/feature/library/src/main/java/app/otakureader/feature/library/category/CategoryManagementScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/category/CategoryManagementScreen.kt
@@ -140,8 +140,9 @@ fun CategoryManagementScreen(
                 editingCategory = null
             },
             onConfirm = { name ->
-                if (editingCategory != null) {
-                    viewModel.onEvent(CategoryEvent.UpdateCategory(editingCategory!!.id, name))
+                val editing = editingCategory
+                if (editing != null) {
+                    viewModel.onEvent(CategoryEvent.UpdateCategory(editing.id, name))
                 } else {
                     viewModel.onEvent(CategoryEvent.CreateCategory(name))
                 }


### PR DESCRIPTION
## Summary

Applies fixes identified during the deep-dive and UI audits of the codebase.

- **`LibraryViewModel.downloadSelected()`** — was a no-op TODO; now iterates selected manga, fetches unread chapters via `ChapterRepository`, and enqueues each via `DownloadRepository.enqueueChapter()`
- **`AppUpdateChecker` / `AppUpdateWorker`** — replaces two TODO stubs with a real GitHub Releases API call (`/repos/HeartlessVeteran2/Otaku-Reader/releases/latest`); injects `OkHttpClient`, compares semver, persists `VersionInfo` JSON to `GeneralPreferences.setLatestVersionInfo()`; Worker now injects `AppUpdateChecker` instead of duplicating the logic
- **`@Immutable` on domain models** — adds missing Compose stability annotations to `SourceInfo`, `SearchIntent` (sealed interface), `ParsedSearchQuery`, and `CachedSmartSearch` to prevent unnecessary recompositions in `LazyGrid`/`LazyColumn`
- **`CategoryManagementScreen` force-unwrap** — replaces `editingCategory!!.id` with a smart-cast local `val` after the null guard, eliminating a potential `NullPointerException`

## Test plan

- [ ] Select multiple manga in the library → tap Download; verify chapters are enqueued in the download queue
- [ ] Trigger `AppUpdateWorker` manually (or call `AppUpdateChecker.checkForUpdate()` in a test); verify it returns `VersionInfo` for a release newer than `1.0.0` and `null` otherwise
- [ ] Open Category Management, edit a category name and confirm — verify no crash
- [ ] Confirm the project compiles without errors (`./gradlew assembleDebug`)

https://claude.ai/code/session_01MPfKSP53eizNEhEY3L9k2D

## Summary by Sourcery

Implement functional app update checking against GitHub Releases, enable bulk chapter downloads for selected library items, and add stability and safety improvements across the UI and domain models.

New Features:
- Enable downloading unread chapters for all currently selected manga in the library view.
- Add a concrete app update check that queries the latest GitHub release and persists version metadata when an update is available.

Bug Fixes:
- Prevent a potential NullPointerException when confirming category edits in the Category Management screen.

Enhancements:
- Annotate key search and source domain models with Compose @Immutable to improve UI recomposition stability and performance.