### PR TITLE
Fix extension install 404 + remove "active repository" UI

### DIFF
--- a/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
@@ -311,8 +311,9 @@ class ExtensionRemoteDataSourceImpl(
 
     override suspend fun downloadApk(apkUrl: String, destination: File): Result<File> {
         return withContext(Dispatchers.IO) {
-            // Try the standard /apk/ URL first, falling back to /apks/ if the repo uses that
-            // layout, so a 404 on one folder name doesn't fail the whole install.
+            // Try the standard /apk/ URL first, falling back to /apks/ only on a 404 (wrong
+            // folder name). Network errors or other HTTP failures abort immediately, since
+            // retrying the same host with a different path would just double the wait.
             var lastError: Exception = ExtensionFetchException("No APK URL to download from $apkUrl")
             for (url in apkUrlCandidates(apkUrl)) {
                 try {
@@ -321,10 +322,12 @@ class ExtensionRemoteDataSourceImpl(
                         .header("Accept", "application/vnd.android.package-archive")
                         .build()
 
+                    var only404 = false
                     val downloaded = httpClient.newCall(request).execute().use { response ->
                         if (!response.isSuccessful) {
                             // H-1: Domain exception instead of error() so the outer Result catches it.
                             lastError = ExtensionFetchException("HTTP ${response.code} downloading APK from $url")
+                            only404 = response.code == 404
                             false
                         } else {
                             val body = response.body
@@ -338,10 +341,12 @@ class ExtensionRemoteDataSourceImpl(
                         }
                     }
                     if (downloaded) return@withContext Result.success(destination)
+                    if (!only404) break
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
                     lastError = e
+                    break
                 }
             }
             Result.failure(lastError)

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
@@ -313,23 +313,24 @@ class ExtensionRemoteDataSourceImpl(
         return withContext(Dispatchers.IO) {
             // Try the standard /apk/ URL first, falling back to /apks/ only on a 404 (wrong
             // folder name). Network errors or other HTTP failures abort immediately, since
-            // retrying the same host with a different path would just double the wait.
+            // retrying the same host with a different path would just double the wait. The loop
+            // condition (not break/continue) drives termination.
+            val candidates = apkUrlCandidates(apkUrl)
             var lastError: Exception = ExtensionFetchException("No APK URL to download from $apkUrl")
-            for (url in apkUrlCandidates(apkUrl)) {
+            var downloaded: File? = null
+            var abort = false
+            var index = 0
+            while (downloaded == null && !abort && index < candidates.size) {
+                val url = candidates[index]
+                index++
                 try {
                     val request = Request.Builder()
                         .url(url)
                         .header("Accept", "application/vnd.android.package-archive")
                         .build()
 
-                    var only404 = false
-                    val downloaded = httpClient.newCall(request).execute().use { response ->
-                        if (!response.isSuccessful) {
-                            // H-1: Domain exception instead of error() so the outer Result catches it.
-                            lastError = ExtensionFetchException("HTTP ${response.code} downloading APK from $url")
-                            only404 = response.code == 404
-                            false
-                        } else {
+                    httpClient.newCall(request).execute().use { response ->
+                        if (response.isSuccessful) {
                             val body = response.body
                                 ?: throw ExtensionFetchException("Empty APK response body from $url")
                             body.byteStream().use { input ->
@@ -337,19 +338,22 @@ class ExtensionRemoteDataSourceImpl(
                                     input.copyTo(output)
                                 }
                             }
-                            true
+                            downloaded = destination
+                        } else {
+                            // H-1: Domain exception instead of error() so the outer Result catches it.
+                            lastError = ExtensionFetchException("HTTP ${response.code} downloading APK from $url")
+                            // Only a 404 (wrong folder name) is worth trying the alternate path.
+                            abort = response.code != 404
                         }
                     }
-                    if (downloaded) return@withContext Result.success(destination)
-                    if (!only404) break
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
                     lastError = e
-                    break
+                    abort = true
                 }
             }
-            Result.failure(lastError)
+            downloaded?.let { Result.success(it) } ?: Result.failure(lastError)
         }
     }
 

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
@@ -311,31 +311,40 @@ class ExtensionRemoteDataSourceImpl(
 
     override suspend fun downloadApk(apkUrl: String, destination: File): Result<File> {
         return withContext(Dispatchers.IO) {
-            try {
-                val request = Request.Builder()
-                    .url(apkUrl)
-                    .header("Accept", "application/vnd.android.package-archive")
-                    .build()
+            // Try the standard /apk/ URL first, falling back to /apks/ if the repo uses that
+            // layout, so a 404 on one folder name doesn't fail the whole install.
+            var lastError: Exception = ExtensionFetchException("No APK URL to download from $apkUrl")
+            for (url in apkUrlCandidates(apkUrl)) {
+                try {
+                    val request = Request.Builder()
+                        .url(url)
+                        .header("Accept", "application/vnd.android.package-archive")
+                        .build()
 
-                httpClient.newCall(request).execute().use { response ->
-                    // H-1: Domain exception instead of error() so the outer Result catches it.
-                    if (!response.isSuccessful) {
-                        throw ExtensionFetchException("HTTP ${response.code} downloading APK from $apkUrl")
-                    }
-                    val body = response.body
-                        ?: throw ExtensionFetchException("Empty APK response body from $apkUrl")
-                    body.byteStream().use { input ->
-                        destination.outputStream().use { output ->
-                            input.copyTo(output)
+                    val downloaded = httpClient.newCall(request).execute().use { response ->
+                        if (!response.isSuccessful) {
+                            // H-1: Domain exception instead of error() so the outer Result catches it.
+                            lastError = ExtensionFetchException("HTTP ${response.code} downloading APK from $url")
+                            false
+                        } else {
+                            val body = response.body
+                                ?: throw ExtensionFetchException("Empty APK response body from $url")
+                            body.byteStream().use { input ->
+                                destination.outputStream().use { output ->
+                                    input.copyTo(output)
+                                }
+                            }
+                            true
                         }
                     }
+                    if (downloaded) return@withContext Result.success(destination)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    lastError = e
                 }
-                Result.success(destination)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
             }
+            Result.failure(lastError)
         }
     }
 
@@ -417,19 +426,29 @@ private fun MinifiedExtensionSourceDto.toDomain(): ExtensionSource {
 }
 
 /**
- * Resolve APK URL from relative filename.
- * Keiyoushi repos store APKs under {base}/apks/{filename} (plural).
- * Komikku repos store APKs under {base}/apk/{filename} (singular).
- * We try "apks" first (most popular), then fall back to "apk".
+ * Resolve APK URL from a relative filename.
+ * Keiyoushi/Mihon repos store APKs under {base}/apk/{filename} (singular); some forks use
+ * {base}/apks/{filename}. We build the standard /apk/ URL here, and [downloadApk] falls back
+ * to the /apks/ variant if the first request 404s.
  */
 private fun resolveApkUrl(baseUrl: String, apkPath: String): String {
     return if (apkPath.startsWith("http://") || apkPath.startsWith("https://")) {
         apkPath
     } else {
         val cleanPath = apkPath.trimStart('/')
-        // Try "apks/" first (Keiyoushi convention), then "apk/" (Komikku)
-        "$baseUrl/apks/$cleanPath"
+        "$baseUrl/apk/$cleanPath"
     }
+}
+
+/**
+ * Candidate APK URLs to try in order. Repos disagree on the APK folder name — the standard
+ * Keiyoushi/Mihon layout is `/apk/`, while some forks use `/apks/`. Trying both makes installs
+ * robust regardless of which layout a repo uses.
+ */
+private fun apkUrlCandidates(apkUrl: String): List<String> = when {
+    apkUrl.contains("/apk/") -> listOf(apkUrl, apkUrl.replaceFirst("/apk/", "/apks/"))
+    apkUrl.contains("/apks/") -> listOf(apkUrl, apkUrl.replaceFirst("/apks/", "/apk/"))
+    else -> listOf(apkUrl)
 }
 
 /**

--- a/core/extension/src/test/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSourceTest.kt
+++ b/core/extension/src/test/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSourceTest.kt
@@ -15,6 +15,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.io.File
 
 class ExtensionRemoteDataSourceTest {
 
@@ -97,8 +98,8 @@ class ExtensionRemoteDataSourceTest {
         assertEquals(false, extension.isNsfw)
         assertEquals(1, extension.sources.size)
 
-        // Verify APK URL is resolved correctly (Keiyoushi convention: apks/ subdirectory)
-        val expectedApkUrl = "$baseUrl/apks/tachiyomi-en.mangadex-v1.2.3.apk"
+        // Verify APK URL is resolved correctly (Keiyoushi/Mihon convention: apk/ subdirectory)
+        val expectedApkUrl = "$baseUrl/apk/tachiyomi-en.mangadex-v1.2.3.apk"
         assertEquals(expectedApkUrl, extension.apkUrl)
 
         // Verify icon URL is resolved correctly
@@ -333,5 +334,24 @@ class ExtensionRemoteDataSourceTest {
         val extensions = result.getOrThrow()
         assertEquals(1, extensions.size)
         assertEquals(true, extensions[0].isNsfw)
+    }
+
+    @Test
+    fun `downloadApk falls back to apks folder when apk folder returns 404`() = runTest {
+        // Given: the standard /apk/ path 404s and the /apks/ fork path serves the file
+        val baseUrl = mockWebServer.url("/").toString().trimEnd('/')
+        val apkUrl = "$baseUrl/apk/test-extension-v1.0.apk"
+        mockWebServer.enqueue(MockResponse().setResponseCode(404))
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("APK-BYTES"))
+        val destination = File.createTempFile("ext", ".apk").apply { deleteOnExit() }
+
+        // When
+        val result = dataSource.downloadApk(apkUrl, destination)
+
+        // Then: the fallback request succeeds, writes the file, and both folders were tried
+        assertTrue(result.isSuccess)
+        assertEquals("APK-BYTES", destination.readText())
+        assertEquals("/apk/test-extension-v1.0.apk", mockWebServer.takeRequest().path)
+        assertEquals("/apks/test-extension-v1.0.apk", mockWebServer.takeRequest().path)
     }
 }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
@@ -188,10 +188,8 @@ private fun ExtensionsContent(
 
             RepositoryManager(
                 repositories = state.repositories,
-                activeRepository = state.activeRepository,
                 onAdd = { onEvent(ExtensionsEvent.AddRepository(it)) },
-                onRemove = { onEvent(ExtensionsEvent.RemoveRepository(it)) },
-                onSetActive = { onEvent(ExtensionsEvent.SetActiveRepository(it)) }
+                onRemove = { onEvent(ExtensionsEvent.RemoveRepository(it)) }
             )
 
             // Tabs
@@ -621,10 +619,8 @@ private fun UpdateAllButton(
 @Composable
 private fun RepositoryManager(
     repositories: List<String>,
-    activeRepository: String?,
     onAdd: (String) -> Unit,
-    onRemove: (String) -> Unit,
-    onSetActive: (String) -> Unit
+    onRemove: (String) -> Unit
 ) {
     var repoInput by remember { mutableStateOf("") }
 
@@ -642,21 +638,12 @@ private fun RepositoryManager(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(text = repo, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                    if (activeRepository == repo) {
-                        Text(
-                            text = "Active",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                }
-                if (activeRepository != repo) {
-                    TextButton(onClick = { onSetActive(repo) }) {
-                        Text(stringResource(R.string.extensions_set_active))
-                    }
-                }
+                Text(
+                    text = repo,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
                 IconButton(onClick = { onRemove(repo) }) {
                     Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.extensions_remove_repo))
                 }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsViewModel.kt
@@ -32,7 +32,6 @@ data class ExtensionsState(
     val extensionsWithUpdates: List<Extension> = emptyList(),
     val updateCount: Int = 0,
     val repositories: List<String> = emptyList(),
-    val activeRepository: String? = null,
     val error: String? = null,
     val showNsfw: Boolean = false,
     val sortMode: SortMode = SortMode.NAME,
@@ -58,7 +57,6 @@ sealed interface ExtensionsEvent : UiEvent {
     data class ToggleExtensionEnabled(val extension: Extension, val enabled: Boolean) : ExtensionsEvent
     data class AddRepository(val url: String) : ExtensionsEvent
     data class RemoveRepository(val url: String) : ExtensionsEvent
-    data class SetActiveRepository(val url: String) : ExtensionsEvent
     data object UpdateAllExtensions : ExtensionsEvent
     data class ToggleNsfw(val show: Boolean) : ExtensionsEvent
     data class SetSortMode(val mode: SortMode) : ExtensionsEvent
@@ -163,7 +161,6 @@ class ExtensionsViewModel @Inject constructor(
             is ExtensionsEvent.ToggleExtensionEnabled -> toggleExtension(event.extension, event.enabled)
             is ExtensionsEvent.AddRepository -> addRepository(event.url)
             is ExtensionsEvent.RemoveRepository -> removeRepository(event.url)
-            is ExtensionsEvent.SetActiveRepository -> setActiveRepository(event.url)
             is ExtensionsEvent.UpdateAllExtensions -> updateAllExtensions()
             is ExtensionsEvent.ToggleNsfw -> viewModelScope.launch {
                 generalPreferences.setShowNsfwContent(event.show)
@@ -306,12 +303,6 @@ class ExtensionsViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching { extensionRepoRepository.removeRepository(url) }
         }
-    }
-
-    private fun setActiveRepository(url: String) {
-        // All repositories are simultaneously active; refresh to pick up any new extensions.
-        _state.update { it.copy(activeRepository = url) }
-        refreshExtensions()
     }
 
     private fun installExtension(extension: Extension) {

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -37,7 +37,6 @@
     <string name="extensions_update">Update</string>
     <string name="extensions_install">Install</string>
     <string name="extensions_remove_repo">Remove repository</string>
-    <string name="extensions_set_active">Set active</string>
 
     <!-- Accessibility: GlobalSearchScreen -->
     <string name="browse_global_search">Search</string>

--- a/feature/browse/src/test/java/app/otakureader/feature/browse/ExtensionsViewModelTest.kt
+++ b/feature/browse/src/test/java/app/otakureader/feature/browse/ExtensionsViewModelTest.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -405,32 +404,6 @@ class ExtensionsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         coVerify { extensionRepoRepository.removeRepository("https://repo1.com") }
-    }
-
-    @Test
-    fun `set active repository updates state and refreshes`() = runTest {
-        // setActiveRepository no longer calls the repository — it updates local state and refreshes.
-        coEvery { extensionRepository.refreshAvailableExtensions() } returns Result.success(Unit)
-        coEvery { extensionRepository.checkForUpdates() } returns 0
-
-        viewModel.onEvent(ExtensionsEvent.SetActiveRepository("https://repo1.com"))
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        assertEquals("https://repo1.com", viewModel.state.value.activeRepository)
-        coVerify { extensionRepository.refreshAvailableExtensions() }
-    }
-
-    @Test
-    fun `set active repository always updates state (no remote call)`() = runTest {
-        // Since setActiveRepository updates state locally without a repository call,
-        // it always succeeds and reflects the new URL in state.
-        val before = viewModel.state.value.activeRepository
-
-        viewModel.onEvent(ExtensionsEvent.SetActiveRepository("https://new.com"))
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        assertNotEquals(before, viewModel.state.value.activeRepository)
-        assertEquals("https://new.com", viewModel.state.value.activeRepository)
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -817,17 +790,6 @@ class ExtensionsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals("Naruto", viewModel.state.value.searchQuery)
-    }
-
-    @Test
-    fun `active repository persists in state`() = runTest {
-        coEvery { extensionRepository.refreshAvailableExtensions() } returns Result.success(Unit)
-        coEvery { extensionRepository.checkForUpdates() } returns 0
-
-        viewModel.onEvent(ExtensionsEvent.SetActiveRepository("https://repo.com"))
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        assertEquals("https://repo.com", viewModel.state.value.activeRepository)
     }
 
     // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## **User description**
## Summary

Two alpha bugs on the **Extensions** screen (reported via screenshots).

### 1. Every extension install failed with HTTP 404
`resolveApkUrl` hardcoded the APK folder as `/apks/`, but keiyoushi (and Mihon's standard layout) serve APKs from `/apk/`. Verified against the live repo:
- `…/repo/apk/tachiyomi-all.ahottie-v1.4.3.apk` → **200** (APK binary)
- `…/repo/apks/…` → **404 Not Found**

The code comment even had the conventions backwards and promised an `/apk/` fallback that was never implemented. Fix: build the standard `/apk/` URL, and in `downloadApk` fall back to the `/apks/` variant if the first request fails — so both repo layouts work regardless.

### 2. Removed the "active repository" concept
`ExtensionRemoteDataSourceImpl.fetchAvailableExtensions()` already iterates **all** repositories and merges them (highest versionCode wins). The per-repo "Set active" / "Active" affordance and the UI-only `activeRepository` state were misleading — they never filtered anything. Repo rows now show just the URL + delete; every repo is effectively active.

## Changes
- `core/extension/.../ExtensionRemoteDataSource.kt`: `resolveApkUrl` → `/apk/`; `downloadApk` tries `/apk/` then `/apks/`; corrected the comment.
- `feature/browse/.../ExtensionsViewModel.kt`: removed `activeRepository` state, `SetActiveRepository` event/handler, `setActiveRepository()`.
- `feature/browse/.../ExtensionsBottomSheet.kt`: simplified `RepositoryManager` (URL + delete only).
- Removed the now-unused `extensions_set_active` string.

## Test plan
- [x] Updated the minified-index APK-URL assertion to `/apk/`; added a `downloadApk` 404→`/apks/` fallback test; removed obsolete active-repository tests.
- [ ] CI: unit tests / Detekt / Ktlint / Assemble — **could not run locally** (no Android SDK in this build env).
- [ ] Device smoke test (not possible here): open Extensions → Available, install a keiyoushi extension and confirm it downloads + installs; confirm the repo list shows no "Set active"/"Active" and extensions from all repos still appear.

Separate from the beta-zeros PR #959 (this is an unrelated alpha fix).

https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd)_


___

## **CodeAnt-AI Description**
**Fix extension installs on repos with different APK folder names and remove the unused active-repository control**

### What Changed
- Extension installs now try the standard APK path first and fall back to the alternate folder if the first request fails, so installs work on both repo layouts.
- The Extensions screen no longer shows an “active repository” state or “Set active” action; repository entries now only show the URL and remove option.
- Related tests were updated to match the new APK path behavior and the removed repository setting.

### Impact
`✅ Fewer extension install 404 errors`
`✅ Works with more extension repositories`
`✅ Clearer repository management in Extensions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extension downloads now attempt multiple URL candidates with smart retry logic, improving reliability when standard paths are unavailable.

* **Refactor**
  * Removed active repository selection feature; all configured repositories are now equally accessible without requiring manual activation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Heartless-Veteran/Otaku-Reader/pull/960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->