### PR TITLE
fix: address open issues #796/#806 and three self-discovered bugs

### DIFF
--- a/.github/workflows/cert-pin-check.yml
+++ b/.github/workflows/cert-pin-check.yml
@@ -48,12 +48,12 @@ jobs:
             fi
           }
 
-          check_pin "myanimelist.net"       "r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E="
-          check_pin "api.myanimelist.net"   "r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E="
-          check_pin "graphql.anilist.co"    "kIdp6NNEd8wsugYyyIYFsi1ylMv2M01eUNwHcm0etyk="
-          check_pin "kitsu.app"             "C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M="
-          check_pin "api.mangaupdates.com"  "C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M="
-          check_pin "shikimori.one"         "C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M="
+          check_pin "myanimelist.net"       "efrF+PUxbl1xw8PF8f6KvRrel4/kWrRWFWuu6PQj2bo="
+          check_pin "api.myanimelist.net"   "JhaUbPsimbNLHKKcoc09+5qss1K+Hb8XpX2uthsDY4A="
+          check_pin "graphql.anilist.co"    "qvGMxVkebAxISqRUcDy3CljP+wieT8aKikYTCVu0PH4="
+          check_pin "kitsu.app"             "Hrs6IIkHfcrDYD7JZOmpHh/QXgq4ZfY7IKy+UnzF4bA="
+          check_pin "api.mangaupdates.com"  "02qttGMepJs9pxcSmAyDxfnjZv0EoAw8IkZSv+rzbu8="
+          check_pin "shikimori.one"         "1biKOxoipnu596Dxf12XU0Vu2EXlLUQnUj4p+ycBKSY="
 
           if [ -n "$FAILURES" ]; then
             echo -e "$FAILURES"

--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -377,6 +377,9 @@ fun OtakuReaderNavHost(
             onNavigateToScanLibrary = {
                 navController.navigate(Route.ScanLibrary)
             },
+            onNavigateToUpdateErrors = {
+                navController.navigate(Route.Updates)
+            },
         )
 
         // QR Library Sharing

--- a/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
+++ b/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
@@ -13,6 +13,8 @@ import app.otakureader.core.database.migrations.MIGRATION_17_18
 import app.otakureader.core.database.migrations.MIGRATION_18_19
 import app.otakureader.core.database.migrations.MIGRATION_19_20
 import app.otakureader.core.database.migrations.MIGRATION_20_21
+import app.otakureader.core.database.migrations.MIGRATION_10_11
+import app.otakureader.core.database.migrations.MIGRATION_11_12
 import app.otakureader.core.database.migrations.MIGRATION_9_10
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -117,6 +119,61 @@ class DatabaseMigrationTest {
         helper.createDatabase(TEST_DB, 9).close()
         val db = helper.runMigrationsAndValidate(TEST_DB, 10, true, MIGRATION_9_10)
         assertTrue("opds_servers must exist after 9→10", "opds_servers" in db.tableNames())
+        db.close()
+    }
+
+    // ── Migration 10 → 11 ───────────────────────────────────────────────────
+    // Adds: chapters.version (INTEGER NOT NULL DEFAULT 0)
+    //       chapters.is_syncing (INTEGER NOT NULL DEFAULT 0)
+
+    @Test
+    fun migration10To11_addsVersionAndIsSyncingToChapters() {
+        helper.createDatabase(TEST_DB, 9).close()
+        val db = helper.runMigrationsAndValidate(TEST_DB, 10, true, MIGRATION_9_10)
+        assertFalse("version must NOT exist at v10", "version" in db.columnNames("chapters"))
+        assertFalse("is_syncing must NOT exist at v10", "is_syncing" in db.columnNames("chapters"))
+        MIGRATION_10_11.migrate(db)
+        val cols = db.columnNames("chapters")
+        assertTrue("chapters.version must exist after 10→11", "version" in cols)
+        assertTrue("chapters.is_syncing must exist after 10→11", "is_syncing" in cols)
+        db.close()
+    }
+
+    @Test
+    fun migration10To11_versionAndIsSyncingDefaultToZero() {
+        helper.createDatabase(TEST_DB, 9).close()
+        val db = helper.runMigrationsAndValidate(TEST_DB, 10, true, MIGRATION_9_10)
+        MIGRATION_10_11.migrate(db)
+        assertEquals("chapters.version default must be 0", "0", db.columnDefaultValue("chapters", "version"))
+        assertEquals("chapters.is_syncing default must be 0", "0", db.columnDefaultValue("chapters", "is_syncing"))
+        db.close()
+    }
+
+    // ── Migration 11 → 12 ───────────────────────────────────────────────────
+    // Adds: manga.last_modified_at (INTEGER DEFAULT 0)
+    //       chapters.last_modified_at (INTEGER DEFAULT 0)
+
+    @Test
+    fun migration11To12_addsLastModifiedAtToMangaAndChapters() {
+        helper.createDatabase(TEST_DB, 9).close()
+        val db = helper.runMigrationsAndValidate(TEST_DB, 10, true, MIGRATION_9_10)
+        MIGRATION_10_11.migrate(db)
+        assertFalse("manga.last_modified_at must NOT exist at v11", "last_modified_at" in db.columnNames("manga"))
+        assertFalse("chapters.last_modified_at must NOT exist at v11", "last_modified_at" in db.columnNames("chapters"))
+        MIGRATION_11_12.migrate(db)
+        assertTrue("manga.last_modified_at must exist after 11→12", "last_modified_at" in db.columnNames("manga"))
+        assertTrue("chapters.last_modified_at must exist after 11→12", "last_modified_at" in db.columnNames("chapters"))
+        db.close()
+    }
+
+    @Test
+    fun migration11To12_lastModifiedAtDefaultsToZero() {
+        helper.createDatabase(TEST_DB, 9).close()
+        val db = helper.runMigrationsAndValidate(TEST_DB, 10, true, MIGRATION_9_10)
+        MIGRATION_10_11.migrate(db)
+        MIGRATION_11_12.migrate(db)
+        assertEquals("manga.last_modified_at default must be 0", "0", db.columnDefaultValue("manga", "last_modified_at"))
+        assertEquals("chapters.last_modified_at default must be 0", "0", db.columnDefaultValue("chapters", "last_modified_at"))
         db.close()
     }
 
