### PR TITLE
test(browse): BrowseViewModel — source, search, pagination, bulk selection

### DIFF
--- a/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
+++ b/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
@@ -1,0 +1,256 @@
+package app.otakureader.feature.browse
+
+import app.otakureader.core.preferences.GeneralPreferences
+import app.otakureader.domain.model.FeedSavedSearch
+import app.otakureader.domain.repository.FeedRepository
+import app.otakureader.domain.usecase.library.AddMangaToLibraryUseCase
+import app.otakureader.domain.usecase.source.GetLatestUpdatesUseCase
+import app.otakureader.domain.usecase.source.GetPopularMangaUseCase
+import app.otakureader.domain.usecase.source.GetSourceFiltersUseCase
+import app.otakureader.domain.usecase.source.GetSourcesUseCase
+import app.otakureader.domain.usecase.source.SearchMangaUseCase
+import app.otakureader.sourceapi.FilterList
+import app.otakureader.sourceapi.MangaPage
+import app.otakureader.sourceapi.MangaSource
+import app.otakureader.sourceapi.SourceManga
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BrowseViewModelTest {
+
+    private val getSourcesUseCase: GetSourcesUseCase = mockk()
+    private val getPopularMangaUseCase: GetPopularMangaUseCase = mockk()
+    private val getLatestUpdatesUseCase: GetLatestUpdatesUseCase = mockk()
+    private val searchMangaUseCase: SearchMangaUseCase = mockk()
+    private val getSourceFiltersUseCase: GetSourceFiltersUseCase = mockk()
+    private val addMangaToLibraryUseCase: AddMangaToLibraryUseCase = mockk()
+    private val feedRepository: FeedRepository = mockk()
+    private val generalPreferences: GeneralPreferences = mockk()
+
+    private lateinit var viewModel: BrowseViewModel
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+
+        // Default stubs
+        every { getSourcesUseCase() } returns flowOf(emptyList())
+        every { generalPreferences.showNsfwContent } returns flowOf(false)
+        every { feedRepository.getSavedSearches() } returns flowOf(emptyList())
+
+        viewModel = BrowseViewModel(
+            getSourcesUseCase = getSourcesUseCase,
+            getPopularMangaUseCase = getPopularMangaUseCase,
+            getLatestUpdatesUseCase = getLatestUpdatesUseCase,
+            searchMangaUseCase = searchMangaUseCase,
+            getSourceFiltersUseCase = getSourceFiltersUseCase,
+            addMangaToLibraryUseCase = addMangaToLibraryUseCase,
+            feedRepository = feedRepository,
+            generalPreferences = generalPreferences
+        )
+    }
+
+    @After
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state has empty sources and no loading`() = runTest {
+        val state = viewModel.state.value
+        assertEquals(emptyList<String>(), state.sources)
+        assertEquals(false, state.isLoading)
+        assertEquals(false, state.isSearching)
+    }
+
+    @Test
+    fun `select source loads popular manga`() = runTest {
+        val source = MangaSource(id = "1", name = "Test Source", lang = "en", isNsfw = false)
+        val mangaPage = MangaPage(
+            mangas = listOf(SourceManga(title = "Manga 1", url = "url1", thumbnailUrl = null)),
+            hasNextPage = true
+        )
+
+        every { getSourcesUseCase() } returns flowOf(listOf(source))
+        coEvery { getPopularMangaUseCase("1", 1) } returns Result.success(mangaPage)
+        every { getSourceFiltersUseCase("1") } returns FilterList()
+
+        viewModel.onEvent(BrowseEvent.SelectSource("1"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals("1", state.currentSourceId)
+        assertEquals(1, state.popularManga.size)
+        assertEquals("Manga 1", state.popularManga[0].title)
+        assertEquals(false, state.isLoading)
+    }
+
+    @Test
+    fun `search query change updates state`() = runTest {
+        viewModel.onEvent(BrowseEvent.OnSearchQueryChange("One Piece"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("One Piece", viewModel.state.value.searchQuery)
+    }
+
+    @Test
+    fun `search performs search with query`() = runTest {
+        val source = MangaSource(id = "1", name = "Test Source", lang = "en", isNsfw = false)
+        val mangaPage = MangaPage(
+            mangas = listOf(
+                SourceManga(title = "One Piece", url = "url1", thumbnailUrl = null),
+                SourceManga(title = "One Punch Man", url = "url2", thumbnailUrl = null)
+            ),
+            hasNextPage = false
+        )
+
+        every { getSourcesUseCase() } returns flowOf(listOf(source))
+        coEvery { searchMangaUseCase("1", "One", 1, any()) } returns Result.success(mangaPage)
+        every { getSourceFiltersUseCase("1") } returns FilterList()
+
+        viewModel.onEvent(BrowseEvent.SelectSource("1"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(BrowseEvent.OnSearchQueryChange("One"))
+        viewModel.onEvent(BrowseEvent.Search)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals(2, state.searchResults.size)
+        assertEquals(false, state.isSearching)
+    }
+
+    @Test
+    fun `toggle filter sheet changes visibility`() = runTest {
+        assertEquals(false, viewModel.state.value.showFilterSheet)
+
+        viewModel.onEvent(BrowseEvent.ToggleFilterSheet)
+        assertEquals(true, viewModel.state.value.showFilterSheet)
+
+        viewModel.onEvent(BrowseEvent.ToggleFilterSheet)
+        assertEquals(false, viewModel.state.value.showFilterSheet)
+    }
+
+    @Test
+    fun `clear selection resets state`() = runTest {
+        val source = MangaSource(id = "1", name = "Test Source", lang = "en", isNsfw = false)
+        val manga = SourceManga(title = "Manga 1", url = "url1", thumbnailUrl = null)
+
+        every { getSourcesUseCase() } returns flowOf(listOf(source))
+        coEvery { getPopularMangaUseCase("1", 1) } returns Result.success(MangaPage(listOf(manga), false))
+        every { getSourceFiltersUseCase("1") } returns FilterList()
+
+        viewModel.onEvent(BrowseEvent.SelectSource("1"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(BrowseEvent.OnMangaLongClick(manga))
+        assertTrue(viewModel.state.value.isBulkSelectionMode)
+        assertEquals(1, viewModel.state.value.selectedManga.size)
+
+        viewModel.onEvent(BrowseEvent.ClearSelection)
+        assertFalse(viewModel.state.value.isBulkSelectionMode)
+        assertEquals(0, viewModel.state.value.selectedManga.size)
+    }
+
+    @Test
+    fun `add selected to library sends success effect`() = runTest {
+        val source = MangaSource(id = "1", name = "Test Source", lang = "en", isNsfw = false)
+        val manga = SourceManga(title = "Manga 1", url = "url1", thumbnailUrl = null)
+
+        every { getSourcesUseCase() } returns flowOf(listOf(source))
+        coEvery { getPopularMangaUseCase("1", 1) } returns Result.success(MangaPage(listOf(manga), false))
+        coEvery { addMangaToLibraryUseCase(listOf(manga), "1") } returns Result.success(1)
+        every { getSourceFiltersUseCase("1") } returns FilterList()
+
+        viewModel.onEvent(BrowseEvent.SelectSource("1"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(BrowseEvent.OnMangaLongClick(manga))
+        viewModel.onEvent(BrowseEvent.AddSelectedToLibrary)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val effect = viewModel.effect.first()
+        assertTrue(effect is BrowseEffect.ShowSnackbar)
+    }
+
+    @Test
+    fun `load next page appends results`() = runTest {
+        val source = MangaSource(id = "1", name = "Test Source", lang = "en", isNsfw = false)
+        val page1 = MangaPage(
+            mangas = listOf(SourceManga(title = "Manga 1", url = "url1", thumbnailUrl = null)),
+            hasNextPage = true
+        )
+        val page2 = MangaPage(
+            mangas = listOf(SourceManga(title = "Manga 2", url = "url2", thumbnailUrl = null)),
+            hasNextPage = false
+        )
+
+        every { getSourcesUseCase() } returns flowOf(listOf(source))
+        coEvery { getPopularMangaUseCase("1", 1) } returns Result.success(page1)
+        coEvery { getPopularMangaUseCase("1", 2) } returns Result.success(page2)
+        every { getSourceFiltersUseCase("1") } returns FilterList()
+
+        viewModel.onEvent(BrowseEvent.SelectSource("1"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, viewModel.state.value.popularManga.size)
+
+        viewModel.onEvent(BrowseEvent.LoadNextPage)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(2, viewModel.state.value.popularManga.size)
+        assertEquals("Manga 1", viewModel.state.value.popularManga[0].title)
+        assertEquals("Manga 2", viewModel.state.value.popularManga[1].title)
+    }
+
+    @Test
+    fun `refresh sources sends snackbar effect`() = runTest {
+        viewModel.onEvent(BrowseEvent.RefreshSources)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val effect = viewModel.effect.first()
+        assertTrue(effect is BrowseEffect.ShowSnackbar)
+    }
+
+    @Test
+    fun `apply filters hides sheet and searches`() = runTest {
+        val source = MangaSource(id = "1", name = "Test Source", lang = "en", isNsfw = false)
+        val mangaPage = MangaPage(
+            mangas = listOf(SourceManga(title = "Manga 1", url = "url1", thumbnailUrl = null)),
+            hasNextPage = false
+        )
+
+        every { getSourcesUseCase() } returns flowOf(listOf(source))
+        every { getSourceFiltersUseCase("1") } returns FilterList()
+        coEvery { searchMangaUseCase("1", "", 1, any()) } returns Result.success(mangaPage)
+
+        viewModel.onEvent(BrowseEvent.SelectSource("1"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(BrowseEvent.ToggleFilterSheet)
+        assertTrue(viewModel.state.value.showFilterSheet)
+
+        viewModel.onEvent(BrowseEvent.ApplyFilters)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(viewModel.state.value.showFilterSheet)
+        assertEquals(1, viewModel.state.value.searchResults.size)
+    }
+}


### PR DESCRIPTION
## **User description**
Adds comprehensive unit tests for BrowseViewModel.

## Coverage
- Initial state verification
- Source selection + popular manga loading
- Search query + search execution
- Filter sheet toggle
- Bulk selection mode (long click, clear, add to library)
- Load next page (pagination)
- Refresh sources
- Apply filters

Uses MockK for repository/usecase mocking and StandardTestDispatcher for coroutine control.

Part of Phase 2 test coverage.


___

## **CodeAnt-AI Description**
Add coverage for browse screen behavior

### What Changed
- Verifies the browse screen starts with empty source data and no loading state
- Covers selecting a source, loading popular manga, searching, moving to the next page, and applying filters
- Confirms filter sheet and bulk selection can be opened, cleared, and used to add manga to the library
- Checks refresh actions and success messages are shown after key actions

### Impact
`✅ Safer browse screen changes`
`✅ Fewer regressions in search and pagination`
`✅ More reliable bulk selection and filter flows`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=3DFVjca_TIQniTLe4z0NyLBXneNjlmIKJtLDnpy2GO4&org=HeartlessVeteran2)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
