### PR TITLE
fix: resolve 3 post-merge compilation errors breaking CI

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(projects.sourceApi)
 
     "fullImplementation"(libs.play.services.auth)
+    "fullImplementation"(libs.kotlinx.coroutines.play.services)
     implementation(libs.paging.runtime)
     implementation(libs.workmanager.ktx)
     implementation(libs.hilt.work)

--- a/data/src/full/java/app/otakureader/data/sync/GoogleDriveSyncProvider.kt
+++ b/data/src/full/java/app/otakureader/data/sync/GoogleDriveSyncProvider.kt
@@ -22,6 +22,9 @@ import app.otakureader.domain.sync.SyncProvider
 import javax.inject.Inject
 import javax.inject.Singleton
 
+@Serializable
+private data class DriveFileMetadata(val name: String, val parents: List<String>)
+
 private const val DRIVE_SCOPE = "https://www.googleapis.com/auth/drive.appdata"
 private const val DRIVE_FILES_URL = "https://www.googleapis.com/drive/v3/files"
 private const val DRIVE_UPLOAD_URL = "https://www.googleapis.com/upload/drive/v3/files"
@@ -202,9 +205,6 @@ class GoogleDriveSyncProvider @Inject constructor(
             json.decodeFromString<DriveFileList>(body).files.firstOrNull()?.id?.takeIf { it.isNotBlank() }
         }
     }
-
-    @Serializable
-    private data class DriveFileMetadata(val name: String, val parents: List<String>)
 
     private fun createDriveFile(token: String, snapshotJson: String): Boolean {
         val metadata = json.encodeToString(DriveFileMetadata(SNAPSHOT_FILE_NAME, listOf("appDataFolder")))

--- a/domain/src/main/java/app/otakureader/domain/usecase/ai/GenerateReadingInsightsUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/ai/GenerateReadingInsightsUseCase.kt
@@ -20,8 +20,8 @@ private data class InsightsResponseDto(val insights: List<InsightDto>)
 class GenerateReadingInsightsUseCase @Inject constructor(
     private val aiRepository: AiRepository,
     private val aiFeatureGate: AiFeatureGate,
-    private val json: Json = Json { ignoreUnknownKeys = true },
 ) {
+    private val json = Json { ignoreUnknownKeys = true }
     suspend operator fun invoke(stats: ReadingStats): Result<ReadingInsightsResult> {
         if (!aiFeatureGate.isFeatureAvailable(AiFeature.READING_INSIGHTS)) {
             return Result.failure(IllegalStateException("Reading insights feature is not available."))

--- a/domain/src/main/java/app/otakureader/domain/usecase/ai/GenerateReadingInsightsUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/ai/GenerateReadingInsightsUseCase.kt
@@ -21,7 +21,9 @@ class GenerateReadingInsightsUseCase @Inject constructor(
     private val aiRepository: AiRepository,
     private val aiFeatureGate: AiFeatureGate,
 ) {
-    private val json = Json { ignoreUnknownKeys = true }
+    companion object {
+        private val json = Json { ignoreUnknownKeys = true }
+    }
     suspend operator fun invoke(stats: ReadingStats): Result<ReadingInsightsResult> {
         if (!aiFeatureGate.isFeatureAvailable(AiFeature.READING_INSIGHTS)) {
             return Result.failure(IllegalStateException("Reading insights feature is not available."))

--- a/feature/statistics/src/test/java/app/otakureader/feature/statistics/StatisticsViewModelTest.kt
+++ b/feature/statistics/src/test/java/app/otakureader/feature/statistics/StatisticsViewModelTest.kt
@@ -1,10 +1,13 @@
 package app.otakureader.feature.statistics
 
 import app.otakureader.core.preferences.ReadingGoalPreferences
+import app.otakureader.domain.ai.AiFeature
+import app.otakureader.domain.ai.AiFeatureGate
 import app.otakureader.domain.model.ReadingGoal
 import app.otakureader.domain.model.ReadingStats
 import app.otakureader.domain.repository.StatisticsRepository
 import app.otakureader.domain.usecase.GetReadingStatsUseCase
+import app.otakureader.domain.usecase.ai.GenerateReadingInsightsUseCase
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -31,6 +34,8 @@ class StatisticsViewModelTest {
     private lateinit var getReadingStatsUseCase: GetReadingStatsUseCase
     private lateinit var statisticsRepository: StatisticsRepository
     private lateinit var readingGoalPreferences: ReadingGoalPreferences
+    private lateinit var generateReadingInsightsUseCase: GenerateReadingInsightsUseCase
+    private lateinit var aiFeatureGate: AiFeatureGate
 
     private val sampleStats = ReadingStats(
         totalMangaInLibrary = 15,
@@ -56,6 +61,10 @@ class StatisticsViewModelTest {
             every { dailyChapterGoal } returns flowOf(5)
             every { weeklyChapterGoal } returns flowOf(30)
         }
+        generateReadingInsightsUseCase = mockk()
+        aiFeatureGate = mockk {
+            every { isFeatureAvailable(AiFeature.READING_INSIGHTS) } returns false
+        }
     }
 
     @After
@@ -64,7 +73,13 @@ class StatisticsViewModelTest {
     }
 
     private fun createViewModel(): StatisticsViewModel {
-        return StatisticsViewModel(getReadingStatsUseCase, statisticsRepository, readingGoalPreferences)
+        return StatisticsViewModel(
+            getReadingStatsUseCase,
+            statisticsRepository,
+            readingGoalPreferences,
+            generateReadingInsightsUseCase,
+            aiFeatureGate,
+        )
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,6 +101,7 @@ kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", versio
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 


### PR DESCRIPTION
## Summary

Three compilation errors introduced by the previous merge were breaking the `build` and `Build Preview APK` CI jobs.

- **Hilt default parameter**: `GenerateReadingInsightsUseCase` had `json: Json = Json { ... }` in its `@Inject` constructor — Hilt does not support default values on injected parameters. Moved to a private class property instead.
- **Nested `@Serializable` class**: `DriveFileMetadata` was declared inside `GoogleDriveSyncProvider`'s class body. kotlinx.serialization KSP cannot generate serializers for nested classes; moved it to file-level scope.
- **Missing dependency**: `GoogleDriveSyncProvider.getAccessToken` calls `.await()` from `kotlinx.coroutines.tasks`, which requires `kotlinx-coroutines-play-services`. Added it to `libs.versions.toml` and as a `fullImplementation` dep in `data/build.gradle.kts`.

## Test plan

- [ ] `./gradlew assembleFullDebug` — builds without error
- [ ] `./gradlew assembleFossDebug` — builds without error
- [ ] `./gradlew testFullDebugUnitTest` — all tests pass
- [ ] CI `build` and `Build Preview APK` jobs green

https://claude.ai/code/session_01S5BU3D6zxzQwdoEohz9nVA

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5BU3D6zxzQwdoEohz9nVA)_

## Summary by Sourcery

Resolve post-merge compilation issues affecting Google Drive sync and AI reading insights generation.

Bug Fixes:
- Make GenerateReadingInsightsUseCase construct its Json instance internally instead of via a default-injected constructor parameter to comply with Hilt injection rules.
- Move DriveFileMetadata to file-level scope so it can be correctly handled by kotlinx.serialization.
- Add the missing kotlinx-coroutines-play-services dependency required by GoogleDriveSyncProvider to use Task.await().

Build:
- Declare kotlinx-coroutines-play-services in libs.versions.toml and use it as a fullImplementation dependency in the data module.