### PR TITLE
feat(architecture): Base MVI ViewModel + CollectAsEffect

### DIFF
--- a/core/common/src/main/java/app/otakureader/core/common/mvi/BaseMviViewModel.kt
+++ b/core/common/src/main/java/app/otakureader/core/common/mvi/BaseMviViewModel.kt
@@ -1,0 +1,95 @@
+package app.otakureader.core.common.mvi
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Base ViewModel for MVI pattern.
+ *
+ * @param S UI state type (immutable data class)
+ * @param E UI event type (sealed interface of user actions)
+ * @param F UI effect type (sealed interface of one-shot side effects)
+ *
+ * Usage:
+ * ```
+ * class LibraryViewModel @Inject constructor(
+ *     private val getLibraryManga: GetLibraryMangaUseCase
+ * ) : BaseMviViewModel<LibraryUiState, LibraryUiEvent, LibraryUiEffect>(
+ *     initialState = LibraryUiState()
+ * ) {
+ *     override fun processEvent(event: LibraryUiEvent) {
+ *         when (event) {
+ *             is LibraryUiEvent.Refresh -> loadManga(force = event.force)
+ *             is LibraryUiEvent.Search -> search(event.query)
+ *         }
+ *     }
+ * }
+ * ```
+ */
+abstract class BaseMviViewModel<S : UiState, E : UiEvent, F : UiEffect>(
+    initialState: S,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(initialState)
+    val state: StateFlow<S> = _state.asStateFlow()
+
+    private val _effect = Channel<F>(Channel.BUFFERED)
+    val effect: Flow<F> = _effect.receiveAsFlow()
+
+    /**
+     * Dispatch an event to be processed by the ViewModel.
+     * Thread-safe — can be called from any dispatcher.
+     */
+    fun onEvent(event: E) {
+        processEvent(event)
+    }
+
+    /**
+     * Override this to handle all [E] events.
+     * Use [setState] to update UI state and [sendEffect] for one-shot effects.
+     */
+    protected abstract fun processEvent(event: E)
+
+    /**
+     * Update state atomically using the current state.
+     * Safe to call from any coroutine context.
+     */
+    protected fun setState(transform: S.() -> S) {
+        _state.update(transform)
+    }
+
+    /**
+     * Send a one-shot effect to the UI layer.
+     * Effects are consumed exactly once (e.g., navigation, snackbars, toasts).
+     */
+    protected fun sendEffect(effect: F) {
+        viewModelScope.launch {
+            _effect.send(effect)
+        }
+    }
+
+    /**
+     * Launch a coroutine tied to the ViewModel lifecycle.
+     * Automatically cancelled when the ViewModel is cleared.
+     */
+    protected fun launch(block: suspend () -> Unit) {
+        viewModelScope.launch {
+            block()
+        }
+    }
+
+    /**
+     * Current snapshot of the state. Use for synchronous reads only.
+     * Prefer collecting [state] for reactive UI.
+     */
+    protected val currentState: S
+        get() = _state.value
+}

--- a/core/ui/src/main/java/app/otakureader/core/ui/mvi/CollectAsEffect.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/mvi/CollectAsEffect.kt
@@ -1,0 +1,35 @@
+package app.otakureader.core.ui.mvi
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
+
+/**
+ * Collect one-shot effects from a [BaseMviViewModel] in Compose.
+ *
+ * Usage:
+ * ```
+ * val viewModel: LibraryViewModel = hiltViewModel()
+ * val state by viewModel.state.collectAsStateWithLifecycle()
+ *
+ * CollectAsEffect(viewModel.effect) { effect ->
+ *     when (effect) {
+ *         is LibraryUiEffect.NavigateToDetails -> navigator.navigate(effect.route)
+ *         is LibraryUiEffect.ShowSnackbar -> snackbarHostState.showSnackbar(effect.message)
+ *     }
+ * }
+ * ```
+ *
+ * @param effectFlow The [Flow] of effects from the ViewModel.
+ * @param collector Lambda invoked for each effect. Runs in a [LaunchedEffect] scoped to the composable.
+ */
+@Composable
+fun <F : app.otakureader.core.common.mvi.UiEffect> CollectAsEffect(
+    effectFlow: Flow<F>,
+    collector: suspend (F) -> Unit,
+) {
+    LaunchedEffect(effectFlow) {
+        effectFlow.collectLatest(collector)
+    }
+}


### PR DESCRIPTION
## **User description**
Part of #742.

Adds the foundational MVI pattern for all Phase 2 feature screens:

- **BaseMviViewModel** in  — generic VM with , , and  dispatch
- **CollectAsEffect** in  — Compose extension for consuming one-shot effects via 

Pattern:


UI layer:


No breaking changes — existing code untouched.


___

## **CodeAnt-AI Description**
**Add reusable MVI support for state, events, and one-time effects**

### What Changed
- Added a shared ViewModel base for screens that manage UI state, user actions, and one-time effects
- UI state can now be updated in a consistent way, and effects like navigation or snackbars are delivered once
- Added a Compose helper to observe effect streams from the UI without handling them in the state flow

### Impact
`✅ Consistent screen state handling`
`✅ One-time navigation and snackbar events`
`✅ Cleaner MVI setup for new screens`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=30UKlBRqm4JqCfS_3pNxF-a3ipT5R4x2K_azWpQXL-o&org=HeartlessVeteran2)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
