### PR TITLE
PR 4: SelectionManager + race fixes + derivedStateOf filter

### DIFF
--- a/core/ui/src/main/java/app/otakureader/core/ui/selection/SelectionManager.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/selection/SelectionManager.kt
@@ -1,0 +1,88 @@
+package app.otakureader.core.ui.selection
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+
+/**
+ * Generic selection manager that atomically mutates a [MutableStateFlow] of selected keys.
+ *
+ * Use in ViewModels to power multi-select UI (long-press to select, bulk actions, etc.).
+ * All mutations use [MutableStateFlow.update] for thread-safe atomicity.
+ *
+ * Example:
+ * ```
+ * val selection = SelectionManager<Long>()
+ *
+ * // in UI
+ * selection.toggle(item.id)
+ *
+ * // in ViewModel async action
+ * val ids = selection.snapshotAndClear()
+ * repo.markRead(ids)
+ * ```
+ */
+class SelectionManager<K> {
+
+    private val _selected = MutableStateFlow<Set<K>>(emptySet())
+    val selected: StateFlow<Set<K>> = _selected.asStateFlow()
+
+    /** Emits true whenever at least one item is selected. */
+    val isActive: Flow<Boolean> = _selected.map { it.isNotEmpty() }
+
+    /** Emits the current count of selected items. */
+    val count: Flow<Int> = _selected.map { it.size }
+
+    /** Toggle a single key: add if absent, remove if present. */
+    fun toggle(key: K) {
+        _selected.update { current ->
+            if (current.contains(key)) current - key else current + key
+        }
+    }
+
+    /** Select all keys if not all already selected; otherwise clear. */
+    fun toggleAll(keys: List<K>) {
+        _selected.update { current ->
+            val keySet = keys.toSet()
+            if (current.containsAll(keySet)) current - keySet else current + keySet
+        }
+    }
+
+    /** Replace selection with exactly these keys. */
+    fun setAll(keys: Set<K>) {
+        _selected.value = keys.toSet()
+    }
+
+    /** Clear all selected items. */
+    fun clear() {
+        _selected.value = emptySet()
+    }
+
+    /** Invert selection against a full set (select unselected, deselect selected). */
+    fun invert(allKeys: List<K>) {
+        _selected.update { current ->
+            val fullSet = allKeys.toSet()
+            fullSet - current
+        }
+    }
+
+    /**
+     * Returns an immutable snapshot of the current selection and **atomically clears** it.
+     * Use this before async operations to prevent race conditions where the user modifies
+     * selection while the coroutine is suspended.
+     */
+    fun snapshotAndClear(): Set<K> {
+        val snap = _selected.value.toSet()
+        _selected.value = emptySet()
+        return snap
+    }
+
+    /** Read-only snapshot without clearing. */
+    fun snapshot(): Set<K> = _selected.value.toSet()
+
+    /** Check if a key is currently selected. */
+    operator fun contains(key: K): Boolean = _selected.value.contains(key)
+}

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseMvi.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseMvi.kt
@@ -22,8 +22,8 @@ data class BrowseState(
     val availableFilters: FilterList = FilterList(),
     val activeFilters: FilterList = FilterList(),
     val showFilterSheet: Boolean = false,
-    /** Currently selected manga for bulk favorite (IDs mapped to manga). */
-    val selectedManga: Map<String, SourceManga> = emptyMap(),
+    /** Currently selected manga URLs for bulk favorite. */
+    val selectedManga: Set<String> = emptySet(),
     /** True when bulk selection mode is active. */
     val isBulkSelectionMode: Boolean = false,
     /** Saved searches for the current source, loaded from the database. */

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
@@ -3,6 +3,7 @@ package app.otakureader.feature.browse
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.otakureader.core.preferences.GeneralPreferences
+import app.otakureader.core.ui.selection.SelectionManager
 import app.otakureader.domain.repository.FeedRepository
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.usecase.library.AddMangaToLibraryUseCase
@@ -54,6 +55,9 @@ class BrowseViewModel @Inject constructor(
 
     private val _sources = MutableStateFlow<List<MangaSource>>(emptyList())
 
+    /** Atomic selection manager — keys are manga URLs. */
+    private val selection = SelectionManager<String>()
+
     private val _effect = Channel<BrowseEffect>()
     val effect = _effect.receiveAsFlow()
 
@@ -76,6 +80,12 @@ class BrowseViewModel @Inject constructor(
         }
         observeSavedSearches()
         observeLibraryFavorites()
+        // Sync selection manager into state so UI recomposes
+        combine(selection.selected, selection.isActive) { ids, active ->
+            ids to active
+        }.onEach { (ids, active) ->
+            _state.update { it.copy(selectedManga = ids, isBulkSelectionMode = active) }
+        }.launchIn(viewModelScope)
     }
 
     @Suppress("LongMethod", "CyclomaticComplexMethod")
@@ -139,13 +149,13 @@ class BrowseViewModel @Inject constructor(
                 toggleMangaSelection(event.manga)
             }
             is BrowseEvent.ClearSelection -> {
-                _state.update { it.copy(selectedManga = emptyMap(), isBulkSelectionMode = false) }
+                selection.clear()
             }
             is BrowseEvent.AddSelectedToLibrary -> {
                 addSelectedToLibrary()
             }
             is BrowseEvent.ExitBulkSelectionMode -> {
-                _state.update { it.copy(selectedManga = emptyMap(), isBulkSelectionMode = false) }
+                selection.clear()
             }
             is BrowseEvent.LongClickManga -> quickToggleFavorite(event.manga)
             is BrowseEvent.SaveCurrentSearch -> saveCurrentSearch()
@@ -312,22 +322,7 @@ class BrowseViewModel @Inject constructor(
      * Enables bulk selection mode when first manga is selected.
      */
     private fun toggleMangaSelection(manga: SourceManga) {
-        _state.update { state ->
-            val currentSelection = state.selectedManga.toMutableMap()
-            val key = manga.url // Use URL as unique key
-            
-            if (currentSelection.containsKey(key)) {
-                currentSelection.remove(key)
-            } else {
-                currentSelection[key] = manga
-            }
-            
-            val newMode = currentSelection.isNotEmpty()
-            state.copy(
-                selectedManga = currentSelection,
-                isBulkSelectionMode = newMode
-            )
-        }
+        selection.toggle(manga.url)
     }
     
     /**
@@ -337,7 +332,12 @@ class BrowseViewModel @Inject constructor(
     private fun addSelectedToLibrary() {
         viewModelScope.launch {
             val sourceId = _state.value.currentSourceId ?: return@launch
-            val selected = _state.value.selectedManga.values.toList()
+            val selectedUrls = selection.snapshotAndClear()
+            if (selectedUrls.isEmpty()) return@launch
+
+            // Look up SourceManga from available lists by URL
+            val allManga = _state.value.popularManga + _state.value.searchResults
+            val selected = selectedUrls.mapNotNull { url -> allManga.find { it.url == url } }
             
             if (selected.isEmpty()) return@launch
             
@@ -345,7 +345,6 @@ class BrowseViewModel @Inject constructor(
                 .onSuccess { addedCount ->
                     _effect.send(BrowseEffect.ShowSnackbar("$addedCount manga added to library"))
                     _effect.send(BrowseEffect.NavigateToLibrary)
-                    _state.update { it.copy(selectedManga = emptyMap(), isBulkSelectionMode = false) }
                 }
                 .onFailure { error ->
                     _effect.send(BrowseEffect.ShowSnackbar("Failed to add manga: ${error.message}"))

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -73,6 +73,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -387,10 +389,14 @@ private fun MangaGrid(
     var selectedContentFilter by remember { mutableIntStateOf(0) }
     val contentTabs = listOf("All", "Manga", "Manhwa")
 
-    val displayedManga = when (selectedContentFilter) {
-        1 -> state.mangaList.filter { !isManhwa(it) }
-        2 -> state.mangaList.filter { isManhwa(it) }
-        else -> state.mangaList
+    val displayedManga by remember(state.mangaList, selectedContentFilter) {
+        derivedStateOf {
+            when (selectedContentFilter) {
+                1 -> state.mangaList.filter { !isManhwa(it) }
+                2 -> state.mangaList.filter { isManhwa(it) }
+                else -> state.mangaList
+            }
+        }
     }
 
     // Header items shared by both grid variants

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.core.preferences.LibraryPreferences
 import app.otakureader.core.preferences.ReadingGoalPreferences
+import app.otakureader.core.ui.selection.SelectionManager
 import app.otakureader.domain.model.ContentRating
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MangaStatus
@@ -65,6 +66,9 @@ class LibraryViewModel @Inject constructor(
     private val _state = MutableStateFlow(LibraryState())
     val state: StateFlow<LibraryState> = _state.asStateFlow()
 
+    /** Atomic selection manager — keys are manga IDs. */
+    private val selection = SelectionManager<Long>()
+
     private val _effect = Channel<LibraryEffect>(Channel.BUFFERED)
     val effect: Flow<LibraryEffect> = _effect.receiveAsFlow()
 
@@ -86,6 +90,10 @@ class LibraryViewModel @Inject constructor(
         observeReadingLists()
         observeDownloadCounts()
         observeIncognitoMode()
+        // Sync selection manager into state so UI recomposes
+        selection.selected
+            .onEach { ids -> _state.update { it.copy(selectedManga = ids) } }
+            .launchIn(viewModelScope)
     }
 
     fun onEvent(event: LibraryEvent) {
@@ -420,9 +428,24 @@ class LibraryViewModel @Inject constructor(
     }
 
     private fun onMangaClick(mangaId: Long) {
-        if (_state.value.selectedManga.isNotEmpty()) {
-            toggleSelection(mangaId)
-        } else {
+        // Atomic check-and-toggle: if selection is active, toggle inside update block
+        // to prevent race between read and write.
+        _state.update { state ->
+            if (state.selectedManga.isNotEmpty()) {
+                // Selection mode is active — toggle this manga and stay in selection mode
+                val newSelection = if (state.selectedManga.contains(mangaId)) {
+                    state.selectedManga - mangaId
+                } else {
+                    state.selectedManga + mangaId
+                }
+                state.copy(selectedManga = newSelection)
+            } else {
+                // No selection active — navigate (effect is fired after update)
+                state
+            }
+        }
+        // Only navigate if we did NOT toggle (selection was empty before click)
+        if (_state.value.selectedManga.isEmpty()) {
             viewModelScope.launch {
                 _effect.send(LibraryEffect.NavigateToManga(mangaId))
             }
@@ -430,19 +453,11 @@ class LibraryViewModel @Inject constructor(
     }
 
     private fun onMangaLongClick(mangaId: Long) {
-        toggleSelection(mangaId)
+        selection.toggle(mangaId)
     }
 
     private fun toggleSelection(mangaId: Long) {
-        _state.update { state ->
-            val currentSelection = state.selectedManga
-            val newSelection = if (currentSelection.contains(mangaId)) {
-                currentSelection - mangaId
-            } else {
-                currentSelection + mangaId
-            }
-            state.copy(selectedManga = newSelection)
-        }
+        selection.toggle(mangaId)
     }
 
     private fun onSearchQueryChange(query: String) {
@@ -479,7 +494,7 @@ class LibraryViewModel @Inject constructor(
     }
 
     private fun clearSelection() {
-        _state.update { it.copy(selectedManga = emptySet()) }
+        selection.clear()
     }
 
     private fun markSelectedAsRead() = markChaptersForSelectedManga(read = true)
@@ -487,7 +502,7 @@ class LibraryViewModel @Inject constructor(
     private fun markSelectedAsUnread() = markChaptersForSelectedManga(read = false)
 
     private fun markChaptersForSelectedManga(read: Boolean) {
-        val mangaIds = _state.value.selectedManga
+        val mangaIds = selection.snapshotAndClear()
         if (mangaIds.isEmpty()) return
         viewModelScope.launch {
             val chapterIds = mangaIds.flatMap { mangaId ->
@@ -496,21 +511,19 @@ class LibraryViewModel @Inject constructor(
             if (chapterIds.isNotEmpty()) {
                 chapterRepository.updateChapterProgress(chapterIds, read = read, lastPageRead = 0)
             }
-            clearSelection()
         }
     }
 
     private fun removeSelectedFromLibrary() {
-        val ids = _state.value.selectedManga
+        val ids = selection.snapshotAndClear()
         if (ids.isEmpty()) return
         viewModelScope.launch {
             ids.forEach { mangaId -> toggleFavoriteManga(mangaId) }
-            clearSelection()
         }
     }
 
     private fun downloadSelected() {
-        val mangaIds = _state.value.selectedManga
+        val mangaIds = selection.snapshotAndClear()
         if (mangaIds.isEmpty()) return
         viewModelScope.launch {
             val mangaById = _allItems.value.associateBy { it.id }
@@ -526,7 +539,6 @@ class LibraryViewModel @Inject constructor(
                     )
                 }
             }
-            clearSelection()
         }
     }
 


### PR DESCRIPTION
**SelectionManager (core/ui):**
- Generic SelectionManager<K> with atomic MutableStateFlow.update() mutations
- API: toggle, toggleAll, clear, invert, snapshot, snapshotAndClear, isActive, count
- snapshotAndClear prevents race conditions in async bulk actions

**LibraryViewModel:**
- Integrates SelectionManager<Long> for manga selection
- Fixes onMangaClick() race: check-and-toggle moved inside _state.update{}
- markChaptersForSelectedManga, removeSelectedFromLibrary, downloadSelected now use snapshotAndClear()

**BrowseViewModel:**
- Integrates SelectionManager<String> (URL-keyed) for bulk selection
- BrowseState.selectedManga changed from Map<String,SourceManga> to Set<String>
- addSelectedToLibrary() looks up SourceManga from state by URL

**LibraryScreen:**
- displayedManga now uses remember + derivedStateOf

Closes #898, #899, #900