### PR TITLE
fix: resolve core/ui compilation errors and P1 security hardening

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -176,6 +176,9 @@ dependencies {
     // SplashScreen — branded launch experience on all API levels
     implementation(libs.splashscreen)
 
+    // Encrypted SharedPreferences for crash log storage
+    implementation(libs.androidx.security.crypto)
+
     // Debug tools (LeakCanary — no-op in release builds)
     debugImplementation(libs.leakcanary)
 

--- a/app/src/main/java/app/otakureader/MainActivity.kt
+++ b/app/src/main/java/app/otakureader/MainActivity.kt
@@ -54,8 +54,11 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+private const val CRASH_REPORT_CLIP_LABEL = "crash_report"
 
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 
@@ -265,6 +268,7 @@ private fun CrashReportDialog(
     onDismiss: () -> Unit,
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -303,8 +307,16 @@ private fun CrashReportDialog(
                     val clipboard =
                         context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                     clipboard.setPrimaryClip(
-                        ClipData.newPlainText("Crash Report", report)
+                        ClipData.newPlainText(CRASH_REPORT_CLIP_LABEL, report)
                     )
+                    scope.launch {
+                        delay(15_000)
+                        if (clipboard.primaryClipDescription?.label == CRASH_REPORT_CLIP_LABEL) {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                                clipboard.clearPrimaryClip()
+                            }
+                        }
+                    }
                     // Android 13+ shows its own "Copied" system notification; show a
                     // Toast only on older versions to avoid double feedback.
                     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {

--- a/app/src/main/java/app/otakureader/MainActivity.kt
+++ b/app/src/main/java/app/otakureader/MainActivity.kt
@@ -57,10 +57,9 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 
 private const val CRASH_REPORT_CLIP_LABEL = "crash_report"
-
-import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -268,7 +267,6 @@ private fun CrashReportDialog(
     onDismiss: () -> Unit,
 ) {
     val context = LocalContext.current
-    val scope = rememberCoroutineScope()
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -309,11 +307,13 @@ private fun CrashReportDialog(
                     clipboard.setPrimaryClip(
                         ClipData.newPlainText(CRASH_REPORT_CLIP_LABEL, report)
                     )
-                    scope.launch {
+                    (context as? ComponentActivity)?.lifecycleScope?.launch {
                         delay(15_000)
                         if (clipboard.primaryClipDescription?.label == CRASH_REPORT_CLIP_LABEL) {
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                                 clipboard.clearPrimaryClip()
+                            } else {
+                                clipboard.setPrimaryClip(ClipData.newPlainText("", ""))
                             }
                         }
                     }

--- a/app/src/main/java/app/otakureader/crash/CrashHandler.kt
+++ b/app/src/main/java/app/otakureader/crash/CrashHandler.kt
@@ -50,7 +50,7 @@ object CrashHandler {
      * Returns `null` when no crash was recorded.
      */
     fun getAndClearCrashReport(context: Context): String? {
-        val prefs = prefs(context)
+        val prefs = try { prefs(context) } catch (_: Throwable) { return null }
         val report = prefs.getString(KEY_CRASH_REPORT, null) ?: return null
 
         // commit() instead of apply() is intentional: the clear must complete

--- a/app/src/main/java/app/otakureader/crash/CrashHandler.kt
+++ b/app/src/main/java/app/otakureader/crash/CrashHandler.kt
@@ -2,6 +2,8 @@ package app.otakureader.crash
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 
 /**
  * Custom [Thread.UncaughtExceptionHandler] that captures fatal crashes, writes the
@@ -99,6 +101,17 @@ object CrashHandler {
         prefs(context).edit().putString(KEY_CRASH_REPORT, report).commit()
     }
 
-    private fun prefs(context: Context): SharedPreferences =
-        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private var cachedPrefs: SharedPreferences? = null
+
+    private fun prefs(context: Context): SharedPreferences {
+        return cachedPrefs ?: EncryptedSharedPreferences.create(
+            context.applicationContext,
+            PREFS_NAME,
+            MasterKey.Builder(context.applicationContext)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build(),
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        ).also { cachedPrefs = it }
+    }
 }

--- a/app/src/main/java/app/otakureader/crash/CrashHandler.kt
+++ b/app/src/main/java/app/otakureader/crash/CrashHandler.kt
@@ -101,17 +101,19 @@ object CrashHandler {
         prefs(context).edit().putString(KEY_CRASH_REPORT, report).commit()
     }
 
-    private var cachedPrefs: SharedPreferences? = null
+    @Volatile private var cachedPrefs: SharedPreferences? = null
 
     private fun prefs(context: Context): SharedPreferences {
-        return cachedPrefs ?: EncryptedSharedPreferences.create(
-            context.applicationContext,
-            PREFS_NAME,
-            MasterKey.Builder(context.applicationContext)
-                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                .build(),
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        ).also { cachedPrefs = it }
+        return cachedPrefs ?: synchronized(this) {
+            cachedPrefs ?: EncryptedSharedPreferences.create(
+                context.applicationContext,
+                PREFS_NAME,
+                MasterKey.Builder(context.applicationContext)
+                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                    .build(),
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            ).also { cachedPrefs = it }
+        }
     }
 }

--- a/core/ui/src/main/java/app/otakureader/core/ui/components/InkSlider.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/components/InkSlider.kt
@@ -127,13 +127,14 @@ fun InkSlider(
             // Thumb
             val thumbRadius = 10.dp.toPx()
             drawCircle(
+                color = Color(0xFFFF4757).copy(alpha = 0.3f),
+                radius = thumbRadius * 2.5f,
+                center = Offset(filledWidth, trackY)
+            )
+            drawCircle(
                 color = Color(0xFFFF4757),
                 radius = thumbRadius,
-                center = Offset(filledWidth, trackY),
-                shadow = Shadow(
-                    color = Color(0xFFFF4757).copy(alpha = 0.5f),
-                    blurRadius = 12f
-                )
+                center = Offset(filledWidth, trackY)
             )
             drawCircle(
                 color = Color.White,

--- a/core/ui/src/main/java/app/otakureader/core/ui/components/NeonSlider.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/components/NeonSlider.kt
@@ -130,13 +130,14 @@ fun NeonSlider(
                     val sparkleY = trackY - 10.dp.toPx() + sparkle.offset * 20.dp.toPx()
 
                     drawCircle(
+                        color = glowColor.copy(alpha = sparkleAlpha * 0.3f),
+                        radius = sparkle.size * 2.5f,
+                        center = Offset(sparkleX, sparkleY)
+                    )
+                    drawCircle(
                         color = Color(0xFF00D2D3).copy(alpha = sparkleAlpha),
                         radius = sparkle.size,
-                        center = Offset(sparkleX, sparkleY),
-                        shadow = Shadow(
-                            color = glowColor.copy(alpha = sparkleAlpha * 0.5f),
-                            blurRadius = sparkle.size * 2
-                        )
+                        center = Offset(sparkleX, sparkleY)
                     )
                 }
             }
@@ -155,13 +156,14 @@ fun NeonSlider(
                 style = Stroke(width = 2.dp.toPx())
             )
             drawCircle(
+                color = glowColor.copy(alpha = 0.3f),
+                radius = 4.dp.toPx() * 2.5f,
+                center = Offset(filledWidth, trackY)
+            )
+            drawCircle(
                 color = Color.White.copy(alpha = 0.9f),
                 radius = 4.dp.toPx(),
-                center = Offset(filledWidth, trackY),
-                shadow = Shadow(
-                    color = glowColor.copy(alpha = 0.8f),
-                    blurRadius = 8f
-                )
+                center = Offset(filledWidth, trackY)
             )
         }
     }

--- a/data/src/main/java/app/otakureader/data/repository/ReaderSettingsRepository.kt
+++ b/data/src/main/java/app/otakureader/data/repository/ReaderSettingsRepository.kt
@@ -554,6 +554,14 @@ class ReaderSettingsRepository @Inject constructor(
         safeEdit { it[Keys.SAVE_PAGES_TO_SEPARATE_FOLDERS] = enabled }
     }
 
+    override val secureScreen: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[Keys.SECURE_SCREEN] ?: false
+    }
+
+    override suspend fun setSecureScreen(enabled: Boolean) {
+        safeEdit { it[Keys.SECURE_SCREEN] = enabled }
+    }
+
 
     /**
      * Wrapper around [DataStore.edit] that catches [java.io.IOException] so that a
@@ -647,6 +655,7 @@ class ReaderSettingsRepository @Inject constructor(
         val SHOW_ACTIONS_ON_LONG_TAP = booleanPreferencesKey("reader_show_actions_on_long_tap")
         val SAVE_PAGES_TO_SEPARATE_FOLDERS = booleanPreferencesKey("reader_save_pages_to_separate_folders")
         val SHOW_PAGE_THUMBNAIL_STRIP = booleanPreferencesKey("reader_show_page_thumbnail_strip")
+        val SECURE_SCREEN = booleanPreferencesKey("reader_secure_screen")
     }
     
     companion object {

--- a/domain/src/main/java/app/otakureader/domain/repository/ReaderSettingsRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/ReaderSettingsRepository.kt
@@ -60,6 +60,7 @@ interface ReaderSettingsRepository {
     val showActionsOnLongTap: Flow<Boolean>
     val savePagesToSeparateFolders: Flow<Boolean>
     val showPageThumbnailStrip: Flow<Boolean>
+    val secureScreen: Flow<Boolean>
 
     suspend fun setReaderMode(mode: ReaderMode)
     suspend fun setBrightness(brightness: Float)
@@ -77,6 +78,7 @@ interface ReaderSettingsRepository {
     suspend fun setCustomTintColor(color: Long)
     suspend fun setCropBordersEnabled(enabled: Boolean)
     suspend fun setShowPageThumbnailStrip(enabled: Boolean)
+    suspend fun setSecureScreen(enabled: Boolean)
 
     companion object {
         const val DEFAULT_PRELOAD_PAGES = 3

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderMvi.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderMvi.kt
@@ -119,6 +119,9 @@ data class ReaderState(
     /** Whether data saver mode is enabled to reduce image quality and bandwidth usage */
     val dataSaverEnabled: Boolean = false,
 
+    /** Prevent screenshots and screen recording (FLAG_SECURE) */
+    val secureScreen: Boolean = false,
+
     // --- Display Settings ---
     /** Show content in display cutout/notch area */
     val showContentInCutout: Boolean = true,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -131,6 +131,19 @@ fun ReaderScreen(
             activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
     }
+
+    // Prevent screenshots when secure mode is enabled (user-opt-in)
+    DisposableEffect(state.secureScreen) {
+        val activity = context as? Activity
+        if (state.secureScreen) {
+            activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        } else {
+            activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+        onDispose {
+            activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
     
     // Handle zoom indicator visibility
     LaunchedEffect(state.zoomLevel) {

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -202,6 +202,7 @@ class ReaderViewModel @Inject constructor(
                     alwaysShowChapterTransition = settingsState.alwaysShowChapterTransition,
                     showActionsOnLongTap = settingsState.showActionsOnLongTap,
                     savePagesToSeparateFolders = settingsState.savePagesToSeparateFolders,
+                    secureScreen = settingsState.secureScreen,
                 )
             }
         }

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderSettingsLoaderDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderSettingsLoaderDelegate.kt
@@ -151,6 +151,12 @@ class ReaderSettingsLoaderDelegate @Inject constructor(
         val showPageThumbnailStripD = async { settingsRepository.showPageThumbnailStrip.first() }
         val savePagesToSeparateFoldersD = async { settingsRepository.savePagesToSeparateFolders.first() }
         val autoScrollSpeedD = async { settingsRepository.autoScrollSpeed.first() }
+        val secureScreenD = async {
+            try { settingsRepository.secureScreen.first() } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                false
+            }
+        }
 
         val mode = modeD.await()
         val direction = directionD.await()
@@ -219,6 +225,7 @@ class ReaderSettingsLoaderDelegate @Inject constructor(
             showPageThumbnailStrip = showPageThumbnailStripD.await(),
             savePagesToSeparateFolders = savePagesToSeparateFoldersD.await(),
             autoScrollSpeed = autoScrollSpeedD.await(),
+            secureScreen = secureScreenD.await(),
         )
     }
 }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/ReaderSettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/ReaderSettingsMvi.kt
@@ -48,4 +48,5 @@ data class ReaderSettingsState(
     val imageQuality: String = ImageQuality.ORIGINAL.name,
     val dataSaverEnabled: Boolean = false,
     val incognitoMode: Boolean = false,
+    val secureScreen: Boolean = false,
 )

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
@@ -202,6 +202,7 @@ sealed interface SettingsEvent : UiEvent {
     data class SetCropBordersEnabled(val enabled: Boolean) : SettingsEvent
     data class SetImageQuality(val quality: String) : SettingsEvent
     data class SetDataSaverEnabled(val enabled: Boolean) : SettingsEvent
+    data class SetSecureScreen(val enabled: Boolean) : SettingsEvent
 
     // Library
     data class SetLibraryGridSize(val size: Int) : SettingsEvent

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsReaderScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsReaderScreen.kt
@@ -136,6 +136,17 @@ private fun ReaderContent(state: SettingsState, onEvent: (SettingsEvent) -> Unit
     )
 
     ListItem(
+        headlineContent = { Text(stringResource(R.string.settings_secure_screen)) },
+        supportingContent = { Text(stringResource(R.string.settings_secure_screen_description)) },
+        trailingContent = {
+            Switch(
+                checked = state.secureScreen,
+                onCheckedChange = { onEvent(SettingsEvent.SetSecureScreen(it)) },
+            )
+        },
+    )
+
+    ListItem(
         headlineContent = { Text(stringResource(R.string.settings_incognito_mode)) },
         supportingContent = { Text(stringResource(R.string.settings_incognito_mode_description)) },
         trailingContent = {

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/ReaderSettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/ReaderSettingsDelegate.kt
@@ -131,12 +131,14 @@ class ReaderSettingsDelegate @Inject constructor(
                 readerSettingsRepository.cropBordersEnabled,
                 readerSettingsRepository.imageQuality,
                 readerSettingsRepository.dataSaverEnabled,
-            ) { preloadAfter, cropBorders, imageQuality, dataSaver ->
+                readerSettingsRepository.secureScreen,
+            ) { preloadAfter, cropBorders, imageQuality, dataSaver, secureScreen ->
                 updateState { it.copy(reader = it.reader.copy(
                     preloadPagesAfter = preloadAfter,
                     cropBordersEnabled = cropBorders,
                     imageQuality = imageQuality.name,
                     dataSaverEnabled = dataSaver,
+                    secureScreen = secureScreen,
                 )) }
             }.collect { }
         }
@@ -188,6 +190,7 @@ class ReaderSettingsDelegate @Inject constructor(
             true
         }
         is SettingsEvent.SetDataSaverEnabled -> { readerSettingsRepository.setDataSaverEnabled(event.enabled); true }
+        is SettingsEvent.SetSecureScreen -> { readerSettingsRepository.setSecureScreen(event.enabled); true }
         else -> false
     }
 }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -81,6 +81,8 @@
     <string name="settings_keep_screen_on_description">Prevent the screen from sleeping while reading</string>
     <string name="settings_incognito_mode">Incognito Mode</string>
     <string name="settings_incognito_mode_description">Reading history and progress are not saved while enabled</string>
+    <string name="settings_secure_screen">Secure Screen</string>
+    <string name="settings_secure_screen_description">Prevent screenshots and screen recording while reading</string>
     <string name="settings_preload_before">Preload Pages Before: %1$d</string>
     <string name="settings_preload_before_description">Number of pages to preload before the current page</string>
     <string name="settings_preload_after">Preload Pages After: %1$d</string>


### PR DESCRIPTION
## **User description**
## Summary

- **P0 — Compilation fix**: `DrawScope.drawCircle()` has no `shadow` parameter; replaced two broken calls in `NeonSlider.kt` and one in `InkSlider.kt` with a two-pass glow pattern (larger low-alpha circle + main circle). This unblocks all CI.
- **P1 — Encrypt crash logs**: `CrashHandler` now uses `EncryptedSharedPreferences` (AES256-GCM) instead of plain `SharedPreferences` so stack traces with file paths are never stored in plaintext.
- **P1 — Clipboard auto-clear**: After copying a crash report, a 15-second delayed clear is scheduled; it only fires if the primary clip label still matches `"crash_report"` so unrelated clipboard content is never disturbed. Guarded by API 28+ for `clearPrimaryClip`.
- **P1 — FLAG_SECURE (user-opt-in)**: Added `secureScreen: Boolean = false` preference wired through `ReaderSettingsRepository` → `ReaderSettingsLoaderDelegate` → `ReaderViewModel` → `ReaderState`. A `DisposableEffect` in `ReaderScreen` sets/clears `FLAG_SECURE` only when the user enables the preference, preserving screenshot sharing by default.

## Constraints honored

- No changes to `core/database/migrations/`, `core/tachiyomi-compat/`, `core/*/di/`, or `core/extension/installer/`
- No DetailsScreen refactoring
- No major version bumps
- Coverage gates unaffected (no test files deleted, no production logic removed)
- FLAG_SECURE is user-opt-in (default `false`) — screenshot sharing works unless user enables secure mode

## Test plan

- [ ] `./gradlew :core:ui:compileDebugKotlin` passes (was failing before this PR)
- [ ] `./gradlew assembleDebug` passes
- [ ] `./gradlew testDebugUnitTest` passes
- [ ] `./gradlew detekt` passes
- [ ] `./gradlew ktlintCheck` passes
- [ ] Verify `grep -rn "drawCircle.*shadow" core/ui/ --include="*.kt"` returns empty
- [ ] Verify `grep -rn "getSharedPreferences.*PREFS_NAME" app/ --include="*.kt"` returns empty
- [ ] Verify `grep -rn "FLAG_SECURE" feature/reader/ --include="*.kt"` returns ≥1 hit
- [ ] Manual: copy crash report → wait 15s → verify clipboard cleared (on API 28+ device)
- [ ] Manual: enable secure mode in reader settings → verify screenshots blocked

https://claude.ai/code/session_015dmLgVzBb1WbjkJHkdYoJn

---
_Generated by [Claude Code](https://claude.ai/code/session_015dmLgVzBb1WbjkJHkdYoJn)_


___

## **CodeAnt-AI Description**
Fix reader drawing and protect crash reports and reader screens

### What Changed
- Fixed the neon and ink slider thumb/glow effects so the app compiles and the sliders keep their visual glow
- Crash reports are now stored in encrypted app data instead of plain text
- Copying a crash report now clears the clipboard after 15 seconds, but only if that report is still there
- Reader mode can now block screenshots and screen recording when the secure screen option is turned on

### Impact
`✅ Restored app builds`
`✅ Safer crash report storage`
`✅ Fewer leftover crash reports in the clipboard`
`✅ Protected reader content from screenshots`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure screen option to prevent screenshots and screen recordings in the reader.

* **Bug Fixes & Improvements**
  * Crash reports are now automatically cleared from clipboard after 15 seconds.
  * Enhanced visual feedback for slider controls with improved glow effects.

* **Security**
  * Crash reports are now encrypted at rest using secure storage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Heartless-Veteran/Otaku-Reader/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->