### PR TITLE
feat(smart-download): auto-download chapters at reading threshold

### DIFF
--- a/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -150,6 +151,26 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
         }
     }
 
+    // --- Smart Download ---
+
+    val smartDownloadEnabled: Flow<Boolean> = dataStore.data.map { it[Keys.SMART_DOWNLOAD_ENABLED] ?: false }
+    suspend fun setSmartDownloadEnabled(value: Boolean) = dataStore.edit { it[Keys.SMART_DOWNLOAD_ENABLED] = value }
+
+    val smartDownloadChaptersAhead: Flow<Int> = dataStore.data.map { it[Keys.SMART_DOWNLOAD_CHAPTERS_AHEAD] ?: 3 }
+    suspend fun setSmartDownloadChaptersAhead(value: Int) = dataStore.edit { it[Keys.SMART_DOWNLOAD_CHAPTERS_AHEAD] = value }
+
+    val smartDownloadThreshold: Flow<Float> = dataStore.data.map { it[Keys.SMART_DOWNLOAD_THRESHOLD] ?: 0.8f }
+    suspend fun setSmartDownloadThreshold(value: Float) = dataStore.edit { it[Keys.SMART_DOWNLOAD_THRESHOLD] = value }
+
+    val smartDownloadWifiOnly: Flow<Boolean> = dataStore.data.map { it[Keys.SMART_DOWNLOAD_WIFI_ONLY] ?: true }
+    suspend fun setSmartDownloadWifiOnly(value: Boolean) = dataStore.edit { it[Keys.SMART_DOWNLOAD_WIFI_ONLY] = value }
+
+    val smartDownloadFavoritesOnly: Flow<Boolean> = dataStore.data.map { it[Keys.SMART_DOWNLOAD_FAVORITES_ONLY] ?: true }
+    suspend fun setSmartDownloadFavoritesOnly(value: Boolean) = dataStore.edit { it[Keys.SMART_DOWNLOAD_FAVORITES_ONLY] = value }
+
+    val smartDownloadMinStorageMb: Flow<Int> = dataStore.data.map { it[Keys.SMART_DOWNLOAD_MIN_STORAGE_MB] ?: 500 }
+    suspend fun setSmartDownloadMinStorageMb(value: Int) = dataStore.edit { it[Keys.SMART_DOWNLOAD_MIN_STORAGE_MB] = value }
+
     // --- Image Cache ---
 
     /**
@@ -182,6 +203,12 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
         val CURRENT_VERSION_CODE = intPreferencesKey("current_version_code")
         val LATEST_VERSION_INFO = stringPreferencesKey("latest_version_info")
         val COIL_DISK_CACHE_SIZE_MB = intPreferencesKey("coil_disk_cache_size_mb")
+        val SMART_DOWNLOAD_ENABLED = booleanPreferencesKey("smart_download_enabled")
+        val SMART_DOWNLOAD_CHAPTERS_AHEAD = intPreferencesKey("smart_download_chapters_ahead")
+        val SMART_DOWNLOAD_THRESHOLD = floatPreferencesKey("smart_download_threshold")
+        val SMART_DOWNLOAD_WIFI_ONLY = booleanPreferencesKey("smart_download_wifi_only")
+        val SMART_DOWNLOAD_FAVORITES_ONLY = booleanPreferencesKey("smart_download_favorites_only")
+        val SMART_DOWNLOAD_MIN_STORAGE_MB = intPreferencesKey("smart_download_min_storage_mb")
     }
 
     companion object {

--- a/domain/src/main/java/app/otakureader/domain/model/SmartDownloadRule.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/SmartDownloadRule.kt
@@ -1,0 +1,44 @@
+package app.otakureader.domain.model
+
+/**
+ * Configuration for smart (auto) download behavior.
+ *
+ * When enabled, the app automatically queues downloads for upcoming chapters
+ * based on reading progress — no manual intervention required.
+ */
+data class SmartDownloadRule(
+    val enabled: Boolean = false,
+    /** How many upcoming chapters to pre-download. */
+    val chaptersAhead: Int = 3,
+    /** Reading progress (0.0–1.0) at which to trigger the next batch. */
+    val progressThreshold: Float = 0.8f,
+    /** Only auto-download on unmetered Wi-Fi. */
+    val wifiOnly: Boolean = true,
+    /** Restrict auto-download to favorited manga only. */
+    val favoritesOnly: Boolean = true,
+    /** Minimum free storage (MB) required before downloading. */
+    val minFreeStorageMb: Int = 500,
+) {
+    companion object {
+        /** Default conservative rule: download next 3 chapters at 80% on Wi-Fi, favorites only. */
+        val DEFAULT = SmartDownloadRule()
+
+        /** Aggressive rule: download 5 chapters at 50%, any network, all manga. */
+        val AGGRESSIVE = SmartDownloadRule(
+            enabled = true,
+            chaptersAhead = 5,
+            progressThreshold = 0.5f,
+            wifiOnly = false,
+            favoritesOnly = false
+        )
+
+        /** Conservative rule: download 1 chapter at 90%, Wi-Fi, favorites only. */
+        val CONSERVATIVE = SmartDownloadRule(
+            enabled = true,
+            chaptersAhead = 1,
+            progressThreshold = 0.9f,
+            wifiOnly = true,
+            favoritesOnly = true
+        )
+    }
+}

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/SmartDownloadTrigger.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/SmartDownloadTrigger.kt
@@ -1,0 +1,103 @@
+package app.otakureader.feature.reader
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.StatFs
+import app.otakureader.core.preferences.GeneralPreferences
+import app.otakureader.domain.model.SmartDownloadRule
+import app.otakureader.domain.repository.ChapterRepository
+import app.otakureader.domain.repository.DownloadRepository
+import app.otakureader.domain.repository.MangaRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Monitors reading progress and triggers smart (auto) downloads when configured.
+ *
+ * Rules are evaluated every time the reader reports progress:
+ * - If progress ≥ threshold and manga is favorited (or favoritesOnly = false)
+ * - And Wi-Fi is available (or wifiOnly = false)
+ * - And free storage ≥ minimum
+ * → Queue next N unread chapters for download.
+ */
+@Singleton
+class SmartDownloadTrigger @Inject constructor(
+    private val context: Context,
+    private val generalPreferences: GeneralPreferences,
+    private val mangaRepository: MangaRepository,
+    private val chapterRepository: ChapterRepository,
+    private val downloadRepository: DownloadRepository,
+) {
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    /**
+     * Call this whenever reader progress updates.
+     *
+     * @param mangaId The manga being read.
+     * @param chapterId The current chapter.
+     * @param progress Normalized progress (0.0–1.0).
+     */
+    fun onProgress(mangaId: Long, chapterId: Long, progress: Float) {
+        scope.launch {
+            val rule = loadRule()
+            if (!rule.enabled) return@launch
+            if (progress < rule.progressThreshold) return@launch
+
+            // Check favorites-only constraint
+            if (rule.favoritesOnly) {
+                val manga = mangaRepository.getMangaById(mangaId).first() ?: return@launch
+                if (!manga.favorite) return@launch
+            }
+
+            // Check Wi-Fi constraint
+            if (rule.wifiOnly && !isUnmeteredNetwork()) return@launch
+
+            // Check storage constraint
+            if (getFreeStorageMb() < rule.minFreeStorageMb) return@launch
+
+            // Queue next N unread chapters
+            val chapters = chapterRepository.getChaptersByMangaId(mangaId).first()
+            val currentIndex = chapters.indexOfFirst { it.id == chapterId }
+            if (currentIndex < 0) return@launch
+
+            val toDownload = chapters
+                .drop(currentIndex + 1)
+                .filter { !it.read && !it.downloaded }
+                .take(rule.chaptersAhead)
+
+            if (toDownload.isNotEmpty()) {
+                downloadRepository.startDownload(chapters = toDownload)
+            }
+        }
+    }
+
+    private suspend fun loadRule(): SmartDownloadRule {
+        return SmartDownloadRule(
+            enabled = generalPreferences.smartDownloadEnabled.first(),
+            chaptersAhead = generalPreferences.smartDownloadChaptersAhead.first(),
+            progressThreshold = generalPreferences.smartDownloadThreshold.first(),
+            wifiOnly = generalPreferences.smartDownloadWifiOnly.first(),
+            favoritesOnly = generalPreferences.smartDownloadFavoritesOnly.first(),
+            minFreeStorageMb = generalPreferences.smartDownloadMinStorageMb.first(),
+        )
+    }
+
+    private fun isUnmeteredNetwork(): Boolean {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager ?: return false
+        val network = cm.activeNetwork ?: return false
+        val capabilities = cm.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+    }
+
+    private fun getFreeStorageMb(): Long {
+        val stat = StatFs(context.getExternalFilesDir(null)?.path ?: return 0L)
+        val availableBlocks = stat.availableBlocksLong
+        val blockSize = stat.blockSizeLong
+        return (availableBlocks * blockSize) / (1024 * 1024)
+    }
+}


