### PR TITLE
fix: address major audit findings — data integrity, architecture, extension safety

### DIFF
--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -222,7 +222,10 @@ fun OtakuReaderNavHost(
                 navController.navigate(Route.MangaDetails(mangaId)) {
                     popUpTo<Route.SourceMangaDetail> { inclusive = true }
                 }
-            }
+            },
+            onNavigateBack = {
+                navController.popBackStack()
+            },
         )
 
         // Extensions bottom sheet

--- a/core/database/schemas/app.otakureader.core.database.OtakuReaderDatabase/24.json
+++ b/core/database/schemas/app.otakureader.core.database.OtakuReaderDatabase/24.json
@@ -1,0 +1,1389 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 24,
+    "identityHash": "9ffdcbd69463f46a51db3fbc5308a952",
+    "entities": [
+      {
+        "tableName": "manga",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `thumbnailUrl` TEXT, `author` TEXT, `artist` TEXT, `description` TEXT, `genre` TEXT, `status` INTEGER NOT NULL, `favorite` INTEGER NOT NULL, `lastUpdate` INTEGER NOT NULL, `initialized` INTEGER NOT NULL, `viewerFlags` INTEGER NOT NULL, `chapterFlags` INTEGER NOT NULL, `coverLastModified` INTEGER NOT NULL, `dateAdded` INTEGER NOT NULL, `autoDownload` INTEGER NOT NULL, `notes` TEXT, `notifyNewChapters` INTEGER NOT NULL, `readerDirection` INTEGER, `readerMode` INTEGER, `readerColorFilter` INTEGER, `readerCustomTintColor` INTEGER, `readerBackgroundColor` INTEGER, `preloadPagesBefore` INTEGER, `preloadPagesAfter` INTEGER, `contentRating` INTEGER NOT NULL, `userCompleted` INTEGER NOT NULL, `userDropped` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdate",
+            "columnName": "lastUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "initialized",
+            "columnName": "initialized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewerFlags",
+            "columnName": "viewerFlags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterFlags",
+            "columnName": "chapterFlags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverLastModified",
+            "columnName": "coverLastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "dateAdded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownload",
+            "columnName": "autoDownload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notifyNewChapters",
+            "columnName": "notifyNewChapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readerDirection",
+            "columnName": "readerDirection",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerMode",
+            "columnName": "readerMode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerColorFilter",
+            "columnName": "readerColorFilter",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerCustomTintColor",
+            "columnName": "readerCustomTintColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerBackgroundColor",
+            "columnName": "readerBackgroundColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "preloadPagesBefore",
+            "columnName": "preloadPagesBefore",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "preloadPagesAfter",
+            "columnName": "preloadPagesAfter",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "contentRating",
+            "columnName": "contentRating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userCompleted",
+            "columnName": "userCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDropped",
+            "columnName": "userDropped",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_manga_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_manga_title",
+            "unique": false,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_title` ON `${TABLE_NAME}` (`title`)"
+          },
+          {
+            "name": "index_manga_favorite",
+            "unique": false,
+            "columnNames": [
+              "favorite"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_favorite` ON `${TABLE_NAME}` (`favorite`)"
+          },
+          {
+            "name": "index_manga_sourceId_url",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_manga_sourceId_url` ON `${TABLE_NAME}` (`sourceId`, `url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mangaId` INTEGER NOT NULL, `url` TEXT NOT NULL, `name` TEXT NOT NULL, `scanlator` TEXT, `read` INTEGER NOT NULL, `bookmark` INTEGER NOT NULL, `lastPageRead` INTEGER NOT NULL, `chapterNumber` REAL NOT NULL, `sourceOrder` INTEGER NOT NULL, `dateFetch` INTEGER NOT NULL, `dateUpload` INTEGER NOT NULL, `lastModified` INTEGER NOT NULL, `userNotes` TEXT, FOREIGN KEY(`mangaId`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scanlator",
+            "columnName": "scanlator",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmark",
+            "columnName": "bookmark",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPageRead",
+            "columnName": "lastPageRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterNumber",
+            "columnName": "chapterNumber",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceOrder",
+            "columnName": "sourceOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateFetch",
+            "columnName": "dateFetch",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateUpload",
+            "columnName": "dateUpload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userNotes",
+            "columnName": "userNotes",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapters_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          },
+          {
+            "name": "index_chapters_mangaId_url",
+            "unique": true,
+            "columnNames": [
+              "mangaId",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chapters_mangaId_url` ON `${TABLE_NAME}` (`mangaId`, `url`)"
+          },
+          {
+            "name": "index_chapters_read",
+            "unique": false,
+            "columnNames": [
+              "read"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_read` ON `${TABLE_NAME}` (`read`)"
+          },
+          {
+            "name": "index_chapters_bookmark",
+            "unique": false,
+            "columnNames": [
+              "bookmark"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_bookmark` ON `${TABLE_NAME}` (`bookmark`)"
+          },
+          {
+            "name": "index_chapters_dateFetch",
+            "unique": false,
+            "columnNames": [
+              "dateFetch"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_dateFetch` ON `${TABLE_NAME}` (`dateFetch`)"
+          },
+          {
+            "name": "index_chapters_mangaId_dateFetch",
+            "unique": false,
+            "columnNames": [
+              "mangaId",
+              "dateFetch"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_mangaId_dateFetch` ON `${TABLE_NAME}` (`mangaId`, `dateFetch`)"
+          },
+          {
+            "name": "index_chapters_mangaId_read_sourceOrder",
+            "unique": false,
+            "columnNames": [
+              "mangaId",
+              "read",
+              "sourceOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_mangaId_read_sourceOrder` ON `${TABLE_NAME}` (`mangaId`, `read`, `sourceOrder`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mangaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `order` INTEGER NOT NULL, `flags` INTEGER NOT NULL, `update_frequency` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "flags",
+            "columnName": "flags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateFrequency",
+            "columnName": "update_frequency",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "manga_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mangaId` INTEGER NOT NULL, `categoryId` INTEGER NOT NULL, PRIMARY KEY(`mangaId`, `categoryId`), FOREIGN KEY(`mangaId`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`categoryId`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "mangaId",
+            "categoryId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_manga_categories_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_categories_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          },
+          {
+            "name": "index_manga_categories_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_categories_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mangaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "categories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "categoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reading_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `chapter_id` INTEGER NOT NULL, `read_at` INTEGER NOT NULL, `read_duration_ms` INTEGER NOT NULL, FOREIGN KEY(`chapter_id`) REFERENCES `chapters`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readAt",
+            "columnName": "read_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readDurationMs",
+            "columnName": "read_duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_history_chapter_id",
+            "unique": true,
+            "columnNames": [
+              "chapter_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_reading_history_chapter_id` ON `${TABLE_NAME}` (`chapter_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chapters",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapter_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reading_streaks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `chapter_count` INTEGER NOT NULL, `read_duration_ms` INTEGER NOT NULL, `last_read_at` INTEGER NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterCount",
+            "columnName": "chapter_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readDurationMs",
+            "columnName": "read_duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadAt",
+            "columnName": "last_read_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        }
+      },
+      {
+        "tableName": "opds_servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_opds_servers_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_opds_servers_url` ON `${TABLE_NAME}` (`url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mangaId` INTEGER NOT NULL, `mangaTitle` TEXT NOT NULL, `mangaThumbnailUrl` TEXT, `chapterId` INTEGER NOT NULL, `chapterName` TEXT NOT NULL, `chapterNumber` REAL NOT NULL, `sourceId` INTEGER NOT NULL, `sourceName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `isRead` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaTitle",
+            "columnName": "mangaTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaThumbnailUrl",
+            "columnName": "mangaThumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterName",
+            "columnName": "chapterName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterNumber",
+            "columnName": "chapterNumber",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "sourceName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_feed_items_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_feed_items_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `sourceName` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `itemCount` INTEGER NOT NULL, `order` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "sourceName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_sources_sourceId",
+            "unique": true,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_feed_sources_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_saved_searches",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `sourceName` TEXT NOT NULL, `query` TEXT NOT NULL, `filtersJson` TEXT, `order` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "sourceName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filtersJson",
+            "columnName": "filtersJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_saved_searches_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_saved_searches_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tracker_sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mangaId` INTEGER NOT NULL, `trackerId` INTEGER NOT NULL, `remoteId` TEXT NOT NULL, `localLastChapterRead` REAL NOT NULL, `localTotalChapters` INTEGER NOT NULL, `localStatus` INTEGER NOT NULL, `localLastModified` INTEGER NOT NULL, `remoteLastChapterRead` REAL NOT NULL, `remoteTotalChapters` INTEGER NOT NULL, `remoteStatus` INTEGER NOT NULL, `remoteLastModified` INTEGER, `syncStatus` INTEGER NOT NULL, `lastSyncAttempt` INTEGER, `lastSuccessfulSync` INTEGER, `syncError` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerId",
+            "columnName": "trackerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localLastChapterRead",
+            "columnName": "localLastChapterRead",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localTotalChapters",
+            "columnName": "localTotalChapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localStatus",
+            "columnName": "localStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localLastModified",
+            "columnName": "localLastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteLastChapterRead",
+            "columnName": "remoteLastChapterRead",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteTotalChapters",
+            "columnName": "remoteTotalChapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteStatus",
+            "columnName": "remoteStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteLastModified",
+            "columnName": "remoteLastModified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncAttempt",
+            "columnName": "lastSyncAttempt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastSuccessfulSync",
+            "columnName": "lastSuccessfulSync",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncError",
+            "columnName": "syncError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tracker_sync_state_mangaId_trackerId",
+            "unique": true,
+            "columnNames": [
+              "mangaId",
+              "trackerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tracker_sync_state_mangaId_trackerId` ON `${TABLE_NAME}` (`mangaId`, `trackerId`)"
+          },
+          {
+            "name": "index_tracker_sync_state_syncStatus",
+            "unique": false,
+            "columnNames": [
+              "syncStatus"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracker_sync_state_syncStatus` ON `${TABLE_NAME}` (`syncStatus`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_configuration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackerId` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `syncDirection` INTEGER NOT NULL, `conflictResolution` INTEGER NOT NULL, `autoSyncInterval` INTEGER NOT NULL, `syncOnChapterRead` INTEGER NOT NULL, `syncOnMarkComplete` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerId",
+            "columnName": "trackerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncDirection",
+            "columnName": "syncDirection",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conflictResolution",
+            "columnName": "conflictResolution",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoSyncInterval",
+            "columnName": "autoSyncInterval",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncOnChapterRead",
+            "columnName": "syncOnChapterRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncOnMarkComplete",
+            "columnName": "syncOnMarkComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_configuration_trackerId",
+            "unique": true,
+            "columnNames": [
+              "trackerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_configuration_trackerId` ON `${TABLE_NAME}` (`trackerId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "page_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `manga_id` INTEGER NOT NULL, `chapter_id` INTEGER NOT NULL, `page_index` INTEGER NOT NULL, `note` TEXT, `created_at` INTEGER NOT NULL, FOREIGN KEY(`chapter_id`) REFERENCES `chapters`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`manga_id`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageIndex",
+            "columnName": "page_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_page_bookmarks_chapter_id",
+            "unique": false,
+            "columnNames": [
+              "chapter_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_bookmarks_chapter_id` ON `${TABLE_NAME}` (`chapter_id`)"
+          },
+          {
+            "name": "index_page_bookmarks_manga_id",
+            "unique": false,
+            "columnNames": [
+              "manga_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_bookmarks_manga_id` ON `${TABLE_NAME}` (`manga_id`)"
+          },
+          {
+            "name": "index_page_bookmarks_manga_id_created_at",
+            "unique": false,
+            "columnNames": [
+              "manga_id",
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_bookmarks_manga_id_created_at` ON `${TABLE_NAME}` (`manga_id`, `created_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chapters",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapter_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "manga_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reading_lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `color` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`listId` INTEGER NOT NULL, `mangaId` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, `note` TEXT, PRIMARY KEY(`listId`, `mangaId`), FOREIGN KEY(`listId`) REFERENCES `reading_lists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`mangaId`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "listId",
+            "mangaId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_list_items_listId",
+            "unique": false,
+            "columnNames": [
+              "listId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_list_items_listId` ON `${TABLE_NAME}` (`listId`)"
+          },
+          {
+            "name": "index_reading_list_items_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_list_items_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          },
+          {
+            "name": "index_reading_list_items_listId_addedAt",
+            "unique": false,
+            "columnNames": [
+              "listId",
+              "addedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_list_items_listId_addedAt` ON `${TABLE_NAME}` (`listId`, `addedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "reading_lists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mangaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "download_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chapter_id` INTEGER NOT NULL, `manga_id` INTEGER NOT NULL, `manga_title` TEXT NOT NULL, `chapter_title` TEXT NOT NULL, `source_name` TEXT NOT NULL, `page_urls_json` TEXT NOT NULL, `priority` INTEGER NOT NULL, `status` TEXT NOT NULL, `added_at` INTEGER NOT NULL, PRIMARY KEY(`chapter_id`))",
+        "fields": [
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaTitle",
+            "columnName": "manga_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterTitle",
+            "columnName": "chapter_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "source_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageUrlsJson",
+            "columnName": "page_urls_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chapter_id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9ffdcbd69463f46a51db3fbc5308a952')"
+    ]
+  }
+}

--- a/core/database/schemas/app.otakureader.core.database.OtakuReaderDatabase/25.json
+++ b/core/database/schemas/app.otakureader.core.database.OtakuReaderDatabase/25.json
@@ -1,0 +1,1503 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 25,
+    "identityHash": "c539a0abbfdc9db6df3586b72f3f98d8",
+    "entities": [
+      {
+        "tableName": "manga",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `thumbnailUrl` TEXT, `author` TEXT, `artist` TEXT, `description` TEXT, `genre` TEXT, `status` INTEGER NOT NULL, `favorite` INTEGER NOT NULL, `lastUpdate` INTEGER NOT NULL, `initialized` INTEGER NOT NULL, `viewerFlags` INTEGER NOT NULL, `chapterFlags` INTEGER NOT NULL, `coverLastModified` INTEGER NOT NULL, `dateAdded` INTEGER NOT NULL, `autoDownload` INTEGER NOT NULL, `notes` TEXT, `notifyNewChapters` INTEGER NOT NULL, `readerDirection` INTEGER, `readerMode` INTEGER, `readerColorFilter` INTEGER, `readerCustomTintColor` INTEGER, `readerBackgroundColor` INTEGER, `preloadPagesBefore` INTEGER, `preloadPagesAfter` INTEGER, `contentRating` INTEGER NOT NULL, `userCompleted` INTEGER NOT NULL, `userDropped` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdate",
+            "columnName": "lastUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "initialized",
+            "columnName": "initialized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewerFlags",
+            "columnName": "viewerFlags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterFlags",
+            "columnName": "chapterFlags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverLastModified",
+            "columnName": "coverLastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "dateAdded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownload",
+            "columnName": "autoDownload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notifyNewChapters",
+            "columnName": "notifyNewChapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readerDirection",
+            "columnName": "readerDirection",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerMode",
+            "columnName": "readerMode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerColorFilter",
+            "columnName": "readerColorFilter",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerCustomTintColor",
+            "columnName": "readerCustomTintColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerBackgroundColor",
+            "columnName": "readerBackgroundColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "preloadPagesBefore",
+            "columnName": "preloadPagesBefore",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "preloadPagesAfter",
+            "columnName": "preloadPagesAfter",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "contentRating",
+            "columnName": "contentRating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userCompleted",
+            "columnName": "userCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDropped",
+            "columnName": "userDropped",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_manga_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_manga_title",
+            "unique": false,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_title` ON `${TABLE_NAME}` (`title`)"
+          },
+          {
+            "name": "index_manga_favorite",
+            "unique": false,
+            "columnNames": [
+              "favorite"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_favorite` ON `${TABLE_NAME}` (`favorite`)"
+          },
+          {
+            "name": "index_manga_sourceId_url",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_manga_sourceId_url` ON `${TABLE_NAME}` (`sourceId`, `url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mangaId` INTEGER NOT NULL, `url` TEXT NOT NULL, `name` TEXT NOT NULL, `scanlator` TEXT, `read` INTEGER NOT NULL, `bookmark` INTEGER NOT NULL, `lastPageRead` INTEGER NOT NULL, `chapterNumber` REAL NOT NULL, `sourceOrder` INTEGER NOT NULL, `dateFetch` INTEGER NOT NULL, `dateUpload` INTEGER NOT NULL, `lastModified` INTEGER NOT NULL, `userNotes` TEXT, FOREIGN KEY(`mangaId`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scanlator",
+            "columnName": "scanlator",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmark",
+            "columnName": "bookmark",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPageRead",
+            "columnName": "lastPageRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterNumber",
+            "columnName": "chapterNumber",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceOrder",
+            "columnName": "sourceOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateFetch",
+            "columnName": "dateFetch",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateUpload",
+            "columnName": "dateUpload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userNotes",
+            "columnName": "userNotes",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapters_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          },
+          {
+            "name": "index_chapters_mangaId_url",
+            "unique": true,
+            "columnNames": [
+              "mangaId",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chapters_mangaId_url` ON `${TABLE_NAME}` (`mangaId`, `url`)"
+          },
+          {
+            "name": "index_chapters_read",
+            "unique": false,
+            "columnNames": [
+              "read"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_read` ON `${TABLE_NAME}` (`read`)"
+          },
+          {
+            "name": "index_chapters_bookmark",
+            "unique": false,
+            "columnNames": [
+              "bookmark"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_bookmark` ON `${TABLE_NAME}` (`bookmark`)"
+          },
+          {
+            "name": "index_chapters_dateFetch",
+            "unique": false,
+            "columnNames": [
+              "dateFetch"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_dateFetch` ON `${TABLE_NAME}` (`dateFetch`)"
+          },
+          {
+            "name": "index_chapters_mangaId_dateFetch",
+            "unique": false,
+            "columnNames": [
+              "mangaId",
+              "dateFetch"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_mangaId_dateFetch` ON `${TABLE_NAME}` (`mangaId`, `dateFetch`)"
+          },
+          {
+            "name": "index_chapters_mangaId_read_sourceOrder",
+            "unique": false,
+            "columnNames": [
+              "mangaId",
+              "read",
+              "sourceOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_mangaId_read_sourceOrder` ON `${TABLE_NAME}` (`mangaId`, `read`, `sourceOrder`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mangaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `order` INTEGER NOT NULL, `flags` INTEGER NOT NULL, `update_frequency` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "flags",
+            "columnName": "flags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateFrequency",
+            "columnName": "update_frequency",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "manga_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mangaId` INTEGER NOT NULL, `categoryId` INTEGER NOT NULL, PRIMARY KEY(`mangaId`, `categoryId`), FOREIGN KEY(`mangaId`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`categoryId`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "mangaId",
+            "categoryId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_manga_categories_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_categories_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          },
+          {
+            "name": "index_manga_categories_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_categories_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mangaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "categories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "categoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reading_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `chapter_id` INTEGER NOT NULL, `read_at` INTEGER NOT NULL, `read_duration_ms` INTEGER NOT NULL, FOREIGN KEY(`chapter_id`) REFERENCES `chapters`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readAt",
+            "columnName": "read_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readDurationMs",
+            "columnName": "read_duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_history_chapter_id",
+            "unique": true,
+            "columnNames": [
+              "chapter_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_reading_history_chapter_id` ON `${TABLE_NAME}` (`chapter_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chapters",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapter_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reading_streaks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `chapter_count` INTEGER NOT NULL, `read_duration_ms` INTEGER NOT NULL, `last_read_at` INTEGER NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterCount",
+            "columnName": "chapter_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readDurationMs",
+            "columnName": "read_duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadAt",
+            "columnName": "last_read_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        }
+      },
+      {
+        "tableName": "opds_servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_opds_servers_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_opds_servers_url` ON `${TABLE_NAME}` (`url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mangaId` INTEGER NOT NULL, `mangaTitle` TEXT NOT NULL, `mangaThumbnailUrl` TEXT, `chapterId` INTEGER NOT NULL, `chapterName` TEXT NOT NULL, `chapterNumber` REAL NOT NULL, `sourceId` INTEGER NOT NULL, `sourceName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `isRead` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaTitle",
+            "columnName": "mangaTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaThumbnailUrl",
+            "columnName": "mangaThumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterName",
+            "columnName": "chapterName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterNumber",
+            "columnName": "chapterNumber",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "sourceName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_feed_items_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_feed_items_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `sourceName` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `itemCount` INTEGER NOT NULL, `order` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "sourceName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_sources_sourceId",
+            "unique": true,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_feed_sources_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_saved_searches",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `sourceName` TEXT NOT NULL, `query` TEXT NOT NULL, `filtersJson` TEXT, `order` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "sourceName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filtersJson",
+            "columnName": "filtersJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_saved_searches_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_saved_searches_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tracker_sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mangaId` INTEGER NOT NULL, `trackerId` INTEGER NOT NULL, `remoteId` TEXT NOT NULL, `localLastChapterRead` REAL NOT NULL, `localTotalChapters` INTEGER NOT NULL, `localStatus` INTEGER NOT NULL, `localLastModified` INTEGER NOT NULL, `remoteLastChapterRead` REAL NOT NULL, `remoteTotalChapters` INTEGER NOT NULL, `remoteStatus` INTEGER NOT NULL, `remoteLastModified` INTEGER, `syncStatus` INTEGER NOT NULL, `lastSyncAttempt` INTEGER, `lastSuccessfulSync` INTEGER, `syncError` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerId",
+            "columnName": "trackerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localLastChapterRead",
+            "columnName": "localLastChapterRead",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localTotalChapters",
+            "columnName": "localTotalChapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localStatus",
+            "columnName": "localStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localLastModified",
+            "columnName": "localLastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteLastChapterRead",
+            "columnName": "remoteLastChapterRead",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteTotalChapters",
+            "columnName": "remoteTotalChapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteStatus",
+            "columnName": "remoteStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteLastModified",
+            "columnName": "remoteLastModified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncAttempt",
+            "columnName": "lastSyncAttempt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastSuccessfulSync",
+            "columnName": "lastSuccessfulSync",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncError",
+            "columnName": "syncError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tracker_sync_state_mangaId_trackerId",
+            "unique": true,
+            "columnNames": [
+              "mangaId",
+              "trackerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tracker_sync_state_mangaId_trackerId` ON `${TABLE_NAME}` (`mangaId`, `trackerId`)"
+          },
+          {
+            "name": "index_tracker_sync_state_syncStatus",
+            "unique": false,
+            "columnNames": [
+              "syncStatus"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracker_sync_state_syncStatus` ON `${TABLE_NAME}` (`syncStatus`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_configuration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackerId` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `syncDirection` INTEGER NOT NULL, `conflictResolution` INTEGER NOT NULL, `autoSyncInterval` INTEGER NOT NULL, `syncOnChapterRead` INTEGER NOT NULL, `syncOnMarkComplete` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerId",
+            "columnName": "trackerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncDirection",
+            "columnName": "syncDirection",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conflictResolution",
+            "columnName": "conflictResolution",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoSyncInterval",
+            "columnName": "autoSyncInterval",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncOnChapterRead",
+            "columnName": "syncOnChapterRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncOnMarkComplete",
+            "columnName": "syncOnMarkComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_configuration_trackerId",
+            "unique": true,
+            "columnNames": [
+              "trackerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_configuration_trackerId` ON `${TABLE_NAME}` (`trackerId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "page_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `manga_id` INTEGER NOT NULL, `chapter_id` INTEGER NOT NULL, `page_index` INTEGER NOT NULL, `note` TEXT, `created_at` INTEGER NOT NULL, FOREIGN KEY(`chapter_id`) REFERENCES `chapters`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`manga_id`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageIndex",
+            "columnName": "page_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_page_bookmarks_chapter_id",
+            "unique": false,
+            "columnNames": [
+              "chapter_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_bookmarks_chapter_id` ON `${TABLE_NAME}` (`chapter_id`)"
+          },
+          {
+            "name": "index_page_bookmarks_manga_id",
+            "unique": false,
+            "columnNames": [
+              "manga_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_bookmarks_manga_id` ON `${TABLE_NAME}` (`manga_id`)"
+          },
+          {
+            "name": "index_page_bookmarks_manga_id_created_at",
+            "unique": false,
+            "columnNames": [
+              "manga_id",
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_bookmarks_manga_id_created_at` ON `${TABLE_NAME}` (`manga_id`, `created_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chapters",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapter_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "manga_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reading_lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `color` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`listId` INTEGER NOT NULL, `mangaId` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, `note` TEXT, PRIMARY KEY(`listId`, `mangaId`), FOREIGN KEY(`listId`) REFERENCES `reading_lists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`mangaId`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "listId",
+            "mangaId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_list_items_listId",
+            "unique": false,
+            "columnNames": [
+              "listId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_list_items_listId` ON `${TABLE_NAME}` (`listId`)"
+          },
+          {
+            "name": "index_reading_list_items_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_list_items_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          },
+          {
+            "name": "index_reading_list_items_listId_addedAt",
+            "unique": false,
+            "columnNames": [
+              "listId",
+              "addedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_list_items_listId_addedAt` ON `${TABLE_NAME}` (`listId`, `addedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "reading_lists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mangaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "download_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chapter_id` INTEGER NOT NULL, `manga_id` INTEGER NOT NULL, `manga_title` TEXT NOT NULL, `chapter_title` TEXT NOT NULL, `source_name` TEXT NOT NULL, `page_urls_json` TEXT NOT NULL, `priority` INTEGER NOT NULL, `status` TEXT NOT NULL, `added_at` INTEGER NOT NULL, PRIMARY KEY(`chapter_id`))",
+        "fields": [
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaTitle",
+            "columnName": "manga_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterTitle",
+            "columnName": "chapter_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "source_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageUrlsJson",
+            "columnName": "page_urls_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chapter_id"
+          ]
+        }
+      },
+      {
+        "tableName": "track_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `manga_id` INTEGER NOT NULL, `tracker_id` INTEGER NOT NULL, `remote_id` INTEGER NOT NULL, `remote_url` TEXT NOT NULL, `title` TEXT NOT NULL, `status` INTEGER NOT NULL, `last_chapter_read` REAL NOT NULL, `total_chapters` INTEGER NOT NULL, `score` REAL NOT NULL, `start_date` INTEGER NOT NULL, `finish_date` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerId",
+            "columnName": "tracker_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteUrl",
+            "columnName": "remote_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChapterRead",
+            "columnName": "last_chapter_read",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalChapters",
+            "columnName": "total_chapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishDate",
+            "columnName": "finish_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_entries_manga_id",
+            "unique": false,
+            "columnNames": [
+              "manga_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_entries_manga_id` ON `${TABLE_NAME}` (`manga_id`)"
+          },
+          {
+            "name": "index_track_entries_tracker_id",
+            "unique": false,
+            "columnNames": [
+              "tracker_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_entries_tracker_id` ON `${TABLE_NAME}` (`tracker_id`)"
+          },
+          {
+            "name": "index_track_entries_manga_id_tracker_id",
+            "unique": true,
+            "columnNames": [
+              "manga_id",
+              "tracker_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_track_entries_manga_id_tracker_id` ON `${TABLE_NAME}` (`manga_id`, `tracker_id`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c539a0abbfdc9db6df3586b72f3f98d8')"
+    ]
+  }
+}

--- a/core/database/src/main/java/app/otakureader/core/database/OtakuReaderDatabase.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/OtakuReaderDatabase.kt
@@ -14,6 +14,7 @@ import app.otakureader.core.database.dao.PageBookmarkDao
 import app.otakureader.core.database.dao.ReadingHistoryDao
 import app.otakureader.core.database.dao.ReadingListDao
 import app.otakureader.core.database.dao.ReadingStreakDao
+import app.otakureader.core.database.dao.TrackEntryDao
 import app.otakureader.core.database.dao.TrackerSyncDao
 import app.otakureader.core.database.entity.CategoryEntity
 import app.otakureader.core.database.entity.ChapterEntity
@@ -30,6 +31,7 @@ import app.otakureader.core.database.entity.ReadingListEntity
 import app.otakureader.core.database.entity.ReadingListItemEntity
 import app.otakureader.core.database.entity.ReadingStreakEntity
 import app.otakureader.core.database.entity.SyncConfigurationEntity
+import app.otakureader.core.database.entity.TrackEntryEntity
 import app.otakureader.core.database.entity.TrackerSyncStateEntity
 
 @Database(
@@ -55,8 +57,10 @@ import app.otakureader.core.database.entity.TrackerSyncStateEntity
         ReadingListItemEntity::class,
         // Download queue persistence
         DownloadQueueEntity::class,
+        // Track entries (persisted tracker state)
+        TrackEntryEntity::class,
     ],
-    version = 24,
+    version = 25,
     exportSchema = true
 )
 @TypeConverters(DatabaseConverters::class)
@@ -75,6 +79,7 @@ abstract class OtakuReaderDatabase : RoomDatabase() {
     abstract fun trackerSyncDao(): TrackerSyncDao
     abstract fun readingListDao(): ReadingListDao
     abstract fun downloadQueueDao(): DownloadQueueDao
+    abstract fun trackEntryDao(): TrackEntryDao
 
     companion object {
         const val DATABASE_NAME = "otakureader.db"

--- a/core/database/src/main/java/app/otakureader/core/database/dao/CategoryDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/CategoryDao.kt
@@ -63,5 +63,5 @@ interface CategoryDao {
     suspend fun toggleNsfwFlag(categoryId: Long)
 
     @Query("UPDATE categories SET update_frequency = :updateFrequency WHERE id = :categoryId")
-    suspend fun updateFrequency(categoryId: Long, updateFrequency: String)
+    suspend fun updateFrequency(categoryId: Long, updateFrequency: Int)
 }

--- a/core/database/src/main/java/app/otakureader/core/database/dao/CategoryDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/CategoryDao.kt
@@ -61,4 +61,7 @@ interface CategoryDao {
 
     @Query("UPDATE categories SET flags = CASE WHEN (flags & 2) = 2 THEN flags - 2 ELSE flags + 2 END WHERE id = :categoryId")
     suspend fun toggleNsfwFlag(categoryId: Long)
+
+    @Query("UPDATE categories SET update_frequency = :updateFrequency WHERE id = :categoryId")
+    suspend fun updateFrequency(categoryId: Long, updateFrequency: String)
 }

--- a/core/database/src/main/java/app/otakureader/core/database/dao/TrackEntryDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/TrackEntryDao.kt
@@ -1,0 +1,24 @@
+package app.otakureader.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import app.otakureader.core.database.entity.TrackEntryEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface TrackEntryDao {
+
+    @Query("SELECT * FROM track_entries WHERE manga_id = :mangaId")
+    fun getByMangaId(mangaId: Long): Flow<List<TrackEntryEntity>>
+
+    @Query("SELECT * FROM track_entries WHERE tracker_id = :trackerId AND remote_id = :remoteId LIMIT 1")
+    suspend fun getByTrackerAndRemote(trackerId: Int, remoteId: Long): TrackEntryEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entry: TrackEntryEntity): Long
+
+    @Query("DELETE FROM track_entries WHERE tracker_id = :trackerId AND remote_id = :remoteId")
+    suspend fun deleteByTrackerAndRemote(trackerId: Int, remoteId: Long)
+}

--- a/core/database/src/main/java/app/otakureader/core/database/dao/TrackEntryDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/TrackEntryDao.kt
@@ -13,12 +13,12 @@ interface TrackEntryDao {
     @Query("SELECT * FROM track_entries WHERE manga_id = :mangaId")
     fun getByMangaId(mangaId: Long): Flow<List<TrackEntryEntity>>
 
-    @Query("SELECT * FROM track_entries WHERE tracker_id = :trackerId AND remote_id = :remoteId LIMIT 1")
-    suspend fun getByTrackerAndRemote(trackerId: Int, remoteId: Long): TrackEntryEntity?
+    @Query("SELECT * FROM track_entries WHERE manga_id = :mangaId AND tracker_id = :trackerId LIMIT 1")
+    suspend fun getByMangaAndTracker(mangaId: Long, trackerId: Int): TrackEntryEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(entry: TrackEntryEntity): Long
 
-    @Query("DELETE FROM track_entries WHERE tracker_id = :trackerId AND remote_id = :remoteId")
-    suspend fun deleteByTrackerAndRemote(trackerId: Int, remoteId: Long)
+    @Query("DELETE FROM track_entries WHERE manga_id = :mangaId AND tracker_id = :trackerId")
+    suspend fun deleteByMangaAndTracker(mangaId: Long, trackerId: Int)
 }

--- a/core/database/src/main/java/app/otakureader/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/di/DatabaseModule.kt
@@ -6,6 +6,7 @@ import androidx.room.Room
 import app.otakureader.core.database.BuildConfig
 import app.otakureader.core.database.OtakuReaderDatabase
 import app.otakureader.core.database.dao.DownloadQueueDao
+import app.otakureader.core.database.dao.TrackEntryDao
 import app.otakureader.core.database.migrations.ALL_MIGRATIONS
 import dagger.Module
 import dagger.Provides
@@ -77,4 +78,7 @@ object DatabaseModule {
 
     @Provides
     fun provideDownloadQueueDao(database: OtakuReaderDatabase): DownloadQueueDao = database.downloadQueueDao()
+
+    @Provides
+    fun provideTrackEntryDao(database: OtakuReaderDatabase): TrackEntryDao = database.trackEntryDao()
 }

--- a/core/database/src/main/java/app/otakureader/core/database/entity/CategoryEntity.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/entity/CategoryEntity.kt
@@ -1,5 +1,6 @@
 package app.otakureader.core.database.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
@@ -10,7 +11,8 @@ data class CategoryEntity(
     val name: String,
     val order: Int = 0,
     val flags: Int = 0,
-    val update_frequency: Int = 1,
+    @ColumnInfo(name = "update_frequency")
+    val updateFrequency: Int = 1,
 ) {
     companion object {
         // Bit flags for category options

--- a/core/database/src/main/java/app/otakureader/core/database/entity/TrackEntryEntity.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/entity/TrackEntryEntity.kt
@@ -1,0 +1,29 @@
+package app.otakureader.core.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "track_entries",
+    indices = [
+        Index(value = ["manga_id"]),
+        Index(value = ["tracker_id"]),
+        Index(value = ["manga_id", "tracker_id"], unique = true)
+    ]
+)
+data class TrackEntryEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @ColumnInfo(name = "manga_id")         val mangaId: Long,
+    @ColumnInfo(name = "tracker_id")       val trackerId: Int,
+    @ColumnInfo(name = "remote_id")        val remoteId: Long,
+    @ColumnInfo(name = "remote_url")       val remoteUrl: String = "",
+    @ColumnInfo(name = "title")            val title: String,
+    @ColumnInfo(name = "status")           val status: Int,
+    @ColumnInfo(name = "last_chapter_read") val lastChapterRead: Float,
+    @ColumnInfo(name = "total_chapters")   val totalChapters: Int,
+    @ColumnInfo(name = "score")            val score: Float,
+    @ColumnInfo(name = "start_date")       val startDate: Long,
+    @ColumnInfo(name = "finish_date")      val finishDate: Long,
+)

--- a/core/database/src/main/java/app/otakureader/core/database/migrations/DatabaseMigrations.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/migrations/DatabaseMigrations.kt
@@ -241,6 +241,30 @@ internal val MIGRATION_23_24 = object : Migration(23, 24) {
     }
 }
 
+internal val MIGRATION_24_25 = object : Migration(24, 25) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("""
+            CREATE TABLE IF NOT EXISTS `track_entries` (
+                `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                `manga_id` INTEGER NOT NULL,
+                `tracker_id` INTEGER NOT NULL,
+                `remote_id` INTEGER NOT NULL,
+                `remote_url` TEXT NOT NULL DEFAULT '',
+                `title` TEXT NOT NULL,
+                `status` INTEGER NOT NULL,
+                `last_chapter_read` REAL NOT NULL,
+                `total_chapters` INTEGER NOT NULL,
+                `score` REAL NOT NULL,
+                `start_date` INTEGER NOT NULL,
+                `finish_date` INTEGER NOT NULL
+            )
+        """.trimIndent())
+        db.execSQL("CREATE INDEX IF NOT EXISTS `index_track_entries_manga_id` ON `track_entries` (`manga_id`)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS `index_track_entries_tracker_id` ON `track_entries` (`tracker_id`)")
+        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_track_entries_manga_id_tracker_id` ON `track_entries` (`manga_id`, `tracker_id`)")
+    }
+}
+
 /** All migrations in order, for use in [Room.databaseBuilder] and migration tests. */
 internal val ALL_MIGRATIONS = arrayOf(
     MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6,
@@ -248,5 +272,5 @@ internal val ALL_MIGRATIONS = arrayOf(
     MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
     MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
     MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
-    MIGRATION_22_23, MIGRATION_23_24
+    MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25
 )

--- a/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
+++ b/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
@@ -17,6 +17,8 @@ import app.otakureader.core.database.migrations.MIGRATION_19_20
 import app.otakureader.core.database.migrations.MIGRATION_20_21
 import app.otakureader.core.database.migrations.MIGRATION_21_22
 import app.otakureader.core.database.migrations.MIGRATION_22_23
+import app.otakureader.core.database.migrations.MIGRATION_23_24
+import app.otakureader.core.database.migrations.MIGRATION_24_25
 import app.otakureader.core.database.migrations.MIGRATION_9_10
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -42,7 +44,7 @@ class DatabaseMigrationTest {
     fun allMigrations_formsContiguousChain() {
         val sorted = ALL_MIGRATIONS.sortedBy { it.startVersion }
         assertEquals("Migration chain must start at version 2", 2, sorted.first().startVersion)
-        assertEquals("Migration chain must end at version 23", 23, sorted.last().endVersion)
+        assertEquals("Migration chain must end at version 25", 25, sorted.last().endVersion)
 
         for (i in 0 until sorted.size - 1) {
             val current = sorted[i]
@@ -69,7 +71,7 @@ class DatabaseMigrationTest {
 
     @Test
     fun allMigrations_count() {
-        assertEquals("Expected 21 migrations (v2→v23)", 21, ALL_MIGRATIONS.size)
+        assertEquals("Expected 23 migrations (v2→v25)", 23, ALL_MIGRATIONS.size)
     }
 
     // ── Migration 9 → 10 ────────────────────────────────────────────────────
@@ -378,21 +380,104 @@ class DatabaseMigrationTest {
         db.close()
     }
 
-    // ── Full chain v9 → v23 ─────────────────────────────────────────────────
-    // Starts from v9 (oldest exported schema JSON). Runs v9→v21 via
-    // runMigrationsAndValidate (which validates against 9.json and 21.json),
-    // then applies MIGRATION_21_22 and MIGRATION_22_23 directly.
+    // ── Migration 23 → 24 ───────────────────────────────────────────────────
+    // Adds: categories.update_frequency (INTEGER NOT NULL DEFAULT 1)
 
     @Test
-    fun fullMigrationChain_v9ToV23() {
+    fun migration23To24_addsCategoryUpdateFrequency() {
+        helper.createDatabase(TEST_DB, 23).close()
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 24, true, MIGRATION_23_24)
+        assertTrue(
+            "categories.update_frequency must exist after 23→24",
+            "update_frequency" in db.columnNames("categories"),
+        )
+        db.close()
+    }
+
+    @Test
+    fun migration23To24_updateFrequencyDefaultsToOne() {
+        val db23 = helper.createDatabase(TEST_DB, 23)
+        db23.execSQL("INSERT INTO categories (`name`, `order`, `flags`) VALUES ('Test Category', 0, 0)")
+        db23.close()
+
+        val db24 = helper.runMigrationsAndValidate(TEST_DB, 24, true, MIGRATION_23_24)
+        val cursor = db24.query("SELECT update_frequency FROM categories WHERE name = 'Test Category'")
+        assertTrue("Row must survive migration", cursor.moveToFirst())
+        assertEquals("update_frequency default must be 1", 1, cursor.getInt(0))
+        cursor.close()
+        db24.close()
+    }
+
+    // ── Migration 24 → 25 ───────────────────────────────────────────────────
+    // Adds: track_entries table with indexes
+
+    @Test
+    fun migration24To25_createsTrackEntries() {
+        val db = helper.createDatabase(TEST_DB, 24)
+        assertFalse("track_entries must NOT exist at v24", "track_entries" in db.tableNames())
+        MIGRATION_24_25.migrate(db)
+        assertTrue("track_entries must exist after 24→25", "track_entries" in db.tableNames())
+        val cols = db.columnNames("track_entries")
+        assertTrue("id must exist", "id" in cols)
+        assertTrue("manga_id must exist", "manga_id" in cols)
+        assertTrue("tracker_id must exist", "tracker_id" in cols)
+        assertTrue("remote_id must exist", "remote_id" in cols)
+        assertTrue("remote_url must exist", "remote_url" in cols)
+        assertTrue("title must exist", "title" in cols)
+        assertTrue("status must exist", "status" in cols)
+        assertTrue("last_chapter_read must exist", "last_chapter_read" in cols)
+        assertTrue("total_chapters must exist", "total_chapters" in cols)
+        assertTrue("score must exist", "score" in cols)
+        assertTrue("start_date must exist", "start_date" in cols)
+        assertTrue("finish_date must exist", "finish_date" in cols)
+        val indexes = db.indexNames("track_entries")
+        assertTrue("index_track_entries_manga_id must exist", "index_track_entries_manga_id" in indexes)
+        assertTrue("index_track_entries_tracker_id must exist", "index_track_entries_tracker_id" in indexes)
+        assertTrue(
+            "index_track_entries_manga_id_tracker_id (unique) must exist",
+            "index_track_entries_manga_id_tracker_id" in indexes,
+        )
+        db.close()
+    }
+
+    @Test
+    fun migration24To25_trackEntriesUniqueConstraint() {
+        val db = helper.createDatabase(TEST_DB, 24)
+        MIGRATION_24_25.migrate(db)
+        db.execSQL(
+            "INSERT INTO track_entries (manga_id, tracker_id, remote_id, remote_url, title, " +
+                "status, last_chapter_read, total_chapters, score, start_date, finish_date) " +
+                "VALUES (1, 2, 100, '', 'Test', 0, 1.0, 10, 5.0, 0, 0)",
+        )
+        var threw = false
+        try {
+            db.execSQL(
+                "INSERT INTO track_entries (manga_id, tracker_id, remote_id, remote_url, title, " +
+                    "status, last_chapter_read, total_chapters, score, start_date, finish_date) " +
+                    "VALUES (1, 2, 200, '', 'Duplicate', 0, 2.0, 10, 5.0, 0, 0)",
+            )
+        } catch (_: Exception) {
+            threw = true
+        }
+        assertTrue("Inserting duplicate (manga_id, tracker_id) must throw", threw)
+        db.close()
+    }
+
+    // ── Full chain v9 → v25 ─────────────────────────────────────────────────
+    // Starts from v9 (oldest exported schema JSON). Runs v9→v24 via
+    // runMigrationsAndValidate (which validates against 9.json and 24.json),
+    // then applies MIGRATION_24_25 directly (no 25.json export yet).
+
+    @Test
+    fun fullMigrationChain_v9ToV25() {
         helper.createDatabase(TEST_DB, 9).close()
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 21, true,
-            *ALL_MIGRATIONS.filter { it.startVersion in 9..20 }.toTypedArray(),
+            TEST_DB, 24, true,
+            *ALL_MIGRATIONS.filter { it.startVersion in 9..23 }.toTypedArray(),
         )
-        assertFalse("download_queue must NOT exist at v21", "download_queue" in db.tableNames())
-        MIGRATION_21_22.migrate(db)
-        MIGRATION_22_23.migrate(db)
+        assertFalse("track_entries must NOT exist at v24", "track_entries" in db.tableNames())
+        MIGRATION_24_25.migrate(db)
         val tables = db.tableNames()
         assertTrue("manga must exist after full chain", "manga" in tables)
         assertTrue("chapters must exist after full chain", "chapters" in tables)
@@ -402,11 +487,20 @@ class DatabaseMigrationTest {
         assertTrue("download_queue must exist after full chain", "download_queue" in tables)
         assertTrue("page_bookmarks must exist after full chain", "page_bookmarks" in tables)
         assertTrue("tracker_sync_state must exist after full chain", "tracker_sync_state" in tables)
+        assertTrue("track_entries must exist after full chain", "track_entries" in tables)
         assertTrue("contentRating must exist in manga after full chain", "contentRating" in db.columnNames("manga"))
         assertTrue("userNotes must exist in chapters after full chain", "userNotes" in db.columnNames("chapters"))
         assertTrue(
+            "update_frequency must exist in categories after full chain",
+            "update_frequency" in db.columnNames("categories"),
+        )
+        assertTrue(
             "index_chapters_mangaId_read_sourceOrder must exist after full chain",
             "index_chapters_mangaId_read_sourceOrder" in db.indexNames("chapters"),
+        )
+        assertTrue(
+            "index_track_entries_manga_id must exist after full chain",
+            "index_track_entries_manga_id" in db.indexNames("track_entries"),
         )
         db.close()
     }

--- a/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
+++ b/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
@@ -465,19 +465,16 @@ class DatabaseMigrationTest {
     }
 
     // ── Full chain v9 → v25 ─────────────────────────────────────────────────
-    // Starts from v9 (oldest exported schema JSON). Runs v9→v24 via
-    // runMigrationsAndValidate (which validates against 9.json and 24.json),
-    // then applies MIGRATION_24_25 directly (no 25.json export yet).
+    // Starts from v9 (oldest exported schema JSON). Runs all migrations v9→v25 via
+    // runMigrationsAndValidate, which validates the final schema against 25.json.
 
     @Test
     fun fullMigrationChain_v9ToV25() {
         helper.createDatabase(TEST_DB, 9).close()
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 24, true,
-            *ALL_MIGRATIONS.filter { it.startVersion in 9..23 }.toTypedArray(),
+            TEST_DB, 25, true,
+            *ALL_MIGRATIONS.filter { it.startVersion in 9..24 }.toTypedArray(),
         )
-        assertFalse("track_entries must NOT exist at v24", "track_entries" in db.tableNames())
-        MIGRATION_24_25.migrate(db)
         val tables = db.tableNames()
         assertTrue("manga must exist after full chain", "manga" in tables)
         assertTrue("chapters must exist after full chain", "chapters" in tables)

--- a/core/extension/src/main/java/app/otakureader/core/extension/di/ExtensionModule.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/di/ExtensionModule.kt
@@ -92,8 +92,7 @@ object ExtensionModule {
         repository: ExtensionRepository,
         loader: ExtensionLoader,
         remoteDataSource: ExtensionRemoteDataSource,
-        trustedSignatureStore: TrustedSignatureStore,
     ): ExtensionInstaller {
-        return ExtensionInstaller(context, repository, loader, remoteDataSource, trustedSignatureStore)
+        return ExtensionInstaller(context, repository, loader, remoteDataSource)
     }
 }

--- a/core/extension/src/main/java/app/otakureader/core/extension/di/ExtensionModule.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/di/ExtensionModule.kt
@@ -91,8 +91,9 @@ object ExtensionModule {
         @ApplicationContext context: Context,
         repository: ExtensionRepository,
         loader: ExtensionLoader,
-        remoteDataSource: ExtensionRemoteDataSource
+        remoteDataSource: ExtensionRemoteDataSource,
+        trustedSignatureStore: TrustedSignatureStore,
     ): ExtensionInstaller {
-        return ExtensionInstaller(context, repository, loader, remoteDataSource)
+        return ExtensionInstaller(context, repository, loader, remoteDataSource, trustedSignatureStore)
     }
 }

--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -235,68 +235,22 @@ class ExtensionInstaller(
                 val destFile = File(extensionsDir, "$pkgName.ext")
                 tempFile = File(extensionsDir, "$pkgName.ext.tmp")
 
-                // 1. Write to temp file — never touch the permanent artifact yet.
                 apkFile.copyTo(tempFile, overwrite = true)
                 tempFile.setReadOnly()
 
-                // 2. Load and validate from the temp file.
                 val loadResult = loader.loadExtension(tempFile.absolutePath)
+                val extension = resolveLoadResult(loadResult, trustedHash)
+                    .getOrElse { return@withContext Result.failure(it) }
 
-                // 3. Resolve whether the loaded extension is acceptable.
-                val extension = when (loadResult) {
-                    is ExtensionLoadResult.Success -> loadResult.extension
-                    is ExtensionLoadResult.Untrusted -> {
-                        val extHash = loadResult.extension.signatureHash
-                        if (trustedHash != null && extHash == trustedHash) {
-                            // Caller already verified this hash against a known-good source;
-                            // allow the untrusted result to proceed.
-                            loadResult.extension
-                        } else {
-                            _installationState.value = InstallationState.Error(
-                                "Extension is not trusted. Please verify its signature before installing.",
-                                null
-                            )
-                            return@withContext Result.failure(
-                                IllegalStateException("Untrusted extension: ${loadResult.extension.pkgName}")
-                            )
-                        }
-                    }
-                    is ExtensionLoadResult.Error -> {
-                        _installationState.value = InstallationState.Error(
-                            loadResult.message, loadResult.throwable
-                        )
-                        return@withContext Result.failure(
-                            loadResult.throwable ?: IllegalStateException(loadResult.message)
-                        )
-                    }
-                }
-
-                // 4. If caller supplied a trusted hash, the loaded extension must match it.
-                if (trustedHash != null && extension.signatureHash != trustedHash) {
-                    return@withContext Result.failure(
-                        SecurityException(
-                            "Trust hash mismatch for ${extension.pkgName}: " +
-                                "expected $trustedHash, got ${extension.signatureHash}"
-                        )
-                    )
-                }
-
-                // 5. Atomic rename temp → permanent.
                 if (!replaceAtomically(tempFile, destFile)) {
                     return@withContext Result.failure(
-                        IllegalStateException(
-                            "Failed to move extension to permanent location: ${destFile.absolutePath}"
-                        )
+                        IllegalStateException("Failed to move extension to permanent location: ${destFile.absolutePath}")
                     )
                 }
-                tempFile = null // Ownership transferred to destFile
+                tempFile = null
 
-                // 6. Trust ONLY after successful load + atomic move.
-                extension.signatureHash?.let { hash ->
-                    loader.trustExtension(hash)
-                }
+                extension.signatureHash?.let { loader.trustExtension(it) }
 
-                // 7. Update repository state.
                 _installationState.value = InstallationState.Installing
                 val finalExtension = extension.copy(apkPath = destFile.absolutePath)
                 val result = repository.installExtension(finalExtension.pkgName, destFile.absolutePath)
@@ -304,9 +258,7 @@ class ExtensionInstaller(
                     _installationState.value = InstallationState.Success(ext)
                     ExtensionInstallReceiver.notifyAdded(context, finalExtension.pkgName)
                 }.onFailure { error ->
-                    _installationState.value = InstallationState.Error(
-                        "Failed to save extension: ${error.message}", error
-                    )
+                    _installationState.value = InstallationState.Error("Failed to save extension: ${error.message}", error)
                 }
                 result
             } catch (e: CancellationException) {
@@ -315,12 +267,40 @@ class ExtensionInstaller(
                 _installationState.value = InstallationState.Error("Installation failed", e)
                 Result.failure(e)
             } finally {
-                // Clean up temp file if the atomic rename never happened.
                 tempFile?.delete()
-                // Clean up the download artifact.
                 if (apkFile.exists() && apkFile.parentFile == downloadsDir) apkFile.delete()
             }
         }
+
+    private fun resolveLoadResult(
+        loadResult: ExtensionLoadResult,
+        trustedHash: String?
+    ): Result<Extension> = when (loadResult) {
+        is ExtensionLoadResult.Success -> {
+            val ext = loadResult.extension
+            if (trustedHash != null && ext.signatureHash != trustedHash) {
+                _installationState.value = InstallationState.Error("Extension trust hash mismatch", null)
+                Result.failure(SecurityException("Trust hash mismatch for ${ext.pkgName}"))
+            } else {
+                Result.success(ext)
+            }
+        }
+        is ExtensionLoadResult.Untrusted -> {
+            val ext = loadResult.extension
+            if (trustedHash != null && ext.signatureHash == trustedHash) {
+                Result.success(ext)
+            } else {
+                _installationState.value = InstallationState.Error(
+                    "Extension is not trusted. Please verify its signature before installing.", null
+                )
+                Result.failure(IllegalStateException("Untrusted extension: ${ext.pkgName}"))
+            }
+        }
+        is ExtensionLoadResult.Error -> {
+            _installationState.value = InstallationState.Error(loadResult.message, loadResult.throwable)
+            Result.failure(loadResult.throwable ?: IllegalStateException(loadResult.message))
+        }
+    }
     
     /**
      * Update an existing extension.

--- a/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/compat/TachiyomiModelsAdapter.kt
+++ b/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/compat/TachiyomiModelsAdapter.kt
@@ -56,7 +56,7 @@ object TachiyomiModelsAdapter {
             name = sChapter.name,
             dateUpload = sChapter.date_upload,
             chapterNumber = sChapter.chapter_number,
-            scanlator = sChapter.scanlator
+            scanlator = sChapter.scanlator ?: ""
         )
     }
 

--- a/data/src/main/java/app/otakureader/data/di/RepositoryModule.kt
+++ b/data/src/main/java/app/otakureader/data/di/RepositoryModule.kt
@@ -24,7 +24,6 @@ import app.otakureader.data.backup.BackupScheduler as BackupSchedulerImpl
 import app.otakureader.data.backup.repository.BackupRepository as BackupRepositoryImpl
 import app.otakureader.data.backup.tachiyomi.TachiyomiBackupImporter as TachiyomiBackupImporterImpl
 import app.otakureader.data.tracking.TrackManager as TrackManagerImpl
-import app.otakureader.data.tracking.repository.TrackRepositoryImpl
 import app.otakureader.data.updater.AppUpdateChecker as AppUpdateCheckerImpl
 import app.otakureader.data.worker.CoverRefreshSchedulerImpl
 import app.otakureader.data.worker.LibraryUpdateScheduler as LibraryUpdateSchedulerImpl
@@ -43,7 +42,6 @@ import app.otakureader.domain.scheduler.CoverRefreshScheduler
 import app.otakureader.domain.scheduler.LibraryUpdateScheduler
 import app.otakureader.domain.scheduler.ReminderScheduler
 import app.otakureader.domain.tracking.TrackManager
-import app.otakureader.domain.tracking.TrackRepository
 import app.otakureader.domain.updater.AppUpdateChecker
 import dagger.Binds
 import dagger.Module
@@ -111,9 +109,6 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun bindTachiyomiBackupImporter(impl: TachiyomiBackupImporterImpl): TachiyomiBackupImporter
-
-    @Binds
-    abstract fun bindTrackRepository(impl: TrackRepositoryImpl): TrackRepository
 
     @Binds
     abstract fun bindTrackManager(impl: TrackManagerImpl): TrackManager

--- a/data/src/main/java/app/otakureader/data/di/RepositoryModule.kt
+++ b/data/src/main/java/app/otakureader/data/di/RepositoryModule.kt
@@ -26,6 +26,7 @@ import app.otakureader.data.backup.tachiyomi.TachiyomiBackupImporter as Tachiyom
 import app.otakureader.data.tracking.TrackManager as TrackManagerImpl
 import app.otakureader.data.tracking.repository.TrackRepositoryImpl
 import app.otakureader.data.updater.AppUpdateChecker as AppUpdateCheckerImpl
+import app.otakureader.data.worker.CoverRefreshSchedulerImpl
 import app.otakureader.data.worker.LibraryUpdateScheduler as LibraryUpdateSchedulerImpl
 import app.otakureader.data.worker.ReadingReminderScheduler as ReadingReminderSchedulerImpl
 import app.otakureader.domain.backup.BackupRepository
@@ -38,6 +39,7 @@ import app.otakureader.data.repository.PageBookmarkRepositoryImpl
 import app.otakureader.data.repository.ReadingListRepositoryImpl
 import app.otakureader.data.repository.SourceRepositoryImpl
 import app.otakureader.data.repository.StatisticsRepositoryImpl
+import app.otakureader.domain.scheduler.CoverRefreshScheduler
 import app.otakureader.domain.scheduler.LibraryUpdateScheduler
 import app.otakureader.domain.scheduler.ReminderScheduler
 import app.otakureader.domain.tracking.TrackManager
@@ -118,4 +120,7 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun bindAppUpdateChecker(impl: AppUpdateCheckerImpl): AppUpdateChecker
+
+    @Binds
+    abstract fun bindCoverRefreshScheduler(impl: CoverRefreshSchedulerImpl): CoverRefreshScheduler
 }

--- a/data/src/main/java/app/otakureader/data/di/RepositoryModule.kt
+++ b/data/src/main/java/app/otakureader/data/di/RepositoryModule.kt
@@ -24,6 +24,7 @@ import app.otakureader.data.backup.BackupScheduler as BackupSchedulerImpl
 import app.otakureader.data.backup.repository.BackupRepository as BackupRepositoryImpl
 import app.otakureader.data.backup.tachiyomi.TachiyomiBackupImporter as TachiyomiBackupImporterImpl
 import app.otakureader.data.tracking.TrackManager as TrackManagerImpl
+import app.otakureader.data.tracking.repository.TrackRepositoryImpl
 import app.otakureader.data.updater.AppUpdateChecker as AppUpdateCheckerImpl
 import app.otakureader.data.worker.LibraryUpdateScheduler as LibraryUpdateSchedulerImpl
 import app.otakureader.data.worker.ReadingReminderScheduler as ReadingReminderSchedulerImpl
@@ -40,6 +41,7 @@ import app.otakureader.data.repository.StatisticsRepositoryImpl
 import app.otakureader.domain.scheduler.LibraryUpdateScheduler
 import app.otakureader.domain.scheduler.ReminderScheduler
 import app.otakureader.domain.tracking.TrackManager
+import app.otakureader.domain.tracking.TrackRepository
 import app.otakureader.domain.updater.AppUpdateChecker
 import dagger.Binds
 import dagger.Module
@@ -107,6 +109,9 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun bindTachiyomiBackupImporter(impl: TachiyomiBackupImporterImpl): TachiyomiBackupImporter
+
+    @Binds
+    abstract fun bindTrackRepository(impl: TrackRepositoryImpl): TrackRepository
 
     @Binds
     abstract fun bindTrackManager(impl: TrackManagerImpl): TrackManager

--- a/data/src/main/java/app/otakureader/data/di/UseCaseModule.kt
+++ b/data/src/main/java/app/otakureader/data/di/UseCaseModule.kt
@@ -1,10 +1,6 @@
 package app.otakureader.data.di
 
-import app.otakureader.domain.repository.ChapterRepository
-import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.OpdsRepository
-import app.otakureader.domain.usecase.GetHistoryUseCase
-import app.otakureader.domain.usecase.SearchLibraryMangaUseCase
 import app.otakureader.domain.usecase.opds.BrowseOpdsCatalogUseCase
 import app.otakureader.domain.usecase.opds.DeleteOpdsServerUseCase
 import app.otakureader.domain.usecase.opds.GetOpdsServersUseCase
@@ -16,20 +12,12 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 
 /**
- * Hilt module that provides use case instances.
- * Use cases are provided (not bound) because they are not interfaces.
+ * OPDS use cases require explicit @Provides because they do not have @Inject constructors.
+ * All other use cases are resolved via @Inject and do not need entries here.
  */
 @Module
 @InstallIn(SingletonComponent::class)
 object UseCaseModule {
-
-    @Provides
-    fun provideGetHistoryUseCase(chapterRepository: ChapterRepository): GetHistoryUseCase =
-        GetHistoryUseCase(chapterRepository)
-
-    @Provides
-    fun provideSearchLibraryMangaUseCase(mangaRepository: MangaRepository): SearchLibraryMangaUseCase =
-        SearchLibraryMangaUseCase(mangaRepository)
 
     @Provides
     fun provideGetOpdsServersUseCase(opdsRepository: OpdsRepository): GetOpdsServersUseCase =

--- a/data/src/main/java/app/otakureader/data/repository/CategoryRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/CategoryRepositoryImpl.kt
@@ -48,7 +48,7 @@ class CategoryRepositoryImpl @Inject constructor(
     
     override suspend fun createCategory(name: String, frequency: CategoryUpdateFrequency): Long {
         val maxOrder = categoryDao.getMaxCategoryOrder()
-        val entity = CategoryEntity(name = name, order = maxOrder + 1, update_frequency = frequency.value)
+        val entity = CategoryEntity(name = name, order = maxOrder + 1, updateFrequency = frequency.value)
         return categoryDao.insert(entity)
     }
     
@@ -58,7 +58,7 @@ class CategoryRepositoryImpl @Inject constructor(
 
     override suspend fun updateCategoryFrequency(categoryId: Long, frequency: CategoryUpdateFrequency) {
         val existing = categoryDao.getCategoryById(categoryId) ?: return
-        categoryDao.update(existing.copy(update_frequency = frequency.value))
+        categoryDao.update(existing.copy(updateFrequency = frequency.value))
     }
 
     override suspend fun deleteCategory(id: Long) {
@@ -83,14 +83,14 @@ class CategoryRepositoryImpl @Inject constructor(
         order = order,
         isHidden = isHidden,
         isNsfw = isNsfw,
-        updateFrequency = CategoryUpdateFrequency.fromInt(update_frequency),
+        updateFrequency = CategoryUpdateFrequency.fromInt(updateFrequency),
     )
 
     private fun Category.toEntity() = CategoryEntity(
         id = id,
         name = name,
         order = order,
-        update_frequency = updateFrequency.value,
+        updateFrequency = updateFrequency.value,
         flags = (if (isHidden) CategoryEntity.FLAG_HIDDEN else 0) or
                 (if (isNsfw) CategoryEntity.FLAG_NSFW else 0)
     )

--- a/data/src/main/java/app/otakureader/data/repository/CategoryRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/CategoryRepositoryImpl.kt
@@ -57,8 +57,7 @@ class CategoryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updateCategoryFrequency(categoryId: Long, frequency: CategoryUpdateFrequency) {
-        val existing = categoryDao.getCategoryById(categoryId) ?: return
-        categoryDao.update(existing.copy(updateFrequency = frequency.value))
+        categoryDao.updateFrequency(categoryId, frequency.value)
     }
 
     override suspend fun deleteCategory(id: Long) {

--- a/data/src/main/java/app/otakureader/data/repository/ReaderSettingsRepository.kt
+++ b/data/src/main/java/app/otakureader/data/repository/ReaderSettingsRepository.kt
@@ -508,7 +508,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.SKIP_READ_CHAPTERS] ?: false
     }
 
-    suspend fun setSkipReadChapters(enabled: Boolean) {
+    override suspend fun setSkipReadChapters(enabled: Boolean) {
         safeEdit { it[Keys.SKIP_READ_CHAPTERS] = enabled }
     }
 
@@ -516,7 +516,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.SKIP_FILTERED_CHAPTERS] ?: true
     }
 
-    suspend fun setSkipFilteredChapters(enabled: Boolean) {
+    override suspend fun setSkipFilteredChapters(enabled: Boolean) {
         safeEdit { it[Keys.SKIP_FILTERED_CHAPTERS] = enabled }
     }
 
@@ -524,7 +524,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.SKIP_DUPLICATE_CHAPTERS] ?: false
     }
 
-    suspend fun setSkipDuplicateChapters(enabled: Boolean) {
+    override suspend fun setSkipDuplicateChapters(enabled: Boolean) {
         safeEdit { it[Keys.SKIP_DUPLICATE_CHAPTERS] = enabled }
     }
 

--- a/data/src/main/java/app/otakureader/data/tracking/repository/TrackEntryMapper.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/repository/TrackEntryMapper.kt
@@ -1,0 +1,33 @@
+package app.otakureader.data.tracking.repository
+
+import app.otakureader.core.database.entity.TrackEntryEntity
+import app.otakureader.domain.model.TrackEntry
+import app.otakureader.domain.model.TrackStatus
+
+internal fun TrackEntryEntity.toDomain() = TrackEntry(
+    remoteId = remoteId,
+    mangaId = mangaId,
+    trackerId = trackerId,
+    title = title,
+    remoteUrl = remoteUrl,
+    status = TrackStatus.fromOrdinal(status),
+    lastChapterRead = lastChapterRead,
+    totalChapters = totalChapters,
+    score = score,
+    startDate = startDate,
+    finishDate = finishDate,
+)
+
+internal fun TrackEntry.toEntity() = TrackEntryEntity(
+    mangaId = mangaId,
+    trackerId = trackerId,
+    remoteId = remoteId,
+    remoteUrl = remoteUrl,
+    title = title,
+    status = status.ordinal,
+    lastChapterRead = lastChapterRead,
+    totalChapters = totalChapters,
+    score = score,
+    startDate = startDate,
+    finishDate = finishDate,
+)

--- a/data/src/main/java/app/otakureader/data/tracking/repository/TrackRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/repository/TrackRepositoryImpl.kt
@@ -1,43 +1,29 @@
 package app.otakureader.data.tracking.repository
 
+import app.otakureader.core.database.dao.TrackEntryDao
 import app.otakureader.domain.model.TrackEntry
 import app.otakureader.domain.tracking.TrackRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/**
- * In-memory implementation of [TrackRepository].
- *
- * A production implementation would persist entries to a Room database table.
- * This implementation is sufficient for the current stage of the project where
- * the tracking database schema has not yet been finalised.
- */
 @Singleton
-class TrackRepositoryImpl @Inject constructor() : TrackRepository {
-
-    private val entries = MutableStateFlow<List<TrackEntry>>(emptyList())
+class TrackRepositoryImpl @Inject constructor(
+    private val dao: TrackEntryDao,
+) : TrackRepository {
 
     override fun observeEntriesForManga(mangaId: Long): Flow<List<TrackEntry>> =
-        entries.map { list -> list.filter { it.mangaId == mangaId } }
+        dao.getByMangaId(mangaId).map { entities -> entities.map { it.toDomain() } }
 
     override suspend fun getEntry(trackerId: Int, remoteId: Long): TrackEntry? =
-        entries.value.firstOrNull { it.trackerId == trackerId && it.remoteId == remoteId }
+        dao.getByTrackerAndRemote(trackerId, remoteId)?.toDomain()
 
     override suspend fun upsertEntry(entry: TrackEntry) {
-        entries.update { list ->
-            val existing = list.indexOfFirst { it.trackerId == entry.trackerId && it.remoteId == entry.remoteId }
-            if (existing >= 0) list.toMutableList().apply { set(existing, entry) }
-            else list + entry
-        }
+        dao.upsert(entry.toEntity())
     }
 
     override suspend fun deleteEntry(trackerId: Int, remoteId: Long) {
-        entries.update { list ->
-            list.filter { !(it.trackerId == trackerId && it.remoteId == remoteId) }
-        }
+        dao.deleteByTrackerAndRemote(trackerId, remoteId)
     }
 }

--- a/data/src/main/java/app/otakureader/data/tracking/repository/TrackRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/repository/TrackRepositoryImpl.kt
@@ -16,14 +16,14 @@ class TrackRepositoryImpl @Inject constructor(
     override fun observeEntriesForManga(mangaId: Long): Flow<List<TrackEntry>> =
         dao.getByMangaId(mangaId).map { entities -> entities.map { it.toDomain() } }
 
-    override suspend fun getEntry(trackerId: Int, remoteId: Long): TrackEntry? =
-        dao.getByTrackerAndRemote(trackerId, remoteId)?.toDomain()
+    override suspend fun getEntry(mangaId: Long, trackerId: Int): TrackEntry? =
+        dao.getByMangaAndTracker(mangaId, trackerId)?.toDomain()
 
     override suspend fun upsertEntry(entry: TrackEntry) {
         dao.upsert(entry.toEntity())
     }
 
-    override suspend fun deleteEntry(trackerId: Int, remoteId: Long) {
-        dao.deleteByTrackerAndRemote(trackerId, remoteId)
+    override suspend fun deleteEntry(mangaId: Long, trackerId: Int) {
+        dao.deleteByMangaAndTracker(mangaId, trackerId)
     }
 }

--- a/data/src/main/java/app/otakureader/data/tracking/repository/TrackerSyncRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/repository/TrackerSyncRepositoryImpl.kt
@@ -218,7 +218,7 @@ class TrackerSyncRepositoryImpl @Inject constructor(
             }
 
             if (useLocal) {
-                val localEntry = trackRepository.getEntry(trackerId, remoteId)
+                val localEntry = trackRepository.getEntry(mangaId, trackerId)
                 if (localEntry != null) {
                     val updated = tracker.update(localEntry)
                     trackerSyncDao.updateSyncState(
@@ -234,7 +234,7 @@ class TrackerSyncRepositoryImpl @Inject constructor(
                     )
                 }
             } else {
-                val localEntry = trackRepository.getEntry(trackerId, remoteId)
+                val localEntry = trackRepository.getEntry(mangaId, trackerId)
                 val entryToUpsert = (localEntry ?: remoteEntry).copy(
                     lastChapterRead = remoteEntry.lastChapterRead,
                     totalChapters = remoteEntry.totalChapters,
@@ -299,7 +299,7 @@ class TrackerSyncRepositoryImpl @Inject constructor(
         val now = Instant.now()
 
         if (useLocal) {
-            val localEntry = trackRepository.getEntry(trackerId, remoteId) ?: return
+            val localEntry = trackRepository.getEntry(mangaId, trackerId) ?: return
             try {
                 val updated = tracker.update(localEntry)
                 trackerSyncDao.updateSyncState(
@@ -327,7 +327,7 @@ class TrackerSyncRepositoryImpl @Inject constructor(
         } else {
             try {
                 val remoteEntry = tracker.find(remoteId) ?: return
-                val localEntry = trackRepository.getEntry(trackerId, remoteId)
+                val localEntry = trackRepository.getEntry(mangaId, trackerId)
                 val entryToUpsert = (localEntry ?: remoteEntry).copy(
                     lastChapterRead = remoteEntry.lastChapterRead,
                     totalChapters = remoteEntry.totalChapters,
@@ -382,7 +382,7 @@ class TrackerSyncRepositoryImpl @Inject constructor(
         val remoteId = syncState.remoteId.toLongOrNull()
             ?: return TrackerSyncRepository.SyncResult(false, "Invalid remote ID")
 
-        val localEntry = trackRepository.getEntry(trackerId, remoteId)
+        val localEntry = trackRepository.getEntry(mangaId, trackerId)
             ?: return TrackerSyncRepository.SyncResult(false, "No local entry found")
 
         val now = Instant.now()
@@ -434,7 +434,7 @@ class TrackerSyncRepositoryImpl @Inject constructor(
             val remoteEntry = tracker.find(remoteId)
                 ?: return TrackerSyncRepository.SyncResult(false, "Entry not found on tracker")
 
-            val localEntry = trackRepository.getEntry(trackerId, remoteId)
+            val localEntry = trackRepository.getEntry(mangaId, trackerId)
             val entryToUpsert = (localEntry ?: remoteEntry).copy(
                 lastChapterRead = remoteEntry.lastChapterRead,
                 totalChapters = remoteEntry.totalChapters,

--- a/data/src/main/java/app/otakureader/data/worker/CoverRefreshSchedulerImpl.kt
+++ b/data/src/main/java/app/otakureader/data/worker/CoverRefreshSchedulerImpl.kt
@@ -1,0 +1,13 @@
+package app.otakureader.data.worker
+
+import android.content.Context
+import app.otakureader.domain.scheduler.CoverRefreshScheduler
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CoverRefreshSchedulerImpl @Inject constructor() : CoverRefreshScheduler {
+    override fun schedule(context: Context) {
+        CoverRefreshWorker.enqueue(context)
+    }
+}

--- a/data/src/main/java/app/otakureader/data/worker/CoverRefreshSchedulerImpl.kt
+++ b/data/src/main/java/app/otakureader/data/worker/CoverRefreshSchedulerImpl.kt
@@ -2,12 +2,15 @@ package app.otakureader.data.worker
 
 import android.content.Context
 import app.otakureader.domain.scheduler.CoverRefreshScheduler
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class CoverRefreshSchedulerImpl @Inject constructor() : CoverRefreshScheduler {
-    override fun schedule(context: Context) {
+class CoverRefreshSchedulerImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : CoverRefreshScheduler {
+    override fun schedule() {
         CoverRefreshWorker.enqueue(context)
     }
 }

--- a/data/src/main/java/app/otakureader/data/worker/CoverRefreshWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/CoverRefreshWorker.kt
@@ -15,8 +15,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import app.otakureader.domain.repository.MangaRepository
 import coil3.ImageLoader
-import coil3.disk.DiskCachePolicy
-import coil3.memory.MemoryCachePolicy
+import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -53,8 +52,8 @@ class CoverRefreshWorker @AssistedInject constructor(
                     }
                     val request = ImageRequest.Builder(context)
                         .data(url)
-                        .memoryCachePolicy(MemoryCachePolicy.DISABLED)
-                        .diskCachePolicy(DiskCachePolicy.WRITE_ONLY)
+                        .memoryCachePolicy(CachePolicy.DISABLED)
+                        .diskCachePolicy(CachePolicy.WRITE_ONLY)
                         .build()
                     try {
                         imageLoader.execute(request)

--- a/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
@@ -134,6 +134,7 @@ class LibraryUpdateWorker @AssistedInject constructor(
             val onWifi = !downloadOnlyOnWifi || isConnectedToWifi()
 
             val mangaWithNewChapters = mutableListOf<NotificationManga>()
+            val successfullyUpdatedCategoryIds = mutableSetOf<Long>()
             var failedUpdates = 0
             var processedCount = 0
             val totalCount = libraryManga.size
@@ -157,6 +158,7 @@ class LibraryUpdateWorker @AssistedInject constructor(
                 val result = updateLibraryManga(manga)
 
                 result.onSuccess { newChapterCount ->
+                    successfullyUpdatedCategoryIds.addAll(manga.categoryIds.filter { it in updatedCategoryIds })
                     if (newChapterCount > 0) {
                         // Only add to notification list if notifications enabled for this manga
                         if (manga.notifyNewChapters) {
@@ -193,10 +195,11 @@ class LibraryUpdateWorker @AssistedInject constructor(
                 progressNotifier?.cancelProgress()
             }
 
-            // Persist per-category last-update timestamps
-            if (updatedCategoryIds.isNotEmpty()) {
+            // Persist per-category last-update timestamps only for categories where
+            // at least one manga was successfully fetched (failures should not advance the clock).
+            if (successfullyUpdatedCategoryIds.isNotEmpty()) {
                 val updated = categoryLastUpdate.toMutableMap()
-                updatedCategoryIds.forEach { catId -> updated[catId] = now }
+                successfullyUpdatedCategoryIds.forEach { catId -> updated[catId] = now }
                 libraryPreferences.setCategoryLastUpdateMs(updated)
             }
 

--- a/data/src/test/java/app/otakureader/data/worker/LibraryUpdateWorkerTest.kt
+++ b/data/src/test/java/app/otakureader/data/worker/LibraryUpdateWorkerTest.kt
@@ -14,6 +14,7 @@ import app.otakureader.data.download.DownloadManager
 import app.otakureader.domain.model.Chapter
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MangaStatus
+import app.otakureader.domain.repository.CategoryRepository
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.usecase.GetLibraryMangaUseCase
 import app.otakureader.domain.usecase.UpdateLibraryMangaUseCase
@@ -52,6 +53,7 @@ class LibraryUpdateWorkerTest {
     private lateinit var libraryPreferences: LibraryPreferences
     private lateinit var downloadManager: DownloadManager
     private lateinit var chapterRepository: ChapterRepository
+    private lateinit var categoryRepository: CategoryRepository
     private lateinit var notificationPreferences: NotificationPreferences
     private lateinit var worker: LibraryUpdateWorker
 
@@ -117,6 +119,7 @@ class LibraryUpdateWorkerTest {
         libraryPreferences = mockk()
         downloadManager = mockk(relaxed = true)
         chapterRepository = mockk()
+        categoryRepository = mockk()
         notificationPreferences = mockk(relaxed = true)
 
         connectivityManager = mockk()
@@ -130,7 +133,13 @@ class LibraryUpdateWorkerTest {
         every { generalPreferences.notificationsEnabled } returns flowOf(true)
         every { libraryPreferences.updateOnlyOnWifi } returns flowOf(false)
         every { libraryPreferences.skipUpdateCategoryIds } returns flowOf(emptySet())
+        every { libraryPreferences.skipUpdatesWithUnread } returns flowOf(false)
+        every { libraryPreferences.skipUpdatesWithCompleted } returns flowOf(false)
+        every { libraryPreferences.skipUpdatesNeverStarted } returns flowOf(false)
+        every { libraryPreferences.categoryLastUpdateMs } returns flowOf(emptyMap())
         every { libraryPreferences.showUpdateProgress } returns flowOf(false)
+        coEvery { categoryRepository.getCategories() } returns flowOf(emptyList())
+        coEvery { libraryPreferences.setCategoryLastUpdateMs(any()) } just runs
 
         // Mock connectivity
         every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
@@ -148,6 +157,7 @@ class LibraryUpdateWorkerTest {
             generalPreferences,
             downloadManager,
             chapterRepository,
+            categoryRepository,
             notificationPreferences
         )
     }

--- a/domain/src/main/java/app/otakureader/domain/scheduler/CoverRefreshScheduler.kt
+++ b/domain/src/main/java/app/otakureader/domain/scheduler/CoverRefreshScheduler.kt
@@ -1,0 +1,8 @@
+package app.otakureader.domain.scheduler
+
+import android.content.Context
+
+/** Schedules a one-shot background job that refreshes all library cover images. */
+interface CoverRefreshScheduler {
+    fun schedule(context: Context)
+}

--- a/domain/src/main/java/app/otakureader/domain/scheduler/CoverRefreshScheduler.kt
+++ b/domain/src/main/java/app/otakureader/domain/scheduler/CoverRefreshScheduler.kt
@@ -1,8 +1,6 @@
 package app.otakureader.domain.scheduler
 
-import android.content.Context
-
 /** Schedules a one-shot background job that refreshes all library cover images. */
 interface CoverRefreshScheduler {
-    fun schedule(context: Context)
+    fun schedule()
 }

--- a/domain/src/main/java/app/otakureader/domain/tracking/TrackRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/tracking/TrackRepository.kt
@@ -11,12 +11,12 @@ interface TrackRepository {
     /** Observe all entries for a given local manga. */
     fun observeEntriesForManga(mangaId: Long): Flow<List<TrackEntry>>
 
-    /** Retrieve a single entry by tracker + remote ID. */
-    suspend fun getEntry(trackerId: Int, remoteId: Long): TrackEntry?
+    /** Retrieve a single entry by the unique (manga, tracker) key. */
+    suspend fun getEntry(mangaId: Long, trackerId: Int): TrackEntry?
 
     /** Insert or replace a track entry. */
     suspend fun upsertEntry(entry: TrackEntry)
 
-    /** Remove an entry from local storage. */
-    suspend fun deleteEntry(trackerId: Int, remoteId: Long)
+    /** Remove an entry from local storage by the unique (manga, tracker) key. */
+    suspend fun deleteEntry(mangaId: Long, trackerId: Int)
 }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailScreen.kt
@@ -3,11 +3,16 @@ package app.otakureader.feature.browse
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 /**
  * Transparent redirect screen for [Route.SourceMangaDetail].
@@ -15,19 +20,38 @@ import androidx.hilt.navigation.compose.hiltViewModel
  * Shows a loading spinner while [SourceMangaDetailViewModel] resolves the manga's
  * database ID (looking it up by source URL, or inserting a stub entry), then
  * immediately forwards to the [Route.MangaDetails] screen via [onNavigateToMangaDetail].
+ *
+ * If the lookup fails or times out the screen calls [onNavigateBack] so the user
+ * is never left on an infinite loading spinner (fixes #901).
  */
 @Composable
 fun SourceMangaDetailScreen(
     onNavigateToMangaDetail: (mangaId: Long) -> Unit,
+    onNavigateBack: () -> Unit,
     viewModel: SourceMangaDetailViewModel = hiltViewModel(),
 ) {
-    LaunchedEffect(Unit) {
-        viewModel.effect.collect { effect ->
-            when (effect) {
-                is SourceMangaDetailEffect.NavigateToMangaDetail -> {
-                    onNavigateToMangaDetail(effect.mangaId)
-                }
+    val redirectState by viewModel.redirectState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val notFoundMessage = stringResource(R.string.source_manga_detail_not_found)
+    val errorPrefix = stringResource(R.string.source_manga_detail_error_prefix)
+
+    LaunchedEffect(redirectState) {
+        when (val state = redirectState) {
+            is RedirectState.Success -> {
+                onNavigateToMangaDetail(state.mangaId)
             }
+            is RedirectState.NotFound -> {
+                snackbarHostState.showSnackbar(notFoundMessage)
+                onNavigateBack()
+            }
+            is RedirectState.Error -> {
+                // Concatenate prefix with detail message for a user-readable string.
+                // TODO: replace with a proper string resource once UX copy is finalised.
+                snackbarHostState.showSnackbar("$errorPrefix: ${state.message}")
+                onNavigateBack()
+            }
+            RedirectState.Loading -> Unit
         }
     }
 

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailScreen.kt
@@ -3,14 +3,11 @@ package app.otakureader.feature.browse
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
@@ -31,26 +28,12 @@ fun SourceMangaDetailScreen(
     viewModel: SourceMangaDetailViewModel = hiltViewModel(),
 ) {
     val redirectState by viewModel.redirectState.collectAsStateWithLifecycle()
-    val snackbarHostState = remember { SnackbarHostState() }
-
-    val notFoundMessage = stringResource(R.string.source_manga_detail_not_found)
-    val errorPrefix = stringResource(R.string.source_manga_detail_error_prefix)
 
     LaunchedEffect(redirectState) {
         when (val state = redirectState) {
-            is RedirectState.Success -> {
-                onNavigateToMangaDetail(state.mangaId)
-            }
-            is RedirectState.NotFound -> {
-                snackbarHostState.showSnackbar(notFoundMessage)
-                onNavigateBack()
-            }
-            is RedirectState.Error -> {
-                // Concatenate prefix with detail message for a user-readable string.
-                // TODO: replace with a proper string resource once UX copy is finalised.
-                snackbarHostState.showSnackbar("$errorPrefix: ${state.message}")
-                onNavigateBack()
-            }
+            is RedirectState.Success -> onNavigateToMangaDetail(state.mangaId)
+            is RedirectState.NotFound -> onNavigateBack()
+            is RedirectState.Error -> onNavigateBack()
             RedirectState.Loading -> Unit
         }
     }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailViewModel.kt
@@ -8,6 +8,7 @@ import app.otakureader.core.navigation.Route
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.repository.MangaRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -75,12 +76,14 @@ class SourceMangaDetailViewModel @Inject constructor(
     private fun resolveAndNavigate(sourceId: String, mangaUrl: String, mangaTitle: String) {
         viewModelScope.launch {
             try {
-                val mangaId = withTimeout(10_000L) {
-                    val sourceIdLong = sourceId.toLongOrNull() ?: 0L
-                    val existing = runCatching {
-                        mangaRepository.getMangaBySourceAndUrl(sourceIdLong, mangaUrl)
-                    }.getOrNull()
+                val sourceIdLong = sourceId.toLongOrNull()
+                if (sourceIdLong == null) {
+                    _redirectState.value = RedirectState.NotFound
+                    return@launch
+                }
 
+                val mangaId = withTimeout(10_000L) {
+                    val existing = mangaRepository.getMangaBySourceAndUrl(sourceIdLong, mangaUrl)
                     if (existing != null) {
                         existing.id
                     } else {
@@ -92,7 +95,7 @@ class SourceMangaDetailViewModel @Inject constructor(
                             title = mangaTitle.ifBlank { mangaUrl },
                             initialized = false
                         )
-                        runCatching { mangaRepository.insertManga(stub) }.getOrDefault(0L)
+                        mangaRepository.insertManga(stub)
                     }
                 }
 
@@ -108,6 +111,8 @@ class SourceMangaDetailViewModel @Inject constructor(
                 // The DB lookup took longer than 10 seconds — treat as not-found so the
                 // screen can navigate back instead of spinning forever.
                 _redirectState.value = RedirectState.NotFound
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _redirectState.value = RedirectState.Error(e.message ?: "Unknown error")
             }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailViewModel.kt
@@ -8,11 +8,35 @@ import app.otakureader.core.navigation.Route
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.repository.MangaRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
+
+/**
+ * Tracks the progress of the source-manga redirect lookup so the screen can
+ * react deterministically to all outcomes instead of waiting indefinitely on
+ * the effect channel.
+ */
+sealed class RedirectState {
+    /** DB lookup is in progress — show a loading indicator. */
+    object Loading : RedirectState()
+
+    /** Lookup succeeded; navigate to the manga detail screen for [mangaId]. */
+    data class Success(val mangaId: Long) : RedirectState()
+
+    /** Lookup returned no usable ID (stub insert yielded 0). */
+    object NotFound : RedirectState()
+
+    /** An unexpected exception occurred during the lookup. */
+    data class Error(val message: String) : RedirectState()
+}
 
 sealed interface SourceMangaDetailEffect {
     data class NavigateToMangaDetail(val mangaId: Long) : SourceMangaDetailEffect
@@ -26,6 +50,9 @@ sealed interface SourceMangaDetailEffect {
  * If the manga is already in the database (previously browsed or in library) its
  * existing ID is reused. Otherwise a stub entry is inserted so the details screen
  * can load chapter/cover data on demand.
+ *
+ * The lookup is wrapped in a 10-second [withTimeout] so a hung DB call can never
+ * leave the screen stuck in [RedirectState.Loading] indefinitely (fixes #901).
  */
 @HiltViewModel
 class SourceMangaDetailViewModel @Inject constructor(
@@ -33,6 +60,10 @@ class SourceMangaDetailViewModel @Inject constructor(
     private val mangaRepository: MangaRepository,
 ) : ViewModel() {
 
+    private val _redirectState = MutableStateFlow<RedirectState>(RedirectState.Loading)
+    val redirectState: StateFlow<RedirectState> = _redirectState.asStateFlow()
+
+    // Kept for backwards-compatibility with any observers still using the effect channel.
     private val _effect = Channel<SourceMangaDetailEffect>()
     val effect: Flow<SourceMangaDetailEffect> = _effect.receiveAsFlow()
 
@@ -43,27 +74,42 @@ class SourceMangaDetailViewModel @Inject constructor(
 
     private fun resolveAndNavigate(sourceId: String, mangaUrl: String, mangaTitle: String) {
         viewModelScope.launch {
-            val sourceIdLong = sourceId.toLongOrNull() ?: 0L
-            val existing = runCatching {
-                mangaRepository.getMangaBySourceAndUrl(sourceIdLong, mangaUrl)
-            }.getOrNull()
+            try {
+                val mangaId = withTimeout(10_000L) {
+                    val sourceIdLong = sourceId.toLongOrNull() ?: 0L
+                    val existing = runCatching {
+                        mangaRepository.getMangaBySourceAndUrl(sourceIdLong, mangaUrl)
+                    }.getOrNull()
 
-            val mangaId = if (existing != null) {
-                existing.id
-            } else {
-                // Insert a lightweight stub so DetailsScreen can load the full info.
-                val stub = Manga(
-                    id = 0,
-                    sourceId = sourceIdLong,
-                    url = mangaUrl,
-                    title = mangaTitle.ifBlank { mangaUrl },
-                    initialized = false
-                )
-                runCatching { mangaRepository.insertManga(stub) }.getOrDefault(0L)
-            }
+                    if (existing != null) {
+                        existing.id
+                    } else {
+                        // Insert a lightweight stub so DetailsScreen can load the full info.
+                        val stub = Manga(
+                            id = 0,
+                            sourceId = sourceIdLong,
+                            url = mangaUrl,
+                            title = mangaTitle.ifBlank { mangaUrl },
+                            initialized = false
+                        )
+                        runCatching { mangaRepository.insertManga(stub) }.getOrDefault(0L)
+                    }
+                }
 
-            if (mangaId > 0L) {
-                _effect.send(SourceMangaDetailEffect.NavigateToMangaDetail(mangaId))
+                if (mangaId > 0L) {
+                    _redirectState.value = RedirectState.Success(mangaId)
+                    // Also emit on the legacy effect channel so existing nav-host collectors
+                    // are not broken by this change.
+                    _effect.send(SourceMangaDetailEffect.NavigateToMangaDetail(mangaId))
+                } else {
+                    _redirectState.value = RedirectState.NotFound
+                }
+            } catch (e: TimeoutCancellationException) {
+                // The DB lookup took longer than 10 seconds — treat as not-found so the
+                // screen can navigate back instead of spinning forever.
+                _redirectState.value = RedirectState.NotFound
+            } catch (e: Exception) {
+                _redirectState.value = RedirectState.Error(e.message ?: "Unknown error")
             }
         }
     }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
@@ -54,10 +54,12 @@ fun NavGraphBuilder.sourceDetailScreen(
 
 fun NavGraphBuilder.sourceMangaDetailScreen(
     onNavigateToMangaDetail: (mangaId: Long) -> Unit,
+    onNavigateBack: () -> Unit,
 ) {
     composable<Route.SourceMangaDetail> {
         SourceMangaDetailScreen(
-            onNavigateToMangaDetail = onNavigateToMangaDetail
+            onNavigateToMangaDetail = onNavigateToMangaDetail,
+            onNavigateBack = onNavigateBack,
         )
     }
 }

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -127,4 +127,8 @@
     <string name="search_history_title">Recent searches</string>
     <string name="search_history_clear">Clear</string>
     <string name="search_history_remove">Remove from history</string>
+
+    <!-- SourceMangaDetailScreen redirect states (#901) -->
+    <string name="source_manga_detail_not_found">Manga not available offline</string>
+    <string name="source_manga_detail_error_prefix">Could not open manga</string>
 </resources>

--- a/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
+++ b/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
@@ -6,6 +6,7 @@ import app.otakureader.domain.repository.FeedRepository
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.usecase.library.AddMangaToLibraryUseCase
+import app.otakureader.domain.usecase.ToggleFavoriteMangaUseCase
 import app.otakureader.domain.usecase.source.GetLatestUpdatesUseCase
 import app.otakureader.domain.usecase.source.GetPopularMangaUseCase
 import app.otakureader.domain.usecase.source.GetSourceFiltersUseCase
@@ -55,6 +56,7 @@ class BrowseViewModelTest {
     private val searchMangaUseCase = SearchMangaUseCase(sourceRepository)
     private val getSourceFiltersUseCase = GetSourceFiltersUseCase(sourceRepository)
     private val addMangaToLibraryUseCase = AddMangaToLibraryUseCase(mangaRepository)
+    private val toggleFavoriteMangaUseCase = ToggleFavoriteMangaUseCase(mangaRepository)
 
     private lateinit var viewModel: BrowseViewModel
     private val testDispatcher = StandardTestDispatcher()
@@ -88,6 +90,8 @@ class BrowseViewModelTest {
             searchMangaUseCase = searchMangaUseCase,
             getSourceFiltersUseCase = getSourceFiltersUseCase,
             addMangaToLibraryUseCase = addMangaToLibraryUseCase,
+            toggleFavoriteMangaUseCase = toggleFavoriteMangaUseCase,
+            mangaRepository = mangaRepository,
             feedRepository = feedRepository,
             generalPreferences = generalPreferences
         )
@@ -376,6 +380,8 @@ class BrowseViewModelTest {
             searchMangaUseCase = searchMangaUseCase,
             getSourceFiltersUseCase = getSourceFiltersUseCase,
             addMangaToLibraryUseCase = addMangaToLibraryUseCase,
+            toggleFavoriteMangaUseCase = toggleFavoriteMangaUseCase,
+            mangaRepository = mangaRepository,
             feedRepository = feedRepository,
             generalPreferences = generalPreferences
         )
@@ -409,6 +415,8 @@ class BrowseViewModelTest {
             searchMangaUseCase = searchMangaUseCase,
             getSourceFiltersUseCase = getSourceFiltersUseCase,
             addMangaToLibraryUseCase = addMangaToLibraryUseCase,
+            toggleFavoriteMangaUseCase = toggleFavoriteMangaUseCase,
+            mangaRepository = mangaRepository,
             feedRepository = feedRepository,
             generalPreferences = generalPreferences
         )

--- a/feature/details/src/main/java/app/otakureader/feature/details/ChapterSection.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/ChapterSection.kt
@@ -1,0 +1,217 @@
+@file:Suppress("MaxLineLength")
+package app.otakureader.feature.details
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import app.otakureader.feature.details.R
+
+@Composable
+internal fun ChapterListHeader(
+    chapterCount: Int,
+    sortOrder: DetailsContract.ChapterSortOrder,
+    isFilterActive: Boolean = false,
+    onToggleSort: () -> Unit,
+    onShowFilter: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = pluralStringResource(R.plurals.details_chapter_count, chapterCount, chapterCount),
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onShowFilter) {
+                Icon(
+                    imageVector = Icons.Default.FilterList,
+                    contentDescription = stringResource(R.string.details_filter_chapters),
+                    tint = if (isFilterActive) MaterialTheme.colorScheme.primary
+                           else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            TextButton(onClick = onToggleSort) {
+                Text(
+                    when (sortOrder) {
+                        DetailsContract.ChapterSortOrder.ASCENDING -> stringResource(R.string.details_sort_ascending)
+                        DetailsContract.ChapterSortOrder.DESCENDING -> stringResource(R.string.details_sort_descending)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun ChapterFilterDialog(
+    filter: DetailsContract.ChapterFilter,
+    scanlators: List<String>,
+    onApply: (DetailsContract.ChapterFilter) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var read by remember { mutableStateOf(filter.read) }
+    var bookmarked by remember { mutableStateOf(filter.bookmarked) }
+    var downloaded by remember { mutableStateOf(filter.downloaded) }
+    var selectedScanlator by remember { mutableStateOf(filter.scanlator) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.details_filter_chapters)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                // Read / Unread filter
+                Text(
+                    text = stringResource(R.string.details_filter_read_label),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                TriStateRow(
+                    labelAll = stringResource(R.string.details_filter_all),
+                    labelOnly = stringResource(R.string.details_filter_read),
+                    labelExclude = stringResource(R.string.details_filter_unread),
+                    state = read,
+                    onStateChange = { read = it }
+                )
+
+                HorizontalDivider()
+
+                // Bookmark filter
+                Text(
+                    text = stringResource(R.string.details_filter_bookmarked_label),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                TriStateRow(
+                    labelAll = stringResource(R.string.details_filter_all),
+                    labelOnly = stringResource(R.string.details_filter_bookmarked),
+                    labelExclude = stringResource(R.string.details_filter_not_bookmarked),
+                    state = bookmarked,
+                    onStateChange = { bookmarked = it }
+                )
+
+                HorizontalDivider()
+
+                // Downloaded filter
+                Text(
+                    text = stringResource(R.string.details_filter_downloaded_label),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                TriStateRow(
+                    labelAll = stringResource(R.string.details_filter_all),
+                    labelOnly = stringResource(R.string.details_filter_downloaded),
+                    labelExclude = stringResource(R.string.details_filter_not_downloaded),
+                    state = downloaded,
+                    onStateChange = { downloaded = it }
+                )
+
+                // Scanlator filter (only shown when multiple scanlators exist)
+                if (scanlators.size > 1) {
+                    HorizontalDivider()
+                    Text(
+                        text = stringResource(R.string.details_filter_scanlator_label),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    // "All scanlators" chip
+                    FilterChip(
+                        selected = selectedScanlator == null,
+                        onClick = { selectedScanlator = null },
+                        label = { Text(stringResource(R.string.details_filter_all)) }
+                    )
+                    scanlators.forEach { s ->
+                        FilterChip(
+                            selected = selectedScanlator == s,
+                            onClick = { selectedScanlator = if (selectedScanlator == s) null else s },
+                            label = { Text(s) }
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                onApply(DetailsContract.ChapterFilter(read, bookmarked, downloaded, selectedScanlator))
+            }) {
+                Text(stringResource(R.string.details_filter_apply))
+            }
+        },
+        dismissButton = {
+            Row {
+                TextButton(onClick = {
+                    onApply(DetailsContract.ChapterFilter())
+                }) {
+                    Text(stringResource(R.string.details_filter_reset))
+                }
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.details_filter_cancel))
+                }
+            }
+        }
+    )
+}
+
+@Composable
+internal fun TriStateRow(
+    labelAll: String,
+    labelOnly: String,
+    labelExclude: String,
+    state: DetailsContract.TriState,
+    onStateChange: (DetailsContract.TriState) -> Unit
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        FilterChip(
+            selected = state == DetailsContract.TriState.ALL,
+            onClick = { onStateChange(DetailsContract.TriState.ALL) },
+            label = { Text(labelAll) }
+        )
+        FilterChip(
+            selected = state == DetailsContract.TriState.ONLY,
+            onClick = { onStateChange(DetailsContract.TriState.ONLY) },
+            label = { Text(labelOnly) }
+        )
+        FilterChip(
+            selected = state == DetailsContract.TriState.EXCLUDE,
+            onClick = { onStateChange(DetailsContract.TriState.EXCLUDE) },
+            label = { Text(labelExclude) }
+        )
+    }
+}
+
+@Composable
+internal fun EmptyScreen(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(stringResource(R.string.details_no_manga))
+    }
+}

--- a/feature/details/src/main/java/app/otakureader/feature/details/ChapterSection.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/ChapterSection.kt
@@ -4,6 +4,8 @@ package app.otakureader.feature.details
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -70,6 +72,7 @@ internal fun ChapterListHeader(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun ChapterFilterDialog(
     filter: DetailsContract.ChapterFilter,
@@ -141,18 +144,19 @@ internal fun ChapterFilterDialog(
                         style = MaterialTheme.typography.labelMedium,
                         fontWeight = FontWeight.SemiBold
                     )
-                    // "All scanlators" chip
-                    FilterChip(
-                        selected = selectedScanlator == null,
-                        onClick = { selectedScanlator = null },
-                        label = { Text(stringResource(R.string.details_filter_all)) }
-                    )
-                    scanlators.forEach { s ->
+                    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         FilterChip(
-                            selected = selectedScanlator == s,
-                            onClick = { selectedScanlator = if (selectedScanlator == s) null else s },
-                            label = { Text(s) }
+                            selected = selectedScanlator == null,
+                            onClick = { selectedScanlator = null },
+                            label = { Text(stringResource(R.string.details_filter_all)) }
                         )
+                        scanlators.forEach { s ->
+                            FilterChip(
+                                selected = selectedScanlator == s,
+                                onClick = { selectedScanlator = if (selectedScanlator == s) null else s },
+                                label = { Text(s) }
+                            )
+                        }
                     }
                 }
             }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
@@ -203,6 +203,7 @@ object DetailsContract {
         // Page preloading settings (#264)
         data class SetPreloadPagesBefore(val count: Int?) : Event
         data class SetPreloadPagesAfter(val count: Int?) : Event
+        data object ResetReaderSettings : Event
         
         // Chapter thumbnail loading
         data class LoadChapterThumbnail(val chapterId: Long) : Event

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -79,7 +79,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -518,12 +517,15 @@ private fun MangaHeader(
     }
     val contentType = if (isOverriddenManhwa) ContentType.MANHWA else ContentType.MANGA
 
-    // Bloom enter animation — fades the hero in on first composition
-    var bloomProgress by remember { mutableFloatStateOf(0f) }
+    // Bloom enter animation — fades the hero in on first composition.
+    // The Animatable is remembered so Compose reads its `value` as observable state,
+    // driving recomposition on every animation frame. Previously, the Animatable was
+    // created inside LaunchedEffect and its value was only copied after animateTo()
+    // completed, so the hero jumped from alpha=0 to alpha=1 with no visible transition.
+    val bloomAnimatable = remember(manga.id) { Animatable(0f) }
     LaunchedEffect(manga.id) {
-        val animatable = Animatable(0f)
-        animatable.animateTo(1f, animationSpec = tween(800, easing = FastOutSlowInEasing))
-        bloomProgress = animatable.value
+        bloomAnimatable.snapTo(0f)
+        bloomAnimatable.animateTo(1f, animationSpec = tween(800, easing = FastOutSlowInEasing))
     }
 
     // Derive splash colors from the Material theme primary/secondary driven by MangaDynamicTheme
@@ -564,7 +566,7 @@ private fun MangaHeader(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(360.dp)
-                    .graphicsLayer { alpha = bloomProgress }
+                    .graphicsLayer { alpha = bloomAnimatable.value }
             ) {
                 // Background layer: CoverSplashBackground when cover URL available,
                 // fallback gradient otherwise

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -2,15 +2,9 @@
 package app.otakureader.feature.details
 
 import android.content.Intent
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -19,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.lazy.LazyColumn
@@ -29,47 +22,29 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.selection.selectableGroup
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.AspectRatio
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.FilterList
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.NotificationsActive
-import androidx.compose.material.icons.filled.NotificationsOff
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.QueryStats
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
-import androidx.compose.material3.FilledIconToggleButton
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -81,47 +56,23 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.blur
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import app.otakureader.core.preferences.DeleteAfterReadMode
 import app.otakureader.core.ui.adaptive.isExpanded
 import app.otakureader.core.ui.adaptive.rememberWindowWidthSizeClass
-import app.otakureader.core.ui.background.CoverSplashBackground
 import app.otakureader.core.ui.component.ErrorScreen
 import app.otakureader.core.ui.component.LoadingScreen
-import app.otakureader.core.ui.components.GlitchText
-import app.otakureader.core.ui.components.GlowButton
-import app.otakureader.core.ui.components.InkButton
-import app.otakureader.core.ui.components.TypewriterText
-import app.otakureader.core.ui.theme.ContentType
-import app.otakureader.core.ui.theme.LocalOtakuColors
 import app.otakureader.core.ui.theme.MangaDynamicTheme
-import app.otakureader.core.ui.theme.manhwaAccent
 import app.otakureader.core.ui.theme.rememberCoverColorScheme
 import app.otakureader.feature.details.R
 import coil3.compose.AsyncImage
@@ -129,21 +80,14 @@ import kotlinx.coroutines.flow.collectLatest
 import androidx.compose.ui.tooling.preview.Preview
 import app.otakureader.core.ui.theme.OtakuReaderTheme
 
-private val MARKDOWN_BOLD_REGEX = Regex("""\*\*(.+?)\*\*""")
-private val MARKDOWN_ITALIC_REGEX = Regex("""(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)""")
-
 // Two-pane split for the Expanded width class. The info pane is given slightly
 // more horizontal space than the chapter list because the manga header and
 // description benefit from extra width; the two weights must sum to 1f.
 private const val INFO_PANE_WEIGHT = 0.55f
 private const val CHAPTER_PANE_WEIGHT = 0.45f
 
-// Parallax hero constants
+// Controls how far the user must scroll before the TopAppBar reaches full opacity.
 private const val HERO_TOP_BAR_FADE_RANGE = 600f
-private const val HERO_BG_PARALLAX_FACTOR = 0.4f
-private const val HERO_FG_PARALLAX_FACTOR = 0.15f
-private const val HERO_BG_SCALE = 1.15f
-private val MARKDOWN_LINK_REGEX = Regex("""\[(.+?)]\((.+?)\)""")
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -488,327 +432,6 @@ private fun LazyListScope.detailsChapterItems(
 }
 
 @Composable
-private fun MangaHeader(
-    manga: app.otakureader.domain.model.Manga,
-    isFavorite: Boolean,
-    showPanoramaCover: Boolean,
-    onToggleFavorite: () -> Unit,
-    onTogglePanoramaCover: () -> Unit,
-    scrollOffset: () -> Float = { 0f },
-    modifier: Modifier = Modifier
-) {
-    val otaku = LocalOtakuColors.current
-
-    // Detect content type from sourceId string representation
-    val sourceIdStr = remember(manga.sourceId) { manga.sourceId.toString() }
-    val autoDetectedContentType = remember(sourceIdStr) {
-        val src = sourceIdStr.lowercase()
-        if (src.contains("manhwa") || src.contains("webtoon") ||
-            src.contains("korean") || src.contains("toon")
-        ) {
-            ContentType.MANHWA
-        } else {
-            ContentType.MANGA
-        }
-    }
-    // Local override toggle — survives recomposition, resets when manga changes
-    var isOverriddenManhwa by rememberSaveable(manga.id) {
-        mutableStateOf(autoDetectedContentType == ContentType.MANHWA)
-    }
-    val contentType = if (isOverriddenManhwa) ContentType.MANHWA else ContentType.MANGA
-
-    // Bloom enter animation — fades the hero in on first composition.
-    // The Animatable is remembered so Compose reads its `value` as observable state,
-    // driving recomposition on every animation frame. Previously, the Animatable was
-    // created inside LaunchedEffect and its value was only copied after animateTo()
-    // completed, so the hero jumped from alpha=0 to alpha=1 with no visible transition.
-    val bloomAnimatable = remember(manga.id) { Animatable(0f) }
-    LaunchedEffect(manga.id) {
-        bloomAnimatable.snapTo(0f)
-        bloomAnimatable.animateTo(1f, animationSpec = tween(800, easing = FastOutSlowInEasing))
-    }
-
-    // Derive splash colors from the Material theme primary/secondary driven by MangaDynamicTheme
-    val dominantColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
-    val vibrantColor = MaterialTheme.colorScheme.secondary.copy(alpha = 0.7f)
-
-    Column(modifier = modifier.fillMaxWidth()) {
-        if (showPanoramaCover) {
-            // Panorama mode - wide banner cover
-            Box(modifier = Modifier.fillMaxWidth()) {
-                AsyncImage(
-                    model = manga.thumbnailUrl,
-                    contentDescription = manga.title,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(200.dp)
-                )
-                IconButton(
-                    onClick = onTogglePanoramaCover,
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(8.dp)
-                        .background(
-                            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.7f),
-                            shape = CircleShape
-                        )
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.AspectRatio,
-                        contentDescription = stringResource(R.string.details_toggle_panorama)
-                    )
-                }
-            }
-        } else {
-            // Enhanced hero — 360dp tall, bloom-animated, content-type-aware
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(360.dp)
-                    .graphicsLayer { alpha = bloomAnimatable.value }
-            ) {
-                // Background layer: CoverSplashBackground when cover URL available,
-                // fallback gradient otherwise
-                if (!manga.thumbnailUrl.isNullOrBlank()) {
-                    CoverSplashBackground(
-                        dominant = dominantColor,
-                        vibrant = vibrantColor,
-                        modifier = Modifier.fillMaxSize()
-                    )
-                } else {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(
-                                Brush.verticalGradient(
-                                    listOf(Color(0xFF12121A), Color(0xFF0A0A0F))
-                                )
-                            )
-                    )
-                }
-
-                // Blurred cover image — parallax depth layer
-                if (!manga.thumbnailUrl.isNullOrBlank()) {
-                    AsyncImage(
-                        model = manga.thumbnailUrl,
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .blur(24.dp)
-                            .alpha(0.35f)
-                            .graphicsLayer {
-                                val offset = scrollOffset()
-                                translationY = offset * HERO_BG_PARALLAX_FACTOR
-                                scaleX = HERO_BG_SCALE
-                                scaleY = HERO_BG_SCALE
-                            }
-                    )
-                }
-
-                // Bottom gradient fade
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(
-                            Brush.verticalGradient(
-                                0f to Color.Transparent,
-                                0.45f to otaku.bg.copy(alpha = 0.35f),
-                                1f to otaku.bg.copy(alpha = 0.95f),
-                            )
-                        )
-                )
-
-                // Foreground content row — cover + info, with subtle parallax
-                Row(
-                    modifier = Modifier
-                        .align(Alignment.BottomStart)
-                        .padding(horizontal = 16.dp, vertical = 16.dp)
-                        .graphicsLayer { translationY = scrollOffset() * HERO_FG_PARALLAX_FACTOR },
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    verticalAlignment = Alignment.Bottom,
-                ) {
-                    // Cover thumbnail with panorama toggle
-                    Box {
-                        AsyncImage(
-                            model = manga.thumbnailUrl,
-                            contentDescription = manga.title,
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier
-                                .size(width = 100.dp, height = 150.dp)
-                                .clip(RoundedCornerShape(8.dp))
-                        )
-                        IconButton(
-                            onClick = onTogglePanoramaCover,
-                            modifier = Modifier
-                                .align(Alignment.TopEnd)
-                                .size(28.dp)
-                                .background(
-                                    color = Color.Black.copy(alpha = 0.5f),
-                                    shape = CircleShape
-                                )
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.AspectRatio,
-                                contentDescription = stringResource(R.string.details_toggle_panorama),
-                                modifier = Modifier.size(14.dp),
-                                tint = Color.White,
-                            )
-                        }
-                    }
-
-                    // Title, author, action buttons
-                    Column(modifier = Modifier.weight(1f)) {
-                        // Animated title: TypewriterText for manga, GlitchText for manhwa
-                        val titleStyle = MaterialTheme.typography.headlineSmall.copy(
-                            fontWeight = FontWeight.Bold,
-                            color = Color.White,
-                        )
-                        if (contentType == ContentType.MANGA) {
-                            TypewriterText(
-                                text = manga.title,
-                                style = titleStyle,
-                                speedMs = 40L
-                            )
-                        } else {
-                            GlitchText(
-                                text = manga.title,
-                                style = titleStyle
-                            )
-                        }
-
-                        Spacer(modifier = Modifier.height(4.dp))
-                        manga.author?.let { author ->
-                            Text(
-                                text = author,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = Color.White.copy(alpha = 0.8f),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
-
-                        Spacer(modifier = Modifier.height(6.dp))
-
-                        // ContentType toggle chip
-                        AssistChip(
-                            onClick = { isOverriddenManhwa = !isOverriddenManhwa },
-                            label = {
-                                Text(
-                                    if (contentType == ContentType.MANGA) "Manga" else "Manhwa",
-                                    style = MaterialTheme.typography.labelSmall
-                                )
-                            }
-                        )
-
-                        Spacer(modifier = Modifier.height(8.dp))
-
-                        // Read button — styled by content type
-                        if (contentType == ContentType.MANGA) {
-                            InkButton(onClick = onToggleFavorite) {
-                                Icon(
-                                    imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(16.dp)
-                                )
-                                Spacer(Modifier.width(4.dp))
-                                Text(
-                                    text = if (isFavorite)
-                                        stringResource(R.string.details_remove_from_library)
-                                    else
-                                        stringResource(R.string.details_add_to_library),
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = Color.White
-                                )
-                            }
-                        } else {
-                            GlowButton(
-                                onClick = onToggleFavorite,
-                                glowColor = ContentType.MANHWA.manhwaAccent()
-                            ) {
-                                Icon(
-                                    imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(16.dp)
-                                )
-                                Spacer(Modifier.width(4.dp))
-                                Text(
-                                    text = if (isFavorite)
-                                        stringResource(R.string.details_remove_from_library)
-                                    else
-                                        stringResource(R.string.details_add_to_library),
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = Color.White
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        
-        // When in panorama mode, show title/info below the banner
-        if (showPanoramaCover) {
-            Spacer(modifier = Modifier.height(16.dp))
-            
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = manga.title,
-                        style = MaterialTheme.typography.headlineSmall,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
-
-                    Spacer(modifier = Modifier.height(4.dp))
-
-                    manga.author?.let { author ->
-                        Text(
-                            text = stringResource(R.string.details_author, author),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-
-                    manga.artist?.let { artist ->
-                        Text(
-                            text = stringResource(R.string.details_artist, artist),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-
-                    Text(
-                        text = stringResource(R.string.details_status, stringResource(manga.status.displayTextResId())),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = manga.status.colorValue()
-                    )
-                }
-                
-                FilledIconToggleButton(
-                    checked = isFavorite,
-                    onCheckedChange = { onToggleFavorite() }
-                ) {
-                    Icon(
-                        imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                        contentDescription = if (isFavorite) {
-                            stringResource(R.string.details_remove_from_library)
-                        } else {
-                            stringResource(R.string.details_add_to_library)
-                        }
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
 private fun MangaNotes(
     notes: String?,
     onEditClick: () -> Unit,
@@ -877,61 +500,6 @@ private fun NoteEditorDialog(
     )
 }
 
-/**
- * Renders a subset of Markdown as an [androidx.compose.ui.text.AnnotatedString].
- * Supported syntax:
- *  - `**text**` → bold
- *  - `*text*`   → italic
- *  - `[label](url)` → underlined link text
- */
-private fun renderMarkdown(source: String): androidx.compose.ui.text.AnnotatedString {
-    return buildAnnotatedString {
-        var remaining = source
-        while (remaining.isNotEmpty()) {
-            val boldMatch = MARKDOWN_BOLD_REGEX.find(remaining)
-            val italicMatch = MARKDOWN_ITALIC_REGEX.find(remaining)
-            val linkMatch = MARKDOWN_LINK_REGEX.find(remaining)
-
-            // Find which match comes first
-            val firstMatch = listOfNotNull(boldMatch, italicMatch, linkMatch)
-                .minByOrNull { it.range.first }
-
-            if (firstMatch == null) {
-                append(remaining)
-                break
-            }
-
-            // Append text before the match
-            if (firstMatch.range.first > 0) {
-                append(remaining.substring(0, firstMatch.range.first))
-            }
-
-            when (firstMatch) {
-                boldMatch -> {
-                    val boldText = firstMatch.groupValues[1]
-                    pushStyle(SpanStyle(fontWeight = FontWeight.Bold))
-                    append(boldText)
-                    pop()
-                }
-                italicMatch -> {
-                    val italicText = firstMatch.groupValues[1]
-                    pushStyle(SpanStyle(fontStyle = FontStyle.Italic))
-                    append(italicText)
-                    pop()
-                }
-                linkMatch -> {
-                    val label = firstMatch.groupValues[1]
-                    pushStyle(SpanStyle(textDecoration = TextDecoration.Underline))
-                    append(label)
-                    pop()
-                }
-            }
-
-            remaining = remaining.substring(firstMatch.range.last + 1)
-        }
-    }
-}
-
 @Composable
 private fun MangaDescription(
     description: String?,
@@ -954,657 +522,6 @@ private fun MangaDescription(
                 Text(if (expanded) stringResource(R.string.details_show_less) else stringResource(R.string.details_show_more))
             }
         }
-    }
-}
-
-@Composable
-private fun DeleteAfterReadOption(
-    override: DeleteAfterReadMode,
-    globalEnabled: Boolean,
-    onChange: (DeleteAfterReadMode) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Column(modifier = modifier) {
-        ListItem(
-            headlineContent = { Text(stringResource(R.string.details_delete_after_read)) },
-            supportingContent = {
-                Column(modifier = Modifier.selectableGroup()) {
-                    val options = listOf(
-                        (if (globalEnabled) {
-                            stringResource(R.string.details_delete_follow_global_on)
-                        } else {
-                            stringResource(R.string.details_delete_follow_global_off)
-                        }) to DeleteAfterReadMode.INHERIT,
-                        stringResource(R.string.details_delete_on) to DeleteAfterReadMode.ENABLED,
-                        stringResource(R.string.details_delete_off) to DeleteAfterReadMode.DISABLED
-                    )
-                    options.forEach { (label, value) ->
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .selectable(
-                                    selected = override == value,
-                                    onClick = { onChange(value) },
-                                    role = Role.RadioButton
-                                )
-                                .padding(vertical = 4.dp)
-                        ) {
-                            RadioButton(
-                                selected = override == value,
-                                onClick = null
-                            )
-                            Text(
-                                text = label,
-                                modifier = Modifier.padding(start = 8.dp)
-                            )
-                        }
-                    }
-                }
-            }
-        )
-    }
-}
-
-@Composable
-private fun NotificationOption(
-    notifyEnabled: Boolean,
-    onToggle: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    ListItem(
-        headlineContent = { Text(stringResource(R.string.details_notify_title)) },
-        supportingContent = {
-            Text(
-                if (notifyEnabled) stringResource(R.string.details_notify_enabled)
-                else stringResource(R.string.details_notify_disabled)
-            )
-        },
-        leadingContent = {
-            Icon(
-                imageVector = if (notifyEnabled) Icons.Default.NotificationsActive else Icons.Default.NotificationsOff,
-                contentDescription = if (notifyEnabled) {
-                    stringResource(R.string.details_notify_icon_on)
-                } else {
-                    stringResource(R.string.details_notify_icon_off)
-                },
-                tint = if (notifyEnabled) MaterialTheme.colorScheme.primary
-                       else MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        },
-        trailingContent = {
-            Switch(
-                checked = notifyEnabled,
-                onCheckedChange = { onToggle() }
-            )
-        },
-        modifier = modifier
-    )
-}
-
-/**
- * Reader settings section for per-manga configuration (#260, #264)
- */
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun ReaderSettingsSection(
-    manga: app.otakureader.domain.model.Manga,
-    onEvent: (DetailsContract.Event) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    var expanded by remember { mutableStateOf(false) }
-
-    Column(modifier = modifier) {
-        ListItem(
-            headlineContent = { Text(stringResource(R.string.details_reader_settings)) },
-            supportingContent = {
-                val hasOverrides = manga.readerDirection != null ||
-                                   manga.readerMode != null ||
-                                   manga.readerColorFilter != null ||
-                                   manga.readerCustomTintColor != null ||
-                                   manga.readerBackgroundColor != null ||
-                                   manga.preloadPagesBefore != null ||
-                                   manga.preloadPagesAfter != null
-                Text(
-                    if (hasOverrides) stringResource(R.string.details_reader_custom_applied)
-                    else stringResource(R.string.details_reader_default)
-                )
-            },
-            trailingContent = {
-                IconButton(onClick = { expanded = !expanded }) {
-                    Icon(
-                        imageVector = if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
-                        contentDescription = if (expanded) {
-                            stringResource(R.string.details_collapse)
-                        } else {
-                            stringResource(R.string.details_expand)
-                        }
-                    )
-                }
-            }
-        )
-
-        if (expanded) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-            ) {
-                // Reading Direction
-                Text(
-                    text = stringResource(R.string.details_reading_direction),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Row(modifier = Modifier.selectableGroup()) {
-                    DirectionOption(stringResource(R.string.details_direction_ltr), 0, manga.readerDirection, onEvent)
-                    DirectionOption(stringResource(R.string.details_direction_rtl), 1, manga.readerDirection, onEvent)
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Reader Mode
-                Text(
-                    text = stringResource(R.string.details_reader_mode),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    ReaderModeOption(stringResource(R.string.details_mode_single), 0, manga.readerMode, onEvent)
-                    ReaderModeOption(stringResource(R.string.details_mode_dual), 1, manga.readerMode, onEvent)
-                    ReaderModeOption(stringResource(R.string.details_mode_webtoon), 2, manga.readerMode, onEvent)
-                    ReaderModeOption(stringResource(R.string.details_mode_smart), 3, manga.readerMode, onEvent)
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Color Filter
-                Text(
-                    text = stringResource(R.string.details_color_filter),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    ColorFilterOption(stringResource(R.string.details_filter_none), 0, manga.readerColorFilter, onEvent)
-                    ColorFilterOption(stringResource(R.string.details_filter_sepia), 1, manga.readerColorFilter, onEvent)
-                    ColorFilterOption(stringResource(R.string.details_filter_greyscale), 2, manga.readerColorFilter, onEvent)
-                    ColorFilterOption(stringResource(R.string.details_filter_invert), 3, manga.readerColorFilter, onEvent)
-                    ColorFilterOption(stringResource(R.string.details_filter_custom_tint), 4, manga.readerColorFilter, onEvent)
-                }
-
-                // Custom Tint Color Picker (shown when Custom Tint is selected)
-                if (manga.readerColorFilter == 4) {
-                    Spacer(modifier = Modifier.height(8.dp))
-                    CustomTintColorPicker(
-                        currentColor = manga.readerCustomTintColor,
-                        onColorChange = { onEvent(DetailsContract.Event.SetReaderCustomTintColor(it)) }
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Background Color
-                Text(
-                    text = stringResource(R.string.details_background_color),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                BackgroundColorPicker(
-                    currentColor = manga.readerBackgroundColor,
-                    onColorChange = { onEvent(DetailsContract.Event.SetReaderBackgroundColor(it)) }
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Preload Pages
-                Text(
-                    text = stringResource(R.string.details_page_preloading),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                PreloadOption(
-                    label = stringResource(R.string.details_pages_before),
-                    value = manga.preloadPagesBefore,
-                    onChange = { onEvent(DetailsContract.Event.SetPreloadPagesBefore(it)) }
-                )
-                PreloadOption(
-                    label = stringResource(R.string.details_pages_after),
-                    value = manga.preloadPagesAfter,
-                    onChange = { onEvent(DetailsContract.Event.SetPreloadPagesAfter(it)) }
-                )
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                // Reset button
-                TextButton(
-                    onClick = {
-                        onEvent(DetailsContract.Event.SetReaderDirection(null))
-                        onEvent(DetailsContract.Event.SetReaderMode(null))
-                        onEvent(DetailsContract.Event.SetReaderColorFilter(null))
-                        onEvent(DetailsContract.Event.SetReaderCustomTintColor(null))
-                        onEvent(DetailsContract.Event.SetReaderBackgroundColor(null))
-                        onEvent(DetailsContract.Event.SetPreloadPagesBefore(null))
-                        onEvent(DetailsContract.Event.SetPreloadPagesAfter(null))
-                    },
-                    modifier = Modifier.align(Alignment.End)
-                ) {
-                    Text(stringResource(R.string.details_reset_defaults))
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun DirectionOption(
-    label: String,
-    value: Int,
-    currentValue: Int?,
-    onEvent: (DetailsContract.Event) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
-            .selectable(
-                selected = currentValue == value,
-                onClick = { onEvent(DetailsContract.Event.SetReaderDirection(value)) },
-                role = Role.RadioButton
-            )
-            .padding(vertical = 4.dp, horizontal = 8.dp)
-    ) {
-        RadioButton(
-            selected = currentValue == value,
-            onClick = null
-        )
-        Text(
-            text = label,
-            modifier = Modifier.padding(start = 8.dp)
-        )
-    }
-}
-
-@Composable
-private fun PreloadOption(
-    label: String,
-    value: Int?,
-    onChange: (Int?) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val decrementDesc = stringResource(R.string.details_stepper_decrement_description)
-    val incrementDesc = stringResource(R.string.details_stepper_increment_description)
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyMedium
-        )
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            TextButton(
-                onClick = { onChange((value ?: 0).coerceAtLeast(0) - 1) },
-                enabled = (value ?: 0) > 0,
-                modifier = Modifier.semantics { contentDescription = decrementDesc }
-            ) {
-                Text(stringResource(R.string.details_stepper_decrement))
-            }
-            Text(
-                text = (value ?: 0).toString(),
-                modifier = Modifier.padding(horizontal = 8.dp)
-            )
-            TextButton(
-                onClick = { onChange((value ?: 0).coerceAtMost(9) + 1) },
-                enabled = (value ?: 0) < 10,
-                modifier = Modifier.semantics { contentDescription = incrementDesc }
-            ) {
-                Text(stringResource(R.string.details_stepper_increment))
-            }
-        }
-    }
-}
-
-@Composable
-private fun ReaderModeOption(
-    label: String,
-    value: Int,
-    currentValue: Int?,
-    onEvent: (DetailsContract.Event) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    FilterChip(
-        selected = currentValue == value,
-        onClick = { onEvent(DetailsContract.Event.SetReaderMode(value)) },
-        label = { Text(label) },
-        modifier = modifier
-    )
-}
-
-@Composable
-private fun ColorFilterOption(
-    label: String,
-    value: Int,
-    currentValue: Int?,
-    onEvent: (DetailsContract.Event) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    FilterChip(
-        selected = currentValue == value,
-        onClick = { onEvent(DetailsContract.Event.SetReaderColorFilter(value)) },
-        label = { Text(label) },
-        modifier = modifier
-    )
-}
-
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun CustomTintColorPicker(
-    currentColor: Long?,
-    onColorChange: (Long?) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        Text(
-            text = stringResource(R.string.details_custom_tint_color),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            val presetColors = listOf(
-                0xFFFF6B6B to stringResource(R.string.details_color_red),
-                0xFFFFA500 to stringResource(R.string.details_color_orange),
-                0xFFFFD93D to stringResource(R.string.details_color_yellow),
-                0xFF6BCB77 to stringResource(R.string.details_color_green),
-                0xFF4D96FF to stringResource(R.string.details_color_blue),
-                0xFF9D84B7 to stringResource(R.string.details_color_purple),
-                0xFFFFB6C1 to stringResource(R.string.details_color_pink)
-            )
-            presetColors.forEach { (color, name) ->
-                ColorChip(
-                    color = color,
-                    label = name,
-                    selected = currentColor == color,
-                    onClick = { onColorChange(color) }
-                )
-            }
-        }
-        Spacer(modifier = Modifier.height(4.dp))
-        TextButton(
-            onClick = { onColorChange(null) },
-            modifier = Modifier.align(Alignment.End)
-        ) {
-            Text(stringResource(R.string.details_reset))
-        }
-    }
-}
-
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun BackgroundColorPicker(
-    currentColor: Long?,
-    onColorChange: (Long?) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        Text(
-            text = stringResource(R.string.details_override_background),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            val presetColors = listOf(
-                0xFF000000 to stringResource(R.string.details_bg_black),
-                0xFF1A1A1A to stringResource(R.string.details_bg_dark_gray),
-                0xFF808080 to stringResource(R.string.details_bg_gray),
-                0xFFFFFFFF to stringResource(R.string.details_bg_white),
-                0xFFFFF8DC to stringResource(R.string.details_bg_cream)
-            )
-            presetColors.forEach { (color, name) ->
-                ColorChip(
-                    color = color,
-                    label = name,
-                    selected = currentColor == color,
-                    onClick = { onColorChange(color) }
-                )
-            }
-        }
-        Spacer(modifier = Modifier.height(4.dp))
-        TextButton(
-            onClick = { onColorChange(null) },
-            modifier = Modifier.align(Alignment.End)
-        ) {
-            Text(stringResource(R.string.details_reset))
-        }
-    }
-}
-
-@Composable
-private fun ColorChip(
-    color: Long,
-    label: String,
-    selected: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    FilterChip(
-        selected = selected,
-        onClick = onClick,
-        label = { Text(label) },
-        leadingIcon = {
-            Box(
-                modifier = Modifier
-                    .size(16.dp)
-                    .background(
-                        color = Color(color),
-                        shape = CircleShape
-                    )
-            )
-        },
-        modifier = modifier
-    )
-}
-
-@Composable
-private fun ChapterListHeader(
-    chapterCount: Int,
-    sortOrder: DetailsContract.ChapterSortOrder,
-    isFilterActive: Boolean = false,
-    onToggleSort: () -> Unit,
-    onShowFilter: () -> Unit = {},
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text(
-            text = pluralStringResource(R.plurals.details_chapter_count, chapterCount, chapterCount),
-            style = MaterialTheme.typography.titleMedium
-        )
-
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            IconButton(onClick = onShowFilter) {
-                Icon(
-                    imageVector = Icons.Default.FilterList,
-                    contentDescription = stringResource(R.string.details_filter_chapters),
-                    tint = if (isFilterActive) MaterialTheme.colorScheme.primary
-                           else MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            TextButton(onClick = onToggleSort) {
-                Text(
-                    when (sortOrder) {
-                        DetailsContract.ChapterSortOrder.ASCENDING -> stringResource(R.string.details_sort_ascending)
-                        DetailsContract.ChapterSortOrder.DESCENDING -> stringResource(R.string.details_sort_descending)
-                    }
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun ChapterFilterDialog(
-    filter: DetailsContract.ChapterFilter,
-    scanlators: List<String>,
-    onApply: (DetailsContract.ChapterFilter) -> Unit,
-    onDismiss: () -> Unit
-) {
-    var read by remember { mutableStateOf(filter.read) }
-    var bookmarked by remember { mutableStateOf(filter.bookmarked) }
-    var downloaded by remember { mutableStateOf(filter.downloaded) }
-    var selectedScanlator by remember { mutableStateOf(filter.scanlator) }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.details_filter_chapters)) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                // Read / Unread filter
-                Text(
-                    text = stringResource(R.string.details_filter_read_label),
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.SemiBold
-                )
-                TriStateRow(
-                    labelAll = stringResource(R.string.details_filter_all),
-                    labelOnly = stringResource(R.string.details_filter_read),
-                    labelExclude = stringResource(R.string.details_filter_unread),
-                    state = read,
-                    onStateChange = { read = it }
-                )
-
-                HorizontalDivider()
-
-                // Bookmark filter
-                Text(
-                    text = stringResource(R.string.details_filter_bookmarked_label),
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.SemiBold
-                )
-                TriStateRow(
-                    labelAll = stringResource(R.string.details_filter_all),
-                    labelOnly = stringResource(R.string.details_filter_bookmarked),
-                    labelExclude = stringResource(R.string.details_filter_not_bookmarked),
-                    state = bookmarked,
-                    onStateChange = { bookmarked = it }
-                )
-
-                HorizontalDivider()
-
-                // Downloaded filter
-                Text(
-                    text = stringResource(R.string.details_filter_downloaded_label),
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.SemiBold
-                )
-                TriStateRow(
-                    labelAll = stringResource(R.string.details_filter_all),
-                    labelOnly = stringResource(R.string.details_filter_downloaded),
-                    labelExclude = stringResource(R.string.details_filter_not_downloaded),
-                    state = downloaded,
-                    onStateChange = { downloaded = it }
-                )
-
-                // Scanlator filter (only shown when multiple scanlators exist)
-                if (scanlators.size > 1) {
-                    HorizontalDivider()
-                    Text(
-                        text = stringResource(R.string.details_filter_scanlator_label),
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.SemiBold
-                    )
-                    // "All scanlators" chip
-                    FilterChip(
-                        selected = selectedScanlator == null,
-                        onClick = { selectedScanlator = null },
-                        label = { Text(stringResource(R.string.details_filter_all)) }
-                    )
-                    scanlators.forEach { s ->
-                        FilterChip(
-                            selected = selectedScanlator == s,
-                            onClick = { selectedScanlator = if (selectedScanlator == s) null else s },
-                            label = { Text(s) }
-                        )
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = {
-                onApply(DetailsContract.ChapterFilter(read, bookmarked, downloaded, selectedScanlator))
-            }) {
-                Text(stringResource(R.string.details_filter_apply))
-            }
-        },
-        dismissButton = {
-            Row {
-                TextButton(onClick = {
-                    onApply(DetailsContract.ChapterFilter())
-                }) {
-                    Text(stringResource(R.string.details_filter_reset))
-                }
-                TextButton(onClick = onDismiss) {
-                    Text(stringResource(R.string.details_filter_cancel))
-                }
-            }
-        }
-    )
-}
-
-@Composable
-private fun TriStateRow(
-    labelAll: String,
-    labelOnly: String,
-    labelExclude: String,
-    state: DetailsContract.TriState,
-    onStateChange: (DetailsContract.TriState) -> Unit
-) {
-    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        FilterChip(
-            selected = state == DetailsContract.TriState.ALL,
-            onClick = { onStateChange(DetailsContract.TriState.ALL) },
-            label = { Text(labelAll) }
-        )
-        FilterChip(
-            selected = state == DetailsContract.TriState.ONLY,
-            onClick = { onStateChange(DetailsContract.TriState.ONLY) },
-            label = { Text(labelOnly) }
-        )
-        FilterChip(
-            selected = state == DetailsContract.TriState.EXCLUDE,
-            onClick = { onStateChange(DetailsContract.TriState.EXCLUDE) },
-            label = { Text(labelExclude) }
-        )
-    }
-}
-
-@Composable
-private fun EmptyScreen(modifier: Modifier = Modifier) {
-    Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(stringResource(R.string.details_no_manga))
     }
 }
 
@@ -1703,16 +620,16 @@ private fun SuggestionItem(
                 .fillMaxWidth()
                 .aspectRatio(0.7f)
         )
-        
+
         Spacer(modifier = Modifier.height(4.dp))
-        
+
         Text(
             text = suggestion.title,
             style = MaterialTheme.typography.bodySmall,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis
         )
-        
+
         suggestion.reason?.let { reason ->
             Text(
                 text = reason,

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -60,7 +60,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -3,25 +3,18 @@ package app.otakureader.feature.details
 
 import android.content.Intent
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
@@ -31,7 +24,6 @@ import androidx.compose.material.icons.filled.QueryStats
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -40,7 +32,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -60,7 +51,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -74,7 +64,6 @@ import app.otakureader.core.ui.component.LoadingScreen
 import app.otakureader.core.ui.theme.MangaDynamicTheme
 import app.otakureader.core.ui.theme.rememberCoverColorScheme
 import app.otakureader.feature.details.R
-import coil3.compose.AsyncImage
 import kotlinx.coroutines.flow.collectLatest
 import androidx.compose.ui.tooling.preview.Preview
 import app.otakureader.core.ui.theme.OtakuReaderTheme
@@ -524,122 +513,6 @@ private fun MangaDescription(
     }
 }
 
-@Composable
-private fun SourceSuggestionsSection(
-    suggestions: List<SourceSuggestion>,
-    isLoading: Boolean,
-    error: String?,
-    onSuggestionClick: (SourceSuggestion) -> Unit,
-    onLoadClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    if (suggestions.isEmpty() && !isLoading && error == null) {
-        // Show load button when no suggestions loaded yet
-        OutlinedButton(
-            onClick = onLoadClick,
-            modifier = modifier.fillMaxWidth()
-        ) {
-            Text(stringResource(R.string.details_load_suggestions))
-        }
-        return
-    }
-
-    Column(modifier = modifier.fillMaxWidth()) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = stringResource(R.string.details_source_suggestions_title),
-                style = MaterialTheme.typography.titleMedium
-            )
-            if (!isLoading && suggestions.isNotEmpty()) {
-                TextButton(onClick = onLoadClick) {
-                    Text(stringResource(R.string.details_refresh))
-                }
-            }
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        when {
-            isLoading -> {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(120.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator()
-                }
-            }
-            error != null -> {
-                Text(
-                    text = error,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.padding(vertical = 8.dp)
-                )
-            }
-            suggestions.isNotEmpty() -> {
-                LazyRow(
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    contentPadding = PaddingValues(horizontal = 4.dp),
-                    modifier = Modifier.height(160.dp)
-                ) {
-                    items(suggestions, key = { it.mangaUrl }) { suggestion ->
-                        SuggestionItem(
-                            suggestion = suggestion,
-                            onClick = { onSuggestionClick(suggestion) }
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun SuggestionItem(
-    suggestion: SourceSuggestion,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Column(
-        modifier = modifier
-            .width(100.dp)
-            .clickable(onClick = onClick)
-    ) {
-        AsyncImage(
-            model = suggestion.thumbnailUrl,
-            contentDescription = suggestion.title,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(0.7f)
-        )
-
-        Spacer(modifier = Modifier.height(4.dp))
-
-        Text(
-            text = suggestion.title,
-            style = MaterialTheme.typography.bodySmall,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis
-        )
-
-        suggestion.reason?.let { reason ->
-            Text(
-                text = reason,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-    }
-}
 
 @Preview(showBackground = true, backgroundColor = 0xFF12121A)
 @Composable

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -126,6 +126,7 @@ class DetailsViewModel @Inject constructor(
             // Page preloading settings (#264)
             is DetailsContract.Event.SetPreloadPagesBefore -> setPreloadPagesBefore(event.count)
             is DetailsContract.Event.SetPreloadPagesAfter -> setPreloadPagesAfter(event.count)
+            is DetailsContract.Event.ResetReaderSettings -> resetReaderSettings()
             
             // Chapter thumbnail loading
             is DetailsContract.Event.LoadChapterThumbnail -> loadChapterThumbnail(event.chapterId)
@@ -844,6 +845,25 @@ class DetailsViewModel @Inject constructor(
                 throw e
             } catch (e: Exception) {
                 _effect.send(DetailsContract.Effect.ShowError("Failed to update preload setting"))
+            }
+        }
+    }
+
+    private fun resetReaderSettings() {
+        viewModelScope.launch {
+            try {
+                mangaRepository.updateReaderDirection(mangaId, null)
+                mangaRepository.updateReaderMode(mangaId, null)
+                mangaRepository.updateReaderColorFilter(mangaId, null)
+                mangaRepository.updateReaderCustomTintColor(mangaId, null)
+                mangaRepository.updateReaderBackgroundColor(mangaId, null)
+                mangaRepository.updatePreloadPagesBefore(mangaId, null)
+                mangaRepository.updatePreloadPagesAfter(mangaId, null)
+                _effect.send(DetailsContract.Effect.ShowSnackbar("Reader settings reset to defaults"))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(DetailsContract.Effect.ShowError("Failed to reset reader settings"))
             }
         }
     }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -212,7 +212,7 @@ class DetailsViewModel @Inject constructor(
                                 name = chapter.name,
                                 dateUpload = chapter.dateUpload,
                                 chapterNumber = chapter.chapterNumber,
-                                scanlator = chapter.scanlator
+                                scanlator = chapter.scanlator ?: ""
                             )
 
                             // Use repository instead of calling source directly (#587)
@@ -868,7 +868,7 @@ class DetailsViewModel @Inject constructor(
                     name = chapter.name,
                     dateUpload = chapter.dateUpload,
                     chapterNumber = chapter.chapterNumber,
-                    scanlator = chapter.scanlator
+                    scanlator = chapter.scanlator ?: ""
                 )
 
                 // Use repository to respect caching and abstraction layers (#587)

--- a/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
@@ -1,0 +1,449 @@
+@file:Suppress("MaxLineLength")
+package app.otakureader.feature.details
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AspectRatio
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.FilledIconToggleButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import app.otakureader.core.ui.background.CoverSplashBackground
+import app.otakureader.core.ui.components.GlitchText
+import app.otakureader.core.ui.components.GlowButton
+import app.otakureader.core.ui.components.InkButton
+import app.otakureader.core.ui.components.TypewriterText
+import app.otakureader.core.ui.theme.ContentType
+import app.otakureader.core.ui.theme.LocalOtakuColors
+import app.otakureader.core.ui.theme.manhwaAccent
+import app.otakureader.feature.details.R
+import coil3.compose.AsyncImage
+
+private val MARKDOWN_BOLD_REGEX = Regex("""\*\*(.+?)\*\*""")
+private val MARKDOWN_ITALIC_REGEX = Regex("""(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)""")
+private val MARKDOWN_LINK_REGEX = Regex("""\[(.+?)]\((.+?)\)""")
+
+// Parallax hero constants
+private const val HERO_BG_PARALLAX_FACTOR = 0.4f
+private const val HERO_FG_PARALLAX_FACTOR = 0.15f
+private const val HERO_BG_SCALE = 1.15f
+
+@Composable
+internal fun MangaHeader(
+    manga: app.otakureader.domain.model.Manga,
+    isFavorite: Boolean,
+    showPanoramaCover: Boolean,
+    onToggleFavorite: () -> Unit,
+    onTogglePanoramaCover: () -> Unit,
+    scrollOffset: () -> Float = { 0f },
+    modifier: Modifier = Modifier
+) {
+    val otaku = LocalOtakuColors.current
+
+    // Detect content type from sourceId string representation
+    val sourceIdStr = remember(manga.sourceId) { manga.sourceId.toString() }
+    val autoDetectedContentType = remember(sourceIdStr) {
+        val src = sourceIdStr.lowercase()
+        if (src.contains("manhwa") || src.contains("webtoon") ||
+            src.contains("korean") || src.contains("toon")
+        ) {
+            ContentType.MANHWA
+        } else {
+            ContentType.MANGA
+        }
+    }
+    // Local override toggle — survives recomposition, resets when manga changes
+    var isOverriddenManhwa by rememberSaveable(manga.id) {
+        mutableStateOf(autoDetectedContentType == ContentType.MANHWA)
+    }
+    val contentType = if (isOverriddenManhwa) ContentType.MANHWA else ContentType.MANGA
+
+    // Bloom enter animation — fades the hero in on first composition.
+    // The Animatable is remembered so Compose reads its `value` as observable state,
+    // driving recomposition on every animation frame. Previously, the Animatable was
+    // created inside LaunchedEffect and its value was only copied after animateTo()
+    // completed, so the hero jumped from alpha=0 to alpha=1 with no visible transition.
+    val bloomAnimatable = remember(manga.id) { Animatable(0f) }
+    LaunchedEffect(manga.id) {
+        bloomAnimatable.snapTo(0f)
+        bloomAnimatable.animateTo(1f, animationSpec = tween(800, easing = FastOutSlowInEasing))
+    }
+
+    // Derive splash colors from the Material theme primary/secondary driven by MangaDynamicTheme
+    val dominantColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
+    val vibrantColor = MaterialTheme.colorScheme.secondary.copy(alpha = 0.7f)
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        if (showPanoramaCover) {
+            // Panorama mode - wide banner cover
+            Box(modifier = Modifier.fillMaxWidth()) {
+                AsyncImage(
+                    model = manga.thumbnailUrl,
+                    contentDescription = manga.title,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                )
+                IconButton(
+                    onClick = onTogglePanoramaCover,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(8.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.7f),
+                            shape = CircleShape
+                        )
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.AspectRatio,
+                        contentDescription = stringResource(R.string.details_toggle_panorama)
+                    )
+                }
+            }
+        } else {
+            // Enhanced hero — 360dp tall, bloom-animated, content-type-aware
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(360.dp)
+                    .graphicsLayer { alpha = bloomAnimatable.value }
+            ) {
+                // Background layer: CoverSplashBackground when cover URL available,
+                // fallback gradient otherwise
+                if (!manga.thumbnailUrl.isNullOrBlank()) {
+                    CoverSplashBackground(
+                        dominant = dominantColor,
+                        vibrant = vibrantColor,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(
+                                Brush.verticalGradient(
+                                    listOf(Color(0xFF12121A), Color(0xFF0A0A0F))
+                                )
+                            )
+                    )
+                }
+
+                // Blurred cover image — parallax depth layer
+                if (!manga.thumbnailUrl.isNullOrBlank()) {
+                    AsyncImage(
+                        model = manga.thumbnailUrl,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .blur(24.dp)
+                            .alpha(0.35f)
+                            .graphicsLayer {
+                                val offset = scrollOffset()
+                                translationY = offset * HERO_BG_PARALLAX_FACTOR
+                                scaleX = HERO_BG_SCALE
+                                scaleY = HERO_BG_SCALE
+                            }
+                    )
+                }
+
+                // Bottom gradient fade
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            Brush.verticalGradient(
+                                0f to Color.Transparent,
+                                0.45f to otaku.bg.copy(alpha = 0.35f),
+                                1f to otaku.bg.copy(alpha = 0.95f),
+                            )
+                        )
+                )
+
+                // Foreground content row — cover + info, with subtle parallax
+                Row(
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(horizontal = 16.dp, vertical = 16.dp)
+                        .graphicsLayer { translationY = scrollOffset() * HERO_FG_PARALLAX_FACTOR },
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    verticalAlignment = Alignment.Bottom,
+                ) {
+                    // Cover thumbnail with panorama toggle
+                    Box {
+                        AsyncImage(
+                            model = manga.thumbnailUrl,
+                            contentDescription = manga.title,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier
+                                .size(width = 100.dp, height = 150.dp)
+                                .clip(RoundedCornerShape(8.dp))
+                        )
+                        IconButton(
+                            onClick = onTogglePanoramaCover,
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .size(28.dp)
+                                .background(
+                                    color = Color.Black.copy(alpha = 0.5f),
+                                    shape = CircleShape
+                                )
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.AspectRatio,
+                                contentDescription = stringResource(R.string.details_toggle_panorama),
+                                modifier = Modifier.size(14.dp),
+                                tint = Color.White,
+                            )
+                        }
+                    }
+
+                    // Title, author, action buttons
+                    Column(modifier = Modifier.weight(1f)) {
+                        // Animated title: TypewriterText for manga, GlitchText for manhwa
+                        val titleStyle = MaterialTheme.typography.headlineSmall.copy(
+                            fontWeight = FontWeight.Bold,
+                            color = Color.White,
+                        )
+                        if (contentType == ContentType.MANGA) {
+                            TypewriterText(
+                                text = manga.title,
+                                style = titleStyle,
+                                speedMs = 40L
+                            )
+                        } else {
+                            GlitchText(
+                                text = manga.title,
+                                style = titleStyle
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(4.dp))
+                        manga.author?.let { author ->
+                            Text(
+                                text = author,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = Color.White.copy(alpha = 0.8f),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(6.dp))
+
+                        // ContentType toggle chip
+                        AssistChip(
+                            onClick = { isOverriddenManhwa = !isOverriddenManhwa },
+                            label = {
+                                Text(
+                                    if (contentType == ContentType.MANGA) "Manga" else "Manhwa",
+                                    style = MaterialTheme.typography.labelSmall
+                                )
+                            }
+                        )
+
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        // Read button — styled by content type
+                        if (contentType == ContentType.MANGA) {
+                            InkButton(onClick = onToggleFavorite) {
+                                Icon(
+                                    imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp)
+                                )
+                                Spacer(Modifier.width(4.dp))
+                                Text(
+                                    text = if (isFavorite)
+                                        stringResource(R.string.details_remove_from_library)
+                                    else
+                                        stringResource(R.string.details_add_to_library),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = Color.White
+                                )
+                            }
+                        } else {
+                            GlowButton(
+                                onClick = onToggleFavorite,
+                                glowColor = ContentType.MANHWA.manhwaAccent()
+                            ) {
+                                Icon(
+                                    imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp)
+                                )
+                                Spacer(Modifier.width(4.dp))
+                                Text(
+                                    text = if (isFavorite)
+                                        stringResource(R.string.details_remove_from_library)
+                                    else
+                                        stringResource(R.string.details_add_to_library),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = Color.White
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // When in panorama mode, show title/info below the banner
+        if (showPanoramaCover) {
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = manga.title,
+                        style = MaterialTheme.typography.headlineSmall,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    manga.author?.let { author ->
+                        Text(
+                            text = stringResource(R.string.details_author, author),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+
+                    manga.artist?.let { artist ->
+                        Text(
+                            text = stringResource(R.string.details_artist, artist),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+
+                    Text(
+                        text = stringResource(R.string.details_status, stringResource(manga.status.displayTextResId())),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = manga.status.colorValue()
+                    )
+                }
+
+                FilledIconToggleButton(
+                    checked = isFavorite,
+                    onCheckedChange = { onToggleFavorite() }
+                ) {
+                    Icon(
+                        imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                        contentDescription = if (isFavorite) {
+                            stringResource(R.string.details_remove_from_library)
+                        } else {
+                            stringResource(R.string.details_add_to_library)
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Renders a subset of Markdown as an [androidx.compose.ui.text.AnnotatedString].
+ * Supported syntax:
+ *  - `**text**` → bold
+ *  - `*text*`   → italic
+ *  - `[label](url)` → underlined link text
+ */
+internal fun renderMarkdown(source: String): androidx.compose.ui.text.AnnotatedString {
+    return buildAnnotatedString {
+        var remaining = source
+        while (remaining.isNotEmpty()) {
+            val boldMatch = MARKDOWN_BOLD_REGEX.find(remaining)
+            val italicMatch = MARKDOWN_ITALIC_REGEX.find(remaining)
+            val linkMatch = MARKDOWN_LINK_REGEX.find(remaining)
+
+            // Find which match comes first
+            val firstMatch = listOfNotNull(boldMatch, italicMatch, linkMatch)
+                .minByOrNull { it.range.first }
+
+            if (firstMatch == null) {
+                append(remaining)
+                break
+            }
+
+            // Append text before the match
+            if (firstMatch.range.first > 0) {
+                append(remaining.substring(0, firstMatch.range.first))
+            }
+
+            when (firstMatch) {
+                boldMatch -> {
+                    val boldText = firstMatch.groupValues[1]
+                    pushStyle(SpanStyle(fontWeight = FontWeight.Bold))
+                    append(boldText)
+                    pop()
+                }
+                italicMatch -> {
+                    val italicText = firstMatch.groupValues[1]
+                    pushStyle(SpanStyle(fontStyle = FontStyle.Italic))
+                    append(italicText)
+                    pop()
+                }
+                linkMatch -> {
+                    val label = firstMatch.groupValues[1]
+                    pushStyle(SpanStyle(textDecoration = TextDecoration.Underline))
+                    append(label)
+                    pop()
+                }
+            }
+
+            remaining = remaining.substring(firstMatch.range.last + 1)
+        }
+    }
+}

--- a/feature/details/src/main/java/app/otakureader/feature/details/MangaSettingsSection.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/MangaSettingsSection.kt
@@ -273,17 +273,9 @@ internal fun ReaderSettingsSection(
 
                 Spacer(modifier = Modifier.height(8.dp))
 
-                // Reset button
+                // Reset button — single atomic event to avoid multiple snackbars
                 TextButton(
-                    onClick = {
-                        onEvent(DetailsContract.Event.SetReaderDirection(null))
-                        onEvent(DetailsContract.Event.SetReaderMode(null))
-                        onEvent(DetailsContract.Event.SetReaderColorFilter(null))
-                        onEvent(DetailsContract.Event.SetReaderCustomTintColor(null))
-                        onEvent(DetailsContract.Event.SetReaderBackgroundColor(null))
-                        onEvent(DetailsContract.Event.SetPreloadPagesBefore(null))
-                        onEvent(DetailsContract.Event.SetPreloadPagesAfter(null))
-                    },
+                    onClick = { onEvent(DetailsContract.Event.ResetReaderSettings) },
                     modifier = Modifier.align(Alignment.End)
                 ) {
                     Text(stringResource(R.string.details_reset_defaults))

--- a/feature/details/src/main/java/app/otakureader/feature/details/MangaSettingsSection.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/MangaSettingsSection.kt
@@ -1,0 +1,512 @@
+@file:Suppress("MaxLineLength")
+package app.otakureader.feature.details
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.NotificationsActive
+import androidx.compose.material.icons.filled.NotificationsOff
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import app.otakureader.core.preferences.DeleteAfterReadMode
+import app.otakureader.feature.details.R
+
+@Composable
+internal fun DeleteAfterReadOption(
+    override: DeleteAfterReadMode,
+    globalEnabled: Boolean,
+    onChange: (DeleteAfterReadMode) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.details_delete_after_read)) },
+            supportingContent = {
+                Column(modifier = Modifier.selectableGroup()) {
+                    val options = listOf(
+                        (if (globalEnabled) {
+                            stringResource(R.string.details_delete_follow_global_on)
+                        } else {
+                            stringResource(R.string.details_delete_follow_global_off)
+                        }) to DeleteAfterReadMode.INHERIT,
+                        stringResource(R.string.details_delete_on) to DeleteAfterReadMode.ENABLED,
+                        stringResource(R.string.details_delete_off) to DeleteAfterReadMode.DISABLED
+                    )
+                    options.forEach { (label, value) ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .selectable(
+                                    selected = override == value,
+                                    onClick = { onChange(value) },
+                                    role = Role.RadioButton
+                                )
+                                .padding(vertical = 4.dp)
+                        ) {
+                            RadioButton(
+                                selected = override == value,
+                                onClick = null
+                            )
+                            Text(
+                                text = label,
+                                modifier = Modifier.padding(start = 8.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        )
+    }
+}
+
+@Composable
+internal fun NotificationOption(
+    notifyEnabled: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.details_notify_title)) },
+        supportingContent = {
+            Text(
+                if (notifyEnabled) stringResource(R.string.details_notify_enabled)
+                else stringResource(R.string.details_notify_disabled)
+            )
+        },
+        leadingContent = {
+            Icon(
+                imageVector = if (notifyEnabled) Icons.Default.NotificationsActive else Icons.Default.NotificationsOff,
+                contentDescription = if (notifyEnabled) {
+                    stringResource(R.string.details_notify_icon_on)
+                } else {
+                    stringResource(R.string.details_notify_icon_off)
+                },
+                tint = if (notifyEnabled) MaterialTheme.colorScheme.primary
+                       else MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        },
+        trailingContent = {
+            Switch(
+                checked = notifyEnabled,
+                onCheckedChange = { onToggle() }
+            )
+        },
+        modifier = modifier
+    )
+}
+
+/**
+ * Reader settings section for per-manga configuration (#260, #264)
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun ReaderSettingsSection(
+    manga: app.otakureader.domain.model.Manga,
+    onEvent: (DetailsContract.Event) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(modifier = modifier) {
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.details_reader_settings)) },
+            supportingContent = {
+                val hasOverrides = manga.readerDirection != null ||
+                                   manga.readerMode != null ||
+                                   manga.readerColorFilter != null ||
+                                   manga.readerCustomTintColor != null ||
+                                   manga.readerBackgroundColor != null ||
+                                   manga.preloadPagesBefore != null ||
+                                   manga.preloadPagesAfter != null
+                Text(
+                    if (hasOverrides) stringResource(R.string.details_reader_custom_applied)
+                    else stringResource(R.string.details_reader_default)
+                )
+            },
+            trailingContent = {
+                IconButton(onClick = { expanded = !expanded }) {
+                    Icon(
+                        imageVector = if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                        contentDescription = if (expanded) {
+                            stringResource(R.string.details_collapse)
+                        } else {
+                            stringResource(R.string.details_expand)
+                        }
+                    )
+                }
+            }
+        )
+
+        if (expanded) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            ) {
+                // Reading Direction
+                Text(
+                    text = stringResource(R.string.details_reading_direction),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Row(modifier = Modifier.selectableGroup()) {
+                    DirectionOption(stringResource(R.string.details_direction_ltr), 0, manga.readerDirection, onEvent)
+                    DirectionOption(stringResource(R.string.details_direction_rtl), 1, manga.readerDirection, onEvent)
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Reader Mode
+                Text(
+                    text = stringResource(R.string.details_reader_mode),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    ReaderModeOption(stringResource(R.string.details_mode_single), 0, manga.readerMode, onEvent)
+                    ReaderModeOption(stringResource(R.string.details_mode_dual), 1, manga.readerMode, onEvent)
+                    ReaderModeOption(stringResource(R.string.details_mode_webtoon), 2, manga.readerMode, onEvent)
+                    ReaderModeOption(stringResource(R.string.details_mode_smart), 3, manga.readerMode, onEvent)
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Color Filter
+                Text(
+                    text = stringResource(R.string.details_color_filter),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    ColorFilterOption(stringResource(R.string.details_filter_none), 0, manga.readerColorFilter, onEvent)
+                    ColorFilterOption(stringResource(R.string.details_filter_sepia), 1, manga.readerColorFilter, onEvent)
+                    ColorFilterOption(stringResource(R.string.details_filter_greyscale), 2, manga.readerColorFilter, onEvent)
+                    ColorFilterOption(stringResource(R.string.details_filter_invert), 3, manga.readerColorFilter, onEvent)
+                    ColorFilterOption(stringResource(R.string.details_filter_custom_tint), 4, manga.readerColorFilter, onEvent)
+                }
+
+                // Custom Tint Color Picker (shown when Custom Tint is selected)
+                if (manga.readerColorFilter == 4) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    CustomTintColorPicker(
+                        currentColor = manga.readerCustomTintColor,
+                        onColorChange = { onEvent(DetailsContract.Event.SetReaderCustomTintColor(it)) }
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Background Color
+                Text(
+                    text = stringResource(R.string.details_background_color),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                BackgroundColorPicker(
+                    currentColor = manga.readerBackgroundColor,
+                    onColorChange = { onEvent(DetailsContract.Event.SetReaderBackgroundColor(it)) }
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Preload Pages
+                Text(
+                    text = stringResource(R.string.details_page_preloading),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                PreloadOption(
+                    label = stringResource(R.string.details_pages_before),
+                    value = manga.preloadPagesBefore,
+                    onChange = { onEvent(DetailsContract.Event.SetPreloadPagesBefore(it)) }
+                )
+                PreloadOption(
+                    label = stringResource(R.string.details_pages_after),
+                    value = manga.preloadPagesAfter,
+                    onChange = { onEvent(DetailsContract.Event.SetPreloadPagesAfter(it)) }
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // Reset button
+                TextButton(
+                    onClick = {
+                        onEvent(DetailsContract.Event.SetReaderDirection(null))
+                        onEvent(DetailsContract.Event.SetReaderMode(null))
+                        onEvent(DetailsContract.Event.SetReaderColorFilter(null))
+                        onEvent(DetailsContract.Event.SetReaderCustomTintColor(null))
+                        onEvent(DetailsContract.Event.SetReaderBackgroundColor(null))
+                        onEvent(DetailsContract.Event.SetPreloadPagesBefore(null))
+                        onEvent(DetailsContract.Event.SetPreloadPagesAfter(null))
+                    },
+                    modifier = Modifier.align(Alignment.End)
+                ) {
+                    Text(stringResource(R.string.details_reset_defaults))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun DirectionOption(
+    label: String,
+    value: Int,
+    currentValue: Int?,
+    onEvent: (DetailsContract.Event) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .selectable(
+                selected = currentValue == value,
+                onClick = { onEvent(DetailsContract.Event.SetReaderDirection(value)) },
+                role = Role.RadioButton
+            )
+            .padding(vertical = 4.dp, horizontal = 8.dp)
+    ) {
+        RadioButton(
+            selected = currentValue == value,
+            onClick = null
+        )
+        Text(
+            text = label,
+            modifier = Modifier.padding(start = 8.dp)
+        )
+    }
+}
+
+@Composable
+internal fun PreloadOption(
+    label: String,
+    value: Int?,
+    onChange: (Int?) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val decrementDesc = stringResource(R.string.details_stepper_decrement_description)
+    val incrementDesc = stringResource(R.string.details_stepper_increment_description)
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            TextButton(
+                onClick = { onChange((value ?: 0).coerceAtLeast(0) - 1) },
+                enabled = (value ?: 0) > 0,
+                modifier = Modifier.semantics { contentDescription = decrementDesc }
+            ) {
+                Text(stringResource(R.string.details_stepper_decrement))
+            }
+            Text(
+                text = (value ?: 0).toString(),
+                modifier = Modifier.padding(horizontal = 8.dp)
+            )
+            TextButton(
+                onClick = { onChange((value ?: 0).coerceAtMost(9) + 1) },
+                enabled = (value ?: 0) < 10,
+                modifier = Modifier.semantics { contentDescription = incrementDesc }
+            ) {
+                Text(stringResource(R.string.details_stepper_increment))
+            }
+        }
+    }
+}
+
+@Composable
+internal fun ReaderModeOption(
+    label: String,
+    value: Int,
+    currentValue: Int?,
+    onEvent: (DetailsContract.Event) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    FilterChip(
+        selected = currentValue == value,
+        onClick = { onEvent(DetailsContract.Event.SetReaderMode(value)) },
+        label = { Text(label) },
+        modifier = modifier
+    )
+}
+
+@Composable
+internal fun ColorFilterOption(
+    label: String,
+    value: Int,
+    currentValue: Int?,
+    onEvent: (DetailsContract.Event) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    FilterChip(
+        selected = currentValue == value,
+        onClick = { onEvent(DetailsContract.Event.SetReaderColorFilter(value)) },
+        label = { Text(label) },
+        modifier = modifier
+    )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun CustomTintColorPicker(
+    currentColor: Long?,
+    onColorChange: (Long?) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.details_custom_tint_color),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            val presetColors = listOf(
+                0xFFFF6B6B to stringResource(R.string.details_color_red),
+                0xFFFFA500 to stringResource(R.string.details_color_orange),
+                0xFFFFD93D to stringResource(R.string.details_color_yellow),
+                0xFF6BCB77 to stringResource(R.string.details_color_green),
+                0xFF4D96FF to stringResource(R.string.details_color_blue),
+                0xFF9D84B7 to stringResource(R.string.details_color_purple),
+                0xFFFFB6C1 to stringResource(R.string.details_color_pink)
+            )
+            presetColors.forEach { (color, name) ->
+                ColorChip(
+                    color = color,
+                    label = name,
+                    selected = currentColor == color,
+                    onClick = { onColorChange(color) }
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        TextButton(
+            onClick = { onColorChange(null) },
+            modifier = Modifier.align(Alignment.End)
+        ) {
+            Text(stringResource(R.string.details_reset))
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun BackgroundColorPicker(
+    currentColor: Long?,
+    onColorChange: (Long?) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.details_override_background),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            val presetColors = listOf(
+                0xFF000000 to stringResource(R.string.details_bg_black),
+                0xFF1A1A1A to stringResource(R.string.details_bg_dark_gray),
+                0xFF808080 to stringResource(R.string.details_bg_gray),
+                0xFFFFFFFF to stringResource(R.string.details_bg_white),
+                0xFFFFF8DC to stringResource(R.string.details_bg_cream)
+            )
+            presetColors.forEach { (color, name) ->
+                ColorChip(
+                    color = color,
+                    label = name,
+                    selected = currentColor == color,
+                    onClick = { onColorChange(color) }
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        TextButton(
+            onClick = { onColorChange(null) },
+            modifier = Modifier.align(Alignment.End)
+        ) {
+            Text(stringResource(R.string.details_reset))
+        }
+    }
+}
+
+@Composable
+internal fun ColorChip(
+    color: Long,
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    FilterChip(
+        selected = selected,
+        onClick = onClick,
+        label = { Text(label) },
+        leadingIcon = {
+            Box(
+                modifier = Modifier
+                    .size(16.dp)
+                    .background(
+                        color = Color(color),
+                        shape = CircleShape
+                    )
+            )
+        },
+        modifier = modifier
+    )
+}

--- a/feature/details/src/main/java/app/otakureader/feature/details/SourceSuggestionsSection.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/SourceSuggestionsSection.kt
@@ -1,0 +1,148 @@
+@file:Suppress("MaxLineLength")
+package app.otakureader.feature.details
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import app.otakureader.feature.details.R
+import coil3.compose.AsyncImage
+
+@Composable
+internal fun SourceSuggestionsSection(
+    suggestions: List<SourceSuggestion>,
+    isLoading: Boolean,
+    error: String?,
+    onSuggestionClick: (SourceSuggestion) -> Unit,
+    onLoadClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (suggestions.isEmpty() && !isLoading && error == null) {
+        // Show load button when no suggestions loaded yet
+        OutlinedButton(
+            onClick = onLoadClick,
+            modifier = modifier.fillMaxWidth()
+        ) {
+            Text(stringResource(R.string.details_load_suggestions))
+        }
+        return
+    }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.details_source_suggestions_title),
+                style = MaterialTheme.typography.titleMedium
+            )
+            if (!isLoading && suggestions.isNotEmpty()) {
+                TextButton(onClick = onLoadClick) {
+                    Text(stringResource(R.string.details_refresh))
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        when {
+            isLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(120.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+            error != null -> {
+                Text(
+                    text = error,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+            }
+            suggestions.isNotEmpty() -> {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    contentPadding = PaddingValues(horizontal = 4.dp),
+                    modifier = Modifier.height(160.dp)
+                ) {
+                    items(suggestions, key = { it.mangaUrl }) { suggestion ->
+                        SuggestionItem(
+                            suggestion = suggestion,
+                            onClick = { onSuggestionClick(suggestion) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun SuggestionItem(
+    suggestion: SourceSuggestion,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .width(100.dp)
+            .clickable(onClick = onClick)
+    ) {
+        AsyncImage(
+            model = suggestion.thumbnailUrl,
+            contentDescription = suggestion.title,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(0.7f)
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+            text = suggestion.title,
+            style = MaterialTheme.typography.bodySmall,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        suggestion.reason?.let { reason ->
+            Text(
+                text = reason,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}

--- a/feature/details/src/main/java/app/otakureader/feature/details/SourceSuggestionsSection.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/SourceSuggestionsSection.kt
@@ -60,7 +60,7 @@ internal fun SourceSuggestionsSection(
                 text = stringResource(R.string.details_source_suggestions_title),
                 style = MaterialTheme.typography.titleMedium
             )
-            if (!isLoading && suggestions.isNotEmpty()) {
+            if (!isLoading && (suggestions.isNotEmpty() || error != null)) {
                 TextButton(onClick = onLoadClick) {
                     Text(stringResource(R.string.details_refresh))
                 }

--- a/feature/feed/src/test/java/app/otakureader/feature/feed/FeedViewModelTest.kt
+++ b/feature/feed/src/test/java/app/otakureader/feature/feed/FeedViewModelTest.kt
@@ -4,6 +4,8 @@ import app.cash.turbine.test
 import app.otakureader.domain.model.FeedItem
 import app.otakureader.domain.model.FeedSource
 import app.otakureader.domain.repository.FeedRepository
+import app.otakureader.domain.repository.MangaRepository
+import app.otakureader.domain.usecase.ToggleFavoriteMangaUseCase
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -30,6 +32,8 @@ class FeedViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var feedRepository: FeedRepository
+    private lateinit var mangaRepository: MangaRepository
+    private lateinit var toggleFavoriteMangaUseCase: ToggleFavoriteMangaUseCase
 
     private val sampleFeedItems = listOf(
         FeedItem(
@@ -50,6 +54,8 @@ class FeedViewModelTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        mangaRepository = mockk(relaxed = true)
+        toggleFavoriteMangaUseCase = ToggleFavoriteMangaUseCase(mangaRepository)
         feedRepository = mockk {
             every { getFeedItems(any()) } returns flowOf(emptyList())
             every { getFeedSources() } returns flowOf(emptyList())
@@ -61,7 +67,7 @@ class FeedViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() = FeedViewModel(feedRepository)
+    private fun createViewModel() = FeedViewModel(feedRepository, mangaRepository, toggleFavoriteMangaUseCase)
 
     @Test
     fun init_stateStartsWithLoadingTrue() {

--- a/feature/library/src/main/java/app/otakureader/feature/library/category/CategoryManagementScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/category/CategoryManagementScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -302,7 +301,7 @@ private fun CategoryListItem(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun CategoryDialog(
     category: CategoryUiItem?,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDownloadAheadDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDownloadAheadDelegate.kt
@@ -74,7 +74,7 @@ class ReaderDownloadAheadDelegate @Inject constructor(
             name = chapter.name,
             dateUpload = chapter.dateUpload,
             chapterNumber = chapter.chapterNumber,
-            scanlator = chapter.scanlator,
+            scanlator = chapter.scanlator ?: "",
         )
         val pageListResult = sourceRepository.getPageList(sourceName, sourceChapter)
         pageListResult.onFailure { throwable ->

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -11,7 +11,6 @@ dependencies {
     implementation(projects.core.common)
     implementation(projects.core.preferences)
     implementation(projects.core.discord)
-    implementation(projects.data)
     implementation(libs.paging.compose)
     implementation(libs.lifecycle.viewmodel.ktx)
     implementation(libs.kotlinx.serialization.json)

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -11,9 +11,7 @@ dependencies {
     implementation(projects.core.common)
     implementation(projects.core.preferences)
     implementation(projects.core.discord)
-    // Note: feature.reader was removed as a dependency here. The shared types
-    // (ImageQuality, ReaderMode, etc.) now come from :domain and ReaderSettingsRepository
-    // comes from :data, which are both already included via the feature convention plugin.
+    implementation(projects.data)
     implementation(libs.paging.compose)
     implementation(libs.lifecycle.viewmodel.ktx)
     implementation(libs.kotlinx.serialization.json)

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
@@ -215,7 +215,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     private fun refreshLibraryCovers() {
-        coverRefreshScheduler.schedule(context)
+        coverRefreshScheduler.schedule()
         viewModelScope.launch {
             _effect.send(SettingsEffect.ShowSnackbar(context.getString(R.string.settings_refresh_covers_started)))
         }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import app.otakureader.core.preferences.AppPreferences
 import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.core.preferences.LocalSourcePreferences
 import app.otakureader.core.preferences.ReadingGoalPreferences
+import app.otakureader.domain.scheduler.CoverRefreshScheduler
 import app.otakureader.domain.scheduler.ReminderScheduler
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.feature.settings.delegate.AppearanceSettingsDelegate
@@ -42,6 +43,7 @@ class SettingsViewModel @Inject constructor(
     private val readingGoalPreferences: ReadingGoalPreferences,
     private val generalPreferences: GeneralPreferences,
     private val readingReminderScheduler: ReminderScheduler,
+    private val coverRefreshScheduler: CoverRefreshScheduler,
     private val chapterRepository: ChapterRepository,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
@@ -213,7 +215,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     private fun refreshLibraryCovers() {
-        app.otakureader.data.worker.CoverRefreshWorker.enqueue(context)
+        coverRefreshScheduler.schedule(context)
         viewModelScope.launch {
             _effect.send(SettingsEffect.ShowSnackbar(context.getString(R.string.settings_refresh_covers_started)))
         }

--- a/feature/settings/src/test/java/app/otakureader/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/java/app/otakureader/feature/settings/SettingsViewModelTest.kt
@@ -6,6 +6,7 @@ import app.otakureader.core.preferences.AppPreferences
 import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.core.preferences.LocalSourcePreferences
 import app.otakureader.core.preferences.ReadingGoalPreferences
+import app.otakureader.domain.scheduler.CoverRefreshScheduler
 import app.otakureader.domain.scheduler.ReminderScheduler
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.feature.settings.delegate.AppearanceSettingsDelegate
@@ -49,6 +50,7 @@ class SettingsViewModelTest {
     private lateinit var readingGoalPreferences: ReadingGoalPreferences
     private lateinit var generalPreferences: GeneralPreferences
     private lateinit var readingReminderScheduler: ReminderScheduler
+    private lateinit var coverRefreshScheduler: CoverRefreshScheduler
     private lateinit var chapterRepository: ChapterRepository
     private lateinit var context: Context
 
@@ -87,6 +89,7 @@ class SettingsViewModelTest {
             every { coilDiskCacheSizeMb } returns flowOf(512)
         }
         readingReminderScheduler = mockk(relaxed = true)
+        coverRefreshScheduler = mockk(relaxed = true)
         chapterRepository = mockk(relaxed = true)
         context = mockk(relaxed = true) {
             every { cacheDir } returns mockk(relaxed = true)
@@ -112,6 +115,7 @@ class SettingsViewModelTest {
         readingGoalPreferences = readingGoalPreferences,
         generalPreferences = generalPreferences,
         readingReminderScheduler = readingReminderScheduler,
+        coverRefreshScheduler = coverRefreshScheduler,
         chapterRepository = chapterRepository,
         context = context,
     )

--- a/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingViewModel.kt
+++ b/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingViewModel.kt
@@ -250,7 +250,7 @@ class TrackingViewModel @Inject constructor(
 
         viewModelScope.launch {
             try {
-                trackRepository.deleteEntry(trackerId, entry.remoteId)
+                trackRepository.deleteEntry(_state.value.mangaId, trackerId)
                 _effect.trySend(TrackingEffect.ShowMessage(
                     context.getString(R.string.tracking_unlink_success, tracker.name)
                 ))

--- a/source-api/src/main/java/app/otakureader/sourceapi/SChapter.kt
+++ b/source-api/src/main/java/app/otakureader/sourceapi/SChapter.kt
@@ -7,3 +7,5 @@ data class SChapter(
     var chapterNumber: Float = -1f,
     var scanlator: String = "",
 )
+
+typealias SourceChapter = SChapter


### PR DESCRIPTION
## **User description**
## Summary

Addresses all P0/P1 issues identified in the recent codebase audit. No feature additions — fixes and cleanup only.

### Data Integrity
- **#902** `TrackRepositoryImpl`: replaced in-memory `MutableStateFlow` with Room-backed DAO. Tracking data (AniList, MAL, Kitsu, Shikimori, MangaUpdates) now survives process death. Added `TrackEntryEntity`, `TrackEntryDao`, `TrackEntryMapper`, and DB migration 24→25.
- **#901** `SourceMangaDetailViewModel`: replaced effect-only redirect pattern with `RedirectState` sealed class + `StateFlow`. DB lookup now has a 10-second timeout; `Error`/`NotFound` states show a snackbar and navigate back instead of hanging forever.

### Extension Safety
- **#907** `ExtensionInstaller`: made APK file replacement atomic (write-temp → validate → rename). A failed validation no longer corrupts a working extension.
- **#905** `TrustedSignatureStore`: `uninstall()` now calls `revoke()` on the signature hash so a compromised extension can't remain trusted after removal.

### Architecture
- **#904** Feature→data layer violation: extracted `CoverRefreshScheduler` domain interface + `CoverRefreshSchedulerImpl` in data layer. `SettingsViewModel` now injects the interface rather than calling `CoverRefreshWorker` directly. Removed `implementation(projects.data)` from `feature/settings/build.gradle.kts`.
- **#888/#889** DI cleanup: removed redundant `@Provides` from `UseCaseModule` for use cases that already have `@Inject` constructors. Verified backup nav, orphan category dir, and DB indexes were all already correct.

### Code Quality
- **#906** `DetailsScreen.kt` (1739 → 656 lines): extracted three focused files:
  - `MangaHeader.kt` — hero cover, parallax scroll, bloom animation, metadata chips
  - `MangaSettingsSection.kt` — per-manga reader settings and all sub-composables
  - `ChapterSection.kt` — chapter list header, filter dialog, tri-state row

### Tests
- Updated `DatabaseMigrationTest` for migrations 23→24 (`categories.update_frequency`) and 24→25 (`track_entries` table): fixed stale count/end-version assertions and added four new test methods including a unique-constraint enforcement test.

### P0 patches audited — all already fixed
NeonSlider busy-loop, TextShimmer overlap, `ImageLoader` leak, `MangaDao` cross-product query, `MangaHeader` bloom animation — verified correct in the codebase before this PR.

## Test plan

- [ ] Run `./gradlew :core:database:testDebugUnitTest` — all migration tests pass including new 23→24 and 24→25
- [ ] Run `./gradlew :data:testDebugUnitTest` — TrackRepository tests pass
- [ ] Run `./gradlew :feature:details:testDebugUnitTest` — no regressions
- [ ] Run `./gradlew :feature:browse:testDebugUnitTest` — SourceMangaDetailViewModel tests pass
- [ ] Track a manga → kill process → reopen → entries still present
- [ ] Source manga detail with DB failure → snackbar + back nav (no infinite spinner)
- [ ] Settings → Library covers refresh → no crash
- [ ] Extension install, then corrupt update → old extension still works
- [ ] `./gradlew detekt` — no new violations
- [ ] `./gradlew :app:assembleFossDebug` — clean build

https://claude.ai/code/session_015M3gzEyFq42eLyT7JJuhMU

---
_Generated by [Claude Code](https://claude.ai/code/session_015M3gzEyFq42eLyT7JJuhMU)_


___

## **CodeAnt-AI Description**
**Persist tracker data, add category update schedules, and keep library updates from hanging**

### What Changed
- Tracker entries are now saved in the database, so tracking information survives app restarts and process death.
- Categories can now be set to update never, daily, every 3 days, or weekly, and the category list shows the current setting.
- Library updates can skip manga with unread chapters, completed manga, or manga that have never been started, with a summary notification showing how many were skipped.
- Source manga pages now return to the previous screen if the lookup fails or takes too long, instead of staying on an endless loading screen.
- Extension installs and updates no longer overwrite a working file before validation, and removing an extension now clears its trusted status.
- Manga chapter scanlator fields are handled safely when missing, avoiding failed chapter loads.

### Impact
`✅ Persistent tracker entries`
`✅ Fewer library update runs`
`✅ Shorter waits on broken source links`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chapter filtering by read status, bookmarks, and downloads.
  * Added tracker entry management with persistent state storage.
  * Added per-manga reader settings reset functionality.
  * Improved source manga detail screen with better error handling and navigation.

* **Bug Fixes**
  * Fixed scanlator field null-safety issues throughout the app.
  * Enhanced library update tracking to only advance category timestamps for successfully updated manga.

* **Documentation**
  * Updated source manga detail screen documentation with redirect/timeout behavior details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Heartless-Veteran/Otaku-Reader/pull/914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->