### PR TITLE
fix(audit-batch4): SettingsViewModel split, adaptive library layout, ZoomableImage audit

### DIFF
--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -72,10 +72,17 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.core.ui.components.MangaCard
 import app.otakureader.domain.model.MangaRecommendation
 import coil3.compose.AsyncImage
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.style.TextAlign
+import app.otakureader.domain.model.MangaStatus
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
@@ -261,6 +268,15 @@ private fun LibraryContent(
     onEvent: (LibraryEvent) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val screenWidthDp = LocalConfiguration.current.screenWidthDp
+    val isExpandedWidth = screenWidthDp >= 840
+    val adaptiveColumns = when {
+        screenWidthDp >= 840 -> (state.gridSize + 2).coerceAtLeast(5)
+        screenWidthDp >= 600 -> (state.gridSize + 1).coerceAtLeast(4)
+        else -> state.gridSize
+    }
+    var detailManga by remember { mutableStateOf<LibraryMangaItem?>(null) }
+
     PullToRefreshBox(
         isRefreshing = state.isRefreshing,
         onRefresh = { onEvent(LibraryEvent.Refresh) },
@@ -281,10 +297,29 @@ private fun LibraryContent(
                     )
                 }
             }
+            isExpandedWidth -> {
+                Row(modifier = Modifier.fillMaxSize()) {
+                    MangaGrid(
+                        state = state,
+                        onEvent = onEvent,
+                        adaptiveColumns = adaptiveColumns,
+                        onMangaSelect = { manga -> detailManga = manga },
+                        modifier = Modifier.weight(0.55f)
+                    )
+                    VerticalDivider()
+                    MangaDetailPanel(
+                        manga = detailManga,
+                        onOpenFullDetails = { onEvent(LibraryEvent.OnMangaClick(it)) },
+                        onClose = { detailManga = null },
+                        modifier = Modifier.weight(0.45f)
+                    )
+                }
+            }
             else -> {
                 MangaGrid(
                     state = state,
-                    onEvent = onEvent
+                    onEvent = onEvent,
+                    adaptiveColumns = adaptiveColumns
                 )
             }
         }