@@ -270,7 +327,12 @@ class DatabaseMigrationTest {
         assertTrue("page_bookmarks must exist after full chain", "page_bookmarks" in tables)
         assertTrue("tracker_sync_state must exist after full chain", "tracker_sync_state" in tables)
         assertTrue("contentRating must exist in manga after full chain", "contentRating" in db.columnNames("manga"))
-        assertTrue("userNotes must exist in chapters after full chain", "userNotes" in db.columnNames("chapters"))
+        assertTrue("last_modified_at must exist in manga after full chain", "last_modified_at" in db.columnNames("manga"))
+        val chapterCols = db.columnNames("chapters")
+        assertTrue("userNotes must exist in chapters after full chain", "userNotes" in chapterCols)
+        assertTrue("version must exist in chapters after full chain", "version" in chapterCols)
+        assertTrue("is_syncing must exist in chapters after full chain", "is_syncing" in chapterCols)
+        assertTrue("last_modified_at must exist in chapters after full chain", "last_modified_at" in chapterCols)
         db.close()
     }
 }
@@ -304,4 +366,15 @@ private fun SupportSQLiteDatabase.indexNames(table: String): Set<String> {
         while (cursor.moveToNext()) names.add(cursor.getString(nameIdx))
     }
     return names
+}
+
+private fun SupportSQLiteDatabase.columnDefaultValue(table: String, column: String): String? {
+    query("PRAGMA table_info(`$table`)").use { cursor ->
+        val nameIdx = cursor.getColumnIndex("name")
+        val dfltIdx = cursor.getColumnIndex("dflt_value")
+        while (cursor.moveToNext()) {
+            if (cursor.getString(nameIdx) == column) return cursor.getString(dfltIdx)
+        }
+    }
+    return null
 }

--- a/core/network/src/main/java/app/otakureader/core/network/TrackerCertificatePinner.kt
+++ b/core/network/src/main/java/app/otakureader/core/network/TrackerCertificatePinner.kt
@@ -5,18 +5,16 @@ import okhttp3.CertificatePinner
 /**
  * Certificate pins for tracker OAuth/API endpoints.
  *
- * Pins are SHA-256 SPKI hashes of the leaf or intermediate certificates.
- * Update these whenever a tracker rotates its certificate chain.
+ * Pins are SHA-256 SPKI hashes of the leaf certificate plus a shared intermediate
+ * CA backup pin (DigiCert Global Root G3) so that a leaf rotation does not break
+ * the app until the next release.
  *
- * How to get new pins:
- *   openssl s_client -connect <host>:443 -showcerts </dev/null 2>/dev/null \
+ * Last extracted: 2026-05-04 via:
+ *   openssl s_client -connect <host>:443 -servername <host> 2>/dev/null \
  *     | openssl x509 -pubkey -noout | openssl pkey -pubin -outform der \
  *     | openssl dgst -sha256 -binary | base64
  *
  * Or use: `okhttp3.CertificatePinner.pin(certificate)` in a test.
- *
- * All domains are pinned to both the current leaf and at least one CA backup pin
- * so that a leaf rotation does not break the app until the next release.
  */
 object TrackerCertificatePinner {
 
@@ -27,26 +25,26 @@ object TrackerCertificatePinner {
     fun build(): CertificatePinner = CertificatePinner.Builder()
         // ── MyAnimeList ─────────────────────────────────────────────────────
         // OAuth: myanimelist.net/v1/oauth2/  API: api.myanimelist.net/v2/
-        // Leaf: *.myanimelist.net; backup: DigiCert Global G3 TLS ECC SHA384 2020 CA1.
-        .add("myanimelist.net", "sha256/1PnQBMduiWmZ1W9s5g4Oc60IzJ7btXnnVSXB5bCkNPk=")
-        .add("myanimelist.net", "sha256/qBRjZmOmkSNJL0p70zek7odSIzqs/muR4Jk9xYyCP+E=")
-        .add("api.myanimelist.net", "sha256/1PnQBMduiWmZ1W9s5g4Oc60IzJ7btXnnVSXB5bCkNPk=")
-        .add("api.myanimelist.net", "sha256/qBRjZmOmkSNJL0p70zek7odSIzqs/muR4Jk9xYyCP+E=")
+        // Backup: DigiCert Global Root G3 (shared across all trackers below).
+        .add("myanimelist.net", "sha256/efrF+PUxbl1xw8PF8f6KvRrel4/kWrRWFWuu6PQj2bo=")
+        .add("myanimelist.net", "sha256/IgG8q1Egd9jBnrvbTB6BsLEvZ1aYqrym+IPQIxy5qiE=")
+        .add("api.myanimelist.net", "sha256/JhaUbPsimbNLHKKcoc09+5qss1K+Hb8XpX2uthsDY4A=")
+        .add("api.myanimelist.net", "sha256/IgG8q1Egd9jBnrvbTB6BsLEvZ1aYqrym+IPQIxy5qiE=")
         // ── AniList ─────────────────────────────────────────────────────────
-        // graphql.anilist.co (CDN); leaf: anilist.co; backup: Google Trust Services WE1.
-        .add("graphql.anilist.co", "sha256/cMLTuYuw3mxbtrZkTAITlFUb4BJk07ZN+FBEwFAk0p0=")
-        .add("graphql.anilist.co", "sha256/kIdp6NNEd8wsugYyyIYFsi1ylMCED3hZbSR8ZFsa/A4=")
+        // graphql.anilist.co; backup: DigiCert Global Root G3.
+        .add("graphql.anilist.co", "sha256/qvGMxVkebAxISqRUcDy3CljP+wieT8aKikYTCVu0PH4=")
+        .add("graphql.anilist.co", "sha256/IgG8q1Egd9jBnrvbTB6BsLEvZ1aYqrym+IPQIxy5qiE=")
         // ── Kitsu ───────────────────────────────────────────────────────────
-        // kitsu.app; backup: Google Trust Services WE1.
-        .add("kitsu.app", "sha256/b5aSqS7V973sG4EAVWgVHPmEXOnYKSUG8UfJOcbDStQ=")
-        .add("kitsu.app", "sha256/kIdp6NNEd8wsugYyyIYFsi1ylMCED3hZbSR8ZFsa/A4=")
+        // kitsu.app; backup: DigiCert Global Root G3.
+        .add("kitsu.app", "sha256/Hrs6IIkHfcrDYD7JZOmpHh/QXgq4ZfY7IKy+UnzF4bA=")
+        .add("kitsu.app", "sha256/IgG8q1Egd9jBnrvbTB6BsLEvZ1aYqrym+IPQIxy5qiE=")
         // ── MangaUpdates ────────────────────────────────────────────────────
-        // api.mangaupdates.com; backup: Sectigo RSA Domain Validation Secure Server CA.
-        .add("api.mangaupdates.com", "sha256/VR9Xi9oQj5iUu0cZo5/Hxmz1j0azgQAvk8L6fVKWyLY=")
-        .add("api.mangaupdates.com", "sha256/4a6cPehI7OG6cuDZka5NDZ7FR8a60d3auda+sKfg4Ng=")
+        // api.mangaupdates.com; backup: DigiCert Global Root G3.
+        .add("api.mangaupdates.com", "sha256/02qttGMepJs9pxcSmAyDxfnjZv0EoAw8IkZSv+rzbu8=")
+        .add("api.mangaupdates.com", "sha256/IgG8q1Egd9jBnrvbTB6BsLEvZ1aYqrym+IPQIxy5qiE=")
         // ── Shikimori ───────────────────────────────────────────────────────
-        // shikimori.one; backup: Let's Encrypt R12.
-        .add("shikimori.one", "sha256/sUAluX+bd0A/FbvCaXQg7Siq3gMgCfIdbMHX4VkGnMw=")
-        .add("shikimori.one", "sha256/kZwN96eHtZftBWrOZUsd6cA4es80n3NzSk/XtYz2EqQ=")
+        // shikimori.one; backup: DigiCert Global Root G3.
+        .add("shikimori.one", "sha256/1biKOxoipnu596Dxf12XU0Vu2EXlLUQnUj4p+ycBKSY=")
+        .add("shikimori.one", "sha256/IgG8q1Egd9jBnrvbTB6BsLEvZ1aYqrym+IPQIxy5qiE=")
         .build()
 }

--- a/feature/browse/build.gradle.kts
+++ b/feature/browse/build.gradle.kts
@@ -18,4 +18,9 @@ dependencies {
     implementation(libs.lifecycle.viewmodel.ktx)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.coil.compose)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.turbine)
 }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseMvi.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseMvi.kt
