### PR TITLE
fix(navigation): clean up remaining old route references

### DIFF
--- a/app/src/main/java/app/otakureader/OtakuReaderBottomBar.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderBottomBar.kt
@@ -25,11 +25,7 @@ import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.currentBackStackEntryAsState
-import app.otakureader.core.navigation.BrowseRoute
-import app.otakureader.core.navigation.HistoryRoute
-import app.otakureader.core.navigation.LibraryRoute
-import app.otakureader.core.navigation.MoreRoute
-import app.otakureader.core.navigation.UpdatesRoute
+import app.otakureader.core.navigation.Route
 
 /**
  * Bottom navigation bar for the main app navigation.
@@ -45,18 +41,18 @@ fun OtakuReaderBottomBar(
     val currentDestination = navBackStackEntry?.destination
 
     val isTopLevelDestination = currentDestination?.hierarchy?.any { destination ->
-        destination.hasRoute(LibraryRoute::class) ||
-        destination.hasRoute(UpdatesRoute::class) ||
-        destination.hasRoute(BrowseRoute::class) ||
-        destination.hasRoute(HistoryRoute::class) ||
-        destination.hasRoute(MoreRoute::class)
+        destination.hasRoute(Route.Library::class) ||
+        destination.hasRoute(Route.Updates::class) ||
+        destination.hasRoute(Route.Browse::class) ||
+        destination.hasRoute(Route.History::class) ||
+        destination.hasRoute(Route.More::class)
     } == true
 
     if (!isTopLevelDestination) return
 
     NavigationBar(modifier = modifier) {
         // Library
-        val librarySelected = currentDestination?.hasRoute(LibraryRoute::class) == true
+        val librarySelected = currentDestination?.hasRoute(Route.Library::class) == true
         val libraryScale by animateFloatAsState(
             targetValue = if (librarySelected) 1.18f else 1f,
             animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMediumLow),
@@ -73,7 +69,7 @@ fun OtakuReaderBottomBar(
             label = { Text(stringResource(R.string.nav_library)) },
             selected = librarySelected,
             onClick = {
-                navController.navigate(LibraryRoute) {
+                navController.navigate(Route.Library) {
                     popUpTo(navController.graph.findStartDestination().id) { saveState = true }
                     launchSingleTop = true
                     restoreState = true
@@ -82,7 +78,7 @@ fun OtakuReaderBottomBar(
         )
 
         // Updates
-        val updatesSelected = currentDestination?.hasRoute(UpdatesRoute::class) == true
+        val updatesSelected = currentDestination?.hasRoute(Route.Updates::class) == true
         val updatesScale by animateFloatAsState(
             targetValue = if (updatesSelected) 1.18f else 1f,
             animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMediumLow),
@@ -109,7 +105,7 @@ fun OtakuReaderBottomBar(
             label = { Text(stringResource(R.string.nav_updates)) },
             selected = updatesSelected,
             onClick = {
-                navController.navigate(UpdatesRoute) {
+                navController.navigate(Route.Updates) {
                     popUpTo(navController.graph.findStartDestination().id) { saveState = true }
                     launchSingleTop = true
                     restoreState = true
@@ -118,7 +114,7 @@ fun OtakuReaderBottomBar(
         )
 
         // Browse
-        val browseSelected = currentDestination?.hasRoute(BrowseRoute::class) == true
+        val browseSelected = currentDestination?.hasRoute(Route.Browse::class) == true
         val browseScale by animateFloatAsState(
             targetValue = if (browseSelected) 1.18f else 1f,
             animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMediumLow),
@@ -135,7 +131,7 @@ fun OtakuReaderBottomBar(
             label = { Text(stringResource(R.string.nav_browse)) },
             selected = browseSelected,
             onClick = {
-                navController.navigate(BrowseRoute) {
+                navController.navigate(Route.Browse) {
                     popUpTo(navController.graph.findStartDestination().id) { saveState = true }
                     launchSingleTop = true
                     restoreState = true
@@ -144,7 +140,7 @@ fun OtakuReaderBottomBar(
         )
 
         // History
-        val historySelected = currentDestination?.hasRoute(HistoryRoute::class) == true
+        val historySelected = currentDestination?.hasRoute(Route.History::class) == true
         val historyScale by animateFloatAsState(
             targetValue = if (historySelected) 1.18f else 1f,
             animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMediumLow),
@@ -161,7 +157,7 @@ fun OtakuReaderBottomBar(
             label = { Text(stringResource(R.string.nav_history)) },
             selected = historySelected,
             onClick = {
-                navController.navigate(HistoryRoute) {
+                navController.navigate(Route.History) {
                     popUpTo(navController.graph.findStartDestination().id) { saveState = true }
                     launchSingleTop = true
                     restoreState = true
@@ -170,7 +166,7 @@ fun OtakuReaderBottomBar(
         )
 
         // More
-        val moreSelected = currentDestination?.hasRoute(MoreRoute::class) == true
+        val moreSelected = currentDestination?.hasRoute(Route.More::class) == true
         val moreScale by animateFloatAsState(
             targetValue = if (moreSelected) 1.18f else 1f,
             animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMediumLow),
@@ -187,7 +183,7 @@ fun OtakuReaderBottomBar(
             label = { Text(stringResource(R.string.nav_more)) },
             selected = moreSelected,
             onClick = {
-                navController.navigate(MoreRoute) {
+                navController.navigate(Route.More) {
                     popUpTo(navController.graph.findStartDestination().id) { saveState = true }
                     launchSingleTop = true
                     restoreState = true

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailScreen.kt
@@ -10,11 +10,11 @@ import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 
 /**
- * Transparent redirect screen for [app.otakureader.core.navigation.SourceMangaDetailRoute].
+ * Transparent redirect screen for [Route.SourceMangaDetail].
  *
  * Shows a loading spinner while [SourceMangaDetailViewModel] resolves the manga's
  * database ID (looking it up by source URL, or inserting a stub entry), then
- * immediately forwards to the [MangaDetailRoute] screen via [onNavigateToMangaDetail].
+ * immediately forwards to the [Route.MangaDetails] screen via [onNavigateToMangaDetail].
  */
 @Composable
 fun SourceMangaDetailScreen(

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import app.otakureader.core.navigation.SourceMangaDetailRoute
+import app.otakureader.core.navigation.Route
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.repository.MangaRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -21,7 +21,7 @@ sealed interface SourceMangaDetailEffect {
 /**
  * Resolves a source manga (identified by [sourceId] + [mangaUrl]) to a database
  * entry and emits [SourceMangaDetailEffect.NavigateToMangaDetail] so the UI can
- * forward to the full [MangaDetailRoute] screen.
+ * forward to the full [Route.MangaDetails] screen.
  *
  * If the manga is already in the database (previously browsed or in library) its
  * existing ID is reused. Otherwise a stub entry is inserted so the details screen
@@ -37,7 +37,7 @@ class SourceMangaDetailViewModel @Inject constructor(
     val effect: Flow<SourceMangaDetailEffect> = _effect.receiveAsFlow()
 
     init {
-        val route = savedStateHandle.toRoute<SourceMangaDetailRoute>()
+        val route = savedStateHandle.toRoute<Route.SourceMangaDetail>()
         resolveAndNavigate(route.sourceId, route.mangaUrl, route.mangaTitle)
     }
 


### PR DESCRIPTION
## **User description**
Follow-up to #752 — fixes 3 files that still referenced old routes from OtakuReaderDestinations.kt.

## Fixed

1. **OtakuReaderBottomBar.kt** — was importing old routes individually (BrowseRoute, LibraryRoute, HistoryRoute, UpdatesRoute, MoreRoute)
   - Now imports unified Route
   - All hasRoute() calls use Route.Xxx::class
   - All navigate() calls use Route.Xxx

2. **SourceMangaDetailViewModel.kt** — was importing old SourceMangaDetailRoute
   - Now uses savedStateHandle.toRoute() with Route.SourceMangaDetail
   - Updated KDoc to reference Route.MangaDetails

3. **SourceMangaDetailScreen.kt** — KDoc comments referenced old routes
   - Updated to Route.SourceMangaDetail and Route.MangaDetails

## Verification
- All old route references now resolved
- OtakuReaderNavigator.kt uses only Route. (confirmed)
- NavHost uses only Route. (confirmed)
- All 12 feature navigation files use only Route. (confirmed)
- OtakuReaderDestinations.kt is deleted (404 confirmed)


___

## **CodeAnt-AI Description**
**Use the current route names in main navigation and manga details**

### What Changed
- The bottom navigation now uses the shared route set for Library, Updates, Browse, History, and More, so the selected tab and taps point to the current destinations.
- The source manga detail flow now reads the current source detail route and sends users to the current manga details screen.
- Comments and screen descriptions were updated to match the current route names.

### Impact
`✅ Fewer broken bottom-tab navigations`
`✅ More reliable source-to-detail redirects`
`✅ Clearer navigation references in app screens`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=c42qIBRw1J_q-jQLHbLBj6OdiCKtx24R3W-Bxxxir1g&org=HeartlessVeteran2)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
