### PR TITLE
Fix #907: Transactional extension install — temp file + atomic rename

### DIFF
--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -146,79 +146,192 @@ class ExtensionInstaller(
     }
 
     /**
+     * Atomically replace [targetFile] with [tempFile].
+     *
+     * Tries API 26+ [java.nio.file.Files.move] with [ATOMIC_MOVE] + [REPLACE_EXISTING]
+     * first. On older Android or when the atomic move fails, falls back to a
+     * backup-then-rename strategy that preserves the original file if anything
+     * goes wrong. Last resort is copy-overwrite.
+     *
+     * @return true on success. On failure [targetFile] is left untouched if possible.
+     */
+    private fun replaceAtomically(tempFile: File, targetFile: File): Boolean {
+        if (!tempFile.exists()) return false
+
+        // API 26+: true atomic move with replace
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            try {
+                java.nio.file.Files.move(
+                    tempFile.toPath(),
+                    targetFile.toPath(),
+                    java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+                    java.nio.file.StandardCopyOption.REPLACE_EXISTING
+                )
+                return true
+            } catch (_: Exception) {
+                // Fall through to fallback
+            }
+        }
+
+        // Pre-API 26: try renameTo first (fast, atomic on same filesystem).
+        // renameTo does not overwrite an existing file on Android.
+        if (!targetFile.exists()) {
+            if (tempFile.renameTo(targetFile)) {
+                return true
+            }
+        } else {
+            // Backup the existing file, then rename temp into place.
+            val backupFile = File(targetFile.parentFile, "${targetFile.name}.bak")
+            if (targetFile.renameTo(backupFile)) {
+                if (tempFile.renameTo(targetFile)) {
+                    backupFile.delete() // Commit: discard backup
+                    return true
+                }
+                // Rollback: restore original file
+                backupFile.renameTo(targetFile)
+                return false
+            }
+        }
+
+        // Last resort: copy temp over target, then delete temp.
+        // Not atomic, but keeps target valid if the copy throws.
+        return try {
+            tempFile.copyTo(targetFile, overwrite = true)
+            targetFile.setReadOnly()
+            tempFile.delete()
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /**
      * Install an extension from a downloaded APK file.
+     *
+     * **Transactional contract**: writes to a temp file (`$pkgName.ext.tmp`), loads and
+     * validates the extension from that temp file, and only after every check passes
+     * atomically renames the temp file to the permanent location (`$pkgName.ext`).
+     * If any step fails the original extension (if any) is left untouched and the temp
+     * file is deleted.
      *
      * @param apkFile The downloaded APK file.
      * @param trustedHash When non-null this hash was already verified by the caller against
-     *   a repository-sourced expected hash. The extension is added to the trust store before
-     *   loading so the universal trust gate inside [ExtensionLoader] passes.  When null (e.g.
-     *   user-sideloaded APK), the extension must already be trusted or [ExtensionLoadResult.Untrusted]
-     *   is returned and the caller must present a user-facing trust confirmation dialog.
+     *   a repository-sourced expected hash. The extension's actual loaded hash is compared
+     *   against this value; the trust store is only updated **after** the extension has been
+     *   successfully loaded and moved to its permanent location.
      */
     suspend fun install(apkFile: File, trustedHash: String? = null): Result<Extension> =
         withContext(Dispatchers.IO) {
-        try {
-            _installationState.value = InstallationState.Verifying
+            var tempFile: File? = null
+            try {
+                _installationState.value = InstallationState.Verifying
 
-            // Pre-trust when the caller has already verified the hash against a known-good source.
-            if (trustedHash != null) {
-                loader.trustExtension(trustedHash)
-            }
-
-            val packageInfo = parseApkInfo(apkFile)
-                ?: return@withContext Result.failure(
-                    IllegalStateException("Failed to parse APK: ${apkFile.absolutePath}")
-                )
-
-            // Move to permanent location first — Android 14+ requires read-only in filesDir
-            val destFile = File(extensionsDir, "${packageInfo.packageName}.ext")
-            apkFile.copyTo(destFile, overwrite = true)
-            destFile.setReadOnly()
-
-            val loadResult = loader.loadExtension(destFile.absolutePath)
-            when (loadResult) {
-                is ExtensionLoadResult.Error -> {
-                    _installationState.value = InstallationState.Error(
-                        loadResult.message, loadResult.throwable
+                val packageInfo = parseApkInfo(apkFile)
+                    ?: return@withContext Result.failure(
+                        IllegalStateException("Failed to parse APK: ${apkFile.absolutePath}")
                     )
-                    Result.failure(loadResult.throwable ?: IllegalStateException(loadResult.message))
-                }
-                is ExtensionLoadResult.Success -> {
-                    _installationState.value = InstallationState.Installing
-                    val finalExtension = loadResult.extension.copy(apkPath = destFile.absolutePath)
-                    val result = repository.installExtension(
-                        finalExtension.pkgName, destFile.absolutePath
-                    )
-                    result.onSuccess { ext ->
-                        _installationState.value = InstallationState.Success(ext)
-                        // Notify the receiver so private extensions appear in the catalogue
-                        ExtensionInstallReceiver.notifyAdded(context, finalExtension.pkgName)
-                    }.onFailure { error ->
+
+                val pkgName = packageInfo.packageName
+                val destFile = File(extensionsDir, "$pkgName.ext")
+                tempFile = File(extensionsDir, "$pkgName.ext.tmp")
+
+                // 1. Write to temp file — never touch the permanent artifact yet.
+                apkFile.copyTo(tempFile, overwrite = true)
+                tempFile.setReadOnly()
+
+                // 2. Load and validate from the temp file.
+                val loadResult = loader.loadExtension(tempFile.absolutePath)
+
+                // 3. Resolve whether the loaded extension is acceptable.
+                val extension = when (loadResult) {
+                    is ExtensionLoadResult.Success -> loadResult.extension
+                    is ExtensionLoadResult.Untrusted -> {
+                        val extHash = loadResult.extension.signatureHash
+                        if (trustedHash != null && extHash == trustedHash) {
+                            // Caller already verified this hash against a known-good source;
+                            // allow the untrusted result to proceed.
+                            loadResult.extension
+                        } else {
+                            _installationState.value = InstallationState.Error(
+                                "Extension is not trusted. Please verify its signature before installing.",
+                                null
+                            )
+                            return@withContext Result.failure(
+                                IllegalStateException("Untrusted extension: ${loadResult.extension.pkgName}")
+                            )
+                        }
+                    }
+                    is ExtensionLoadResult.Error -> {
                         _installationState.value = InstallationState.Error(
-                            "Failed to save extension: ${error.message}", error
+                            loadResult.message, loadResult.throwable
+                        )
+                        return@withContext Result.failure(
+                            loadResult.throwable ?: IllegalStateException(loadResult.message)
                         )
                     }
-                    result
                 }
-                is ExtensionLoadResult.Untrusted -> {
-                    _installationState.value = InstallationState.Error(
-                        "Extension is not trusted. Please verify its signature before installing.", null
+
+                // 4. If caller supplied a trusted hash, the loaded extension must match it.
+                if (trustedHash != null && extension.signatureHash != trustedHash) {
+                    return@withContext Result.failure(
+                        SecurityException(
+                            "Trust hash mismatch for ${extension.pkgName}: " +
+                                "expected $trustedHash, got ${extension.signatureHash}"
+                        )
                     )
-                    Result.failure(IllegalStateException("Untrusted extension: ${loadResult.extension.pkgName}"))
                 }
+
+                // 5. Atomic rename temp → permanent.
+                if (!replaceAtomically(tempFile, destFile)) {
+                    return@withContext Result.failure(
+                        IllegalStateException(
+                            "Failed to move extension to permanent location: ${destFile.absolutePath}"
+                        )
+                    )
+                }
+                tempFile = null // Ownership transferred to destFile
+
+                // 6. Trust ONLY after successful load + atomic move.
+                extension.signatureHash?.let { hash ->
+                    loader.trustExtension(hash)
+                }
+
+                // 7. Update repository state.
+                _installationState.value = InstallationState.Installing
+                val finalExtension = extension.copy(apkPath = destFile.absolutePath)
+                val result = repository.installExtension(finalExtension.pkgName, destFile.absolutePath)
+                result.onSuccess { ext ->
+                    _installationState.value = InstallationState.Success(ext)
+                    ExtensionInstallReceiver.notifyAdded(context, finalExtension.pkgName)
+                }.onFailure { error ->
+                    _installationState.value = InstallationState.Error(
+                        "Failed to save extension: ${error.message}", error
+                    )
+                }
+                result
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _installationState.value = InstallationState.Error("Installation failed", e)
+                Result.failure(e)
+            } finally {
+                // Clean up temp file if the atomic rename never happened.
+                tempFile?.delete()
+                // Clean up the download artifact.
+                if (apkFile.exists() && apkFile.parentFile == downloadsDir) apkFile.delete()
             }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            _installationState.value = InstallationState.Error("Installation failed", e)
-            Result.failure(e)
-        } finally {
-            if (apkFile.exists() && apkFile.parentFile == downloadsDir) apkFile.delete()
         }
-    }
     
     /**
      * Update an existing extension.
+     *
+     * **Transactional contract**: writes the new APK to a temp file (`$pkgName.ext.tmp`),
+     * parses it, loads the extension from the temp file, and verifies signer continuity
+     * against the currently installed version. Only after every validation step passes
+     * is the temp file atomically promoted to the permanent location (`$pkgName.ext`).
+     * If any step fails the original extension remains untouched and the temp file is
+     * cleaned up.
+     *
      * @param pkgName Package name of the extension to update
      * @param newApkFile The new APK file
      * @return Result containing the updated Extension
@@ -226,6 +339,7 @@ class ExtensionInstaller(
     @Suppress("LongMethod")
     suspend fun update(pkgName: String, newApkFile: File): Result<Extension> =
         withContext(Dispatchers.IO) {
+            var tempFile: File? = null
             try {
                 _installationState.value = InstallationState.Verifying
 
@@ -242,55 +356,79 @@ class ExtensionInstaller(
                     )
                 }
 
-                // Move to permanent location first — Android 14+ requires read-only in filesDir
                 val destFile = File(extensionsDir, "$pkgName.ext")
-                newApkFile.copyTo(destFile, overwrite = true)
-                destFile.setReadOnly()
+                tempFile = File(extensionsDir, "$pkgName.ext.tmp")
 
-                when (val loadResult = loader.loadExtension(destFile.absolutePath)) {
+                // 1. Write to temp file — preserve the working artifact until validation passes.
+                newApkFile.copyTo(tempFile, overwrite = true)
+                tempFile.setReadOnly()
+
+                // 2. Load and validate from the temp file.
+                val loadResult = loader.loadExtension(tempFile.absolutePath)
+
+                val extension = when (loadResult) {
+                    is ExtensionLoadResult.Success -> loadResult.extension
+                    is ExtensionLoadResult.Untrusted -> {
+                        _installationState.value = InstallationState.Error(
+                            "Extension is not trusted. Please verify its signature before updating.",
+                            null
+                        )
+                        return@withContext Result.failure(
+                            IllegalStateException("Untrusted extension: ${loadResult.extension.pkgName}")
+                        )
+                    }
                     is ExtensionLoadResult.Error -> {
                         _installationState.value = InstallationState.Error(
                             loadResult.message, loadResult.throwable
                         )
-                        Result.failure(loadResult.throwable ?: IllegalStateException(loadResult.message))
-                    }
-                    is ExtensionLoadResult.Success -> {
-                        // Signer continuity: reject if signing certificate changed — a compromised
-                        // repository could swap a trusted extension for a differently-signed one.
-                        val oldExtension = repository.getExtension(pkgName)
-                        val newHash = loadResult.extension.signatureHash
-                        if (oldExtension?.signatureHash != null && newHash != oldExtension.signatureHash) {
-                            return@withContext Result.failure(
-                                SecurityException("Extension update rejected: signing certificate changed for $pkgName")
-                            )
-                        }
-                        _installationState.value = InstallationState.Installing
-                        oldExtension?.apkPath?.let { File(it).delete() }
-                        val result = repository.updateExtension(pkgName, destFile.absolutePath)
-                        result.onSuccess { ext ->
-                            _installationState.value = InstallationState.Success(ext)
-                            // Notify the receiver so private extensions appear in the catalogue
-                            ExtensionInstallReceiver.notifyReplaced(context, pkgName)
-                        }.onFailure { error ->
-                            _installationState.value = InstallationState.Error(
-                                "Failed to update extension: ${error.message}", error
-                            )
-                        }
-                        result
-                    }
-                    is ExtensionLoadResult.Untrusted -> {
-                        _installationState.value = InstallationState.Error(
-                            "Extension is not trusted. Please verify its signature before updating.", null
+                        return@withContext Result.failure(
+                            loadResult.throwable ?: IllegalStateException(loadResult.message)
                         )
-                        Result.failure(IllegalStateException("Untrusted extension: ${loadResult.extension.pkgName}"))
                     }
                 }
+                // 3. Signer continuity: reject if signing certificate changed — a compromised
+                // repository could swap a trusted extension for a differently-signed one.
+                val oldExtension = repository.getExtension(pkgName)
+                val newHash = extension.signatureHash
+                if (oldExtension?.signatureHash != null && newHash != oldExtension.signatureHash) {
+                    return@withContext Result.failure(
+                        SecurityException(
+                            "Extension update rejected: signing certificate changed for $pkgName"
+                        )
+                    )
+                }
+
+                // 4. Atomic rename temp → permanent.
+                if (!replaceAtomically(tempFile, destFile)) {
+                    return@withContext Result.failure(
+                        IllegalStateException(
+                            "Failed to move extension to permanent location: ${destFile.absolutePath}"
+                        )
+                    )
+                }
+                tempFile = null // Ownership transferred to destFile
+
+                // 5. Update repository state. The old file has already been replaced atomically.
+                _installationState.value = InstallationState.Installing
+                val result = repository.updateExtension(pkgName, destFile.absolutePath)
+                result.onSuccess { ext ->
+                    _installationState.value = InstallationState.Success(ext)
+                    ExtensionInstallReceiver.notifyReplaced(context, pkgName)
+                }.onFailure { error ->
+                    _installationState.value = InstallationState.Error(
+                        "Failed to update extension: ${error.message}", error
+                    )
+                }
+                result
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 _installationState.value = InstallationState.Error("Update failed", e)
                 Result.failure(e)
             } finally {
+                // Clean up temp file if the atomic rename never happened.
+                tempFile?.delete()
+                // Clean up the download artifact.
                 if (newApkFile.exists() && newApkFile.parentFile == downloadsDir) newApkFile.delete()
             }
         }


### PR DESCRIPTION
## **User description**
Closes #907

## What
Makes extension install/update operations atomic. Previously, the installer copied directly to the permanent file, then validated — meaning a failed validation could corrupt the working extension.

## How
- Writes to  first
- Loads and validates from the temp file
- Only after successful load: atomic rename temp → permanent
- If anything fails: temp deleted, original untouched
- Trust store updated **after** successful load (not before)

## Safety layers
1.  on API 26+
2. Backup-then-rename ( + rollback) for pre-API 26
3. Copy-overwrite fallback as last resort

## Behavior
- Success paths: unchanged
- Failure paths: now safe — no corrupted extensions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installations and updates now use atomic file replacement to prevent partial installs and improve reliability.
  * Signature validation and trust checks are strictly enforced; provided trust values must match installed signatures.
  * Updates now require signer continuity before replacing an extension.
  * Improved error reporting and guaranteed cleanup of temporary installation files after failures.
  * Notifications are sent only after a successful atomic install/update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Heartless-Veteran/Otaku-Reader/pull/913?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Make extension installs and updates safe until validation finishes**

### What Changed
- Extension installs and updates now stay in a temporary file until the new package is loaded and checked successfully
- If validation fails, the existing extension is left in place and the temporary file is cleaned up
- Trusted extensions are now marked trusted only after the new file has been loaded and moved into place
- Update flow now rejects packages signed by a different certificate than the installed version
- When replacing an extension file, the app now tries safer move paths first and falls back to a copy only if needed

### Impact
`✅ Fewer corrupted extensions after failed installs`
`✅ Safer extension updates`
`✅ Fewer broken installs on older Android versions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