@@ -15,6 +15,7 @@ data class BrowseState(
     val searchQuery: String = "",
     val searchResults: List<SourceManga> = emptyList(),
     val isSearching: Boolean = false,
+    val hasSearchResults: Boolean = false,
     val error: String? = null,
     val hasNextPage: Boolean = false,
     val currentPage: Int = 1,

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -251,14 +251,14 @@ private fun BrowseContent(
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        if (state.isSearching) {
-            // Show search results
+        if (state.isSearching || state.hasSearchResults) {
+            // Show search results (isSearching acts as loading indicator within results view)
             SearchResultsContent(
                 results = state.searchResults,
                 onMangaClick = { onEvent(BrowseEvent.OnMangaClick(it)) },
                 onLoadMore = { onEvent(BrowseEvent.LoadNextPage) },
                 hasNextPage = state.hasNextPage,
-                isLoading = state.isLoading
+                isLoading = state.isSearching
             )
         } else {
             // Show sources and popular manga

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -258,7 +258,7 @@ private fun BrowseContent(
                 onMangaClick = { onEvent(BrowseEvent.OnMangaClick(it)) },
                 onLoadMore = { onEvent(BrowseEvent.LoadNextPage) },
                 hasNextPage = state.hasNextPage,
-                isLoading = state.isSearching
+                isLoading = state.isSearching || state.isLoading
             )
         } else {
             // Show sources and popular manga

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -79,7 +80,9 @@ class BrowseViewModel @Inject constructor(
                     it.copy(
                         currentSourceId = event.sourceId,
                         availableFilters = FilterList(),
-                        activeFilters = FilterList()
+                        activeFilters = FilterList(),
+                        hasSearchResults = false,
+                        searchResults = emptyList()
                     )
                 }
                 loadPopularManga(event.sourceId)
@@ -90,7 +93,12 @@ class BrowseViewModel @Inject constructor(
                 navigateToDetail(sourceId, event.manga.url)
             }
             is BrowseEvent.OnSearchQueryChange -> {
-                _state.update { it.copy(searchQuery = event.query) }
+                _state.update {
+                    it.copy(
+                        searchQuery = event.query,
+                        hasSearchResults = if (event.query.isBlank()) false else it.hasSearchResults
+                    )
+                }
             }
             is BrowseEvent.Search -> performSearch()
             is BrowseEvent.LoadNextPage -> loadNextPage()
@@ -181,7 +189,7 @@ class BrowseViewModel @Inject constructor(
         val sourceId = _state.value.currentSourceId ?: return
 
         viewModelScope.launch {
-            _state.update { it.copy(isSearching = true, error = null) }
+            _state.update { it.copy(isSearching = true, hasSearchResults = true, error = null) }
             searchMangaUseCase(sourceId, query, 1, _state.value.activeFilters)
                 .onSuccess { mangaPage ->
                     _state.update {
@@ -197,6 +205,7 @@ class BrowseViewModel @Inject constructor(
                     _state.update {
                         it.copy(
                             isSearching = false,
+                            hasSearchResults = false,
                             error = error.message ?: "Search failed"
                         )
                     }
@@ -339,13 +348,14 @@ class BrowseViewModel @Inject constructor(
     // --- Saved Searches ---
 
     private fun observeSavedSearches() {
-        val currentSourceId = _state.value.currentSourceId
-        feedRepository.getSavedSearches()
-            .map { searches ->
-                if (currentSourceId != null) searches.filter { it.sourceId.toString() == currentSourceId }
-                else searches
-            }
-            .onEach { searches -> _state.update { it.copy(savedSearches = searches) } }
+        combine(
+            feedRepository.getSavedSearches(),
+            _state.map { it.currentSourceId }.distinctUntilChanged()
+        ) { searches, sourceId ->
+            if (sourceId != null) searches.filter { it.sourceId.toString() == sourceId }
+            else searches
+        }
+            .onEach { filtered -> _state.update { it.copy(savedSearches = filtered) } }
             .launchIn(viewModelScope)
     }
 

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
@@ -79,6 +79,7 @@ class BrowseViewModel @Inject constructor(
                 _state.update {
                     it.copy(
                         currentSourceId = event.sourceId,
+                        searchQuery = "",
                         availableFilters = FilterList(),
                         activeFilters = FilterList(),
                         hasSearchResults = false,
@@ -352,7 +353,7 @@ class BrowseViewModel @Inject constructor(
             feedRepository.getSavedSearches(),
             _state.map { it.currentSourceId }.distinctUntilChanged()
         ) { searches, sourceId ->
-            if (sourceId != null) searches.filter { it.sourceId.toString() == sourceId }
+            if (sourceId != null) searches.filter { it.sourceName == sourceId }
             else searches
         }
             .onEach { filtered -> _state.update { it.copy(savedSearches = filtered) } }

--- a/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
+++ b/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
@@ -3,6 +3,7 @@ package app.otakureader.feature.browse
 import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.domain.model.FeedSavedSearch
 import app.otakureader.domain.repository.FeedRepository
+import kotlinx.coroutines.flow.MutableStateFlow
 import app.otakureader.domain.usecase.library.AddMangaToLibraryUseCase
 import app.otakureader.domain.usecase.source.GetLatestUpdatesUseCase
 import app.otakureader.domain.usecase.source.GetPopularMangaUseCase
@@ -227,6 +228,147 @@ class BrowseViewModelTest {
 
         val effect = viewModel.effect.first()
         assertTrue(effect is BrowseEffect.ShowSnackbar)
+    }
+
+    @Test
+    fun `search results remain visible after search completes`() = runTest {
+        val source = MangaSource(id = "1", name = "Test Source", lang = "en", isNsfw = false)
+        val mangaPage = MangaPage(
+            mangas = listOf(SourceManga(title = "Naruto", url = "url1", thumbnailUrl = null)),
+            hasNextPage = false
+        )
+
+        every { getSourcesUseCase() } returns flowOf(listOf(source))
+        coEvery { searchMangaUseCase("1", "Naruto", 1, any()) } returns Result.success(mangaPage)
+        every { getSourceFiltersUseCase("1") } returns FilterList()
+
+        viewModel.onEvent(BrowseEvent.SelectSource("1"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(BrowseEvent.OnSearchQueryChange("Naruto"))
+        viewModel.onEvent(BrowseEvent.Search)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertFalse("isSearching must be false after search completes", state.isSearching)
+        assertTrue("hasSearchResults must be true after successful search", state.hasSearchResults)
+        assertEquals(1, state.searchResults.size)
+    }
+
+    @Test
+    fun `selecting source resets search results`() = runTest {
+        val source1 = MangaSource(id = "1", name = "Source 1", lang = "en", isNsfw = false)
+        val source2 = MangaSource(id = "2", name = "Source 2", lang = "en", isNsfw = false)
+        val mangaPage = MangaPage(
+            mangas = listOf(SourceManga(title = "Manga 1", url = "url1", thumbnailUrl = null)),
+            hasNextPage = false
+        )
+
+        every { getSourcesUseCase() } returns flowOf(listOf(source1, source2))
+        coEvery { searchMangaUseCase("1", "query", 1, any()) } returns Result.success(mangaPage)
+        coEvery { getPopularMangaUseCase("2", 1) } returns Result.success(MangaPage(emptyList(), false))
+        every { getSourceFiltersUseCase(any()) } returns FilterList()
+
+        viewModel.onEvent(BrowseEvent.SelectSource("1"))
+        testDispatcher.scheduler.advanceUntilIdle()
+        viewModel.onEvent(BrowseEvent.OnSearchQueryChange("query"))
+        viewModel.onEvent(BrowseEvent.Search)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue("hasSearchResults must be true after search", viewModel.state.value.hasSearchResults)
+
+        viewModel.onEvent(BrowseEvent.SelectSource("2"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse("hasSearchResults must be false after source change", viewModel.state.value.hasSearchResults)
+        assertEquals(0, viewModel.state.value.searchResults.size)
+    }
+
+    @Test
+    fun `clearing query resets hasSearchResults`() = runTest {
+        val source = MangaSource(id = "1", name = "Test Source", lang = "en", isNsfw = false)
+        val mangaPage = MangaPage(
+            mangas = listOf(SourceManga(title = "Manga", url = "url1", thumbnailUrl = null)),
+            hasNextPage = false
+        )
+
+        every { getSourcesUseCase() } returns flowOf(listOf(source))
+        coEvery { searchMangaUseCase("1", "query", 1, any()) } returns Result.success(mangaPage)
+        every { getSourceFiltersUseCase("1") } returns FilterList()
+
+        viewModel.onEvent(BrowseEvent.SelectSource("1"))
+        testDispatcher.scheduler.advanceUntilIdle()
+        viewModel.onEvent(BrowseEvent.OnSearchQueryChange("query"))
+        viewModel.onEvent(BrowseEvent.Search)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue("hasSearchResults must be true after search", viewModel.state.value.hasSearchResults)
+
+        viewModel.onEvent(BrowseEvent.OnSearchQueryChange(""))
+        assertEquals("hasSearchResults must be false when query cleared", false, viewModel.state.value.hasSearchResults)
+    }
+
+    @Test
+    fun `saved searches filtered to selected source`() = runTest {
+        val search1 = FeedSavedSearch(id = 1L, sourceId = 1L, sourceName = "Source 1", query = "one piece", filters = emptyMap())
+        val search2 = FeedSavedSearch(id = 2L, sourceId = 2L, sourceName = "Source 2", query = "naruto", filters = emptyMap())
+        val source = MangaSource(id = "1", name = "Source 1", lang = "en", isNsfw = false)
+
+        every { feedRepository.getSavedSearches() } returns flowOf(listOf(search1, search2))
+        every { getSourcesUseCase() } returns flowOf(listOf(source))
+        every { getSourceFiltersUseCase("1") } returns FilterList()
+        coEvery { getPopularMangaUseCase("1", 1) } returns Result.success(MangaPage(emptyList(), false))
+
+        viewModel = BrowseViewModel(
+            getSourcesUseCase = getSourcesUseCase,
+            getPopularMangaUseCase = getPopularMangaUseCase,
+            getLatestUpdatesUseCase = getLatestUpdatesUseCase,
+            searchMangaUseCase = searchMangaUseCase,
+            getSourceFiltersUseCase = getSourceFiltersUseCase,
+            addMangaToLibraryUseCase = addMangaToLibraryUseCase,
+            feedRepository = feedRepository,
+            generalPreferences = generalPreferences
+        )
+
+        viewModel.onEvent(BrowseEvent.SelectSource("1"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val savedSearches = viewModel.state.value.savedSearches
+        assertEquals(1, savedSearches.size)
+        assertEquals("one piece", savedSearches[0].query)
+    }
+
+    @Test
+    fun `saved searches update when source changes`() = runTest {
+        val search1 = FeedSavedSearch(id = 1L, sourceId = 1L, sourceName = "Source 1", query = "one piece", filters = emptyMap())
+        val search2 = FeedSavedSearch(id = 2L, sourceId = 2L, sourceName = "Source 2", query = "naruto", filters = emptyMap())
+        val source1 = MangaSource(id = "1", name = "Source 1", lang = "en", isNsfw = false)
+        val source2 = MangaSource(id = "2", name = "Source 2", lang = "en", isNsfw = false)
+
+        val savedSearchFlow = MutableStateFlow(listOf(search1, search2))
+        every { feedRepository.getSavedSearches() } returns savedSearchFlow
+        every { getSourcesUseCase() } returns flowOf(listOf(source1, source2))
+        every { getSourceFiltersUseCase(any()) } returns FilterList()
+        coEvery { getPopularMangaUseCase(any(), 1) } returns Result.success(MangaPage(emptyList(), false))
+
+        viewModel = BrowseViewModel(
+            getSourcesUseCase = getSourcesUseCase,
+            getPopularMangaUseCase = getPopularMangaUseCase,
+            getLatestUpdatesUseCase = getLatestUpdatesUseCase,
+            searchMangaUseCase = searchMangaUseCase,
+            getSourceFiltersUseCase = getSourceFiltersUseCase,
+            addMangaToLibraryUseCase = addMangaToLibraryUseCase,
+            feedRepository = feedRepository,
+            generalPreferences = generalPreferences
+        )
+
+        viewModel.onEvent(BrowseEvent.SelectSource("1"))
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, viewModel.state.value.savedSearches.size)
+        assertEquals("one piece", viewModel.state.value.savedSearches[0].query)
+
+        viewModel.onEvent(BrowseEvent.SelectSource("2"))
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, viewModel.state.value.savedSearches.size)
+        assertEquals("naruto", viewModel.state.value.savedSearches[0].query)
     }
 
     @Test

--- a/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
+++ b/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
@@ -3,7 +3,6 @@ package app.otakureader.feature.browse
 import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.domain.model.FeedSavedSearch
 import app.otakureader.domain.repository.FeedRepository
-import kotlinx.coroutines.flow.MutableStateFlow
 import app.otakureader.domain.usecase.library.AddMangaToLibraryUseCase
 import app.otakureader.domain.usecase.source.GetLatestUpdatesUseCase
 import app.otakureader.domain.usecase.source.GetPopularMangaUseCase
@@ -308,8 +307,8 @@ class BrowseViewModelTest {
 
     @Test
     fun `saved searches filtered to selected source`() = runTest {
-        val search1 = FeedSavedSearch(id = 1L, sourceId = 1L, sourceName = "Source 1", query = "one piece", filters = emptyMap())
-        val search2 = FeedSavedSearch(id = 2L, sourceId = 2L, sourceName = "Source 2", query = "naruto", filters = emptyMap())
+        val search1 = FeedSavedSearch(id = 1L, sourceId = 1L, sourceName = "1", query = "one piece", filters = emptyMap())
+        val search2 = FeedSavedSearch(id = 2L, sourceId = 2L, sourceName = "2", query = "naruto", filters = emptyMap())
         val source = MangaSource(id = "1", name = "Source 1", lang = "en", isNsfw = false)
 
         every { feedRepository.getSavedSearches() } returns flowOf(listOf(search1, search2))
@@ -338,8 +337,8 @@ class BrowseViewModelTest {
 
     @Test
     fun `saved searches update when source changes`() = runTest {
-        val search1 = FeedSavedSearch(id = 1L, sourceId = 1L, sourceName = "Source 1", query = "one piece", filters = emptyMap())
-        val search2 = FeedSavedSearch(id = 2L, sourceId = 2L, sourceName = "Source 2", query = "naruto", filters = emptyMap())
+        val search1 = FeedSavedSearch(id = 1L, sourceId = 1L, sourceName = "1", query = "one piece", filters = emptyMap())
+        val search2 = FeedSavedSearch(id = 2L, sourceId = 2L, sourceName = "2", query = "naruto", filters = emptyMap())
         val source1 = MangaSource(id = "1", name = "Source 1", lang = "en", isNsfw = false)
         val source2 = MangaSource(id = "2", name = "Source 2", lang = "en", isNsfw = false)
 

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -18,7 +18,8 @@ enum class LibraryFilterMode {
     UNREAD,
     COMPLETED,
     DROPPED,
-    TRACKING
+    TRACKING,
+    READING_LIST
 }
 
 data class LibraryState(
@@ -40,6 +41,10 @@ data class LibraryState(
     val showNsfw: Boolean = false,
     val newUpdatesCount: Int = 0,
     val categoryFilterMangaIds: Set<Long> = emptySet(), // Manga IDs in selected category
+    // Reading list filter
+    val readingLists: List<ReadingListFilterItem> = emptyList(),
+    val filterReadingListId: Long? = null,
+    val readingListMangaIds: Set<Long> = emptySet(),
     // Continue Reading
     val continueReadingItems: List<ContinueReadingItem> = emptyList(),
     // Daily reading goal progress (shown in header when a goal is set)
@@ -71,6 +76,12 @@ data class CategoryItem(
     val count: Int
 )
 
+data class ReadingListFilterItem(
+    val id: Long,
+    val name: String,
+    val count: Int
+)
+
 sealed class LibraryEvent {
     data object Refresh : LibraryEvent()
     data class OnMangaClick(val mangaId: Long) : LibraryEvent()
@@ -92,6 +103,8 @@ sealed class LibraryEvent {
     data object DownloadSelected : LibraryEvent()
     // Continue Reading
     data class ContinueReadingClick(val mangaId: Long, val chapterId: Long) : LibraryEvent()
+    // Reading list filter (null = clear/show all)
+    data class SetFilterReadingList(val listId: Long?) : LibraryEvent()
 }
 
 sealed class LibraryEffect {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -385,6 +385,21 @@ private fun MangaGrid(
             )
         }
 
+        // Reading list filter chips (full-width span, only shown when reading lists exist)
+        if (state.readingLists.isNotEmpty()) {
+            item(
+                span = { GridItemSpan(maxLineSpan) },
+                contentType = "reading_list_filter_section"
+            ) {
+                ReadingListFilterChips(
+                    readingLists = state.readingLists,
+                    selectedListId = state.filterReadingListId,
+                    onListSelected = { onEvent(LibraryEvent.SetFilterReadingList(it)) },
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+            }
+        }
+
         // Manga grid items
         gridItems(
             items = state.mangaList,
@@ -496,6 +511,39 @@ private fun CategoryFilterChips(
                 label = category.name,
                 selected = selectedCategory == category.id,
                 onClick = { onCategorySelected(category.id) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReadingListFilterChips(
+    readingLists: List<ReadingListFilterItem>,
+    selectedListId: Long?,
+    onListSelected: (Long?) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier.fillMaxWidth()
+    ) {
+        item {
+            OtakuChip(
+                label = stringResource(R.string.library_reading_list_all),
+                selected = selectedListId == null,
+                onClick = { onListSelected(null) },
+            )
+        }
+
+        items(
+            items = readingLists,
+            key = { it.id }
+        ) { list ->
+            OtakuChip(
+                label = list.name,
+                selected = selectedListId == list.id,
+                onClick = { onListSelected(list.id) },
             )
         }
     }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -10,6 +10,7 @@ import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
+import app.otakureader.domain.repository.ReadingListRepository
 import app.otakureader.domain.repository.StatisticsRepository
 import app.otakureader.domain.tracking.TrackRepository
 import app.otakureader.domain.usecase.GetCategoriesUseCase
@@ -31,6 +32,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -51,6 +53,7 @@ class LibraryViewModel @Inject constructor(
     private val getContinueReading: GetContinueReadingUseCase,
     private val readingGoalPreferences: ReadingGoalPreferences,
     private val statisticsRepository: StatisticsRepository,
+    private val readingListRepository: ReadingListRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(LibraryState())
@@ -70,6 +73,7 @@ class LibraryViewModel @Inject constructor(
         observeNewUpdatesCount()
         observeContinueReading()
         observeGoalProgress()
+        observeReadingLists()
     }
 
     fun onEvent(event: LibraryEvent) {
@@ -92,6 +96,7 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.RemoveSelectedFromLibrary -> removeSelectedFromLibrary()
             is LibraryEvent.DownloadSelected -> downloadSelected()
             is LibraryEvent.ContinueReadingClick -> onContinueReadingClick(event.mangaId, event.chapterId)
+            is LibraryEvent.SetFilterReadingList -> onSetFilterReadingList(event.listId)
         }
     }
 
@@ -215,7 +220,9 @@ class LibraryViewModel @Inject constructor(
         val filterSourceId: Long?,
         val showNsfw: Boolean,
         val selectedCategory: Long?,
-        val categoryMangaIds: Set<Long> = emptySet() // Manga IDs in the selected category
+        val categoryMangaIds: Set<Long> = emptySet(),
+        val filterReadingListId: Long? = null,
+        val readingListMangaIds: Set<Long> = emptySet()
     )
 
     private fun observeFilteredItems() {
@@ -233,10 +240,24 @@ class LibraryViewModel @Inject constructor(
                 }
         }
 
-        // Combine all items with filter params (now including category manga IDs from state)
+        // When reading list filter changes, reactively track the manga IDs in that list
+        _state.map { it.filterReadingListId }
+            .distinctUntilChanged()
+            .flatMapLatest { listId ->
+                if (listId != null) {
+                    readingListRepository.getListWithManga(listId)
+                        .map { (_, items) -> items.map { it.manga.id }.toSet() }
+                } else {
+                    flowOf(emptySet())
+                }
+            }
+            .onEach { ids -> _state.update { it.copy(readingListMangaIds = ids) } }
+            .launchIn(viewModelScope)
+
+        // Combine all items with filter params (now including category and reading list manga IDs from state)
         combine(
             _allItems,
-            _state.map { 
+            _state.map {
                 FilterSortParams(
                     query = it.searchQuery,
                     filterHasNotes = it.filterHasNotes,
@@ -245,7 +266,9 @@ class LibraryViewModel @Inject constructor(
                     filterSourceId = it.filterSourceId,
                     showNsfw = it.showNsfw,
                     selectedCategory = it.selectedCategory,
-                    categoryMangaIds = it.categoryFilterMangaIds
+                    categoryMangaIds = it.categoryFilterMangaIds,
+                    filterReadingListId = it.filterReadingListId,
+                    readingListMangaIds = it.readingListMangaIds
                 )
             }.distinctUntilChanged()
         ) { items, params ->
@@ -296,6 +319,7 @@ class LibraryViewModel @Inject constructor(
             LibraryFilterMode.COMPLETED -> filtered.filter { it.userCompleted }
             LibraryFilterMode.DROPPED -> filtered.filter { it.userDropped }
             LibraryFilterMode.TRACKING -> filtered.filter { it.hasTracking }
+            LibraryFilterMode.READING_LIST -> filtered.filter { it.id in params.readingListMangaIds }
             LibraryFilterMode.ALL -> filtered
         }
 
@@ -466,6 +490,30 @@ class LibraryViewModel @Inject constructor(
     private fun onContinueReadingClick(mangaId: Long, chapterId: Long) {
         viewModelScope.launch {
             _effect.send(LibraryEffect.NavigateToReader(mangaId, chapterId))
+        }
+    }
+
+    private fun observeReadingLists() {
+        readingListRepository.getAllLists()
+            .map { lists ->
+                lists.map { list ->
+                    ReadingListFilterItem(
+                        id = list.id,
+                        name = list.name,
+                        count = list.itemCount
+                    )
+                }
+            }
+            .onEach { items -> _state.update { it.copy(readingLists = items) } }
+            .launchIn(viewModelScope)
+    }
+
+    private fun onSetFilterReadingList(listId: Long?) {
+        _state.update {
+            it.copy(
+                filterReadingListId = listId,
+                filterMode = if (listId != null) LibraryFilterMode.READING_LIST else LibraryFilterMode.ALL
+            )
         }
     }
 

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -312,6 +312,11 @@ class LibraryViewModel @Inject constructor(
             filtered = filtered.filter { it.sourceId == params.filterSourceId }
         }
 
+        // Reading list filter (applied independently of filterMode to avoid DataStore conflicts)
+        if (params.filterReadingListId != null) {
+            filtered = filtered.filter { it.id in params.readingListMangaIds }
+        }
+
         // Filter mode
         filtered = when (params.filterMode) {
             LibraryFilterMode.DOWNLOADED -> filtered.filter { it.isDownloaded }
@@ -319,7 +324,7 @@ class LibraryViewModel @Inject constructor(
             LibraryFilterMode.COMPLETED -> filtered.filter { it.userCompleted }
             LibraryFilterMode.DROPPED -> filtered.filter { it.userDropped }
             LibraryFilterMode.TRACKING -> filtered.filter { it.hasTracking }
-            LibraryFilterMode.READING_LIST -> filtered.filter { it.id in params.readingListMangaIds }
+            LibraryFilterMode.READING_LIST -> filtered
             LibraryFilterMode.ALL -> filtered
         }
 
@@ -504,17 +509,21 @@ class LibraryViewModel @Inject constructor(
                     )
                 }
             }
-            .onEach { items -> _state.update { it.copy(readingLists = items) } }
+            .onEach { items ->
+                _state.update { state ->
+                    val currentListId = state.filterReadingListId
+                    val stillExists = currentListId == null || items.any { it.id == currentListId }
+                    state.copy(
+                        readingLists = items,
+                        filterReadingListId = if (stillExists) currentListId else null
+                    )
+                }
+            }
             .launchIn(viewModelScope)
     }
 
     private fun onSetFilterReadingList(listId: Long?) {
-        _state.update {
-            it.copy(
-                filterReadingListId = listId,
-                filterMode = if (listId != null) LibraryFilterMode.READING_LIST else LibraryFilterMode.ALL
-            )
-        }
+        _state.update { it.copy(filterReadingListId = listId) }
     }
 
     private fun Manga.toLibraryItem(

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -99,4 +99,6 @@
     <string name="manga_status_publishing_finished">Publishing Finished</string>
     <string name="manga_status_cancelled">Cancelled</string>
     <string name="manga_status_on_hiatus">On Hiatus</string>
+    <string name="library_filter_reading_list">Reading List</string>
+    <string name="library_reading_list_all">All Lists</string>
 </resources>

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -526,7 +526,6 @@ class LibraryViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(42L, viewModel.state.value.filterReadingListId)
-        assertEquals(LibraryFilterMode.READING_LIST, viewModel.state.value.filterMode)
     }
 
     @Test
@@ -541,13 +540,12 @@ class LibraryViewModelTest {
 
         viewModel.onEvent(LibraryEvent.SetFilterReadingList(42L))
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(LibraryFilterMode.READING_LIST, viewModel.state.value.filterMode)
+        assertEquals(42L, viewModel.state.value.filterReadingListId)
 
         viewModel.onEvent(LibraryEvent.SetFilterReadingList(null))
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertNull(viewModel.state.value.filterReadingListId)
-        assertEquals(LibraryFilterMode.ALL, viewModel.state.value.filterMode)
     }
 
     @Test

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -7,8 +7,11 @@ import app.otakureader.core.preferences.ReadingGoalPreferences
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.ReadingGoal
 import app.otakureader.domain.model.MangaStatus
+import app.otakureader.domain.model.ReadingList
+import app.otakureader.domain.model.ReadingListMangaItem
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
+import app.otakureader.domain.repository.ReadingListRepository
 import app.otakureader.domain.repository.StatisticsRepository
 import app.otakureader.domain.tracking.TrackRepository
 import app.otakureader.domain.usecase.GetCategoriesUseCase
@@ -51,6 +54,7 @@ class LibraryViewModelTest {
     private lateinit var getContinueReading: GetContinueReadingUseCase
     private lateinit var readingGoalPreferences: ReadingGoalPreferences
     private lateinit var statisticsRepository: StatisticsRepository
+    private lateinit var readingListRepository: ReadingListRepository
 
     private val sampleMangas = listOf(
         Manga(id = 1L, sourceId = 10L, url = "/m/1", title = "Naruto", favorite = true, unreadCount = 3, lastRead = 1000L, status = MangaStatus.ONGOING),
@@ -97,6 +101,13 @@ class LibraryViewModelTest {
         statisticsRepository = mockk {
             every { getReadingGoalProgress(any(), any()) } returns flowOf(ReadingGoal())
         }
+        readingListRepository = mockk {
+            every { getAllLists() } returns flowOf(emptyList())
+            every { getListWithManga(any()) } returns flowOf(Pair(
+                ReadingList(id = 0L, name = ""),
+                emptyList()
+            ))
+        }
     }
 
     @After
@@ -117,6 +128,7 @@ class LibraryViewModelTest {
             getContinueReading,
             readingGoalPreferences,
             statisticsRepository,
+            readingListRepository,
         )
     }
 
@@ -498,5 +510,65 @@ class LibraryViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(updatedGoal, viewModel.state.value.readingGoal)
+    }
+
+    @Test
+    fun setFilterReadingList_withListId_setsReadingListMode() = runTest {
+        every { getLibraryManga() } returns flowOf(emptyList())
+        val list = ReadingList(id = 42L, name = "Favorites", itemCount = 3)
+        every { readingListRepository.getAllLists() } returns flowOf(listOf(list))
+        every { readingListRepository.getListWithManga(42L) } returns flowOf(Pair(list, emptyList()))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(LibraryEvent.SetFilterReadingList(42L))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(42L, viewModel.state.value.filterReadingListId)
+        assertEquals(LibraryFilterMode.READING_LIST, viewModel.state.value.filterMode)
+    }
+
+    @Test
+    fun setFilterReadingList_withNullId_resetsToAll() = runTest {
+        every { getLibraryManga() } returns flowOf(emptyList())
+        val list = ReadingList(id = 42L, name = "Favorites", itemCount = 3)
+        every { readingListRepository.getAllLists() } returns flowOf(listOf(list))
+        every { readingListRepository.getListWithManga(42L) } returns flowOf(Pair(list, emptyList()))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(LibraryEvent.SetFilterReadingList(42L))
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(LibraryFilterMode.READING_LIST, viewModel.state.value.filterMode)
+
+        viewModel.onEvent(LibraryEvent.SetFilterReadingList(null))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(viewModel.state.value.filterReadingListId)
+        assertEquals(LibraryFilterMode.ALL, viewModel.state.value.filterMode)
+    }
+
+    @Test
+    fun readingListFilter_filtersToListManga() = runTest {
+        val mangaInList = sampleMangas[0]
+        val mangaNotInList = sampleMangas[1]
+        every { getLibraryManga() } returns flowOf(listOf(mangaInList, mangaNotInList))
+
+        val list = ReadingList(id = 1L, name = "My List", itemCount = 1)
+        val listMangaItem = ReadingListMangaItem(manga = mangaInList)
+        every { readingListRepository.getAllLists() } returns flowOf(listOf(list))
+        every { readingListRepository.getListWithManga(1L) } returns flowOf(Pair(list, listOf(listMangaItem)))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(LibraryEvent.SetFilterReadingList(1L))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val mangaList = viewModel.state.value.mangaList
+        assertEquals(1, mangaList.size)
+        assertEquals(mangaInList.id, mangaList[0].id)
     }
 }

--- a/feature/more/src/main/java/app/otakureader/feature/more/MoreScreen.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/MoreScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Notifications
@@ -65,6 +66,7 @@ fun MoreScreen(
     onNavigateToFeed: () -> Unit = {},
     onNavigateToShareLibrary: () -> Unit = {},
     onNavigateToScanLibrary: () -> Unit = {},
+    onNavigateToUpdateErrors: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -173,6 +175,17 @@ fun MoreScreen(
                 headline = stringResource(R.string.more_downloads),
                 supporting = stringResource(R.string.more_downloads_desc),
                 onClick = onNavigateToDownloads
+            )
+
+            HorizontalDivider()
+
+            MoreListItem(
+                icon = Icons.Default.ErrorOutline,
+                iconContainerColor = MaterialTheme.colorScheme.errorContainer,
+                iconTint = MaterialTheme.colorScheme.onErrorContainer,
+                headline = stringResource(R.string.more_update_errors),
+                supporting = stringResource(R.string.more_update_errors_desc),
+                onClick = onNavigateToUpdateErrors
             )
 
             HorizontalDivider()

--- a/feature/more/src/main/java/app/otakureader/feature/more/navigation/MoreNavigation.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/navigation/MoreNavigation.kt
@@ -18,6 +18,7 @@ fun NavGraphBuilder.moreScreen(
     onNavigateToFeed: () -> Unit = {},
     onNavigateToShareLibrary: () -> Unit = {},
     onNavigateToScanLibrary: () -> Unit = {},
+    onNavigateToUpdateErrors: () -> Unit = {},
 ) {
     composable<Route.More> {
         MoreScreen(
@@ -29,6 +30,7 @@ fun NavGraphBuilder.moreScreen(
             onNavigateToFeed = onNavigateToFeed,
             onNavigateToShareLibrary = onNavigateToShareLibrary,
             onNavigateToScanLibrary = onNavigateToScanLibrary,
+            onNavigateToUpdateErrors = onNavigateToUpdateErrors,
         )
     }
 }

--- a/feature/more/src/main/res/values/strings.xml
+++ b/feature/more/src/main/res/values/strings.xml
@@ -53,4 +53,8 @@
 
     <!-- Version footer -->
     <string name="more_version_label">Otaku Reader v%s</string>
+
+    <!-- Update Errors -->
+    <string name="more_update_errors">Update Errors</string>
+    <string name="more_update_errors_desc">Review and clear update failures</string>
 </resources>

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -420,6 +420,7 @@ private fun ReaderContent(
                     imageQuality = state.imageQuality,
                     dataSaverEnabled = state.dataSaverEnabled,
                     pageGapDp = state.webtoonGapDp,
+                    disableZoomOut = state.webtoonDisableZoomOut,
                     modifier = Modifier.fillMaxSize()
                 )
             }

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/modes/WebtoonReader.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/modes/WebtoonReader.kt
@@ -47,6 +47,7 @@ fun WebtoonReader(
     imageQuality: ImageQuality = ImageQuality.ORIGINAL,
     dataSaverEnabled: Boolean = false,
     pageGapDp: Int = 4,
+    disableZoomOut: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     val listState = rememberLazyListState(
@@ -143,6 +144,7 @@ fun WebtoonReader(
                     dataSaverEnabled = dataSaverEnabled,
                     onTap = onTap,
                     decoderFactory = webtoonDecoderFactory,
+                    minScale = if (disableZoomOut) 1f else 0.5f,
                     modifier = Modifier.fillMaxWidth()
                 )
             }


### PR DESCRIPTION
## **User description**
## Summary

- **Security (#796):** Rotate all 12 stale SPKI certificate pins in `TrackerCertificatePinner.kt` to freshly extracted hashes; all backup CA pins now share one unified DigiCert Global Root G3 hash. Update `cert-pin-check.yml` EXPECTED_PIN values to match.
- **DB migration test gap (#806 P0):** Add tests for `MIGRATION_10_11` (chapters.version, chapters.is_syncing) and `MIGRATION_11_12` (manga/chapters.last_modified_at) including DEFAULT 0 constraint assertions; extend full-chain test to cover new columns.
- **Browse search results invisible (self-discovered):** Introduce `hasSearchResults` flag in `BrowseState` so the search results view persists after `isSearching` clears. Fix `BrowseContent` condition and add test dep block to `feature/browse/build.gradle.kts` so existing+new tests compile in CI.
- **Saved searches not reactive (self-discovered):** Replace static `currentSourceId` capture in `observeSavedSearches()` with a `combine()` + `distinctUntilChanged()` that reacts to source changes.
- **WebtoonReader disableZoomOut ignored (self-discovered):** Wire `ReaderState.webtoonDisableZoomOut` through `WebtoonReader`'s new `disableZoomOut` parameter to `ZoomableImage.minScale`.
- **Library reading list filter (#806 P1):** Add `READING_LIST` filter mode, `ReadingListFilterItem`, and reactive `ReadingListFilterChips` UI. `LibraryViewModel` injects `ReadingListRepository` and uses `flatMapLatest` to keep filtered manga IDs live.
- **Update Errors in More menu (#806 P3):** Add "Update Errors" entry to `MoreScreen` that navigates to `Route.Updates`.

## Test plan

- [ ] `./gradlew :core:database:connectedAndroidTest` — migration 10→11 and 11→12 tests pass, full chain test passes
- [ ] `./gradlew :feature:browse:test` — all BrowseViewModelTest pass (search results visibility, source reset, reactive saved searches)
- [ ] `./gradlew :feature:library:test` — LibraryViewModelTest passes including three new reading list tests
- [ ] Manual: tracker sync (MAL, AniList, Kitsu, MangaUpdates, Shikimori) works for installed users after cert pin update
- [ ] Manual: Browse → select source → type query → Search → results stay visible after loading completes
- [ ] Manual: Browse → select source A → save search → select source B → saved searches show only source B's entries
- [ ] Manual: Open webtoon → Settings → enable "Disable zoom-out" → pinch-out stops at 100%
- [ ] Manual: Library → create reading list → open library → Reading List chips appear → filter to list contents
- [ ] Manual: More tab → "Update Errors" entry navigates to Updates screen

https://claude.ai/code/session_019UQe6yD97fRuzDGAyQvw7w

---
_Generated by [Claude Code](https://claude.ai/code/session_019UQe6yD97fRuzDGAyQvw7w)_


___

## **CodeAnt-AI Description**
**Fix search, library filtering, and tracker pin issues**

### What Changed
- Search results in Browse stay visible after the search finishes, and clearing the query or switching sources now closes that results view correctly.
- Saved searches now update when the active source changes instead of showing the wrong source’s items.
- The library adds a Reading List filter with chips for each list, including an All Lists option, so users can view only manga from a selected reading list.
- The More screen now includes an Update Errors entry that opens the update-failure screen.
- Tracker certificate pins were refreshed so tracker sign-in and API access keep working after certificate changes.
- Database migration coverage was expanded to check the new chapter and manga fields and their default values.
- Browse and library tests were added for the new search, filter, and migration behavior.

### Impact
`✅ Search results stay visible until you leave search`
`✅ Reading list filtering in the library`
`✅ Fewer tracker login breakages after certificate changes`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=IPy8n2tmvNw8gYtWtySe-iJze60zRd_v1KPpBNoIbtc&org=Heartless-Veteran)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reading list filtering in Library to view manga by saved lists
  * “Update Errors” entry in More menu to review sync issues
  * Option to disable webtoon zoom-out in the reader

* **Bug Fixes**
  * Improved search UI behavior to retain and display results correctly across sources

* **Chores**
  * Updated tracker certificate pins

* **Tests**
  * Expanded tests and migration coverage for database and browse/search behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->