@@ -295,10 +330,12 @@ private fun LibraryContent(
 private fun MangaGrid(
     state: LibraryState,
     onEvent: (LibraryEvent) -> Unit,
+    adaptiveColumns: Int = state.gridSize,
+    onMangaSelect: ((LibraryMangaItem) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     LazyVerticalGrid(
-        columns = GridCells.Fixed(state.gridSize),
+        columns = GridCells.Fixed(adaptiveColumns),
         contentPadding = PaddingValues(8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -362,7 +399,10 @@ private fun MangaGrid(
             MangaCard(
                 title = manga.title,
                 coverUrl = manga.thumbnailUrl,
-                onClick = { onEvent(LibraryEvent.OnMangaClick(manga.id)) },
+                onClick = {
+                    if (onMangaSelect != null) onMangaSelect(manga)
+                    else onEvent(LibraryEvent.OnMangaClick(manga.id))
+                },
                 onLongClick = { onEvent(LibraryEvent.OnMangaLongClick(manga.id)) },
                 isSelected = manga.id in state.selectedManga,
                 readProgress = readProgress,
@@ -802,3 +842,86 @@ private fun ContinueReadingCard(
     }
 }
 
+
+@Composable
+private fun MangaDetailPanel(
+    manga: LibraryMangaItem?,
+    onOpenFullDetails: (Long) -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (manga == null) {
+        Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(R.string.library_detail_panel_hint),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(32.dp)
+            )
+        }
+        return
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        AsyncImage(
+            model = manga.thumbnailUrl,
+            contentDescription = manga.title,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .fillMaxWidth(0.6f)
+                .aspectRatio(2f / 3f)
+                .align(Alignment.CenterHorizontally)
+                .clip(MaterialTheme.shapes.medium)
+        )
+        Text(
+            text = manga.title,
+            style = MaterialTheme.typography.titleMedium,
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis
+        )
+        if (manga.unreadCount > 0) {
+            Text(
+                text = stringResource(R.string.library_detail_unread_chapters, manga.unreadCount),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+        val statusText = when (manga.status) {
+            MangaStatus.ONGOING -> stringResource(R.string.manga_status_ongoing)
+            MangaStatus.COMPLETED -> stringResource(R.string.manga_status_completed)
+            MangaStatus.LICENSED -> stringResource(R.string.manga_status_licensed)
+            MangaStatus.PUBLISHING_FINISHED -> stringResource(R.string.manga_status_publishing_finished)
+            MangaStatus.CANCELLED -> stringResource(R.string.manga_status_cancelled)
+            MangaStatus.ON_HIATUS -> stringResource(R.string.manga_status_on_hiatus)
+            else -> null
+        }
+        if (statusText != null) {
+            Text(
+                text = statusText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            androidx.compose.material3.Button(
+                onClick = { onOpenFullDetails(manga.id) },
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(stringResource(R.string.library_detail_open))
+            }
+            OutlinedButton(onClick = onClose) {
+                Text(stringResource(R.string.library_detail_close))
+            }
+        }
+    }
+}

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -66,4 +66,18 @@
     <string name="library_continue_reading_title">Continue Reading</string>
     <string name="library_continue_reading_cover">Cover for %1$s</string>
     <string name="library_continue_reading_chapter">Ch. %.1f</string>
+
+    <!-- Detail panel (tablet two-pane) -->
+    <string name="library_detail_panel_hint">Tap a manga to view details</string>
+    <string name="library_detail_unread_chapters">%d unread chapters</string>
+    <string name="library_detail_open">Open Details</string>
+    <string name="library_detail_close">Close</string>
+
+    <!-- Manga status labels (used in detail panel) -->
+    <string name="manga_status_ongoing">Ongoing</string>
+    <string name="manga_status_completed">Completed</string>
+    <string name="manga_status_licensed">Licensed</string>
+    <string name="manga_status_publishing_finished">Publishing Finished</string>
+    <string name="manga_status_cancelled">Cancelled</string>
+    <string name="manga_status_on_hiatus">On Hiatus</string>
 </resources>

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/components/ZoomableImage.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/components/ZoomableImage.kt
@@ -217,7 +217,13 @@ fun ZoomableImage(
 }
 
 /**
- * Advanced zoomable state with smooth animations and boundary constraints
+ * Advanced zoomable state with smooth animations and boundary constraints.
+ *
+ * Thread-safety / animation-queue note: _scale, _offsetX, _offsetY are created once and reused for
+ * the lifetime of the state object. High-frequency pinch input calls snapTo() (not animateTo()), so
+ * it never queues animations. The animateTo() path is only reached on discrete events (double-tap,
+ * fling, reset), and Animatable.animateTo() already cancels any previous running animation before
+ * starting a new one — so there is no risk of animation back-log.
  */
 @Stable
 class ZoomableState {

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
@@ -1,30 +1,23 @@
 package app.otakureader.feature.settings
 
 import android.content.Context
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import app.otakureader.core.preferences.AiPreferences
-import app.otakureader.core.preferences.AiTier
 import app.otakureader.core.preferences.AppPreferences
-import app.otakureader.core.preferences.BackupPreferences
-import app.otakureader.core.preferences.DownloadPreferences
-import app.otakureader.core.preferences.GeneralPreferences
-import app.otakureader.core.preferences.LibraryPreferences
 import app.otakureader.core.preferences.LocalSourcePreferences
-import app.otakureader.core.preferences.ReaderPreferences
 import app.otakureader.core.preferences.ReadingGoalPreferences
-import app.otakureader.core.preferences.SyncPreferences
-import app.otakureader.core.discord.DiscordRpcService
-import app.otakureader.data.backup.BackupScheduler
-import app.otakureader.data.tracking.TrackManager
-import app.otakureader.data.worker.LibraryUpdateScheduler
 import app.otakureader.data.worker.ReadingReminderScheduler
-import app.otakureader.domain.repository.AiRepository
-import app.otakureader.domain.sync.SyncManager
-import app.otakureader.domain.sync.SyncStatus as DomainSyncStatus
-import app.otakureader.feature.reader.model.ImageQuality
+import app.otakureader.domain.repository.ChapterRepository
+import app.otakureader.feature.settings.delegate.AiSettingsDelegate
+import app.otakureader.feature.settings.delegate.AppearanceSettingsDelegate
+import app.otakureader.feature.settings.delegate.BackupSettingsDelegate
+import app.otakureader.feature.settings.delegate.DownloadSettingsDelegate
+import app.otakureader.feature.settings.delegate.LibrarySettingsDelegate
+import app.otakureader.feature.settings.delegate.ReaderSettingsDelegate
+import app.otakureader.feature.settings.delegate.TrackerSyncSettingsDelegate
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -38,28 +31,19 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    private val generalPreferences: GeneralPreferences,
-    private val libraryPreferences: LibraryPreferences,
-    private val readerPreferences: ReaderPreferences,
-    private val downloadPreferences: DownloadPreferences,
+    private val appearanceDelegate: AppearanceSettingsDelegate,
+    private val readerDelegate: ReaderSettingsDelegate,
+    private val libraryDelegate: LibrarySettingsDelegate,
+    private val downloadDelegate: DownloadSettingsDelegate,
+    private val backupDelegate: BackupSettingsDelegate,
+    private val aiDelegate: AiSettingsDelegate,
+    private val trackerSyncDelegate: TrackerSyncSettingsDelegate,
     private val localSourcePreferences: LocalSourcePreferences,
-    private val backupPreferences: BackupPreferences,
-    private val backupRepository: app.otakureader.data.backup.repository.BackupRepository,
-    private val backupScheduler: BackupScheduler,
-    private val readerSettingsRepository: app.otakureader.feature.reader.repository.ReaderSettingsRepository,
-    private val trackManager: TrackManager,
     private val appPreferences: AppPreferences,
-    private val libraryUpdateScheduler: LibraryUpdateScheduler,
-    private val aiPreferences: AiPreferences,
-    private val aiRepository: AiRepository,
     private val readingGoalPreferences: ReadingGoalPreferences,
     private val readingReminderScheduler: ReadingReminderScheduler,
-    private val discordRpcService: DiscordRpcService,
-    private val syncPreferences: SyncPreferences,
-    private val syncManager: SyncManager,
-    private val appUpdateChecker: app.otakureader.data.updater.AppUpdateChecker,
-    private val chapterRepository: app.otakureader.domain.repository.ChapterRepository,
-    @dagger.hilt.android.qualifiers.ApplicationContext private val context: Context
+    private val chapterRepository: ChapterRepository,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(SettingsState())
@@ -71,716 +55,105 @@ class SettingsViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             try {
-                aiPreferences.migrateLegacyApiKeyIfNeeded()
+                aiDelegate.initAiPrefs()
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 _effect.send(SettingsEffect.ShowSnackbar("Failed to load AI settings. You may need to re-enter your API key."))
             }
         }
-        observePreferences()
-        observeAiPreferences()
+        val update: ((SettingsState) -> SettingsState) -> Unit = { _state.update(it) }
+        appearanceDelegate.startObserving(viewModelScope, update)
+        readerDelegate.startObserving(viewModelScope, update)
+        libraryDelegate.startObserving(viewModelScope, update)
+        downloadDelegate.startObserving(viewModelScope, update)
+        backupDelegate.startObserving(viewModelScope, update)
+        aiDelegate.startObserving(viewModelScope, update)
+        trackerSyncDelegate.startObserving(viewModelScope, update)
+        observeLocalSourcePreferences()
+        observeMigrationPreferences()
         observeReadingGoalPreferences()
-        observeSyncPreferences()
-        observeAppUpdatePreferences()
-        refreshTrackers()
-    }
-
-    private fun observePreferences() {
-        observeGeneralPreferences()
-        observeLibraryPreferences()
-        observeReaderDisplayPreferences()
-        observeReaderBehaviorPreferences()
-        observeDownloadPreferences()
-        observeLocalAndBackupPreferences()
-    }
-
-    private fun observeGeneralPreferences() {
-        viewModelScope.launch {
-            combine(
-                generalPreferences.themeMode,
-                generalPreferences.useDynamicColor,
-                generalPreferences.usePureBlackDarkMode,
-                generalPreferences.useHighContrast,
-                generalPreferences.colorScheme
-            ) { themeMode, useDynamicColor, pureBlack, highContrast, colorScheme ->
-                _state.update { it.copy(
-                    themeMode = themeMode,
-                    useDynamicColor = useDynamicColor,
-                    usePureBlackDarkMode = pureBlack,
-                    useHighContrast = highContrast,
-                    colorScheme = colorScheme,
-                ) }
-            }.collect { }
-        }
-        viewModelScope.launch {
-            combine(
-                generalPreferences.customAccentColor,
-                generalPreferences.locale,
-                generalPreferences.notificationsEnabled,
-                generalPreferences.updateCheckInterval,
-                generalPreferences.showNsfwContent
-            ) { accent, locale, notifications, updateInterval, showNsfw ->
-                _state.update { it.copy(
-                    customAccentColor = accent,
-                    locale = locale,
-                    notificationsEnabled = notifications,
-                    updateCheckInterval = updateInterval,
-                    showNsfwContent = showNsfw,
-                ) }
-            }.collect { }
-        }
-        viewModelScope.launch {
-            generalPreferences.discordRpcEnabled.collect { discordRpc ->
-                _state.update { it.copy(discordRpcEnabled = discordRpc) }
-            }
-        }
-        viewModelScope.launch {
-            generalPreferences.autoThemeColor.collect { autoTheme ->
-                _state.update { it.copy(autoThemeColor = autoTheme) }
-            }
-        }
-    }
-
-    private fun observeLibraryPreferences() {
-        viewModelScope.launch {
-            combine(
-                libraryPreferences.gridSize,
-                libraryPreferences.showBadges,
-                libraryPreferences.updateOnlyOnWifi,
-                libraryPreferences.updateOnlyPinnedCategories,
-                libraryPreferences.autoRefreshOnStart
-            ) { gridSize, showBadges, updateOnWifi, updatePinned, autoRefresh ->
-                _state.update { it.copy(
-                    libraryGridSize = gridSize,
-                    showBadges = showBadges,
-                    updateOnlyOnWifi = updateOnWifi,
-                    updateOnlyPinnedCategories = updatePinned,
-                    autoRefreshOnStart = autoRefresh,
-                ) }
-            }.collect { }
-        }
-        viewModelScope.launch {
-            libraryPreferences.showUpdateProgress.collect { showProgress ->
-                _state.update { it.copy(showUpdateProgress = showProgress) }
-            }
-        }
-    }
-
-    private fun observeReaderDisplayPreferences() {
-        viewModelScope.launch {
-            combine(
-                readerPreferences.readerMode,
-                readerPreferences.keepScreenOn,
-                readerPreferences.fullscreen,
-                readerPreferences.showContentInCutout,
-                readerPreferences.showPageNumber
-            ) { readerMode, keepScreenOn, fullscreen, showCutout, showPageNum ->
-                _state.update { it.copy(
-                    readerMode = readerMode,
-                    keepScreenOn = keepScreenOn,
-                    fullscreen = fullscreen,
-                    showContentInCutout = showCutout,
-                    showPageNumber = showPageNum,
-                ) }
-            }.collect { }
-        }
-        viewModelScope.launch {
-            combine(
-                readerPreferences.backgroundColor,
-                readerPreferences.animatePageTransitions,
-                readerPreferences.showReadingModeOverlay,
-                readerPreferences.showTapZonesOverlay,
-                readerPreferences.readerScale
-            ) { bgColor, animate, showMode, showZones, scale ->
-                _state.update { it.copy(
-                    backgroundColor = bgColor,
-                    animatePageTransitions = animate,
-                    showReadingModeOverlay = showMode,
-                    showTapZonesOverlay = showZones,
-                    readerScale = scale,
-                ) }
-            }.collect { }
-        }
-        viewModelScope.launch {
-            combine(
-                readerPreferences.autoZoomWideImages,
-                readerPreferences.tapZoneConfig,
-                readerPreferences.invertTapZones,
-                readerPreferences.volumeKeysEnabled,
-                readerPreferences.volumeKeysInverted
-            ) { autoZoom, tapConfig, invertZones, volKeys, volInvert ->
-                _state.update { it.copy(
-                    autoZoomWideImages = autoZoom,
-                    tapZoneConfig = tapConfig,
-                    invertTapZones = invertZones,
-                    volumeKeysEnabled = volKeys,
-                    volumeKeysInverted = volInvert,
-                ) }
-            }.collect { }
-        }
-        viewModelScope.launch {
-            combine(
-                readerPreferences.doubleTapAnimationSpeed,
-                readerPreferences.showActionsOnLongTap,
-                readerPreferences.savePagesToSeparateFolders,
-                readerPreferences.webtoonSidePadding,
-                readerPreferences.webtoonMenuHideSensitivity
-            ) { animSpeed, longTap, separateFolders, sidePadding, menuSensitivity ->
-                _state.update { it.copy(
-                    doubleTapAnimationSpeed = animSpeed,
-                    showActionsOnLongTap = longTap,
-                    savePagesToSeparateFolders = separateFolders,
-                    webtoonSidePadding = sidePadding,
-                    webtoonMenuHideSensitivity = menuSensitivity,
-                ) }
-            }.collect { }
-        }
-        viewModelScope.launch {
-            combine(
-                readerPreferences.webtoonDoubleTapZoom,
-                readerPreferences.webtoonDisableZoomOut,
-                readerPreferences.einkFlashOnPageChange,
-                readerPreferences.einkBlackAndWhite,
-                readerPreferences.skipReadChapters
-            ) { dtZoom, disableZoomOut, einkFlash, einkBw, skipRead ->
-                _state.update { it.copy(
-                    webtoonDoubleTapZoom = dtZoom,
-                    webtoonDisableZoomOut = disableZoomOut,
-                    einkFlashOnPageChange = einkFlash,
-                    einkBlackAndWhite = einkBw,
-                    skipReadChapters = skipRead,
-                ) }
-            }.collect { }
-        }
-    }
-
-    private fun observeReaderBehaviorPreferences() {
-        viewModelScope.launch {
-            combine(
-                readerPreferences.skipFilteredChapters,
-                readerPreferences.skipDuplicateChapters,
-                readerPreferences.alwaysShowChapterTransition,
-                readerSettingsRepository.incognitoMode,
-                readerSettingsRepository.preloadPagesBefore
-            ) { skipFiltered, skipDupes, showTransition, incognito, preloadBefore ->
-                _state.update { it.copy(
-                    skipFilteredChapters = skipFiltered,
-                    skipDuplicateChapters = skipDupes,
-                    alwaysShowChapterTransition = showTransition,
-                    incognitoMode = incognito,
-                    preloadPagesBefore = preloadBefore,
-                ) }
-            }.collect { }
-        }
-        viewModelScope.launch {
-            combine(
-                readerSettingsRepository.preloadPagesAfter,
-                readerSettingsRepository.cropBordersEnabled,
-                readerSettingsRepository.imageQuality,
-                readerSettingsRepository.dataSaverEnabled
-            ) { preloadAfter, cropBorders, imageQuality, dataSaver ->
-                _state.update { it.copy(
-                    preloadPagesAfter = preloadAfter,
-                    cropBordersEnabled = cropBorders,
-                    imageQuality = imageQuality.name,
-                    dataSaverEnabled = dataSaver,
-                ) }
-            }.collect { }
-        }
-    }
-
-    private fun observeDownloadPreferences() {
-        viewModelScope.launch {
-            combine(
-                downloadPreferences.deleteAfterReading,
-                downloadPreferences.saveAsCbz,
-                downloadPreferences.autoDownloadEnabled,
-                downloadPreferences.downloadOnlyOnWifi,
-                downloadPreferences.autoDownloadLimit
-            ) { deleteAfter, saveCbz, autoDownload, dlWifi, dlLimit ->
-                _state.update { it.copy(
-                    deleteAfterReading = deleteAfter,
-                    saveAsCbz = saveCbz,
-                    autoDownloadEnabled = autoDownload,
-                    downloadOnlyOnWifi = dlWifi,
-                    autoDownloadLimit = dlLimit,
-                ) }
-            }.collect { }
-        }
-        viewModelScope.launch {
-            combine(
-                downloadPreferences.concurrentDownloads,
-                downloadPreferences.downloadAheadWhileReading,
-                downloadPreferences.downloadAheadOnlyOnWifi,
-                downloadPreferences.downloadLocation
-            ) { concurrent, dlAhead, dlAheadWifi, dlLocation ->
-                _state.update { it.copy(
-                    concurrentDownloads = concurrent,
-                    downloadAheadWhileReading = dlAhead,
-                    downloadAheadOnlyOnWifi = dlAheadWifi,
-                    downloadLocation = dlLocation,
-                ) }
-            }.collect { }
-        }
-    }
-
-    private fun observeLocalAndBackupPreferences() {
-        viewModelScope.launch {
-            combine(
-                localSourcePreferences.localSourceDirectory,
-                appPreferences.migrationSimilarityThreshold,
-                appPreferences.migrationAlwaysConfirm,
-                appPreferences.migrationMinChapterCount,
-                backupPreferences.autoBackupEnabled
-            ) { localDir, threshold, alwaysConfirm, minChapters, autoBackup ->
-                _state.update { it.copy(
-                    localSourceDirectory = localDir,
-                    migrationSimilarityThreshold = threshold,
-                    migrationAlwaysConfirm = alwaysConfirm,
-                    migrationMinChapterCount = minChapters,
-                    autoBackupEnabled = autoBackup,
-                ) }
-            }.collect { }
-        }
-        viewModelScope.launch {
-            combine(
-                backupPreferences.autoBackupIntervalHours,
-                backupPreferences.autoBackupMaxCount
-            ) { backupInterval, backupMax ->
-                _state.update { it.copy(
-                    autoBackupIntervalHours = backupInterval,
-                    autoBackupMaxCount = backupMax,
-                ) }
-            }.collect { }
-        }
-    }
-
-    private fun refreshTrackers() {
-        _state.update { it.copy(trackers = trackManager.all.map { t -> TrackerInfo(t.id, t.name, t.isLoggedIn) }) }
     }
 
     fun onEvent(event: SettingsEvent) {
         viewModelScope.launch {
-            when (event) {
-                // Appearance
-                is SettingsEvent.SetThemeMode -> generalPreferences.setThemeMode(event.mode)
-                is SettingsEvent.SetDynamicColor -> generalPreferences.setUseDynamicColor(event.enabled)
-                is SettingsEvent.SetPureBlackDarkMode -> generalPreferences.setUsePureBlackDarkMode(event.enabled)
-                is SettingsEvent.SetHighContrast -> generalPreferences.setUseHighContrast(event.enabled)
-                is SettingsEvent.SetColorScheme -> generalPreferences.setColorScheme(event.scheme)
-                is SettingsEvent.SetCustomAccentColor -> generalPreferences.setCustomAccentColor(event.color)
-                is SettingsEvent.SetLocale -> generalPreferences.setLocale(event.locale)
-                is SettingsEvent.SetAutoThemeColor -> generalPreferences.setAutoThemeColor(event.enabled)
-
-                // Reader - Display
-                is SettingsEvent.SetReaderMode -> readerPreferences.setReaderMode(event.mode)
-                is SettingsEvent.SetKeepScreenOn -> readerPreferences.setKeepScreenOn(event.enabled)
-                is SettingsEvent.SetFullscreen -> readerPreferences.setFullscreen(event.enabled)
-                is SettingsEvent.SetShowContentInCutout -> readerPreferences.setShowContentInCutout(event.enabled)
-                is SettingsEvent.SetShowPageNumber -> readerPreferences.setShowPageNumber(event.enabled)
-                is SettingsEvent.SetBackgroundColor -> readerPreferences.setBackgroundColor(event.color)
-                is SettingsEvent.SetAnimatePageTransitions -> readerPreferences.setAnimatePageTransitions(event.enabled)
-                is SettingsEvent.SetShowReadingModeOverlay -> readerPreferences.setShowReadingModeOverlay(event.enabled)
-                is SettingsEvent.SetShowTapZonesOverlay -> readerPreferences.setShowTapZonesOverlay(event.enabled)
-
-                // Reader - Scale
-                is SettingsEvent.SetReaderScale -> readerPreferences.setReaderScale(event.scale)
-                is SettingsEvent.SetAutoZoomWideImages -> readerPreferences.setAutoZoomWideImages(event.enabled)
-
-                // Reader - Tap Zones
-                is SettingsEvent.SetTapZoneConfig -> readerPreferences.setTapZoneConfig(event.config)
-                is SettingsEvent.SetInvertTapZones -> readerPreferences.setInvertTapZones(event.enabled)
-
-                // Reader - Volume Keys
-                is SettingsEvent.SetVolumeKeysEnabled -> readerPreferences.setVolumeKeysEnabled(event.enabled)
-                is SettingsEvent.SetVolumeKeysInverted -> readerPreferences.setVolumeKeysInverted(event.enabled)
-
-                // Reader - Interaction
-                is SettingsEvent.SetDoubleTapAnimationSpeed -> readerPreferences.setDoubleTapAnimationSpeed(event.speed)
-                is SettingsEvent.SetShowActionsOnLongTap -> readerPreferences.setShowActionsOnLongTap(event.enabled)
-                is SettingsEvent.SetSavePagesToSeparateFolders -> readerPreferences.setSavePagesToSeparateFolders(event.enabled)
-
-                // Reader - Webtoon
-                is SettingsEvent.SetWebtoonSidePadding -> readerPreferences.setWebtoonSidePadding(event.padding)
-                is SettingsEvent.SetWebtoonMenuHideSensitivity -> readerPreferences.setWebtoonMenuHideSensitivity(event.sensitivity)
-                is SettingsEvent.SetWebtoonDoubleTapZoom -> readerPreferences.setWebtoonDoubleTapZoom(event.enabled)
-                is SettingsEvent.SetWebtoonDisableZoomOut -> readerPreferences.setWebtoonDisableZoomOut(event.enabled)
-
-                // Reader - E-ink
-                is SettingsEvent.SetEinkFlashOnPageChange -> readerPreferences.setEinkFlashOnPageChange(event.enabled)
-                is SettingsEvent.SetEinkBlackAndWhite -> readerPreferences.setEinkBlackAndWhite(event.enabled)
-
-                // Reader - Behavior
-                is SettingsEvent.SetSkipReadChapters -> readerPreferences.setSkipReadChapters(event.enabled)
-                is SettingsEvent.SetSkipFilteredChapters -> readerPreferences.setSkipFilteredChapters(event.enabled)
-                is SettingsEvent.SetSkipDuplicateChapters -> readerPreferences.setSkipDuplicateChapters(event.enabled)
-                is SettingsEvent.SetAlwaysShowChapterTransition -> readerPreferences.setAlwaysShowChapterTransition(event.enabled)
-
-                // Reader - Other
-                is SettingsEvent.SetIncognitoMode -> readerSettingsRepository.setIncognitoMode(event.enabled)
-                is SettingsEvent.SetPreloadPagesBefore -> readerSettingsRepository.setPreloadPagesBefore(event.count)
-                is SettingsEvent.SetPreloadPagesAfter -> readerSettingsRepository.setPreloadPagesAfter(event.count)
-                is SettingsEvent.SetCropBordersEnabled -> readerSettingsRepository.setCropBordersEnabled(event.enabled)
-                is SettingsEvent.SetImageQuality -> {
-                    val normalizedInput = event.quality.trim().uppercase()
-                    val quality = ImageQuality.entries.firstOrNull { 
-                        it.name.equals(normalizedInput, ignoreCase = true) 
-                    } ?: ImageQuality.ORIGINAL
-                    readerSettingsRepository.setImageQuality(quality)
-                }
-                is SettingsEvent.SetDataSaverEnabled -> readerSettingsRepository.setDataSaverEnabled(event.enabled)
-
-                // Library
-                is SettingsEvent.SetLibraryGridSize -> libraryPreferences.setGridSize(event.size)
-                is SettingsEvent.SetShowBadges -> libraryPreferences.setShowBadges(event.enabled)
-                is SettingsEvent.SetUpdateOnlyOnWifi -> handleSetUpdateOnlyOnWifi(event.enabled)
-                is SettingsEvent.SetUpdateOnlyPinnedCategories -> libraryPreferences.setUpdateOnlyPinnedCategories(event.enabled)
-                is SettingsEvent.SetAutoRefreshOnStart -> libraryPreferences.setAutoRefreshOnStart(event.enabled)
-                is SettingsEvent.SetShowUpdateProgress -> libraryPreferences.setShowUpdateProgress(event.enabled)
-
-                // Downloads
-                is SettingsEvent.SetDeleteAfterReading -> downloadPreferences.setDeleteAfterReading(event.enabled)
-                is SettingsEvent.SetSaveAsCbz -> downloadPreferences.setSaveAsCbz(event.enabled)
-                is SettingsEvent.SetAutoDownloadEnabled -> downloadPreferences.setAutoDownloadEnabled(event.enabled)
-                is SettingsEvent.SetDownloadOnlyOnWifi -> downloadPreferences.setDownloadOnlyOnWifi(event.enabled)
-                is SettingsEvent.SetAutoDownloadLimit -> downloadPreferences.setAutoDownloadLimit(event.limit)
-                is SettingsEvent.SetConcurrentDownloads -> downloadPreferences.setConcurrentDownloads(event.count)
-                is SettingsEvent.SetDownloadAheadWhileReading -> downloadPreferences.setDownloadAheadWhileReading(event.count)
-                is SettingsEvent.SetDownloadAheadOnlyOnWifi -> downloadPreferences.setDownloadAheadOnlyOnWifi(event.enabled)
-                is SettingsEvent.SetDownloadLocation -> downloadPreferences.setDownloadLocation(event.location)
-
-                // Local Source
-                is SettingsEvent.SetLocalSourceDirectory -> localSourcePreferences.setLocalSourceDirectory(event.path)
-
-                // Notifications
-                is SettingsEvent.SetNotificationsEnabled -> generalPreferences.setNotificationsEnabled(event.enabled)
-                is SettingsEvent.SetUpdateInterval -> handleSetUpdateInterval(event.hours)
-
-                // Backup
-                SettingsEvent.OnCreateBackup -> _effect.send(SettingsEffect.ShowBackupPicker)
-                SettingsEvent.OnRestoreBackup -> _effect.send(SettingsEffect.ShowRestorePicker)
-                is SettingsEvent.CreateBackupWithUri -> handleCreateBackupWithUri(event.uri)
-                is SettingsEvent.RestoreBackupFromUri -> handleRestoreBackupFromUri(event.uri)
-                is SettingsEvent.SetAutoBackupEnabled -> handleSetAutoBackupEnabled(event.enabled)
-                is SettingsEvent.SetAutoBackupInterval -> handleSetAutoBackupInterval(event.hours)
-                is SettingsEvent.SetAutoBackupMaxCount -> backupPreferences.setAutoBackupMaxCount(event.count)
-                SettingsEvent.RefreshLocalBackups -> refreshLocalBackups()
-                is SettingsEvent.RestoreLocalBackup -> restoreLocalBackup(event.fileName)
-
-                // Tracking
-                is SettingsEvent.LoginTracker -> loginTracker(event.trackerId, event.username, event.password)
-                is SettingsEvent.LogoutTracker -> logoutTracker(event.trackerId)
-
-                // Migration
-                is SettingsEvent.SetMigrationSimilarityThreshold -> appPreferences.setMigrationSimilarityThreshold(event.threshold)
-                is SettingsEvent.SetMigrationAlwaysConfirm -> appPreferences.setMigrationAlwaysConfirm(event.enabled)
-                is SettingsEvent.SetMigrationMinChapterCount -> appPreferences.setMigrationMinChapterCount(event.count)
-                SettingsEvent.OnNavigateToMigration -> _effect.send(SettingsEffect.NavigateToMigrationEntry)
-
-                // Browse
-                is SettingsEvent.SetShowNsfwContent -> generalPreferences.setShowNsfwContent(event.enabled)
-
-                // Discord
-                is SettingsEvent.SetDiscordRpcEnabled -> handleSetDiscordRpcEnabled(event.enabled)
-
-                // AI
-                is SettingsEvent.SetAiEnabled -> aiPreferences.setAiEnabled(event.enabled)
-                is SettingsEvent.SetAiTier -> aiPreferences.setAiTier(event.tier)
-                is SettingsEvent.SetAiApiKey -> handleSetAiApiKey(event.key)
-                SettingsEvent.RemoveAiApiKey -> _state.update { it.copy(showRemoveApiKeyDialog = true) }
-                SettingsEvent.ConfirmRemoveAiApiKey -> handleConfirmRemoveAiApiKey()
-                SettingsEvent.DismissRemoveApiKeyDialog -> _state.update { it.copy(showRemoveApiKeyDialog = false) }
-                is SettingsEvent.SetAiReadingInsights -> aiPreferences.setAiReadingInsights(event.enabled)
-                is SettingsEvent.SetAiSmartSearch -> aiPreferences.setAiSmartSearch(event.enabled)
-                is SettingsEvent.SetAiRecommendations -> aiPreferences.setAiRecommendations(event.enabled)
-                is SettingsEvent.SetAiPanelReader -> aiPreferences.setAiPanelReader(event.enabled)
-                is SettingsEvent.SetAiSfxTranslation -> aiPreferences.setAiSfxTranslation(event.enabled)
-                is SettingsEvent.SetAiSummaryTranslation -> aiPreferences.setAiSummaryTranslation(event.enabled)
-                is SettingsEvent.SetAiSourceIntelligence -> aiPreferences.setAiSourceIntelligence(event.enabled)
-                is SettingsEvent.SetAiSmartNotifications -> aiPreferences.setAiSmartNotifications(event.enabled)
-                is SettingsEvent.SetAiAutoCategorization -> aiPreferences.setAiAutoCategorization(event.enabled)
-                SettingsEvent.ClearAiCache -> handleClearAiCache()
-
-                // Reading Goals
-                is SettingsEvent.SetDailyChapterGoal -> readingGoalPreferences.setDailyChapterGoal(event.goal)
-                is SettingsEvent.SetWeeklyChapterGoal -> readingGoalPreferences.setWeeklyChapterGoal(event.goal)
-                is SettingsEvent.SetReadingRemindersEnabled -> handleSetReadingRemindersEnabled(event.enabled)
-                is SettingsEvent.SetReadingReminderHour -> handleSetReadingReminderHour(event.hour)
-
-                // Cloud Sync
-                is SettingsEvent.SetSyncEnabled -> handleSetSyncEnabled(event.enabled, event.providerId)
-                SettingsEvent.TriggerManualSync -> handleTriggerManualSync()
-                is SettingsEvent.SetAutoSyncEnabled -> syncPreferences.setAutoSyncEnabled(event.enabled)
-                is SettingsEvent.SetSyncIntervalHours -> syncPreferences.setSyncIntervalHours(event.hours)
-                is SettingsEvent.SetSyncOnlyOnWifi -> syncPreferences.setSyncOnlyOnWifi(event.onlyWifi)
-                is SettingsEvent.SetConflictResolutionStrategy -> syncPreferences.setConflictResolutionStrategy(event.strategy)
-                is SettingsEvent.SetSelfHostedServerUrl -> syncPreferences.setSelfHostedServerUrl(event.url)
-                is SettingsEvent.SetSelfHostedAuthToken -> syncPreferences.setSelfHostedAuthToken(event.token)
-                is SettingsEvent.GoogleSignInResult -> handleGoogleSignInResult(event.email)
-                SettingsEvent.DisconnectGoogleDrive -> handleDisconnectGoogleDrive()
-
-                // App Update Checker
-                is SettingsEvent.SetAppUpdateCheckEnabled -> generalPreferences.setAppUpdateCheckEnabled(event.enabled)
-                SettingsEvent.CheckForAppUpdate -> handleCheckForAppUpdate()
-
-                // Data management
-                SettingsEvent.ClearImageCache -> clearImageCache()
-                SettingsEvent.ClearHistory -> clearHistory()
-
-                SettingsEvent.NavigateToAbout -> _effect.send(SettingsEffect.NavigateToAbout)
+            val send: suspend (SettingsEffect) -> Unit = { _effect.send(it) }
+            when {
+                appearanceDelegate.handleEvent(event, send) -> Unit
+                readerDelegate.handleEvent(event, send) -> Unit
+                libraryDelegate.handleEvent(event, send) -> Unit
+                downloadDelegate.handleEvent(event, send) -> Unit
+                backupDelegate.handleEvent(event, send) -> Unit
+                aiDelegate.handleEvent(event, send) -> Unit
+                trackerSyncDelegate.handleEvent(event, send) -> Unit
+                else -> handleRemainingEvent(event)
             }
         }
     }
 
-    private fun handleSetAiApiKey(key: String) {
-        viewModelScope.launch {
-            if (key.isNotBlank() && !isGeminiApiKeyFormatValid(key)) {
-                _effect.send(SettingsEffect.ShowSnackbar("Invalid API key format"))
-                return@launch
-            }
-            aiPreferences.setGeminiApiKey(key)
-            val persistedKey = aiPreferences.getGeminiApiKey()
-            val isSet = persistedKey.isNotBlank()
-            _state.update { it.copy(aiApiKeySet = isSet) }
-            if (key.isNotBlank() && !isSet) {
-                _effect.send(SettingsEffect.ShowSnackbar("Failed to save AI API key"))
-            } else if (isSet) {
-                aiRepository.clearApiKey()
-                aiRepository.initialize(persistedKey)
-            }
-        }
-    }
-
-    private fun handleConfirmRemoveAiApiKey() {
-        viewModelScope.launch {
-            _state.update { it.copy(showRemoveApiKeyDialog = false) }
-            aiPreferences.clearGeminiApiKey()
-            aiRepository.clearApiKey()
-            _state.update { it.copy(aiApiKeySet = false) }
-            _effect.send(SettingsEffect.ShowSnackbar("AI API key removed"))
-        }
-    }
-
-    private fun handleClearAiCache() {
-        viewModelScope.launch {
-            aiPreferences.setAiCacheLastCleared(System.currentTimeMillis())
-            _effect.send(SettingsEffect.ShowSnackbar("AI suggestions will refresh for future requests"))
-        }
-    }
-
-    private fun isGeminiApiKeyFormatValid(key: String): Boolean {
-        return key.matches(Regex("^AIza[0-9A-Za-z_-]{35}$"))
-    }
-
-    private fun handleSetDiscordRpcEnabled(enabled: Boolean) {
-        viewModelScope.launch {
-            generalPreferences.setDiscordRpcEnabled(enabled)
-            if (enabled) {
-                discordRpcService.initialize()
-            } else {
-                discordRpcService.disconnect()
-            }
-        }
-    }
-
+    // Delegates provide a public shim used by the backup file-picker result callbacks in
+    // SettingsScreen (the screen calls these directly because ActivityResultLauncher callbacks
+    // are not routed through onEvent).
     fun createBackup(uri: android.net.Uri) { onEvent(SettingsEvent.CreateBackupWithUri(uri)) }
     fun restoreBackup(uri: android.net.Uri) { onEvent(SettingsEvent.RestoreBackupFromUri(uri)) }
 
-    private fun handleCreateBackupWithUri(uri: android.net.Uri) {
+    private suspend fun handleRemainingEvent(event: SettingsEvent) {
+        when (event) {
+            // Local source
+            is SettingsEvent.SetLocalSourceDirectory ->
+                localSourcePreferences.setLocalSourceDirectory(event.path)
+
+            // Migration
+            is SettingsEvent.SetMigrationSimilarityThreshold ->
+                appPreferences.setMigrationSimilarityThreshold(event.threshold)
+            is SettingsEvent.SetMigrationAlwaysConfirm ->
+                appPreferences.setMigrationAlwaysConfirm(event.enabled)
+            is SettingsEvent.SetMigrationMinChapterCount ->
+                appPreferences.setMigrationMinChapterCount(event.count)
+            SettingsEvent.OnNavigateToMigration ->
+                _effect.send(SettingsEffect.NavigateToMigrationEntry)
+
+            // Reading goals
+            is SettingsEvent.SetDailyChapterGoal ->
+                readingGoalPreferences.setDailyChapterGoal(event.goal)
+            is SettingsEvent.SetWeeklyChapterGoal ->
+                readingGoalPreferences.setWeeklyChapterGoal(event.goal)
+            is SettingsEvent.SetReadingRemindersEnabled ->
+                handleSetReadingRemindersEnabled(event.enabled)
+            is SettingsEvent.SetReadingReminderHour ->
+                handleSetReadingReminderHour(event.hour)
+
+            // Data management
+            SettingsEvent.ClearImageCache -> clearImageCache()
+            SettingsEvent.ClearHistory -> clearHistory()
+
+            // Navigation
+            SettingsEvent.NavigateToAbout -> _effect.send(SettingsEffect.NavigateToAbout)
+
+            else -> Unit
+        }
+    }
+
+    private fun observeLocalSourcePreferences() {
         viewModelScope.launch {
-            _state.update { it.copy(isBackupInProgress = true) }
-            try {
-                backupRepository.createBackup(uri)
-                _effect.send(SettingsEffect.ShowSnackbar("Backup created successfully"))
-            } catch (e: Exception) {
-                _effect.send(SettingsEffect.ShowSnackbar("Failed to create backup: ${e.message}"))
-            } finally {
-                _state.update { it.copy(isBackupInProgress = false) }
+            localSourcePreferences.localSourceDirectory.collect { dir ->
+                _state.update { it.copy(localSourceDirectory = dir) }
             }
         }
     }
 
-    private fun handleRestoreBackupFromUri(uri: android.net.Uri) {
-        viewModelScope.launch {
-            _state.update { it.copy(isRestoreInProgress = true) }
-            try {
-                backupRepository.restoreBackup(uri)
-                _effect.send(SettingsEffect.ShowSnackbar("Backup restored successfully"))
-            } catch (e: Exception) {
-                _effect.send(SettingsEffect.ShowSnackbar("Failed to restore backup: ${e.message}"))
-            } finally {
-                _state.update { it.copy(isRestoreInProgress = false) }
-            }
-        }
-    }
-
-    private fun handleSetAutoBackupEnabled(enabled: Boolean) {
-        viewModelScope.launch {
-            backupPreferences.setAutoBackupEnabled(enabled)
-            if (enabled) {
-                val intervalHours = backupPreferences.autoBackupIntervalHours.first()
-                backupScheduler.schedule(intervalHours)
-            } else {
-                backupScheduler.cancel()
-            }
-        }
-    }
-
-    private fun handleSetUpdateOnlyOnWifi(enabled: Boolean) {
-        viewModelScope.launch {
-            libraryPreferences.setUpdateOnlyOnWifi(enabled)
-            val intervalHours = state.value.updateCheckInterval
-            scheduleLibraryUpdateOrShowError(intervalHours, enabled)
-        }
-    }
-
-    private fun handleSetUpdateInterval(hours: Int) {
-        viewModelScope.launch {
-            generalPreferences.setUpdateCheckInterval(hours)
-            val wifiOnly = state.value.updateOnlyOnWifi
-            scheduleLibraryUpdateOrShowError(hours, wifiOnly)
-        }
-    }
-
-    private suspend fun scheduleLibraryUpdateOrShowError(intervalHours: Int, wifiOnly: Boolean) {
-        try {
-            libraryUpdateScheduler.schedule(intervalHours = intervalHours, wifiOnly = wifiOnly)
-        } catch (e: Exception) {
-            Log.e("SettingsViewModel", "Failed to schedule library update (intervalHours=$intervalHours, wifiOnly=$wifiOnly)", e)
-            _effect.send(SettingsEffect.ShowSnackbar("Failed to update library scheduler settings"))
-        }
-    }
-
-    private fun handleSetAutoBackupInterval(hours: Int) {
-        viewModelScope.launch {
-            backupPreferences.setAutoBackupIntervalHours(hours)
-            if (backupPreferences.autoBackupEnabled.first()) {
-                backupScheduler.schedule(hours)
-            }
-        }
-    }
-
-    private fun refreshLocalBackups() {
-        viewModelScope.launch {
-            val files = backupRepository.listLocalBackups().map { it.name }
-            _state.update { it.copy(localBackupFiles = files) }
-        }
-    }
-
-    private fun restoreLocalBackup(fileName: String) {
-        viewModelScope.launch {
-            _state.update { it.copy(
-                isRestoreInProgress = true,
-                restoringBackupFileName = fileName
-            )}
-            try {
-                val allFiles = backupRepository.listLocalBackups()
-                val file = allFiles.firstOrNull { it.name == fileName }
-                    ?: throw IllegalArgumentException("Backup file not found: $fileName")
-                backupRepository.restoreLocalBackup(file)
-                _effect.send(SettingsEffect.ShowSnackbar("Backup restored successfully"))
-            } catch (e: Exception) {
-                _effect.send(SettingsEffect.ShowSnackbar("Failed to restore backup: ${e.message}"))
-            } finally {
-                _state.update { it.copy(
-                    isRestoreInProgress = false,
-                    restoringBackupFileName = null
-                )}
-            }
-        }
-    }
-
-    private fun loginTracker(trackerId: Int, username: String, password: String) {
-        viewModelScope.launch {
-            _state.update { it.copy(trackingLoginInProgress = true) }
-            try {
-                val tracker = trackManager.get(trackerId)
-                if (tracker != null) {
-                    val success = tracker.login(username, password)
-                    if (success) {
-                        refreshTrackers()
-                        _effect.send(SettingsEffect.ShowSnackbar("Logged in to ${tracker.name}"))
-                    } else {
-                        _effect.send(SettingsEffect.ShowSnackbar("Failed to login to ${tracker.name}"))
-                    }
-                }
-            } catch (e: Exception) {
-                _effect.send(SettingsEffect.ShowSnackbar("Error: ${e.message}"))
-            } finally {
-                _state.update { it.copy(trackingLoginInProgress = false) }
-            }
-        }
-    }
-
-    private fun logoutTracker(trackerId: Int) {
-        viewModelScope.launch {
-            val tracker = trackManager.get(trackerId)
-            tracker?.logout()
-            refreshTrackers()
-            _effect.send(SettingsEffect.ShowSnackbar("Logged out from ${tracker?.name}"))
-        }
-    }
-
-    private fun handleSetReadingRemindersEnabled(enabled: Boolean) {
-        viewModelScope.launch {
-            readingGoalPreferences.setRemindersEnabled(enabled)
-            if (enabled) {
-                val hour = readingGoalPreferences.reminderHour.first()
-                readingReminderScheduler.schedule(hour)
-            } else {
-                readingReminderScheduler.cancel()
-            }
-        }
-    }
-
-    private fun handleSetReadingReminderHour(hour: Int) {
-        viewModelScope.launch {
-            readingGoalPreferences.setReminderHour(hour)
-            if (readingGoalPreferences.remindersEnabled.first()) {
-                readingReminderScheduler.schedule(hour)
-            }
-        }
-    }
-
-    private fun observeAiPreferences() {
+    private fun observeMigrationPreferences() {
         viewModelScope.launch {
             combine(
-                aiPreferences.aiEnabled,
-                aiPreferences.aiTier,
-                aiPreferences.aiReadingInsights,
-                aiPreferences.aiSmartSearch,
-                aiPreferences.aiRecommendations
-            ) { enabled, tier, insights, smartSearch, recs ->
+                appPreferences.migrationSimilarityThreshold,
+                appPreferences.migrationAlwaysConfirm,
+                appPreferences.migrationMinChapterCount
+            ) { threshold, alwaysConfirm, minChapters ->
                 _state.update { it.copy(
-                    aiEnabled = enabled,
-                    aiTier = tier,
-                    aiApiKeySet = aiPreferences.getGeminiApiKey().isNotBlank(),
-                    aiReadingInsights = insights,
-                    aiSmartSearch = smartSearch,
-                    aiRecommendations = recs,
+                    migrationSimilarityThreshold = threshold,
+                    migrationAlwaysConfirm = alwaysConfirm,
+                    migrationMinChapterCount = minChapters,
                 ) }
             }.collect { }
-        }
-        viewModelScope.launch {
-            combine(
-                aiPreferences.aiPanelReader,
-                aiPreferences.aiSfxTranslation,
-                aiPreferences.aiSummaryTranslation,
-                aiPreferences.aiSourceIntelligence,
-                aiPreferences.aiSmartNotifications
-            ) { panelReader, sfx, summary, sourceIntel, smartNotif ->
-                _state.update { it.copy(
-                    aiPanelReader = panelReader,
-                    aiSfxTranslation = sfx,
-                    aiSummaryTranslation = summary,
-                    aiSourceIntelligence = sourceIntel,
-                    aiSmartNotifications = smartNotif,
-                ) }
-            }.collect { }
-        }
-        viewModelScope.launch {
-            aiPreferences.aiAutoCategorization.collect { autoCat ->
-                _state.update { it.copy(aiAutoCategorization = autoCat) }
-            }
         }
     }
 
@@ -792,140 +165,33 @@ class SettingsViewModel @Inject constructor(
                 readingGoalPreferences.remindersEnabled,
                 readingGoalPreferences.reminderHour
             ) { daily, weekly, reminders, hour ->
-                _state.update { current ->
-                    current.copy(
-                        dailyChapterGoal = daily,
-                        weeklyChapterGoal = weekly,
-                        readingRemindersEnabled = reminders,
-                        readingReminderHour = hour
-                    )
-                }
+                _state.update { it.copy(
+                    dailyChapterGoal = daily,
+                    weeklyChapterGoal = weekly,
+                    readingRemindersEnabled = reminders,
+                    readingReminderHour = hour,
+                ) }
             }.collect { }
         }
     }
 
-    private fun observeSyncPreferences() {
-        viewModelScope.launch {
-            // Combine first 5 flows, then zip in additional ones to stay within the typed overload limit.
-            combine(
-                syncPreferences.isSyncEnabled,
-                syncPreferences.providerId,
-                syncPreferences.autoSyncEnabled,
-                syncPreferences.syncIntervalHours,
-                syncPreferences.syncOnlyOnWifi
-            ) { enabled, providerId, autoSync, interval, wifiOnly ->
-                SyncPrefBundle(enabled, providerId, autoSync, interval, wifiOnly)
-            }.combine(syncPreferences.conflictResolutionStrategy) { bundle, strategy ->
-                val lastSync = if (bundle.enabled) syncManager.getLastSyncTime() else null
-                _state.update { current ->
-                    current.copy(
-                        syncEnabled = bundle.enabled,
-                        syncProviderId = bundle.providerId,
-                        autoSyncEnabled = bundle.autoSync,
-                        syncIntervalHours = bundle.interval,
-                        syncOnlyOnWifi = bundle.wifiOnly,
-                        conflictResolutionStrategy = strategy,
-                        lastSyncTime = lastSync
-                    )
-                }
-            }.collect { }
-        }
-        // Self-hosted and Google Drive settings (separate flows to keep combine limit manageable)
-        viewModelScope.launch {
-            combine(
-                syncPreferences.selfHostedServerUrlFlow,
-                syncPreferences.selfHostedAuthTokenFlow,
-                syncPreferences.googleDriveEmailFlow
-            ) { url, token, driveEmail ->
-                Triple(url ?: "", token ?: "", driveEmail)
-            }.collect { (url, token, driveEmail) ->
-                _state.update { current ->
-                    current.copy(
-                        selfHostedServerUrl = url,
-                        selfHostedAuthToken = token,
-                        googleDriveAccountEmail = driveEmail
-                    )
-                }
-            }
+    private suspend fun handleSetReadingRemindersEnabled(enabled: Boolean) {
+        readingGoalPreferences.setRemindersEnabled(enabled)
+        if (enabled) {
+            val hour = readingGoalPreferences.reminderHour.first()
+            readingReminderScheduler.schedule(hour)
+        } else {
+            readingReminderScheduler.cancel()
         }
     }
 
-    private fun observeAppUpdatePreferences() {
-        viewModelScope.launch {
-            combine(
-                generalPreferences.appUpdateCheckEnabled,
-                generalPreferences.lastAppUpdateCheck
-            ) { enabled, lastCheck ->
-                _state.update { current ->
-                    current.copy(
-                        appUpdateCheckEnabled = enabled,
-                        lastAppUpdateCheck = lastCheck
-                    )
-                }
-            }.collect { }
+    private suspend fun handleSetReadingReminderHour(hour: Int) {
+        readingGoalPreferences.setReminderHour(hour)
+        if (readingGoalPreferences.remindersEnabled.first()) {
+            readingReminderScheduler.schedule(hour)
         }
     }
 
-    private fun handleSetSyncEnabled(enabled: Boolean, providerId: String?) {
-        viewModelScope.launch {
-            if (enabled && providerId != null) {
-                // For Google Drive, launch sign-in if not yet connected
-                if (providerId == "google_drive" && _state.value.googleDriveAccountEmail.isNullOrBlank()) {
-                    _effect.send(SettingsEffect.LaunchGoogleSignIn)
-                    return@launch
-                }
-                syncManager.enableSync(providerId)
-            } else {
-                syncManager.disableSync()
-            }
-        }
-    }
-
-    private fun handleTriggerManualSync() {
-        viewModelScope.launch {
-            syncManager.sync()
-        }
-    }
-
-    private fun handleGoogleSignInResult(email: String) {
-        viewModelScope.launch {
-            syncPreferences.setGoogleDriveEmail(email)
-            _state.update { it.copy(googleDriveAccountEmail = email) }
-            syncManager.enableSync("google_drive")
-        }
-    }
-
-    private fun handleDisconnectGoogleDrive() {
-        viewModelScope.launch {
-            syncPreferences.clearGoogleDriveAccount()
-            _state.update { it.copy(googleDriveAccountEmail = null) }
-            if (_state.value.syncProviderId == "google_drive") {
-                syncManager.disableSync()
-            }
-        }
-    }
-
-    /** Intermediate bundle used inside [observeSyncPreferences] to work around the 5-Flow combine limit. */
-    private data class SyncPrefBundle(
-        val enabled: Boolean,
-        val providerId: String?,
-        val autoSync: Boolean,
-        val interval: Int,
-        val wifiOnly: Boolean,
-    )
-
-    private fun handleCheckForAppUpdate() {
-        viewModelScope.launch {
-            val versionInfo = appUpdateChecker.checkForUpdate()
-            if (versionInfo != null) {
-                _effect.send(SettingsEffect.ShowSnackbar("Update available: ${versionInfo.versionName}"))
-            } else {
-                _effect.send(SettingsEffect.ShowSnackbar("App is up to date"))
-            }
-        }
-    }
-
-    /** Clears the on-disk image cache directory used by Coil. */
     private fun clearImageCache() {
         viewModelScope.launch {
             try {
@@ -937,18 +203,19 @@ class SettingsViewModel @Inject constructor(
                     _effect.send(SettingsEffect.ShowSnackbar(context.getString(R.string.settings_clear_cache_failed)))
                 }
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 _effect.send(SettingsEffect.ShowSnackbar(context.getString(R.string.settings_clear_cache_failed)))
             }
         }
     }
 
-    /** Clears all reading history from the database. */
     private fun clearHistory() {
         viewModelScope.launch {
             try {
                 chapterRepository.clearAllHistory()
                 _effect.send(SettingsEffect.ShowSnackbar(context.getString(R.string.settings_clear_history_success)))
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 _effect.send(SettingsEffect.ShowSnackbar(context.getString(R.string.settings_clear_history_failed)))
             }
         }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/AiSettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/AiSettingsDelegate.kt
@@ -1,0 +1,131 @@
+package app.otakureader.feature.settings.delegate
+
+import app.otakureader.core.preferences.AiPreferences
+import app.otakureader.domain.repository.AiRepository
+import app.otakureader.feature.settings.SettingsEffect
+import app.otakureader.feature.settings.SettingsEvent
+import app.otakureader.feature.settings.SettingsState
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AiSettingsDelegate @Inject constructor(
+    private val aiPreferences: AiPreferences,
+    private val aiRepository: AiRepository,
+) {
+
+    private var updateState: ((SettingsState) -> SettingsState) -> Unit = {}
+
+    /** Perform any one-time migration; call from ViewModel.init before [startObserving]. */
+    suspend fun initAiPrefs() {
+        aiPreferences.migrateLegacyApiKeyIfNeeded()
+    }
+
+    fun startObserving(
+        scope: CoroutineScope,
+        updateState: ((SettingsState) -> SettingsState) -> Unit,
+    ) {
+        this.updateState = updateState
+        scope.launch {
+            combine(
+                aiPreferences.aiEnabled,
+                aiPreferences.aiTier,
+                aiPreferences.aiReadingInsights,
+                aiPreferences.aiSmartSearch,
+                aiPreferences.aiRecommendations,
+            ) { enabled, tier, insights, smartSearch, recs ->
+                updateState { it.copy(
+                    aiEnabled = enabled,
+                    aiTier = tier,
+                    aiApiKeySet = aiPreferences.getGeminiApiKey().isNotBlank(),
+                    aiReadingInsights = insights,
+                    aiSmartSearch = smartSearch,
+                    aiRecommendations = recs,
+                ) }
+            }.collect { }
+        }
+        scope.launch {
+            combine(
+                aiPreferences.aiPanelReader,
+                aiPreferences.aiSfxTranslation,
+                aiPreferences.aiSummaryTranslation,
+                aiPreferences.aiSourceIntelligence,
+                aiPreferences.aiSmartNotifications,
+            ) { panelReader, sfx, summary, sourceIntel, smartNotif ->
+                updateState { it.copy(
+                    aiPanelReader = panelReader,
+                    aiSfxTranslation = sfx,
+                    aiSummaryTranslation = summary,
+                    aiSourceIntelligence = sourceIntel,
+                    aiSmartNotifications = smartNotif,
+                ) }
+            }.collect { }
+        }
+        scope.launch {
+            aiPreferences.aiAutoCategorization.collect { autoCat ->
+                updateState { it.copy(aiAutoCategorization = autoCat) }
+            }
+        }
+    }
+
+    suspend fun handleEvent(
+        event: SettingsEvent,
+        sendEffect: suspend (SettingsEffect) -> Unit,
+    ): Boolean = when (event) {
+        is SettingsEvent.SetAiEnabled -> { aiPreferences.setAiEnabled(event.enabled); true }
+        is SettingsEvent.SetAiTier -> { aiPreferences.setAiTier(event.tier); true }
+        is SettingsEvent.SetAiApiKey -> { handleSetAiApiKey(event.key, sendEffect); true }
+        SettingsEvent.RemoveAiApiKey -> { updateState { it.copy(showRemoveApiKeyDialog = true) }; true }
+        SettingsEvent.ConfirmRemoveAiApiKey -> { handleConfirmRemoveAiApiKey(sendEffect); true }
+        SettingsEvent.DismissRemoveApiKeyDialog -> { updateState { it.copy(showRemoveApiKeyDialog = false) }; true }
+        is SettingsEvent.SetAiReadingInsights -> { aiPreferences.setAiReadingInsights(event.enabled); true }
+        is SettingsEvent.SetAiSmartSearch -> { aiPreferences.setAiSmartSearch(event.enabled); true }
+        is SettingsEvent.SetAiRecommendations -> { aiPreferences.setAiRecommendations(event.enabled); true }
+        is SettingsEvent.SetAiPanelReader -> { aiPreferences.setAiPanelReader(event.enabled); true }
+        is SettingsEvent.SetAiSfxTranslation -> { aiPreferences.setAiSfxTranslation(event.enabled); true }
+        is SettingsEvent.SetAiSummaryTranslation -> { aiPreferences.setAiSummaryTranslation(event.enabled); true }
+        is SettingsEvent.SetAiSourceIntelligence -> { aiPreferences.setAiSourceIntelligence(event.enabled); true }
+        is SettingsEvent.SetAiSmartNotifications -> { aiPreferences.setAiSmartNotifications(event.enabled); true }
+        is SettingsEvent.SetAiAutoCategorization -> { aiPreferences.setAiAutoCategorization(event.enabled); true }
+        SettingsEvent.ClearAiCache -> { handleClearAiCache(sendEffect); true }
+        else -> false
+    }
+
+    private suspend fun handleSetAiApiKey(key: String, sendEffect: suspend (SettingsEffect) -> Unit) {
+        if (key.isNotBlank() && !isGeminiApiKeyFormatValid(key)) {
+            sendEffect(SettingsEffect.ShowSnackbar("Invalid API key format"))
+            return
+        }
+        aiPreferences.setGeminiApiKey(key)
+        val persistedKey = aiPreferences.getGeminiApiKey()
+        val isSet = persistedKey.isNotBlank()
+        updateState { it.copy(aiApiKeySet = isSet) }
+        if (key.isNotBlank() && !isSet) {
+            sendEffect(SettingsEffect.ShowSnackbar("Failed to save AI API key"))
+        } else if (isSet) {
+            aiRepository.clearApiKey()
+            aiRepository.initialize(persistedKey)
+        }
+    }
+
+    private suspend fun handleConfirmRemoveAiApiKey(sendEffect: suspend (SettingsEffect) -> Unit) {
+        updateState { it.copy(showRemoveApiKeyDialog = false) }
+        aiPreferences.clearGeminiApiKey()
+        aiRepository.clearApiKey()
+        updateState { it.copy(aiApiKeySet = false) }
+        sendEffect(SettingsEffect.ShowSnackbar("AI API key removed"))
+    }
+
+    private suspend fun handleClearAiCache(sendEffect: suspend (SettingsEffect) -> Unit) {
+        aiPreferences.setAiCacheLastCleared(System.currentTimeMillis())
+        sendEffect(SettingsEffect.ShowSnackbar("AI suggestions will refresh for future requests"))
+    }
+
+    private fun isGeminiApiKeyFormatValid(key: String): Boolean {
+        return key.matches(Regex("^AIza[0-9A-Za-z_-]{35}$"))
+    }
+}

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/AppearanceSettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/AppearanceSettingsDelegate.kt
@@ -1,0 +1,107 @@
+package app.otakureader.feature.settings.delegate
+
+import app.otakureader.core.discord.DiscordRpcService
+import app.otakureader.core.preferences.GeneralPreferences
+import app.otakureader.feature.settings.SettingsEffect
+import app.otakureader.feature.settings.SettingsEvent
+import app.otakureader.feature.settings.SettingsState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AppearanceSettingsDelegate @Inject constructor(
+    private val generalPreferences: GeneralPreferences,
+    private val discordRpcService: DiscordRpcService,
+) {
+
+    fun startObserving(
+        scope: CoroutineScope,
+        updateState: ((SettingsState) -> SettingsState) -> Unit,
+    ) {
+        scope.launch {
+            combine(
+                generalPreferences.themeMode,
+                generalPreferences.useDynamicColor,
+                generalPreferences.usePureBlackDarkMode,
+                generalPreferences.useHighContrast,
+                generalPreferences.colorScheme,
+            ) { themeMode, useDynamicColor, pureBlack, highContrast, colorScheme ->
+                updateState { it.copy(
+                    themeMode = themeMode,
+                    useDynamicColor = useDynamicColor,
+                    usePureBlackDarkMode = pureBlack,
+                    useHighContrast = highContrast,
+                    colorScheme = colorScheme,
+                ) }
+            }.collect { }
+        }
+        scope.launch {
+            combine(
+                generalPreferences.customAccentColor,
+                generalPreferences.locale,
+                generalPreferences.notificationsEnabled,
+                generalPreferences.updateCheckInterval,
+                generalPreferences.showNsfwContent,
+            ) { accent, locale, notifications, updateInterval, showNsfw ->
+                updateState { it.copy(
+                    customAccentColor = accent,
+                    locale = locale,
+                    notificationsEnabled = notifications,
+                    updateCheckInterval = updateInterval,
+                    showNsfwContent = showNsfw,
+                ) }
+            }.collect { }
+        }
+        scope.launch {
+            generalPreferences.discordRpcEnabled.collect { discordRpc ->
+                updateState { it.copy(discordRpcEnabled = discordRpc) }
+            }
+        }
+        scope.launch {
+            generalPreferences.autoThemeColor.collect { autoTheme ->
+                updateState { it.copy(autoThemeColor = autoTheme) }
+            }
+        }
+        scope.launch {
+            combine(
+                generalPreferences.appUpdateCheckEnabled,
+                generalPreferences.lastAppUpdateCheck,
+            ) { enabled, lastCheck ->
+                updateState { it.copy(
+                    appUpdateCheckEnabled = enabled,
+                    lastAppUpdateCheck = lastCheck,
+                ) }
+            }.collect { }
+        }
+    }
+
+    suspend fun handleEvent(
+        event: SettingsEvent,
+        sendEffect: suspend (SettingsEffect) -> Unit,
+    ): Boolean = when (event) {
+        is SettingsEvent.SetThemeMode -> { generalPreferences.setThemeMode(event.mode); true }
+        is SettingsEvent.SetDynamicColor -> { generalPreferences.setUseDynamicColor(event.enabled); true }
+        is SettingsEvent.SetPureBlackDarkMode -> { generalPreferences.setUsePureBlackDarkMode(event.enabled); true }
+        is SettingsEvent.SetHighContrast -> { generalPreferences.setUseHighContrast(event.enabled); true }
+        is SettingsEvent.SetColorScheme -> { generalPreferences.setColorScheme(event.scheme); true }
+        is SettingsEvent.SetCustomAccentColor -> { generalPreferences.setCustomAccentColor(event.color); true }
+        is SettingsEvent.SetLocale -> { generalPreferences.setLocale(event.locale); true }
+        is SettingsEvent.SetAutoThemeColor -> { generalPreferences.setAutoThemeColor(event.enabled); true }
+        is SettingsEvent.SetDiscordRpcEnabled -> { handleSetDiscordRpcEnabled(event.enabled); true }
+        is SettingsEvent.SetNotificationsEnabled -> { generalPreferences.setNotificationsEnabled(event.enabled); true }
+        is SettingsEvent.SetShowNsfwContent -> { generalPreferences.setShowNsfwContent(event.enabled); true }
+        else -> false
+    }
+
+    private suspend fun handleSetDiscordRpcEnabled(enabled: Boolean) {
+        generalPreferences.setDiscordRpcEnabled(enabled)
+        if (enabled) {
+            discordRpcService.initialize()
+        } else {
+            discordRpcService.disconnect()
+        }
+    }
+}

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/BackupSettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/BackupSettingsDelegate.kt
@@ -1,0 +1,121 @@
+package app.otakureader.feature.settings.delegate
+
+import app.otakureader.core.preferences.BackupPreferences
+import app.otakureader.data.backup.BackupScheduler
+import app.otakureader.data.backup.repository.BackupRepository
+import app.otakureader.feature.settings.SettingsEffect
+import app.otakureader.feature.settings.SettingsEvent
+import app.otakureader.feature.settings.SettingsState
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BackupSettingsDelegate @Inject constructor(
+    private val backupPreferences: BackupPreferences,
+    private val backupRepository: BackupRepository,
+    private val backupScheduler: BackupScheduler,
+) {
+
+    private var updateState: ((SettingsState) -> SettingsState) -> Unit = {}
+
+    fun startObserving(
+        scope: CoroutineScope,
+        updateState: ((SettingsState) -> SettingsState) -> Unit,
+    ) {
+        this.updateState = updateState
+        scope.launch {
+            combine(
+                backupPreferences.autoBackupEnabled,
+                backupPreferences.autoBackupIntervalHours,
+                backupPreferences.autoBackupMaxCount,
+            ) { autoBackup, backupInterval, backupMax ->
+                updateState { it.copy(
+                    autoBackupEnabled = autoBackup,
+                    autoBackupIntervalHours = backupInterval,
+                    autoBackupMaxCount = backupMax,
+                ) }
+            }.collect { }
+        }
+    }
+
+    suspend fun handleEvent(
+        event: SettingsEvent,
+        sendEffect: suspend (SettingsEffect) -> Unit,
+    ): Boolean = when (event) {
+        SettingsEvent.OnCreateBackup -> { sendEffect(SettingsEffect.ShowBackupPicker); true }
+        SettingsEvent.OnRestoreBackup -> { sendEffect(SettingsEffect.ShowRestorePicker); true }
+        is SettingsEvent.CreateBackupWithUri -> {
+            updateState { it.copy(isBackupInProgress = true) }
+            try {
+                backupRepository.createBackup(event.uri)
+                sendEffect(SettingsEffect.ShowSnackbar("Backup created successfully"))
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                sendEffect(SettingsEffect.ShowSnackbar("Failed to create backup: ${e.message}"))
+            } finally {
+                updateState { it.copy(isBackupInProgress = false) }
+            }
+            true
+        }
+        is SettingsEvent.RestoreBackupFromUri -> {
+            updateState { it.copy(isRestoreInProgress = true) }
+            try {
+                backupRepository.restoreBackup(event.uri)
+                sendEffect(SettingsEffect.ShowSnackbar("Backup restored successfully"))
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                sendEffect(SettingsEffect.ShowSnackbar("Failed to restore backup: ${e.message}"))
+            } finally {
+                updateState { it.copy(isRestoreInProgress = false) }
+            }
+            true
+        }
+        is SettingsEvent.SetAutoBackupEnabled -> { handleSetAutoBackupEnabled(event.enabled); true }
+        is SettingsEvent.SetAutoBackupInterval -> { handleSetAutoBackupInterval(event.hours); true }
+        is SettingsEvent.SetAutoBackupMaxCount -> { backupPreferences.setAutoBackupMaxCount(event.count); true }
+        SettingsEvent.RefreshLocalBackups -> {
+            val files = backupRepository.listLocalBackups().map { it.name }
+            updateState { it.copy(localBackupFiles = files) }
+            true
+        }
+        is SettingsEvent.RestoreLocalBackup -> {
+            updateState { it.copy(isRestoreInProgress = true, restoringBackupFileName = event.fileName) }
+            try {
+                val allFiles = backupRepository.listLocalBackups()
+                val file = allFiles.firstOrNull { it.name == event.fileName }
+                    ?: throw IllegalArgumentException("Backup file not found: ${event.fileName}")
+                backupRepository.restoreLocalBackup(file)
+                sendEffect(SettingsEffect.ShowSnackbar("Backup restored successfully"))
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                sendEffect(SettingsEffect.ShowSnackbar("Failed to restore backup: ${e.message}"))
+            } finally {
+                updateState { it.copy(isRestoreInProgress = false, restoringBackupFileName = null) }
+            }
+            true
+        }
+        else -> false
+    }
+
+    private suspend fun handleSetAutoBackupEnabled(enabled: Boolean) {
+        backupPreferences.setAutoBackupEnabled(enabled)
+        if (enabled) {
+            val intervalHours = backupPreferences.autoBackupIntervalHours.first()
+            backupScheduler.schedule(intervalHours)
+        } else {
+            backupScheduler.cancel()
+        }
+    }
+
+    private suspend fun handleSetAutoBackupInterval(hours: Int) {
+        backupPreferences.setAutoBackupIntervalHours(hours)
+        if (backupPreferences.autoBackupEnabled.first()) {
+            backupScheduler.schedule(hours)
+        }
+    }
+}

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/DownloadSettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/DownloadSettingsDelegate.kt
@@ -1,0 +1,71 @@
+package app.otakureader.feature.settings.delegate
+
+import app.otakureader.core.preferences.DownloadPreferences
+import app.otakureader.feature.settings.SettingsEffect
+import app.otakureader.feature.settings.SettingsEvent
+import app.otakureader.feature.settings.SettingsState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DownloadSettingsDelegate @Inject constructor(
+    private val downloadPreferences: DownloadPreferences,
+) {
+
+    fun startObserving(
+        scope: CoroutineScope,
+        updateState: ((SettingsState) -> SettingsState) -> Unit,
+    ) {
+        scope.launch {
+            combine(
+                downloadPreferences.deleteAfterReading,
+                downloadPreferences.saveAsCbz,
+                downloadPreferences.autoDownloadEnabled,
+                downloadPreferences.downloadOnlyOnWifi,
+                downloadPreferences.autoDownloadLimit,
+            ) { deleteAfter, saveCbz, autoDownload, dlWifi, dlLimit ->
+                updateState { it.copy(
+                    deleteAfterReading = deleteAfter,
+                    saveAsCbz = saveCbz,
+                    autoDownloadEnabled = autoDownload,
+                    downloadOnlyOnWifi = dlWifi,
+                    autoDownloadLimit = dlLimit,
+                ) }
+            }.collect { }
+        }
+        scope.launch {
+            combine(
+                downloadPreferences.concurrentDownloads,
+                downloadPreferences.downloadAheadWhileReading,
+                downloadPreferences.downloadAheadOnlyOnWifi,
+                downloadPreferences.downloadLocation,
+            ) { concurrent, dlAhead, dlAheadWifi, dlLocation ->
+                updateState { it.copy(
+                    concurrentDownloads = concurrent,
+                    downloadAheadWhileReading = dlAhead,
+                    downloadAheadOnlyOnWifi = dlAheadWifi,
+                    downloadLocation = dlLocation,
+                ) }
+            }.collect { }
+        }
+    }
+
+    suspend fun handleEvent(
+        event: SettingsEvent,
+        @Suppress("UNUSED_PARAMETER") sendEffect: suspend (SettingsEffect) -> Unit,
+    ): Boolean = when (event) {
+        is SettingsEvent.SetDeleteAfterReading -> { downloadPreferences.setDeleteAfterReading(event.enabled); true }
+        is SettingsEvent.SetSaveAsCbz -> { downloadPreferences.setSaveAsCbz(event.enabled); true }
+        is SettingsEvent.SetAutoDownloadEnabled -> { downloadPreferences.setAutoDownloadEnabled(event.enabled); true }
+        is SettingsEvent.SetDownloadOnlyOnWifi -> { downloadPreferences.setDownloadOnlyOnWifi(event.enabled); true }
+        is SettingsEvent.SetAutoDownloadLimit -> { downloadPreferences.setAutoDownloadLimit(event.limit); true }
+        is SettingsEvent.SetConcurrentDownloads -> { downloadPreferences.setConcurrentDownloads(event.count); true }
+        is SettingsEvent.SetDownloadAheadWhileReading -> { downloadPreferences.setDownloadAheadWhileReading(event.count); true }
+        is SettingsEvent.SetDownloadAheadOnlyOnWifi -> { downloadPreferences.setDownloadAheadOnlyOnWifi(event.enabled); true }
+        is SettingsEvent.SetDownloadLocation -> { downloadPreferences.setDownloadLocation(event.location); true }
+        else -> false
+    }
+}

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/LibrarySettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/LibrarySettingsDelegate.kt
@@ -1,0 +1,106 @@
+package app.otakureader.feature.settings.delegate
+
+import android.util.Log
+import app.otakureader.core.preferences.GeneralPreferences
+import app.otakureader.core.preferences.LibraryPreferences
+import app.otakureader.data.worker.LibraryUpdateScheduler
+import app.otakureader.feature.settings.SettingsEffect
+import app.otakureader.feature.settings.SettingsEvent
+import app.otakureader.feature.settings.SettingsState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LibrarySettingsDelegate @Inject constructor(
+    private val libraryPreferences: LibraryPreferences,
+    private val generalPreferences: GeneralPreferences,
+    private val libraryUpdateScheduler: LibraryUpdateScheduler,
+) {
+
+    // Keep latest values to use for rescheduling when the other changes
+    private var latestUpdateCheckInterval: Int = 12
+    private var latestUpdateOnlyOnWifi: Boolean = false
+
+    fun startObserving(
+        scope: CoroutineScope,
+        updateState: ((SettingsState) -> SettingsState) -> Unit,
+    ) {
+        scope.launch {
+            combine(
+                libraryPreferences.gridSize,
+                libraryPreferences.showBadges,
+                libraryPreferences.updateOnlyOnWifi,
+                libraryPreferences.updateOnlyPinnedCategories,
+                libraryPreferences.autoRefreshOnStart,
+            ) { gridSize, showBadges, updateOnWifi, updatePinned, autoRefresh ->
+                latestUpdateOnlyOnWifi = updateOnWifi
+                updateState { it.copy(
+                    libraryGridSize = gridSize,
+                    showBadges = showBadges,
+                    updateOnlyOnWifi = updateOnWifi,
+                    updateOnlyPinnedCategories = updatePinned,
+                    autoRefreshOnStart = autoRefresh,
+                ) }
+            }.collect { }
+        }
+        scope.launch {
+            libraryPreferences.showUpdateProgress.collect { showProgress ->
+                updateState { it.copy(showUpdateProgress = showProgress) }
+            }
+        }
+        scope.launch {
+            generalPreferences.updateCheckInterval.collect { interval ->
+                latestUpdateCheckInterval = interval
+                updateState { it.copy(updateCheckInterval = interval) }
+            }
+        }
+    }
+
+    suspend fun handleEvent(
+        event: SettingsEvent,
+        sendEffect: suspend (SettingsEffect) -> Unit,
+    ): Boolean = when (event) {
+        is SettingsEvent.SetLibraryGridSize -> { libraryPreferences.setGridSize(event.size); true }
+        is SettingsEvent.SetShowBadges -> { libraryPreferences.setShowBadges(event.enabled); true }
+        is SettingsEvent.SetUpdateOnlyOnWifi -> {
+            libraryPreferences.setUpdateOnlyOnWifi(event.enabled)
+            latestUpdateOnlyOnWifi = event.enabled
+            scheduleLibraryUpdateOrShowError(latestUpdateCheckInterval, event.enabled, sendEffect)
+            true
+        }
+        is SettingsEvent.SetUpdateOnlyPinnedCategories -> {
+            libraryPreferences.setUpdateOnlyPinnedCategories(event.enabled)
+            true
+        }
+        is SettingsEvent.SetAutoRefreshOnStart -> { libraryPreferences.setAutoRefreshOnStart(event.enabled); true }
+        is SettingsEvent.SetShowUpdateProgress -> { libraryPreferences.setShowUpdateProgress(event.enabled); true }
+        is SettingsEvent.SetUpdateInterval -> {
+            generalPreferences.setUpdateCheckInterval(event.hours)
+            latestUpdateCheckInterval = event.hours
+            scheduleLibraryUpdateOrShowError(event.hours, latestUpdateOnlyOnWifi, sendEffect)
+            true
+        }
+        is SettingsEvent.SetNotificationsEnabled -> {
+            // Library delegate also handles notification toggle (shared with Appearance)
+            // Appearance delegate will handle the actual pref write; we just pass through
+            false
+        }
+        else -> false
+    }
+
+    private suspend fun scheduleLibraryUpdateOrShowError(
+        intervalHours: Int,
+        wifiOnly: Boolean,
+        sendEffect: suspend (SettingsEffect) -> Unit,
+    ) {
+        try {
+            libraryUpdateScheduler.schedule(intervalHours = intervalHours, wifiOnly = wifiOnly)
+        } catch (e: Exception) {
+            Log.e("LibrarySettingsDelegate", "Failed to schedule library update (intervalHours=$intervalHours, wifiOnly=$wifiOnly)", e)
+            sendEffect(SettingsEffect.ShowSnackbar("Failed to update library scheduler settings"))
+        }
+    }
+}

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/ReaderSettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/ReaderSettingsDelegate.kt
@@ -1,0 +1,191 @@
+package app.otakureader.feature.settings.delegate
+
+import app.otakureader.core.preferences.ReaderPreferences
+import app.otakureader.feature.reader.model.ImageQuality
+import app.otakureader.feature.reader.repository.ReaderSettingsRepository
+import app.otakureader.feature.settings.SettingsEffect
+import app.otakureader.feature.settings.SettingsEvent
+import app.otakureader.feature.settings.SettingsState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReaderSettingsDelegate @Inject constructor(
+    private val readerPreferences: ReaderPreferences,
+    private val readerSettingsRepository: ReaderSettingsRepository,
+) {
+
+    fun startObserving(
+        scope: CoroutineScope,
+        updateState: ((SettingsState) -> SettingsState) -> Unit,
+    ) {
+        scope.launch {
+            combine(
+                readerPreferences.readerMode,
+                readerPreferences.keepScreenOn,
+                readerPreferences.fullscreen,
+                readerPreferences.showContentInCutout,
+                readerPreferences.showPageNumber,
+            ) { readerMode, keepScreenOn, fullscreen, showCutout, showPageNum ->
+                updateState { it.copy(
+                    readerMode = readerMode,
+                    keepScreenOn = keepScreenOn,
+                    fullscreen = fullscreen,
+                    showContentInCutout = showCutout,
+                    showPageNumber = showPageNum,
+                ) }
+            }.collect { }
+        }
+        scope.launch {
+            combine(
+                readerPreferences.backgroundColor,
+                readerPreferences.animatePageTransitions,
+                readerPreferences.showReadingModeOverlay,
+                readerPreferences.showTapZonesOverlay,
+                readerPreferences.readerScale,
+            ) { bgColor, animate, showMode, showZones, scale ->
+                updateState { it.copy(
+                    backgroundColor = bgColor,
+                    animatePageTransitions = animate,
+                    showReadingModeOverlay = showMode,
+                    showTapZonesOverlay = showZones,
+                    readerScale = scale,
+                ) }
+            }.collect { }
+        }
+        scope.launch {
+            combine(
+                readerPreferences.autoZoomWideImages,
+                readerPreferences.tapZoneConfig,
+                readerPreferences.invertTapZones,
+                readerPreferences.volumeKeysEnabled,
+                readerPreferences.volumeKeysInverted,
+            ) { autoZoom, tapConfig, invertZones, volKeys, volInvert ->
+                updateState { it.copy(
+                    autoZoomWideImages = autoZoom,
+                    tapZoneConfig = tapConfig,
+                    invertTapZones = invertZones,
+                    volumeKeysEnabled = volKeys,
+                    volumeKeysInverted = volInvert,
+                ) }
+            }.collect { }
+        }
+        scope.launch {
+            combine(
+                readerPreferences.doubleTapAnimationSpeed,
+                readerPreferences.showActionsOnLongTap,
+                readerPreferences.savePagesToSeparateFolders,
+                readerPreferences.webtoonSidePadding,
+                readerPreferences.webtoonMenuHideSensitivity,
+            ) { animSpeed, longTap, separateFolders, sidePadding, menuSensitivity ->
+                updateState { it.copy(
+                    doubleTapAnimationSpeed = animSpeed,
+                    showActionsOnLongTap = longTap,
+                    savePagesToSeparateFolders = separateFolders,
+                    webtoonSidePadding = sidePadding,
+                    webtoonMenuHideSensitivity = menuSensitivity,
+                ) }
+            }.collect { }
+        }
+        scope.launch {
+            combine(
+                readerPreferences.webtoonDoubleTapZoom,
+                readerPreferences.webtoonDisableZoomOut,
+                readerPreferences.einkFlashOnPageChange,
+                readerPreferences.einkBlackAndWhite,
+                readerPreferences.skipReadChapters,
+            ) { dtZoom, disableZoomOut, einkFlash, einkBw, skipRead ->
+                updateState { it.copy(
+                    webtoonDoubleTapZoom = dtZoom,
+                    webtoonDisableZoomOut = disableZoomOut,
+                    einkFlashOnPageChange = einkFlash,
+                    einkBlackAndWhite = einkBw,
+                    skipReadChapters = skipRead,
+                ) }
+            }.collect { }
+        }
+        scope.launch {
+            combine(
+                readerPreferences.skipFilteredChapters,
+                readerPreferences.skipDuplicateChapters,
+                readerPreferences.alwaysShowChapterTransition,
+                readerSettingsRepository.incognitoMode,
+                readerSettingsRepository.preloadPagesBefore,
+            ) { skipFiltered, skipDupes, showTransition, incognito, preloadBefore ->
+                updateState { it.copy(
+                    skipFilteredChapters = skipFiltered,
+                    skipDuplicateChapters = skipDupes,
+                    alwaysShowChapterTransition = showTransition,
+                    incognitoMode = incognito,
+                    preloadPagesBefore = preloadBefore,
+                ) }
+            }.collect { }
+        }
+        scope.launch {
+            combine(
+                readerSettingsRepository.preloadPagesAfter,
+                readerSettingsRepository.cropBordersEnabled,
+                readerSettingsRepository.imageQuality,
+                readerSettingsRepository.dataSaverEnabled,
+            ) { preloadAfter, cropBorders, imageQuality, dataSaver ->
+                updateState { it.copy(
+                    preloadPagesAfter = preloadAfter,
+                    cropBordersEnabled = cropBorders,
+                    imageQuality = imageQuality.name,
+                    dataSaverEnabled = dataSaver,
+                ) }
+            }.collect { }
+        }
+    }
+
+    suspend fun handleEvent(
+        event: SettingsEvent,
+        @Suppress("UNUSED_PARAMETER") sendEffect: suspend (SettingsEffect) -> Unit,
+    ): Boolean = when (event) {
+        is SettingsEvent.SetReaderMode -> { readerPreferences.setReaderMode(event.mode); true }
+        is SettingsEvent.SetKeepScreenOn -> { readerPreferences.setKeepScreenOn(event.enabled); true }
+        is SettingsEvent.SetFullscreen -> { readerPreferences.setFullscreen(event.enabled); true }
+        is SettingsEvent.SetShowContentInCutout -> { readerPreferences.setShowContentInCutout(event.enabled); true }
+        is SettingsEvent.SetShowPageNumber -> { readerPreferences.setShowPageNumber(event.enabled); true }
+        is SettingsEvent.SetBackgroundColor -> { readerPreferences.setBackgroundColor(event.color); true }
+        is SettingsEvent.SetAnimatePageTransitions -> { readerPreferences.setAnimatePageTransitions(event.enabled); true }
+        is SettingsEvent.SetShowReadingModeOverlay -> { readerPreferences.setShowReadingModeOverlay(event.enabled); true }
+        is SettingsEvent.SetShowTapZonesOverlay -> { readerPreferences.setShowTapZonesOverlay(event.enabled); true }
+        is SettingsEvent.SetReaderScale -> { readerPreferences.setReaderScale(event.scale); true }
+        is SettingsEvent.SetAutoZoomWideImages -> { readerPreferences.setAutoZoomWideImages(event.enabled); true }
+        is SettingsEvent.SetTapZoneConfig -> { readerPreferences.setTapZoneConfig(event.config); true }
+        is SettingsEvent.SetInvertTapZones -> { readerPreferences.setInvertTapZones(event.enabled); true }
+        is SettingsEvent.SetVolumeKeysEnabled -> { readerPreferences.setVolumeKeysEnabled(event.enabled); true }
+        is SettingsEvent.SetVolumeKeysInverted -> { readerPreferences.setVolumeKeysInverted(event.enabled); true }
+        is SettingsEvent.SetDoubleTapAnimationSpeed -> { readerPreferences.setDoubleTapAnimationSpeed(event.speed); true }
+        is SettingsEvent.SetShowActionsOnLongTap -> { readerPreferences.setShowActionsOnLongTap(event.enabled); true }
+        is SettingsEvent.SetSavePagesToSeparateFolders -> { readerPreferences.setSavePagesToSeparateFolders(event.enabled); true }
+        is SettingsEvent.SetWebtoonSidePadding -> { readerPreferences.setWebtoonSidePadding(event.padding); true }
+        is SettingsEvent.SetWebtoonMenuHideSensitivity -> { readerPreferences.setWebtoonMenuHideSensitivity(event.sensitivity); true }
+        is SettingsEvent.SetWebtoonDoubleTapZoom -> { readerPreferences.setWebtoonDoubleTapZoom(event.enabled); true }
+        is SettingsEvent.SetWebtoonDisableZoomOut -> { readerPreferences.setWebtoonDisableZoomOut(event.enabled); true }
+        is SettingsEvent.SetEinkFlashOnPageChange -> { readerPreferences.setEinkFlashOnPageChange(event.enabled); true }
+        is SettingsEvent.SetEinkBlackAndWhite -> { readerPreferences.setEinkBlackAndWhite(event.enabled); true }
+        is SettingsEvent.SetSkipReadChapters -> { readerPreferences.setSkipReadChapters(event.enabled); true }
+        is SettingsEvent.SetSkipFilteredChapters -> { readerPreferences.setSkipFilteredChapters(event.enabled); true }
+        is SettingsEvent.SetSkipDuplicateChapters -> { readerPreferences.setSkipDuplicateChapters(event.enabled); true }
+        is SettingsEvent.SetAlwaysShowChapterTransition -> { readerPreferences.setAlwaysShowChapterTransition(event.enabled); true }
+        is SettingsEvent.SetIncognitoMode -> { readerSettingsRepository.setIncognitoMode(event.enabled); true }
+        is SettingsEvent.SetPreloadPagesBefore -> { readerSettingsRepository.setPreloadPagesBefore(event.count); true }
+        is SettingsEvent.SetPreloadPagesAfter -> { readerSettingsRepository.setPreloadPagesAfter(event.count); true }
+        is SettingsEvent.SetCropBordersEnabled -> { readerSettingsRepository.setCropBordersEnabled(event.enabled); true }
+        is SettingsEvent.SetImageQuality -> {
+            val normalizedInput = event.quality.trim().uppercase()
+            val quality = ImageQuality.entries.firstOrNull {
+                it.name.equals(normalizedInput, ignoreCase = true)
+            } ?: ImageQuality.ORIGINAL
+            readerSettingsRepository.setImageQuality(quality)
+            true
+        }
+        is SettingsEvent.SetDataSaverEnabled -> { readerSettingsRepository.setDataSaverEnabled(event.enabled); true }
+        else -> false
+    }
+}

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/TrackerSyncSettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/TrackerSyncSettingsDelegate.kt
@@ -1,0 +1,229 @@
+package app.otakureader.feature.settings.delegate
+
+import app.otakureader.core.preferences.GeneralPreferences
+import app.otakureader.core.preferences.SyncPreferences
+import app.otakureader.data.tracking.TrackManager
+import app.otakureader.data.updater.AppUpdateChecker
+import app.otakureader.domain.sync.SyncManager
+import app.otakureader.feature.settings.SettingsEffect
+import app.otakureader.feature.settings.SettingsEvent
+import app.otakureader.feature.settings.SettingsState
+import app.otakureader.feature.settings.TrackerInfo
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TrackerSyncSettingsDelegate @Inject constructor(
+    private val trackManager: TrackManager,
+    private val syncPreferences: SyncPreferences,
+    private val syncManager: SyncManager,
+    private val appUpdateChecker: AppUpdateChecker,
+    private val generalPreferences: GeneralPreferences,
+) {
+
+    private var updateState: ((SettingsState) -> SettingsState) -> Unit = {}
+
+    fun startObserving(
+        scope: CoroutineScope,
+        updateState: ((SettingsState) -> SettingsState) -> Unit,
+    ) {
+        this.updateState = updateState
+        refreshTrackers()
+
+        // Sync preferences — combine first 5 flows then zip additional ones
+        scope.launch {
+            combine(
+                syncPreferences.isSyncEnabled,
+                syncPreferences.providerId,
+                syncPreferences.autoSyncEnabled,
+                syncPreferences.syncIntervalHours,
+                syncPreferences.syncOnlyOnWifi,
+            ) { enabled, providerId, autoSync, interval, wifiOnly ->
+                SyncPrefBundle(enabled, providerId, autoSync, interval, wifiOnly)
+            }.combine(syncPreferences.conflictResolutionStrategy) { bundle, strategy ->
+                val lastSync = if (bundle.enabled) syncManager.getLastSyncTime() else null
+                updateState { current ->
+                    current.copy(
+                        syncEnabled = bundle.enabled,
+                        syncProviderId = bundle.providerId,
+                        autoSyncEnabled = bundle.autoSync,
+                        syncIntervalHours = bundle.interval,
+                        syncOnlyOnWifi = bundle.wifiOnly,
+                        conflictResolutionStrategy = strategy,
+                        lastSyncTime = lastSync,
+                    )
+                }
+            }.collect { }
+        }
+
+        // Self-hosted and Google Drive settings
+        scope.launch {
+            combine(
+                syncPreferences.selfHostedServerUrlFlow,
+                syncPreferences.selfHostedAuthTokenFlow,
+                syncPreferences.googleDriveEmailFlow,
+            ) { url, token, driveEmail ->
+                Triple(url ?: "", token ?: "", driveEmail)
+            }.collect { (url, token, driveEmail) ->
+                updateState { current ->
+                    current.copy(
+                        selfHostedServerUrl = url,
+                        selfHostedAuthToken = token,
+                        googleDriveAccountEmail = driveEmail,
+                    )
+                }
+            }
+        }
+
+        // App update preferences
+        scope.launch {
+            combine(
+                generalPreferences.appUpdateCheckEnabled,
+                generalPreferences.lastAppUpdateCheck,
+            ) { enabled, lastCheck ->
+                updateState { current ->
+                    current.copy(
+                        appUpdateCheckEnabled = enabled,
+                        lastAppUpdateCheck = lastCheck,
+                    )
+                }
+            }.collect { }
+        }
+    }
+
+    fun refreshTrackers() {
+        updateState { it.copy(trackers = trackManager.all.map { t -> TrackerInfo(t.id, t.name, t.isLoggedIn) }) }
+    }
+
+    suspend fun handleEvent(
+        event: SettingsEvent,
+        sendEffect: suspend (SettingsEffect) -> Unit,
+    ): Boolean = when (event) {
+        is SettingsEvent.LoginTracker -> { loginTracker(event.trackerId, event.username, event.password, sendEffect); true }
+        is SettingsEvent.LogoutTracker -> { logoutTracker(event.trackerId, sendEffect); true }
+        is SettingsEvent.SetSyncEnabled -> { handleSetSyncEnabled(event.enabled, event.providerId, sendEffect); true }
+        SettingsEvent.TriggerManualSync -> { syncManager.sync(); true }
+        is SettingsEvent.SetAutoSyncEnabled -> { syncPreferences.setAutoSyncEnabled(event.enabled); true }
+        is SettingsEvent.SetSyncIntervalHours -> { syncPreferences.setSyncIntervalHours(event.hours); true }
+        is SettingsEvent.SetSyncOnlyOnWifi -> { syncPreferences.setSyncOnlyOnWifi(event.onlyWifi); true }
+        is SettingsEvent.SetConflictResolutionStrategy -> { syncPreferences.setConflictResolutionStrategy(event.strategy); true }
+        is SettingsEvent.SetSelfHostedServerUrl -> { syncPreferences.setSelfHostedServerUrl(event.url); true }
+        is SettingsEvent.SetSelfHostedAuthToken -> { syncPreferences.setSelfHostedAuthToken(event.token); true }
+        is SettingsEvent.GoogleSignInResult -> { handleGoogleSignInResult(event.email); true }
+        SettingsEvent.DisconnectGoogleDrive -> { handleDisconnectGoogleDrive(); true }
+        is SettingsEvent.SetAppUpdateCheckEnabled -> { generalPreferences.setAppUpdateCheckEnabled(event.enabled); true }
+        SettingsEvent.CheckForAppUpdate -> { handleCheckForAppUpdate(sendEffect); true }
+        else -> false
+    }
+
+    private suspend fun loginTracker(
+        trackerId: Int,
+        username: String,
+        password: String,
+        sendEffect: suspend (SettingsEffect) -> Unit,
+    ) {
+        updateState { it.copy(trackingLoginInProgress = true) }
+        try {
+            val tracker = trackManager.get(trackerId)
+            if (tracker != null) {
+                val success = tracker.login(username, password)
+                if (success) {
+                    refreshTrackers()
+                    sendEffect(SettingsEffect.ShowSnackbar("Logged in to ${tracker.name}"))
+                } else {
+                    sendEffect(SettingsEffect.ShowSnackbar("Failed to login to ${tracker.name}"))
+                }
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            sendEffect(SettingsEffect.ShowSnackbar("Error: ${e.message}"))
+        } finally {
+            updateState { it.copy(trackingLoginInProgress = false) }
+        }
+    }
+
+    private suspend fun logoutTracker(trackerId: Int, sendEffect: suspend (SettingsEffect) -> Unit) {
+        val tracker = trackManager.get(trackerId)
+        tracker?.logout()
+        refreshTrackers()
+        sendEffect(SettingsEffect.ShowSnackbar("Logged out from ${tracker?.name}"))
+    }
+
+    private suspend fun handleSetSyncEnabled(
+        enabled: Boolean,
+        providerId: String?,
+        sendEffect: suspend (SettingsEffect) -> Unit,
+    ) {
+        if (enabled && providerId != null) {
+            // For Google Drive, launch sign-in if not yet connected
+            if (providerId == "google_drive") {
+                val currentEmail = syncPreferences.googleDriveEmailFlow.let {
+                    // Read current value inline via state
+                    null // will be checked below via updateState snapshot
+                }
+                // We need the current googleDriveAccountEmail from state.
+                // Since delegates are @Singleton we can't easily read state here.
+                // We use a flag approach: check syncPreferences directly.
+                val email = try {
+                    // Peek at Google Drive email from preferences directly
+                    var result: String? = null
+                    syncPreferences.googleDriveEmailFlow.collect { result = it; return@collect }
+                    result
+                } catch (_: Exception) {
+                    null
+                }
+                if (email.isNullOrBlank()) {
+                    sendEffect(SettingsEffect.LaunchGoogleSignIn)
+                    return
+                }
+            }
+            syncManager.enableSync(providerId)
+        } else {
+            syncManager.disableSync()
+        }
+    }
+
+    private suspend fun handleGoogleSignInResult(email: String) {
+        syncPreferences.setGoogleDriveEmail(email)
+        updateState { it.copy(googleDriveAccountEmail = email) }
+        syncManager.enableSync("google_drive")
+    }
+
+    private suspend fun handleDisconnectGoogleDrive() {
+        syncPreferences.clearGoogleDriveAccount()
+        updateState { it.copy(googleDriveAccountEmail = null) }
+        // Disable sync if currently using Google Drive
+        val currentProviderId = syncPreferences.providerId.let {
+            var result: String? = null
+            try {
+                it.collect { v -> result = v; return@collect }
+            } catch (_: Exception) { }
+            result
+        }
+        if (currentProviderId == "google_drive") {
+            syncManager.disableSync()
+        }
+    }
+
+    private suspend fun handleCheckForAppUpdate(sendEffect: suspend (SettingsEffect) -> Unit) {
+        val versionInfo = appUpdateChecker.checkForUpdate()
+        if (versionInfo != null) {
+            sendEffect(SettingsEffect.ShowSnackbar("Update available: ${versionInfo.versionName}"))
+        } else {
+            sendEffect(SettingsEffect.ShowSnackbar("App is up to date"))
+        }
+    }
+
+    /** Intermediate bundle used inside [startObserving] to work around the 5-Flow combine limit. */
+    private data class SyncPrefBundle(
+        val enabled: Boolean,
+        val providerId: String?,
+        val autoSync: Boolean,
+        val interval: Int,
+        val wifiOnly: Boolean,
+    )
+}


### PR DESCRIPTION
## Summary

Fourth batch of audit fixes addressing issues #592, #595, and #605.

### #592 — SettingsViewModel 956-line God object split

`SettingsViewModel` dropped from **956 → 223 lines** by extracting all preference-domain logic into 7 focused `@Singleton` delegate classes under `feature/settings/.../delegate/`:

| Delegate | Owns |
|---|---|
| `AppearanceSettingsDelegate` | Theme, locale, Discord RPC, NSFW, app update check |
| `ReaderSettingsDelegate` | All reader display/behavior/webtoon/e-ink prefs + `ReaderSettingsRepository` |
| `LibrarySettingsDelegate` | Library grid, badges, update scheduling, wifi-only |
| `DownloadSettingsDelegate` | Download location, concurrent, auto-download, ahead-while-reading |
| `BackupSettingsDelegate` | Backup creation/restore, auto-backup scheduling, local backup listing |
| `AiSettingsDelegate` | Gemini API key, AI feature toggles, cache clear |
| `TrackerSyncSettingsDelegate` | Tracker login/logout, sync prefs, Google Drive, app update check |

Each delegate follows the same contract:
```kotlin
fun startObserving(scope: CoroutineScope, updateState: ((SettingsState) -> SettingsState) -> Unit)
suspend fun handleEvent(event: SettingsEvent, sendEffect: suspend (SettingsEffect) -> Unit): Boolean
```

`SettingsViewModel` now just wires delegates together and handles the remaining small domains (local source, migration, reading goals, data management). **`SettingsScreen.kt` is unchanged.**

### #595 — Adaptive two-pane layout for tablet/DeX

`LibraryScreen` now adapts to screen width using `LocalConfiguration.current.screenWidthDp`:

- **< 600 dp** (phone): `GridCells.Fixed(gridSize)` — current behaviour
- **600–839 dp** (medium tablet): `gridSize + 1` columns (minimum 4)
- **≥ 840 dp** (large tablet / DeX): `gridSize + 2` columns (minimum 5) **+ two-pane layout**

On expanded screens a `Row` splits the content:
- **Left pane (55%)** — manga grid; tapping a card selects it into the detail panel instead of navigating
- **Right pane (45%)** — `MangaDetailPanel` shows cover, title, unread count, status; "Open Details" triggers full navigation, "Close" deselects

No new library dependencies required — uses `LocalConfiguration` and existing Material3 components.

### #605 — ZoomableImage Animatable queue (verified no fix needed)

Confirmed the existing `ZoomableState` implementation is already correct:
- `_scale`, `_offsetX`, `_offsetY` are `Animatable` instances created **once** in the class body and reused
- The high-frequency pinch path calls `snapTo()` (instantaneous) — never `animateTo()`
- `animateTo()` is only called on discrete events (double-tap, fling, reset); `Animatable.animateTo()` automatically cancels any in-flight animation before starting a new one

Added a doc comment on `ZoomableState` to explain this invariant for future readers.

## Test plan

- [ ] Settings screen: open and change a preference in each section — verify all sections still update correctly
- [ ] Settings screen: AI section — enter/remove API key, verify snackbar feedback
- [ ] Settings screen: Backup — create and restore a backup
- [ ] Library screen on phone (< 600dp): grid uses configured column count, tapping navigates to details
- [ ] Library screen on tablet/DeX (≥ 840dp): wider grid + two-pane panel; tapping card shows detail in right pane; "Open Details" navigates; "Close" hides panel
- [ ] Reader screen: pinch zoom on a manga page — confirm no zoom jank or animation backlog

https://claude.ai/code/session_01N2HM7WoonYbDiYXxA2vQHo

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2HM7WoonYbDiYXxA2vQHo)_

## Summary by Sourcery

Refactor settings state management into focused delegate classes and introduce an adaptive, two-pane library layout for larger screens while documenting ZoomableImage animation behavior.

New Features:
- Add an adaptive library grid that increases column count on larger screens and supports a two-pane layout with an inline manga detail panel on wide devices.

Enhancements:
- Split the monolithic SettingsViewModel into domain-specific delegates for appearance, reader, library, downloads, backup, AI, and tracking/sync concerns, simplifying event handling and state observation.

Documentation:
- Document ZoomableState’s use of Animatable instances and animation-queue behavior to clarify thread-safety and avoid future regressions.