### PR TITLE
feat(#862,#863): smart update skip logic + per-category update frequency

### DIFF
--- a/core/database/src/main/java/app/otakureader/core/database/OtakuReaderDatabase.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/OtakuReaderDatabase.kt
@@ -56,7 +56,7 @@ import app.otakureader.core.database.entity.TrackerSyncStateEntity
         // Download queue persistence
         DownloadQueueEntity::class,
     ],
-    version = 23,
+    version = 24,
     exportSchema = true
 )
 @TypeConverters(DatabaseConverters::class)

--- a/core/database/src/main/java/app/otakureader/core/database/entity/CategoryEntity.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/entity/CategoryEntity.kt
@@ -9,7 +9,8 @@ data class CategoryEntity(
     val id: Long = 0,
     val name: String,
     val order: Int = 0,
-    val flags: Int = 0
+    val flags: Int = 0,
+    val update_frequency: Int = 1,
 ) {
     companion object {
         // Bit flags for category options

--- a/core/database/src/main/java/app/otakureader/core/database/migrations/DatabaseMigrations.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/migrations/DatabaseMigrations.kt
@@ -235,6 +235,12 @@ internal val MIGRATION_22_23 = object : Migration(22, 23) {
     }
 }
 
+internal val MIGRATION_23_24 = object : Migration(23, 24) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE categories ADD COLUMN update_frequency INTEGER NOT NULL DEFAULT 1")
+    }
+}
+
 /** All migrations in order, for use in [Room.databaseBuilder] and migration tests. */
 internal val ALL_MIGRATIONS = arrayOf(
     MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6,
@@ -242,5 +248,5 @@ internal val ALL_MIGRATIONS = arrayOf(
     MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
     MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
     MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
-    MIGRATION_22_23
+    MIGRATION_22_23, MIGRATION_23_24
 )

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/LibraryPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/LibraryPreferences.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -98,6 +99,40 @@ class LibraryPreferences(private val dataStore: DataStore<Preferences>) {
     val newUpdatesCount: Flow<Int> = dataStore.data.map { it[Keys.NEW_UPDATES_COUNT] ?: 0 }
     suspend fun setNewUpdatesCount(value: Int) = dataStore.edit { it[Keys.NEW_UPDATES_COUNT] = value }
 
+    // --- Smart Update Skip ---
+
+    /** Skip manga that still have unread chapters during global library update. */
+    val skipUpdatesWithUnread: Flow<Boolean> = dataStore.data.map { it[Keys.SKIP_UPDATES_WITH_UNREAD] ?: false }
+    suspend fun setSkipUpdatesWithUnread(value: Boolean) = dataStore.edit { it[Keys.SKIP_UPDATES_WITH_UNREAD] = value }
+
+    /** Skip manga whose status is Completed during global library update. */
+    val skipUpdatesWithCompleted: Flow<Boolean> = dataStore.data.map { it[Keys.SKIP_UPDATES_WITH_COMPLETED] ?: false }
+    suspend fun setSkipUpdatesWithCompleted(value: Boolean) = dataStore.edit { it[Keys.SKIP_UPDATES_WITH_COMPLETED] = value }
+
+    /** Skip manga that have never been started (lastRead == null) during global library update. */
+    val skipUpdatesNeverStarted: Flow<Boolean> = dataStore.data.map { it[Keys.SKIP_UPDATES_NEVER_STARTED] ?: false }
+    suspend fun setSkipUpdatesNeverStarted(value: Boolean) = dataStore.edit { it[Keys.SKIP_UPDATES_NEVER_STARTED] = value }
+
+    // --- Per-Category Last Update Tracking ---
+
+    /** Serialized map of "categoryId:timestampMs" pairs for per-category frequency filtering. */
+    val categoryLastUpdateMs: Flow<Map<Long, Long>> = dataStore.data.map { prefs ->
+        val raw = prefs[Keys.CATEGORY_LAST_UPDATE_MS] ?: ""
+        if (raw.isEmpty()) emptyMap()
+        else raw.split(",").mapNotNull { entry ->
+            val parts = entry.split(":")
+            if (parts.size == 2) parts[0].toLongOrNull()?.let { id -> id to (parts[1].toLongOrNull() ?: 0L) }
+            else null
+        }.toMap()
+    }
+
+    suspend fun setCategoryLastUpdateMs(map: Map<Long, Long>) {
+        dataStore.edit { prefs ->
+            prefs[Keys.CATEGORY_LAST_UPDATE_MS] =
+                if (map.isEmpty()) "" else map.entries.joinToString(",") { "${it.key}:${it.value}" }
+        }
+    }
+
     private object Keys {
         val GRID_SIZE = intPreferencesKey("library_grid_size")
         val IS_STAGGERED_GRID = booleanPreferencesKey("is_staggered_grid")
@@ -116,5 +151,9 @@ class LibraryPreferences(private val dataStore: DataStore<Preferences>) {
         val AUTO_REFRESH_ON_START = booleanPreferencesKey("library_auto_refresh_on_start")
         val SHOW_UPDATE_PROGRESS = booleanPreferencesKey("library_show_update_progress")
         val NEW_UPDATES_COUNT = intPreferencesKey("library_new_updates_count")
+        val SKIP_UPDATES_WITH_UNREAD = booleanPreferencesKey("skip_updates_with_unread")
+        val SKIP_UPDATES_WITH_COMPLETED = booleanPreferencesKey("skip_updates_with_completed")
+        val SKIP_UPDATES_NEVER_STARTED = booleanPreferencesKey("skip_updates_never_started")
+        val CATEGORY_LAST_UPDATE_MS = stringPreferencesKey("category_last_update_ms")
     }
 }

--- a/data/src/main/java/app/otakureader/data/repository/CategoryRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/CategoryRepositoryImpl.kt
@@ -4,6 +4,7 @@ import app.otakureader.core.database.dao.CategoryDao
 import app.otakureader.core.database.entity.CategoryEntity
 import app.otakureader.core.database.entity.MangaCategoryEntity
 import app.otakureader.domain.model.Category
+import app.otakureader.domain.model.CategoryUpdateFrequency
 import app.otakureader.domain.repository.CategoryRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -45,16 +46,21 @@ class CategoryRepositoryImpl @Inject constructor(
         return categoryDao.getCategoryById(id)?.toDomain()
     }
     
-    override suspend fun createCategory(name: String): Long {
+    override suspend fun createCategory(name: String, frequency: CategoryUpdateFrequency): Long {
         val maxOrder = categoryDao.getMaxCategoryOrder()
-        val entity = CategoryEntity(name = name, order = maxOrder + 1)
+        val entity = CategoryEntity(name = name, order = maxOrder + 1, update_frequency = frequency.value)
         return categoryDao.insert(entity)
     }
     
     override suspend fun updateCategory(category: Category) {
         categoryDao.update(category.toEntity())
     }
-    
+
+    override suspend fun updateCategoryFrequency(categoryId: Long, frequency: CategoryUpdateFrequency) {
+        val existing = categoryDao.getCategoryById(categoryId) ?: return
+        categoryDao.update(existing.copy(update_frequency = frequency.value))
+    }
+
     override suspend fun deleteCategory(id: Long) {
         categoryDao.deleteById(id)
     }
@@ -76,13 +82,15 @@ class CategoryRepositoryImpl @Inject constructor(
         name = name,
         order = order,
         isHidden = isHidden,
-        isNsfw = isNsfw
+        isNsfw = isNsfw,
+        updateFrequency = CategoryUpdateFrequency.fromInt(update_frequency),
     )
 
     private fun Category.toEntity() = CategoryEntity(
         id = id,
         name = name,
         order = order,
+        update_frequency = updateFrequency.value,
         flags = (if (isHidden) CategoryEntity.FLAG_HIDDEN else 0) or
                 (if (isNsfw) CategoryEntity.FLAG_NSFW else 0)
     )

--- a/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
@@ -18,6 +18,7 @@ import app.otakureader.core.preferences.LibraryPreferences
 import app.otakureader.data.download.ChapterDownloadRequest
 import app.otakureader.data.download.DownloadManager
 import app.otakureader.domain.model.CategoryUpdateFrequency
+import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.repository.CategoryRepository
 import app.otakureader.domain.repository.ChapterRepository
@@ -78,7 +79,7 @@ class LibraryUpdateWorker @AssistedInject constructor(
             val skipWithUnread = libraryPreferences.skipUpdatesWithUnread.first()
             val skipCompleted = libraryPreferences.skipUpdatesWithCompleted.first()
             val skipNeverStarted = libraryPreferences.skipUpdatesNeverStarted.first()
-            val skippedManga = mutableListOf<app.otakureader.domain.model.Manga>()
+            val skippedManga = mutableListOf<Manga>()
             if (skipWithUnread || skipCompleted || skipNeverStarted) {
                 libraryManga = libraryManga.filter { manga ->
                     when {
@@ -98,18 +99,21 @@ class LibraryUpdateWorker @AssistedInject constructor(
             val updatedCategoryIds = mutableSetOf<Long>()
             libraryManga = libraryManga.filter { manga ->
                 val catIds = manga.categoryIds
-                catIds.isEmpty() || catIds.any { catId ->
+                if (catIds.isEmpty()) return@filter true
+                // Evaluate ALL categories so every due category's timestamp is refreshed,
+                // not just the first one found by short-circuit evaluation.
+                val dueCatIds = catIds.filter { catId ->
                     val freq = categoryFrequencyMap[catId] ?: CategoryUpdateFrequency.DAILY
                     val elapsed = now - (categoryLastUpdate[catId] ?: 0L)
-                    val include = when (freq) {
+                    when (freq) {
                         CategoryUpdateFrequency.NEVER -> false
-                        CategoryUpdateFrequency.DAILY -> elapsed >= 24 * 3_600_000L
-                        CategoryUpdateFrequency.EVERY_3_DAYS -> elapsed >= 3 * 24 * 3_600_000L
-                        CategoryUpdateFrequency.WEEKLY -> elapsed >= 7 * 24 * 3_600_000L
+                        CategoryUpdateFrequency.DAILY -> elapsed >= TimeUnit.DAYS.toMillis(1)
+                        CategoryUpdateFrequency.EVERY_3_DAYS -> elapsed >= TimeUnit.DAYS.toMillis(3)
+                        CategoryUpdateFrequency.WEEKLY -> elapsed >= TimeUnit.DAYS.toMillis(7)
                     }
-                    if (include) updatedCategoryIds.add(catId)
-                    include
                 }
+                updatedCategoryIds.addAll(dueCatIds)
+                dueCatIds.isNotEmpty()
             }
 
             val notificationsEnabled = generalPreferences.notificationsEnabled.first()

--- a/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
@@ -17,6 +17,9 @@ import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.core.preferences.LibraryPreferences
 import app.otakureader.data.download.ChapterDownloadRequest
 import app.otakureader.data.download.DownloadManager
+import app.otakureader.domain.model.CategoryUpdateFrequency
+import app.otakureader.domain.model.MangaStatus
+import app.otakureader.domain.repository.CategoryRepository
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.usecase.GetLibraryMangaUseCase
 import app.otakureader.domain.usecase.UpdateLibraryMangaUseCase
@@ -42,6 +45,7 @@ class LibraryUpdateWorker @AssistedInject constructor(
     private val generalPreferences: GeneralPreferences,
     private val downloadManager: DownloadManager,
     private val chapterRepository: ChapterRepository,
+    private val categoryRepository: CategoryRepository,
     private val notificationPreferences: app.otakureader.core.preferences.NotificationPreferences
 ) : CoroutineWorker(context, workerParams) {
 
@@ -70,14 +74,56 @@ class LibraryUpdateWorker @AssistedInject constructor(
                 }
             }
 
+            // Smart skip: exclude manga based on configurable conditions
+            val skipWithUnread = libraryPreferences.skipUpdatesWithUnread.first()
+            val skipCompleted = libraryPreferences.skipUpdatesWithCompleted.first()
+            val skipNeverStarted = libraryPreferences.skipUpdatesNeverStarted.first()
+            val skippedManga = mutableListOf<app.otakureader.domain.model.Manga>()
+            if (skipWithUnread || skipCompleted || skipNeverStarted) {
+                libraryManga = libraryManga.filter { manga ->
+                    when {
+                        skipWithUnread && manga.unreadCount > 0 -> { skippedManga += manga; false }
+                        skipCompleted && manga.status == MangaStatus.COMPLETED -> { skippedManga += manga; false }
+                        skipNeverStarted && (manga.lastRead == null || manga.lastRead == 0L) -> { skippedManga += manga; false }
+                        else -> true
+                    }
+                }
+            }
+
+            // Per-category frequency filter: skip categories whose interval has not elapsed
+            val now = System.currentTimeMillis()
+            val categoryFrequencyMap = categoryRepository.getCategories().first()
+                .associate { it.id to it.updateFrequency }
+            val categoryLastUpdate = libraryPreferences.categoryLastUpdateMs.first()
+            val updatedCategoryIds = mutableSetOf<Long>()
+            libraryManga = libraryManga.filter { manga ->
+                val catIds = manga.categoryIds
+                catIds.isEmpty() || catIds.any { catId ->
+                    val freq = categoryFrequencyMap[catId] ?: CategoryUpdateFrequency.DAILY
+                    val elapsed = now - (categoryLastUpdate[catId] ?: 0L)
+                    val include = when (freq) {
+                        CategoryUpdateFrequency.NEVER -> false
+                        CategoryUpdateFrequency.DAILY -> elapsed >= 24 * 3_600_000L
+                        CategoryUpdateFrequency.EVERY_3_DAYS -> elapsed >= 3 * 24 * 3_600_000L
+                        CategoryUpdateFrequency.WEEKLY -> elapsed >= 7 * 24 * 3_600_000L
+                    }
+                    if (include) updatedCategoryIds.add(catId)
+                    include
+                }
+            }
+
+            val notificationsEnabled = generalPreferences.notificationsEnabled.first()
+
             if (libraryManga.isEmpty()) {
+                if (notificationsEnabled && skippedManga.isNotEmpty()) {
+                    try { UpdateNotifier(applicationContext).showSkippedSummaryNotification(skippedManga.size) } catch (_: Exception) { }
+                }
                 return Result.success()
             }
 
             val autoDownloadEnabled = downloadPreferences.autoDownloadEnabled.first()
             val downloadOnlyOnWifi = downloadPreferences.downloadOnlyOnWifi.first()
             val autoDownloadLimit = downloadPreferences.autoDownloadLimit.first()
-            val notificationsEnabled = generalPreferences.notificationsEnabled.first()
             val showUpdateProgress = libraryPreferences.showUpdateProgress.first()
 
             // Check if Wi-Fi is available for downloads requiring Wi-Fi
@@ -141,6 +187,20 @@ class LibraryUpdateWorker @AssistedInject constructor(
             // Cancel progress notification
             if (showUpdateProgress) {
                 progressNotifier?.cancelProgress()
+            }
+
+            // Persist per-category last-update timestamps
+            if (updatedCategoryIds.isNotEmpty()) {
+                val updated = categoryLastUpdate.toMutableMap()
+                updatedCategoryIds.forEach { catId -> updated[catId] = now }
+                libraryPreferences.setCategoryLastUpdateMs(updated)
+            }
+
+            // Send skipped-summary notification if any manga were skipped
+            if (notificationsEnabled && skippedManga.isNotEmpty()) {
+                try {
+                    UpdateNotifier(applicationContext).showSkippedSummaryNotification(skippedManga.size)
+                } catch (_: Exception) { }
             }
 
             // Send notification if new chapters were found and notifications are enabled

--- a/data/src/main/java/app/otakureader/data/worker/UpdateNotifier.kt
+++ b/data/src/main/java/app/otakureader/data/worker/UpdateNotifier.kt
@@ -257,4 +257,30 @@ class UpdateNotifier(private val context: Context) {
     fun cancelProgress() {
         notificationManager.cancel(UPDATE_NOTIFICATION_TAG, PROGRESS_NOTIFICATION_ID)
     }
+
+    /**
+     * Shows a dismissible summary notification listing how many manga were skipped during
+     * the library update due to smart-skip conditions.
+     */
+    @SuppressLint("MissingPermission")
+    fun showSkippedSummaryNotification(skippedCount: Int) {
+        if (skippedCount <= 0) return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(
+                    context, Manifest.permission.POST_NOTIFICATIONS
+                ) != PackageManager.PERMISSION_GRANTED
+            ) return
+        }
+        val notification = NotificationCompat.Builder(context, UPDATE_CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.stat_notify_more)
+            .setContentTitle("Library update — $skippedCount skipped")
+            .setContentText("Some manga were skipped based on your smart-update settings.")
+            .setStyle(NotificationCompat.BigTextStyle()
+                .bigText("$skippedCount manga were skipped (unread, completed, or never started). Adjust this in Settings → Library."))
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setAutoCancel(true)
+            .setContentIntent(buildLaunchIntent())
+            .build()
+        notificationManager.notify(UPDATE_NOTIFICATION_TAG, PROGRESS_NOTIFICATION_ID - 1, notification)
+    }
 }

--- a/data/src/main/java/app/otakureader/data/worker/UpdateNotifier.kt
+++ b/data/src/main/java/app/otakureader/data/worker/UpdateNotifier.kt
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat
 import coil3.imageLoader
 import coil3.request.ImageRequest
 import coil3.toBitmap
+import app.otakureader.data.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -273,10 +274,10 @@ class UpdateNotifier(private val context: Context) {
         }
         val notification = NotificationCompat.Builder(context, UPDATE_CHANNEL_ID)
             .setSmallIcon(android.R.drawable.stat_notify_more)
-            .setContentTitle("Library update — $skippedCount skipped")
-            .setContentText("Some manga were skipped based on your smart-update settings.")
+            .setContentTitle(context.getString(R.string.update_notifier_skipped_title, skippedCount))
+            .setContentText(context.getString(R.string.update_notifier_skipped_text))
             .setStyle(NotificationCompat.BigTextStyle()
-                .bigText("$skippedCount manga were skipped (unread, completed, or never started). Adjust this in Settings → Library."))
+                .bigText(context.getString(R.string.update_notifier_skipped_big_text, skippedCount)))
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setAutoCancel(true)
             .setContentIntent(buildLaunchIntent())

--- a/data/src/main/res/values/strings.xml
+++ b/data/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Library update worker notifications -->
+    <string name="update_notifier_skipped_title">Library update — %1$d skipped</string>
+    <string name="update_notifier_skipped_text">Some manga were skipped based on your smart-update settings.</string>
+    <string name="update_notifier_skipped_big_text">%1$d manga were skipped (unread, completed, or never started). Adjust this in Settings → Library.</string>
+</resources>

--- a/domain/src/main/java/app/otakureader/domain/model/Category.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/Category.kt
@@ -14,5 +14,6 @@ data class Category(
     val order: Int = 0,
     val mangaCount: Int = 0,
     val isHidden: Boolean = false,
-    val isNsfw: Boolean = false
+    val isNsfw: Boolean = false,
+    val updateFrequency: CategoryUpdateFrequency = CategoryUpdateFrequency.DAILY,
 )

--- a/domain/src/main/java/app/otakureader/domain/model/CategoryUpdateFrequency.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/CategoryUpdateFrequency.kt
@@ -1,0 +1,13 @@
+package app.otakureader.domain.model
+
+enum class CategoryUpdateFrequency(val value: Int) {
+    NEVER(0),
+    DAILY(1),
+    EVERY_3_DAYS(2),
+    WEEKLY(3);
+
+    companion object {
+        fun fromInt(value: Int): CategoryUpdateFrequency =
+            entries.find { it.value == value } ?: DAILY
+    }
+}

--- a/domain/src/main/java/app/otakureader/domain/repository/CategoryRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/CategoryRepository.kt
@@ -1,7 +1,7 @@
 package app.otakureader.domain.repository
 
 import app.otakureader.domain.model.Category
-import app.otakureader.domain.model.Manga
+import app.otakureader.domain.model.CategoryUpdateFrequency
 import kotlinx.coroutines.flow.Flow
 
 interface CategoryRepository {
@@ -9,8 +9,9 @@ interface CategoryRepository {
     fun getVisibleCategories(): Flow<List<Category>>
     fun getHiddenCategories(): Flow<List<Category>>
     suspend fun getCategoryById(id: Long): Category?
-    suspend fun createCategory(name: String): Long
+    suspend fun createCategory(name: String, frequency: CategoryUpdateFrequency = CategoryUpdateFrequency.DAILY): Long
     suspend fun updateCategory(category: Category)
+    suspend fun updateCategoryFrequency(categoryId: Long, frequency: CategoryUpdateFrequency)
     suspend fun deleteCategory(id: Long)
     suspend fun addMangaToCategory(mangaId: Long, categoryId: Long)
     suspend fun removeMangaFromCategory(mangaId: Long, categoryId: Long)

--- a/domain/src/main/java/app/otakureader/domain/usecase/CreateCategoryUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/CreateCategoryUseCase.kt
@@ -1,12 +1,16 @@
 package app.otakureader.domain.usecase
 
+import app.otakureader.domain.model.CategoryUpdateFrequency
 import app.otakureader.domain.repository.CategoryRepository
 import javax.inject.Inject
 
 class CreateCategoryUseCase @Inject constructor(
     private val categoryRepository: CategoryRepository
 ) {
-    suspend operator fun invoke(name: String): Long {
-        return categoryRepository.createCategory(name.trim())
+    suspend operator fun invoke(
+        name: String,
+        frequency: CategoryUpdateFrequency = CategoryUpdateFrequency.DAILY,
+    ): Long {
+        return categoryRepository.createCategory(name.trim(), frequency)
     }
 }

--- a/domain/src/main/java/app/otakureader/domain/usecase/UpdateCategoryUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/UpdateCategoryUseCase.kt
@@ -1,13 +1,23 @@
 package app.otakureader.domain.usecase
 
+import app.otakureader.domain.model.CategoryUpdateFrequency
 import app.otakureader.domain.repository.CategoryRepository
 import javax.inject.Inject
 
 class UpdateCategoryUseCase @Inject constructor(
     private val categoryRepository: CategoryRepository
 ) {
-    suspend operator fun invoke(categoryId: Long, name: String) {
+    suspend operator fun invoke(
+        categoryId: Long,
+        name: String,
+        frequency: CategoryUpdateFrequency? = null,
+    ) {
         val category = categoryRepository.getCategoryById(categoryId) ?: return
-        categoryRepository.updateCategory(category.copy(name = name.trim()))
+        categoryRepository.updateCategory(
+            category.copy(
+                name = name.trim(),
+                updateFrequency = frequency ?: category.updateFrequency,
+            )
+        )
     }
 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/category/CategoryManagementMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/category/CategoryManagementMvi.kt
@@ -3,13 +3,15 @@ package app.otakureader.feature.library.category
 import app.otakureader.core.common.mvi.UiEffect
 import app.otakureader.core.common.mvi.UiEvent
 import app.otakureader.core.common.mvi.UiState
+import app.otakureader.domain.model.CategoryUpdateFrequency
 
 data class CategoryUiItem(
     val id: Long,
     val name: String,
     val mangaCount: Int,
     val isHidden: Boolean,
-    val isNsfw: Boolean
+    val isNsfw: Boolean,
+    val updateFrequency: CategoryUpdateFrequency = CategoryUpdateFrequency.DAILY,
 )
 
 data class CategoryManagementState(
@@ -18,8 +20,15 @@ data class CategoryManagementState(
 ) : UiState
 
 sealed interface CategoryEvent : UiEvent {
-    data class CreateCategory(val name: String) : CategoryEvent
-    data class UpdateCategory(val categoryId: Long, val name: String) : CategoryEvent
+    data class CreateCategory(
+        val name: String,
+        val frequency: CategoryUpdateFrequency = CategoryUpdateFrequency.DAILY,
+    ) : CategoryEvent
+    data class UpdateCategory(
+        val categoryId: Long,
+        val name: String,
+        val frequency: CategoryUpdateFrequency,
+    ) : CategoryEvent
     data class DeleteCategory(val categoryId: Long) : CategoryEvent
     data class ToggleHidden(val categoryId: Long) : CategoryEvent
     data class ToggleNsfw(val categoryId: Long) : CategoryEvent

--- a/feature/library/src/main/java/app/otakureader/feature/library/category/CategoryManagementScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/category/CategoryManagementScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -31,12 +32,16 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import app.otakureader.domain.model.CategoryUpdateFrequency
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -144,12 +149,12 @@ fun CategoryManagementScreen(
                 showCreateDialog = false
                 editingCategory = null
             },
-            onConfirm = { name ->
+            onConfirm = { name, frequency ->
                 val editing = editingCategory
                 if (editing != null) {
-                    viewModel.onEvent(CategoryEvent.UpdateCategory(editing.id, name))
+                    viewModel.onEvent(CategoryEvent.UpdateCategory(editing.id, name, frequency))
                 } else {
-                    viewModel.onEvent(CategoryEvent.CreateCategory(name))
+                    viewModel.onEvent(CategoryEvent.CreateCategory(name, frequency))
                 }
             }
         )
@@ -181,6 +186,14 @@ fun CategoryManagementScreen(
 }
 
 @Composable
+private fun CategoryUpdateFrequency.label(): String = when (this) {
+    CategoryUpdateFrequency.NEVER -> stringResource(R.string.category_freq_never)
+    CategoryUpdateFrequency.DAILY -> stringResource(R.string.category_freq_daily)
+    CategoryUpdateFrequency.EVERY_3_DAYS -> stringResource(R.string.category_freq_3days)
+    CategoryUpdateFrequency.WEEKLY -> stringResource(R.string.category_freq_weekly)
+}
+
+@Composable
 private fun CategoryListItem(
     category: CategoryUiItem,
     onEdit: () -> Unit,
@@ -205,6 +218,11 @@ private fun CategoryListItem(
                     Text(
                         text = stringResource(R.string.category_manga_count, category.mangaCount),
                         style = MaterialTheme.typography.bodySmall
+                    )
+                    Text(
+                        text = stringResource(R.string.category_update_freq_label, category.updateFrequency.label()),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     if (category.isHidden) {
                         Icon(
@@ -284,13 +302,16 @@ private fun CategoryListItem(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun CategoryDialog(
     category: CategoryUiItem?,
     onDismiss: () -> Unit,
-    onConfirm: (String) -> Unit
+    onConfirm: (String, CategoryUpdateFrequency) -> Unit,
 ) {
     var name by remember { mutableStateOf(category?.name ?: "") }
+    var frequency by remember { mutableStateOf(category?.updateFrequency ?: CategoryUpdateFrequency.DAILY) }
+    val freqOptions = CategoryUpdateFrequency.entries
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -303,18 +324,34 @@ private fun CategoryDialog(
             )
         },
         text = {
-            OutlinedTextField(
-                value = name,
-                onValueChange = { name = it },
-                label = { Text(stringResource(R.string.category_name_label)) },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth()
-            )
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(stringResource(R.string.category_name_label)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Text(
+                    text = stringResource(R.string.category_update_frequency_label),
+                    style = MaterialTheme.typography.labelMedium,
+                )
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    freqOptions.forEachIndexed { index, option ->
+                        SegmentedButton(
+                            selected = frequency == option,
+                            onClick = { frequency = option },
+                            shape = SegmentedButtonDefaults.itemShape(index, freqOptions.size),
+                            label = { Text(option.label(), style = MaterialTheme.typography.labelSmall) },
+                        )
+                    }
+                }
+            }
         },
         confirmButton = {
             TextButton(
-                onClick = { onConfirm(name) },
-                enabled = name.isNotBlank()
+                onClick = { onConfirm(name, frequency) },
+                enabled = name.isNotBlank(),
             ) {
                 Text(stringResource(R.string.category_save))
             }
@@ -323,7 +360,7 @@ private fun CategoryDialog(
             TextButton(onClick = onDismiss) {
                 Text(stringResource(R.string.category_cancel))
             }
-        }
+        },
     )
 }
 

--- a/feature/library/src/main/java/app/otakureader/feature/library/category/CategoryManagementViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/category/CategoryManagementViewModel.kt
@@ -55,7 +55,8 @@ class CategoryManagementViewModel @Inject constructor(
                             name = category.name,
                             mangaCount = mangaIds.size,
                             isHidden = category.isHidden,
-                            isNsfw = category.isNsfw
+                            isNsfw = category.isNsfw,
+                            updateFrequency = category.updateFrequency,
                         )
                     }.sortedBy { it.name }
 
@@ -69,18 +70,18 @@ class CategoryManagementViewModel @Inject constructor(
 
     fun onEvent(event: CategoryEvent) {
         when (event) {
-            is CategoryEvent.CreateCategory -> createCategory(event.name)
-            is CategoryEvent.UpdateCategory -> updateCategory(event.categoryId, event.name)
+            is CategoryEvent.CreateCategory -> createCategory(event)
+            is CategoryEvent.UpdateCategory -> updateCategory(event)
             is CategoryEvent.DeleteCategory -> deleteCategory(event.categoryId)
             is CategoryEvent.ToggleHidden -> toggleHidden(event.categoryId)
             is CategoryEvent.ToggleNsfw -> toggleNsfw(event.categoryId)
         }
     }
 
-    private fun createCategory(name: String) {
+    private fun createCategory(event: CategoryEvent.CreateCategory) {
         viewModelScope.launch {
             try {
-                createCategoryUseCase(name)
+                createCategoryUseCase(event.name, event.frequency)
                 _effect.emit(CategoryEffect.DismissDialog)
                 _effect.emit(CategoryEffect.ShowSnackbar("Category created"))
             } catch (e: CancellationException) {
@@ -91,10 +92,10 @@ class CategoryManagementViewModel @Inject constructor(
         }
     }
 
-    private fun updateCategory(categoryId: Long, name: String) {
+    private fun updateCategory(event: CategoryEvent.UpdateCategory) {
         viewModelScope.launch {
             try {
-                updateCategoryUseCase(categoryId, name)
+                updateCategoryUseCase(event.categoryId, event.name, event.frequency)
                 _effect.emit(CategoryEffect.DismissDialog)
                 _effect.emit(CategoryEffect.ShowSnackbar("Category updated"))
             } catch (e: CancellationException) {

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -55,6 +55,12 @@
     <string name="category_mark_nsfw">Mark as NSFW</string>
     <string name="category_remove_nsfw">Remove NSFW</string>
     <string name="category_nsfw_toggled">NSFW status updated</string>
+    <string name="category_update_frequency_label">Update frequency</string>
+    <string name="category_update_freq_label">Update: %1$s</string>
+    <string name="category_freq_never">Never</string>
+    <string name="category_freq_daily">Daily</string>
+    <string name="category_freq_3days">3 days</string>
+    <string name="category_freq_weekly">Weekly</string>
     <!-- Search -->
     <string name="library_search">Search library</string>
     <string name="library_search_placeholder">Search…</string>

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/LibrarySettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/LibrarySettingsMvi.kt
@@ -11,4 +11,7 @@ data class LibrarySettingsState(
     val updateOnlyPinnedCategories: Boolean = false,
     val autoRefreshOnStart: Boolean = false,
     val showUpdateProgress: Boolean = true,
+    val skipUpdatesWithUnread: Boolean = false,
+    val skipUpdatesWithCompleted: Boolean = false,
+    val skipUpdatesNeverStarted: Boolean = false,
 )

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsLibraryScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsLibraryScreen.kt
@@ -204,6 +204,42 @@ private fun LibraryContent(state: SettingsState, onEvent: (SettingsEvent) -> Uni
     )
 
     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+    SectionHeader(title = stringResource(R.string.settings_smart_update_skip))
+
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.settings_skip_updates_unread)) },
+        supportingContent = { Text(stringResource(R.string.settings_skip_updates_unread_description)) },
+        trailingContent = {
+            Switch(
+                checked = state.skipUpdatesWithUnread,
+                onCheckedChange = { onEvent(SettingsEvent.SetSkipUpdatesWithUnread(it)) },
+            )
+        },
+    )
+
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.settings_skip_updates_completed)) },
+        supportingContent = { Text(stringResource(R.string.settings_skip_updates_completed_description)) },
+        trailingContent = {
+            Switch(
+                checked = state.skipUpdatesWithCompleted,
+                onCheckedChange = { onEvent(SettingsEvent.SetSkipUpdatesWithCompleted(it)) },
+            )
+        },
+    )
+
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.settings_skip_updates_never_started)) },
+        supportingContent = { Text(stringResource(R.string.settings_skip_updates_never_started_description)) },
+        trailingContent = {
+            Switch(
+                checked = state.skipUpdatesNeverStarted,
+                onCheckedChange = { onEvent(SettingsEvent.SetSkipUpdatesNeverStarted(it)) },
+            )
+        },
+    )
+
+    HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
     SectionHeader(title = stringResource(R.string.settings_update_check_interval))
 
     Column(modifier = Modifier.selectableGroup()) {

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
@@ -115,6 +115,9 @@ data class SettingsState(
     val updateOnlyPinnedCategories get() = library.updateOnlyPinnedCategories
     val autoRefreshOnStart get() = library.autoRefreshOnStart
     val showUpdateProgress get() = library.showUpdateProgress
+    val skipUpdatesWithUnread get() = library.skipUpdatesWithUnread
+    val skipUpdatesWithCompleted get() = library.skipUpdatesWithCompleted
+    val skipUpdatesNeverStarted get() = library.skipUpdatesNeverStarted
 
     // --- Downloads ---
     val deleteAfterReading get() = downloads.deleteAfterReading
@@ -215,6 +218,9 @@ sealed interface SettingsEvent : UiEvent {
     data class SetUpdateOnlyPinnedCategories(val enabled: Boolean) : SettingsEvent
     data class SetAutoRefreshOnStart(val enabled: Boolean) : SettingsEvent
     data class SetShowUpdateProgress(val enabled: Boolean) : SettingsEvent
+    data class SetSkipUpdatesWithUnread(val enabled: Boolean) : SettingsEvent
+    data class SetSkipUpdatesWithCompleted(val enabled: Boolean) : SettingsEvent
+    data class SetSkipUpdatesNeverStarted(val enabled: Boolean) : SettingsEvent
 
     // Downloads
     data class SetDeleteAfterReading(val enabled: Boolean) : SettingsEvent

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/LibrarySettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/LibrarySettingsDelegate.kt
@@ -62,6 +62,21 @@ class LibrarySettingsDelegate @Inject constructor(
             }
         }
         scope.launch {
+            libraryPreferences.skipUpdatesWithUnread.collect { v ->
+                updateState { it.copy(library = it.library.copy(skipUpdatesWithUnread = v)) }
+            }
+        }
+        scope.launch {
+            libraryPreferences.skipUpdatesWithCompleted.collect { v ->
+                updateState { it.copy(library = it.library.copy(skipUpdatesWithCompleted = v)) }
+            }
+        }
+        scope.launch {
+            libraryPreferences.skipUpdatesNeverStarted.collect { v ->
+                updateState { it.copy(library = it.library.copy(skipUpdatesNeverStarted = v)) }
+            }
+        }
+        scope.launch {
             generalPreferences.updateCheckInterval.collect { interval ->
                 latestUpdateCheckInterval = interval
                 updateState { it.copy(updateCheckInterval = interval) }
@@ -89,6 +104,9 @@ class LibrarySettingsDelegate @Inject constructor(
         }
         is SettingsEvent.SetAutoRefreshOnStart -> { libraryPreferences.setAutoRefreshOnStart(event.enabled); true }
         is SettingsEvent.SetShowUpdateProgress -> { libraryPreferences.setShowUpdateProgress(event.enabled); true }
+        is SettingsEvent.SetSkipUpdatesWithUnread -> { libraryPreferences.setSkipUpdatesWithUnread(event.enabled); true }
+        is SettingsEvent.SetSkipUpdatesWithCompleted -> { libraryPreferences.setSkipUpdatesWithCompleted(event.enabled); true }
+        is SettingsEvent.SetSkipUpdatesNeverStarted -> { libraryPreferences.setSkipUpdatesNeverStarted(event.enabled); true }
         is SettingsEvent.SetUpdateInterval -> {
             generalPreferences.setUpdateCheckInterval(event.hours)
             latestUpdateCheckInterval = event.hours

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -361,6 +361,15 @@
     <string name="settings_show_update_progress">Show Update Progress</string>
     <string name="settings_show_update_progress_description">Display notification during library update</string>
 
+    <!-- Smart Update Skip -->
+    <string name="settings_smart_update_skip">Smart Update Skip</string>
+    <string name="settings_skip_updates_unread">Skip Manga with Unread Chapters</string>
+    <string name="settings_skip_updates_unread_description">Don\'t check for new chapters when unread ones already exist</string>
+    <string name="settings_skip_updates_completed">Skip Completed Manga</string>
+    <string name="settings_skip_updates_completed_description">Don\'t check for updates on manga marked as Completed</string>
+    <string name="settings_skip_updates_never_started">Skip Never-Started Manga</string>
+    <string name="settings_skip_updates_never_started_description">Don\'t check updates for manga you haven\'t read yet</string>
+
     <!-- Download Settings -->
     <string name="settings_download_location">Download Location</string>
     <string name="settings_download_location_default">Default location</string>


### PR DESCRIPTION
## **User description**
Closes #862
Closes #863

## Summary

- **#862 — Smart Global Update Skip Logic**: Three new DataStore toggles let users skip manga with unread chapters, skip completed manga, and skip never-started manga during global library updates. A dismissible summary notification shows how many titles were skipped and why.
- **#863 — Per-Category Update Frequency**: DB migration 23→24 adds `update_frequency` column to the `categories` table. Each category can now be set to Never / Daily / Every 3 Days / Weekly via a segmented button picker in the category edit dialog. `LibraryUpdateWorker` reads per-category timestamps from DataStore and filters manga accordingly.

## Changes

### Domain / Data
- `CategoryUpdateFrequency` enum created (`NEVER=0`, `DAILY=1`, `EVERY_3_DAYS=2`, `WEEKLY=3`)
- `Category` domain model gains `updateFrequency` field
- `CategoryEntity` gains `update_frequency: Int = 1`; `MIGRATION_23_24` added; DB bumped to version 24
- `CategoryRepository` interface: `createCategory` now accepts frequency; new `updateCategoryFrequency()` method
- `CategoryRepositoryImpl`: mapper updated both directions; new method implemented
- `CreateCategoryUseCase` / `UpdateCategoryUseCase` updated with frequency params

### Preferences
- `LibraryPreferences`: 3 new boolean keys (`skipUpdatesWithUnread`, `skipUpdatesWithCompleted`, `skipUpdatesNeverStarted`) + `categoryLastUpdateMs` string key (CSV `"id:ts"` format)

### Worker
- `LibraryUpdateWorker`: smart-skip filter block + per-category frequency filter; persists updated timestamps after each run
- `UpdateNotifier`: `showSkippedSummaryNotification()` — dismissible BigTextStyle notification

### Settings UI
- `SettingsLibraryScreen`: new "Smart Update Skip" section with 3 Switch list items
- `SettingsMvi` / `LibrarySettingsMvi` / `LibrarySettingsDelegate`: 3 new state fields + events wired end-to-end
- `feature/settings/res/values/strings.xml`: 7 new strings

### Category Management UI
- `CategoryManagementScreen`: frequency picker (`SingleChoiceSegmentedButtonRow`) in create/edit dialog; supporting text shows current frequency per category item
- `CategoryManagementMvi` / `CategoryManagementViewModel`: `UpdateFrequency` field in events; `loadCategories` maps frequency from domain

## Test plan

- [ ] Settings → Library: "Smart Update Skip" section shows 3 toggles; enabling "Skip with unread" prevents manga with unread chapters from being fetched in the next update run
- [ ] Settings → Library: skipped-items notification appears (dismissible) when at least one manga is skipped
- [ ] Category management: edit dialog shows Never / Daily / 3 Days / Weekly segmented buttons; selection persists across app restarts
- [ ] Category set to Never: manga in that category are excluded from global updates
- [ ] Category set to Weekly: manga updated less than 7 days ago are skipped; included after interval elapses
- [ ] DB upgrade from v23 → v24 without data loss (existing categories default to Daily)

https://claude.ai/code/session_015M3gzEyFq42eLyT7JJuhMU

---
_Generated by [Claude Code](https://claude.ai/code/session_015M3gzEyFq42eLyT7JJuhMU)_


___

## **CodeAnt-AI Description**
Add library badges, update controls, and quick actions across browse, feed, reader, and settings

### What Changed
- Library covers can now show a downloaded-chapter badge, and the library screen can show both unread and downloaded counts together
- Library adds an incognito mode banner and a one-tap toggle in the top bar
- Categories now let you choose how often they should be checked for updates, and the list shows each category’s current frequency
- Library updates can skip manga with unread chapters, completed manga, or manga that have never been started, and skipped items are summarized after the update
- Browse and Feed now support long-press to quickly add or remove a manga from the library, with an icon showing items already saved
- Reader adds a chapter filter sheet for skipping read, filtered, or duplicate chapters
- Settings adds controls for download badges, smart update skip options, and a background library cover refresh action

### Impact
`✅ Clearer library status at a glance`
`✅ Fewer unnecessary library update checks`
`✅ Faster add/remove actions from browse and feed`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
