### PR TITLE
feat: activate all extension repositories simultaneously

### DIFF
--- a/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepoRepositoryImpl.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepoRepositoryImpl.kt
@@ -3,16 +3,14 @@ package app.otakureader.core.extension.data.repository
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import app.otakureader.core.extension.domain.repository.ExtensionRepoRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 /**
  * Implementation of ExtensionRepoRepository using DataStore.
- * Stores repository URLs as a set and tracks the active repository.
+ * All stored repository URLs are simultaneously active — there is no single "active" repo concept.
  */
 class ExtensionRepoRepositoryImpl(
     private val dataStore: DataStore<Preferences>
@@ -20,7 +18,6 @@ class ExtensionRepoRepositoryImpl(
 
     companion object {
         private val REPOSITORIES_KEY = stringSetPreferencesKey("extension_repositories")
-        private val ACTIVE_REPOSITORY_KEY = stringPreferencesKey("active_extension_repository")
     }
 
     override fun getRepositories(): Flow<List<String>> {
@@ -34,11 +31,6 @@ class ExtensionRepoRepositoryImpl(
             val currentRepos = preferences[REPOSITORIES_KEY]?.toMutableSet() ?: mutableSetOf()
             currentRepos.add(url)
             preferences[REPOSITORIES_KEY] = currentRepos
-
-            // If this is the first repository, set it as active
-            if (!preferences.contains(ACTIVE_REPOSITORY_KEY)) {
-                preferences[ACTIVE_REPOSITORY_KEY] = url
-            }
         }
     }
 
@@ -46,26 +38,6 @@ class ExtensionRepoRepositoryImpl(
         dataStore.edit { preferences ->
             val currentRepos = preferences[REPOSITORIES_KEY]?.toMutableSet() ?: mutableSetOf()
             currentRepos.remove(url)
-            preferences[REPOSITORIES_KEY] = currentRepos
-
-            // If removing the active repository, clear it
-            if (preferences[ACTIVE_REPOSITORY_KEY] == url) {
-                preferences.remove(ACTIVE_REPOSITORY_KEY)
-            }
-        }
-    }
-
-    override suspend fun getActiveRepository(): String? {
-        return dataStore.data.first()[ACTIVE_REPOSITORY_KEY]
-    }
-
-    override suspend fun setActiveRepository(url: String) {
-        dataStore.edit { preferences ->
-            preferences[ACTIVE_REPOSITORY_KEY] = url
-
-            // Ensure the URL is in the repositories list
-            val currentRepos = preferences[REPOSITORIES_KEY]?.toMutableSet() ?: mutableSetOf()
-            currentRepos.add(url)
             preferences[REPOSITORIES_KEY] = currentRepos
         }
     }
@@ -78,7 +50,6 @@ class ExtensionRepoRepositoryImpl(
     override suspend fun clearRepositories() {
         dataStore.edit { preferences ->
             preferences.remove(REPOSITORIES_KEY)
-            preferences.remove(ACTIVE_REPOSITORY_KEY)
         }
     }
 }

--- a/core/extension/src/main/java/app/otakureader/core/extension/domain/repository/ExtensionRepoRepository.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/domain/repository/ExtensionRepoRepository.kt
@@ -4,7 +4,12 @@ import kotlinx.coroutines.flow.Flow
 
 /**
  * Repository for managing extension repository URLs.
- * Supports adding/removing third-party extension repositories (e.g., Keiyoushi, Komikku, Suwayomi).
+ * Supports adding/removing third-party extension repositories
+ * (e.g., Keiyoushi, Suwayomi, Yuzono).
+ *
+ * All configured repositories are simultaneously active — extensions from every
+ * added repository are fetched and merged. There is no concept of a single
+ * "active" repository.
  *
  * The system automatically detects and supports both:
  * - index.min.json (common format for Keiyoushi, Komikku, Suwayomi repositories)
@@ -13,7 +18,7 @@ import kotlinx.coroutines.flow.Flow
 interface ExtensionRepoRepository {
 
     /**
-     * Get all configured repository URLs.
+     * Get all configured repository URLs. All returned URLs are treated as active.
      */
     fun getRepositories(): Flow<List<String>>
 
@@ -28,16 +33,6 @@ interface ExtensionRepoRepository {
      * @param url The repository URL to remove
      */
     suspend fun removeRepository(url: String)
-
-    /**
-     * Get the currently active repository URL, or null if none is set.
-     */
-    suspend fun getActiveRepository(): String?
-
-    /**
-     * Set the active repository URL.
-     */
-    suspend fun setActiveRepository(url: String)
 
     /**
      * No-op. Retained for interface compatibility.

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="browse_save_search">Save search</string>
     <string name="browse_delete_saved_search">Delete saved search</string>
     <string name="browse_install_extension">Install Extension</string>
-    <string name="browse_search_placeholder">Search manga…</string>
+    <string name="browse_search_placeholder">Search manga&#8230;</string>
     <string name="browse_filters">Filters</string>
     <string name="browse_select_source">Select a source to browse manga</string>
     <string name="browse_load_more">Load more</string>
@@ -47,7 +47,7 @@
 
     <!-- Update All button -->
     <string name="extensions_update_all">Update All</string>
-    <string name="extensions_updating_all">Updating all\u2026</string>
+    <string name="extensions_updating_all">Updating all…</string>
     <plurals name="extensions_updates_available">
         <item quantity="one">%d update available</item>
         <item quantity="other">%d updates available</item>
@@ -81,7 +81,7 @@
     <string name="extensions_install_download_cd">Download</string>
     <string name="extensions_install_file_open_cd">Open file</string>
     <string name="extensions_install_instructions">Instructions</string>
-    <string name="extensions_install_instructions_body">1. To install a Tachiyomi extension, you need the APK file.\n\n2. You can download extensions from:\n   • Suwayomi repository\n   • Tachiyomi extensions archive\n\n3. Enter the URL or local file path above.\n\n4. The extension will be loaded and its sources will appear in Browse.</string>
+    <string name="extensions_install_instructions_body">1. To install a Tachiyomi extension, you need the APK file.\n\n2. You can download extensions from:\n   &#8226; Suwayomi repository\n   &#8226; Tachiyomi extensions archive\n\n3. Enter the URL or local file path above.\n\n4. The extension will be loaded and its sources will appear in Browse.</string>
 
     <!-- SourceFilterSheet -->
     <string name="browse_filters_reset">Reset</string>
@@ -95,13 +95,12 @@
     <string name="browse_group_expand">Expand</string>
 
     <!-- GlobalSearchScreen -->
-    <string name="browse_global_search_placeholder">Search all sources…</string>
+    <string name="browse_global_search_placeholder">Search all sources&#8230;</string>
     <string name="browse_global_search_idle_hint">Enter a query to search all sources</string>
 
     <!-- ExtensionsBottomSheet -->
     <string name="extensions_sheet_title">Extensions</string>
     <string name="extensions_search_placeholder">Search extensions...</string>
-    <string name="extensions_set_active">Set Active</string>
     <string name="extensions_repo_url_placeholder">https://.../repo</string>
     <string name="extensions_add_repository">Add repository</string>
     <string name="extensions_repositories_title">Repositories</string>
@@ -112,8 +111,8 @@
     <string name="extensions_language_flag_cd">Extension language</string>
 
     <!-- Source Intelligence -->
-    <string name="browse_source_intel_label">✨ Source Intelligence</string>
-    <string name="browse_source_intel_analyzing">Analyzing source…</string>
+    <string name="browse_source_intel_label">&#10024; Source Intelligence</string>
+    <string name="browse_source_intel_analyzing">Analyzing source&#8230;</string>
     
     <!-- Bulk favorite -->
     <string name="browse_add_to_library">Add to Library</string>


### PR DESCRIPTION
## **User description**
## Summary

- Removes the single-active-repository concept from `ExtensionRepoRepository` and its DataStore implementation — all added repositories are now simultaneously active
- Removes `getActiveRepository`/`setActiveRepository` from the domain interface and `ACTIVE_REPOSITORY_KEY` from `ExtensionRepoRepositoryImpl`
- Includes all `core/ui` design-system compilation fixes for Compose BOM 2026.04.01 (9 files: wrong `IntOffset`/`IntSize` package, removed `animation.with`, `GenericShape` API change, missing `Spring`/`VectorConverter`/`onSizeChanged`/`delay` imports)
- Fixes `LibraryScreen` TabRow indicator and `ReaderSettingsDelegate` `combine` overload issues

## Test plan

- [ ] `./gradlew :core:ui:compileDebugKotlin` — confirms design-system fixes
- [ ] `./gradlew assembleDebug` — full app compiles
- [ ] `./gradlew :app:kspDebugKotlin` — Hilt graph valid
- [ ] `./gradlew testDebugUnitTest` — unit tests pass
- [ ] Browse screen: adding multiple extension repos should show all as active simultaneously
- [ ] Settings screen: verify no active-repo toggle/selector remains in UI


---
_Generated by [Claude Code](https://claude.ai/code/session_015dmLgVzBb1WbjkJHkdYoJn)_


___

## **CodeAnt-AI Description**
**Make every added extension repository active**

### What Changed
- All added extension repositories are now treated as active at the same time, so extensions from every saved source can appear in Browse without choosing one “active” repository.
- The app no longer shows an active-repository option in the Extensions screen.
- Search and status text were cleaned up to use the correct ellipsis and bullet characters in Browse and install instructions.

### Impact
`✅ All saved extension sources stay available`
`✅ Fewer missing extensions after adding a repository`
`✅ Clearer Extensions screen with no active-repository choice`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extension repositories are now all simultaneously active, eliminating the need to select a single active repository.

* **Removed Features**
  * Removed the "Set Active" repository option.

* **Style**
  * Updated text rendering for consistent character display across the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Heartless-Veteran/Otaku-Reader/pull/852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->