### PR DESCRIPTION
## **User description**
## What

Implements smart download rules — auto-download upcoming chapters when reading progress hits a threshold.

- **SmartDownloadRule** — domain model with 3 presets (Default, Aggressive, Conservative)
- **SmartDownloadTrigger** — monitors reader progress, evaluates rules, auto-queues downloads
- **GeneralPreferences** — 6 new DataStore keys for configuration
- Constraints: Wi-Fi only, favorites only, min free storage

## How it works

1. User reads a chapter
2. At 80% progress (configurable), trigger fires
3. Checks: Wi-Fi? Favorited? Storage OK?
4. Queues next N unread chapters for download

## Part of

#711 — Post-Phase 2 Differentiators


___

## **CodeAnt-AI Description**
**Auto-download upcoming chapters while reading**

### What Changed
- The app can now queue upcoming unread chapters automatically when reading progress reaches a chosen threshold
- Auto-download only runs when the manga is favorited, the connection is unmetered Wi‑Fi if required, and free storage meets the minimum set in preferences
- Added preset download rules for default, aggressive, and conservative reading patterns
- Users can now control whether smart downloads are enabled, how many chapters are queued, when they trigger, and the network/storage limits

### Impact
`✅ Fewer manual downloads while reading`
`✅ Reduced downloads on mobile data`
`✅ Fewer download failures from low storage`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=LmylloA9xwMEA467hK1GT2gCXZeLLh5C2Dp4FRw-jKI&org=HeartlessVeteran2)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
