### PR TITLE
extension: surface the real instantiation failure to the user

### DIFF
--- a/core/extension/src/main/java/app/otakureader/core/extension/loader/ExtensionLoader.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/loader/ExtensionLoader.kt
@@ -303,9 +303,20 @@ class ExtensionLoader(
             return ExtensionLoadResult.Error("Invalid parameters for class loader: ${e.message}", e)
         }
 
-        // Resolve source instances from the metadata
-        val sources = ExtensionLoadingUtils.resolveSourcesFromMetadata(appInfo, pkgName, classLoader)
-            .ifEmpty { return ExtensionLoadResult.Error("No valid sources found in extension $pkgName") }
+        // Resolve source instances from the metadata. The resolution carries any
+        // per-class failure reasons so we can surface them in the user-visible error
+        // instead of just saying "no valid sources found" (the loader used to be silent
+        // for LinkageError / ctor-threw / etc. — see ExtensionLoadingUtils.instantiateClass).
+        val resolution = ExtensionLoadingUtils.resolveSourcesFromMetadata(appInfo, pkgName, classLoader)
+        if (resolution.sources.isEmpty()) {
+            val detail = if (resolution.errors.isEmpty()) {
+                "no source class declared in manifest metadata"
+            } else {
+                resolution.errors.joinToString(separator = "; ")
+            }
+            return ExtensionLoadResult.Error("No valid sources found in extension $pkgName ($detail)")
+        }
+        val sources = resolution.sources
 
         val extension = buildExtension(apkPath, packageInfo, sources, isNsfw, isShared)
 

--- a/core/extension/src/main/java/app/otakureader/core/extension/loader/ExtensionLoadingUtils.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/loader/ExtensionLoadingUtils.kt
@@ -7,6 +7,36 @@ import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
 
 /**
+ * Outcome of attempting to instantiate a class from an extension APK.
+ *
+ * Surfaces the reason on failure so the loader can include it in its user-visible error
+ * message instead of just saying "no valid sources found" — without this, every cause
+ * (missing class, missing no-arg ctor, constructor threw, linkage / NoClassDefFoundError,
+ * static-initializer error) produced the same opaque toast.
+ */
+sealed class InstantiationResult {
+    data class Success(val instance: Any) : InstantiationResult()
+
+    /** Class isn't in the APK. Expected for non-source entries in a `;`-separated class list. */
+    data object NotFound : InstantiationResult()
+
+    /** Class was found but couldn't be instantiated. [reason] is a short single-line label. */
+    data class Failure(val reason: String, val cause: Throwable) : InstantiationResult()
+}
+
+/**
+ * Result of resolving source instances from an extension's manifest metadata.
+ *
+ * [errors] holds one short string per class/factory that was declared in the manifest but
+ * couldn't be instantiated (in declaration order). The loader includes them in its error
+ * message when [sources] ends up empty, so the user sees *why* the extension didn't load.
+ */
+data class SourceResolution(
+    val sources: List<Source>,
+    val errors: List<String>,
+)
+
+/**
  * Shared utilities for loading Tachiyomi-compatible extension APKs.
  *
  * These utilities are used by ExtensionLoader to avoid code duplication.
@@ -74,48 +104,55 @@ object ExtensionLoadingUtils {
     /**
      * Instantiate a class by name using the provided class loader.
      *
+     * Every failure mode is captured as [InstantiationResult.Failure] with a short reason
+     * label and the original [Throwable], and is also logged at warn level so it appears in
+     * `adb logcat -s ExtensionLoadingUtils`. The only exception is [ClassNotFoundException]
+     * which maps to [InstantiationResult.NotFound] — that's a routine outcome when walking
+     * a `;`-separated class list where not every entry exists in the APK.
+     *
      * @param classLoader The DexClassLoader to use for loading the class
      * @param className The fully-qualified class name to instantiate
-     * @return Instance of the class, or null if instantiation fails
      */
-    fun instantiateClass(classLoader: ClassLoader, className: String): Any? {
+    fun instantiateClass(classLoader: ClassLoader, className: String): InstantiationResult {
         require(className.isNotBlank()) { "Class name must not be blank" }
 
         return try {
-            Class.forName(className, false, classLoader)
+            val instance = Class.forName(className, false, classLoader)
                 .getDeclaredConstructor()
                 .newInstance()
+            InstantiationResult.Success(instance)
         } catch (e: ClassNotFoundException) {
-            // Class not found in APK - expected for invalid/missing source classes
-            null
+            // Routine when iterating a `;`-separated class list. Logged at debug only.
+            runCatching { Log.d(TAG, "Class not found: $className") }
+            InstantiationResult.NotFound
         } catch (e: NoSuchMethodException) {
-            // No parameterless constructor - expected for non-source classes
-            null
+            failure(className, "NoSuchMethodException (no no-arg constructor)", e)
         } catch (e: InstantiationException) {
-            // Cannot instantiate (abstract class/interface) - expected for invalid sources
-            null
+            failure(className, "InstantiationException (abstract class or interface)", e)
         } catch (e: IllegalAccessException) {
-            // Constructor not accessible - expected for inaccessible classes
-            null
+            failure(className, "IllegalAccessException (constructor not accessible)", e)
         } catch (e: SecurityException) {
-            // Security manager denies access - rare but expected
-            null
+            failure(className, "SecurityException", e)
+        } catch (e: java.lang.reflect.InvocationTargetException) {
+            val cause = e.targetException ?: e
+            failure(className, "InvocationTargetException: ${cause.javaClass.simpleName}: ${cause.message}", cause)
+        } catch (e: ExceptionInInitializerError) {
+            val cause = e.cause ?: e
+            failure(className, "ExceptionInInitializerError: ${cause.javaClass.simpleName}: ${cause.message}", cause)
+        } catch (e: LinkageError) {
+            // Typically NoClassDefFoundError → an extension references a class the host
+            // (core/tachiyomi-compat) doesn't ship. This is the most common silent failure
+            // for Komikku/Keiyoushi extensions, so surface the missing class name.
+            failure(className, "LinkageError: ${e.javaClass.simpleName}: ${e.message}", e)
         } catch (e: RuntimeException) {
             // Some class loaders (or test stubs) may throw RuntimeException instead of ClassNotFoundException.
-            runCatching {
-                Log.w(TAG, "RuntimeException instantiating extension class: $className", e)
-            }
-            null
-        } catch (e: java.lang.reflect.InvocationTargetException) {
-            // Constructor threw an exception - expected for extension code with initialization errors
-            null
-        } catch (e: ExceptionInInitializerError) {
-            // Static initializer threw an exception - expected for extension code with init errors
-            null
-        } catch (e: LinkageError) {
-            // Class linking failed - expected for extensions with missing dependencies
-            null
+            failure(className, "RuntimeException: ${e.javaClass.simpleName}: ${e.message}", e)
         }
+    }
+
+    private fun failure(className: String, reason: String, cause: Throwable): InstantiationResult.Failure {
+        runCatching { Log.w(TAG, "Failed to instantiate $className — $reason", cause) }
+        return InstantiationResult.Failure(reason, cause)
     }
 
     /**
@@ -125,63 +162,117 @@ object ExtensionLoadingUtils {
      * METADATA_SOURCE_CLASS. Both keys support multiple class names separated by `;`.
      * Relative class names starting with `.` are expanded using the package name.
      *
+     * The returned [SourceResolution] carries one error string per class/factory that was
+     * declared but couldn't be instantiated, so the caller can include them in a
+     * user-visible error when `sources` ends up empty.
+     *
      * @param metadata Bundle containing extension metadata
      * @param pkgName Package name for resolving relative class names
      * @param classLoader DexClassLoader for loading classes
      * @param filterType Optional class to filter by (e.g., CatalogueSource::class.java)
-     * @return List of Source instances
      */
     fun resolveSourcesFromMetadata(
         metadata: android.os.Bundle,
         pkgName: String,
         classLoader: ClassLoader,
         filterType: Class<*>? = null
-    ): List<Source> {
-        // Prefer SourceFactory when declared
+    ): SourceResolution {
+        val sources = mutableListOf<Source>()
+        val errors = mutableListOf<String>()
+
+        // SourceFactory path: short-circuits the class list if it succeeds (prior behaviour).
         val factoryClassName = metadata.getString(METADATA_SOURCE_FACTORY)
         if (!factoryClassName.isNullOrBlank()) {
-            val resolvedClass = resolveClassName(factoryClassName.trim(), pkgName)
-            val instance = instantiateClass(classLoader, resolvedClass)
-            if (instance is SourceFactory) {
-                val sources = instance.createSources()
-                return if (filterType != null) {
-                    sources.filter { filterType.isInstance(it) }
-                } else {
-                    sources
-                }
-            }
+            val handled = tryFactoryEntry(
+                resolveClassName(factoryClassName.trim(), pkgName),
+                classLoader, filterType, sources, errors,
+            )
+            if (handled) return SourceResolution(sources, errors)
         }
 
-        // Fall back to direct source class(es)
         val sourceClassEntry = metadata.getString(METADATA_SOURCE_CLASS)
-            ?: return emptyList()
+        if (sourceClassEntry.isNullOrBlank()) return SourceResolution(sources, errors)
 
-        return sourceClassEntry
+        sourceClassEntry
             .split(";")
             .map { it.trim() }
             .filter { it.isNotEmpty() }
-            .flatMap { rawClass ->
-                val resolvedClass = resolveClassName(rawClass, pkgName)
-                when (val instance = instantiateClass(classLoader, resolvedClass)) {
-                    is SourceFactory -> {
-                        val sources = instance.createSources()
-                        if (filterType != null) {
-                            sources.filter { filterType.isInstance(it) }
-                        } else {
-                            sources
-                        }
-                    }
-                    is Source -> {
-                        if (filterType == null || filterType.isInstance(instance)) {
-                            listOf(instance)
-                        } else {
-                            emptyList()
-                        }
-                    }
-                    else -> emptyList()
-                }
+            .forEach { rawClass ->
+                processClassEntry(
+                    resolveClassName(rawClass, pkgName),
+                    classLoader, filterType, sources, errors,
+                )
             }
+
+        return SourceResolution(sources, errors)
     }
+
+    /**
+     * Try the `tachiyomi.extension.factory` entry. Returns true when it produced sources
+     * (caller short-circuits the class list, matching prior behaviour). Errors are
+     * accumulated into [errors] regardless.
+     */
+    private fun tryFactoryEntry(
+        resolvedClass: String,
+        classLoader: ClassLoader,
+        filterType: Class<*>?,
+        sources: MutableList<Source>,
+        errors: MutableList<String>,
+    ): Boolean {
+        when (val result = instantiateClass(classLoader, resolvedClass)) {
+            is InstantiationResult.Success -> {
+                val instance = result.instance
+                if (instance is SourceFactory) {
+                    sources += keepByType(instance.createSources(), filterType)
+                    return true
+                }
+                errors += "$resolvedClass: declared as factory but is not a SourceFactory"
+            }
+            is InstantiationResult.NotFound -> errors += "$resolvedClass: ClassNotFoundException"
+            is InstantiationResult.Failure -> errors += "$resolvedClass: ${result.reason}"
+        }
+        return false
+    }
+
+    /** Walk a single `tachiyomi.extension.class` entry; tolerate `NotFound` silently. */
+    private fun processClassEntry(
+        resolvedClass: String,
+        classLoader: ClassLoader,
+        filterType: Class<*>?,
+        sources: MutableList<Source>,
+        errors: MutableList<String>,
+    ) {
+        when (val result = instantiateClass(classLoader, resolvedClass)) {
+            is InstantiationResult.Success -> appendSuccess(resolvedClass, result.instance, filterType, sources, errors)
+            is InstantiationResult.NotFound -> Unit // routine for `;`-separated lists
+            is InstantiationResult.Failure -> errors += "$resolvedClass: ${result.reason}"
+        }
+    }
+
+    private fun appendSuccess(
+        resolvedClass: String,
+        instance: Any,
+        filterType: Class<*>?,
+        sources: MutableList<Source>,
+        errors: MutableList<String>,
+    ) {
+        when (instance) {
+            is SourceFactory -> sources += keepByType(instance.createSources(), filterType)
+            is Source -> if (filterType == null || filterType.isInstance(instance)) {
+                sources += instance
+            } else {
+                val instanceName = instance.javaClass.simpleName
+                errors += "$resolvedClass: $instanceName does not match required type ${filterType.simpleName}"
+            }
+            else -> {
+                val instanceName = instance.javaClass.simpleName
+                errors += "$resolvedClass: instantiated to $instanceName, not a Source or SourceFactory"
+            }
+        }
+    }
+
+    private fun keepByType(sources: List<Source>, filterType: Class<*>?): List<Source> =
+        if (filterType == null) sources else sources.filter { filterType.isInstance(it) }
 
     /**
      * Resolve Source instances from ApplicationInfo metadata.
@@ -192,15 +283,14 @@ object ExtensionLoadingUtils {
      * @param pkgName Package name for resolving relative class names
      * @param classLoader DexClassLoader for loading classes
      * @param filterType Optional class to filter by (e.g., CatalogueSource::class.java)
-     * @return List of Source instances, empty if metadata is null
      */
     fun resolveSourcesFromMetadata(
         appInfo: ApplicationInfo,
         pkgName: String,
         classLoader: ClassLoader,
         filterType: Class<*>? = null
-    ): List<Source> {
-        val metadata = appInfo.metaData ?: return emptyList()
+    ): SourceResolution {
+        val metadata = appInfo.metaData ?: return SourceResolution(emptyList(), emptyList())
         return resolveSourcesFromMetadata(metadata, pkgName, classLoader, filterType)
     }
 

--- a/core/extension/src/test/java/app/otakureader/core/extension/loader/ExtensionLoadingUtilsTest.kt
+++ b/core/extension/src/test/java/app/otakureader/core/extension/loader/ExtensionLoadingUtilsTest.kt
@@ -2,6 +2,7 @@ package app.otakureader.core.extension.loader
 
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 
@@ -38,8 +39,65 @@ class ExtensionLoadingUtilsTest {
         }
     }
 
-    // Note: Testing instantiateClass with a real ChildFirstPathClassLoader requires Android runtime
-    // The production code will properly return null for ClassNotFoundException, etc.
+    // ────────────────────────────────────────────────────────────────────────────
+    // Diagnostic tests — lock in the reason-string format so a future refactor
+    // doesn't quietly regress the loader's user-visible error message. Each test
+    // exercises a distinct catch branch in `instantiateClass` using a locally
+    // declared fixture loaded through the host JVM classloader (no Android, no
+    // DexClassLoader needed for these branches).
+    // ────────────────────────────────────────────────────────────────────────────
+
+    /** Constructor that always throws — exercises the InvocationTargetException branch. */
+    class CtorThrowsFixture {
+        init { error("ctor boom") }
+    }
+
+    /** Class with no no-arg constructor — exercises the NoSuchMethodException branch. */
+    @Suppress("UNUSED_PARAMETER")
+    class NoNoArgCtorFixture(value: Int)
+
+    @Test
+    fun `instantiateClass returns NotFound for a missing class`() {
+        val result = ExtensionLoadingUtils.instantiateClass(
+            classLoader = javaClass.classLoader!!,
+            className = "com.example.definitely.not.a.real.Class"
+        )
+        assertEquals(InstantiationResult.NotFound, result)
+    }
+
+    @Test
+    fun `instantiateClass returns Failure with NoSuchMethodException reason for parameterised ctor`() {
+        val result = ExtensionLoadingUtils.instantiateClass(
+            classLoader = javaClass.classLoader!!,
+            className = NoNoArgCtorFixture::class.java.name
+        )
+        assertTrue("Expected Failure but got $result", result is InstantiationResult.Failure)
+        val failure = result as InstantiationResult.Failure
+        assertTrue(
+            "Reason should mention NoSuchMethodException, was: ${failure.reason}",
+            failure.reason.contains("NoSuchMethodException")
+        )
+    }
+
+    @Test
+    fun `instantiateClass returns Failure with InvocationTargetException reason when ctor throws`() {
+        val result = ExtensionLoadingUtils.instantiateClass(
+            classLoader = javaClass.classLoader!!,
+            className = CtorThrowsFixture::class.java.name
+        )
+        assertTrue("Expected Failure but got $result", result is InstantiationResult.Failure)
+        val failure = result as InstantiationResult.Failure
+        assertTrue(
+            "Reason should mention InvocationTargetException, was: ${failure.reason}",
+            failure.reason.contains("InvocationTargetException")
+        )
+        // The underlying ctor-thrown exception must be preserved so the loader can include
+        // its message in the user-visible toast — that's the whole point of the diagnostic.
+        assertTrue(
+            "Reason should include the underlying ctor message, was: ${failure.reason}",
+            failure.reason.contains("ctor boom")
+        )
+    }
 
     @Test
     fun `resolveClassName expands relative class name`() {

--- a/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/compat/TachiyomiExtensionLoader.kt
+++ b/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/compat/TachiyomiExtensionLoader.kt
@@ -3,6 +3,7 @@ package app.otakureader.core.tachiyomi.compat
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
+import android.util.Log
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
@@ -36,6 +37,9 @@ class TachiyomiExtensionLoader(
 ) {
 
     companion object {
+        /** Logcat tag — filter with `adb logcat -s TachiyomiExtensionLoader:*`. */
+        private const val TAG = "TachiyomiExtensionLoader"
+
         /** Uses-feature flag that identifies a Tachiyomi-compatible extension package. */
         const val TACHIYOMI_EXTENSION_FEATURE = "tachiyomi.extension"
 
@@ -47,6 +51,19 @@ class TachiyomiExtensionLoader(
 
         /** Metadata key indicating NSFW content (integer 1 = nsfw). */
         const val METADATA_NSFW = "tachiyomi.extension.nsfw"
+    }
+
+    /**
+     * Outcome of attempting to instantiate an extension class.
+     *
+     * Intentionally duplicated from [app.otakureader.core.extension.loader.InstantiationResult]
+     * because core:tachiyomi-compat can't depend on core:extension (would be a cycle).
+     * Kept private — only [instantiateClass] and [resolveSourcesFromMetadata] use it.
+     */
+    private sealed class InstantiationResult {
+        data class Success(val instance: Any) : InstantiationResult()
+        data object NotFound : InstantiationResult()
+        data class Failure(val reason: String, val cause: Throwable) : InstantiationResult()
     }
 
     private val loadedExtensions = ConcurrentHashMap<String, LoadedExtension>()
@@ -176,11 +193,19 @@ class TachiyomiExtensionLoader(
             parentClassLoader,
         )
 
-        // Resolve source instances
-        val sources = resolveSourcesFromMetadata(metadata, packageName, classLoader)
+        // Resolve source instances; collect per-class failure reasons so they aren't swallowed.
+        val errors = mutableListOf<String>()
+        val sources = resolveSourcesFromMetadata(metadata, packageName, classLoader, errors)
 
         if (sources.isEmpty()) {
-            // No valid sources found — discard the class loader and skip this extension
+            // No valid sources found — discard the class loader and skip this extension.
+            // Log the reason so the user can debug a failed sideloaded/Komikku extension.
+            val detail = if (errors.isEmpty()) {
+                "no source class declared in manifest metadata"
+            } else {
+                errors.joinToString(separator = "; ")
+            }
+            runCatching { Log.w(TAG, "No valid sources for $packageName ($detail)") }
             return null
         }
 
@@ -213,39 +238,64 @@ class TachiyomiExtensionLoader(
      * Checks [METADATA_SOURCE_FACTORY] first; if absent, reads class names from
      * [METADATA_SOURCE_CLASS].  Class names starting with `.` are expanded using
      * the package name.
+     *
+     * Per-class failures are accumulated in [errors] (declaration order); the caller logs
+     * them when the result list is empty so a sideloaded Komikku/Keiyoushi extension that
+     * fails to instantiate doesn't disappear silently.
      */
     private fun resolveSourcesFromMetadata(
         metadata: android.os.Bundle,
         pkgName: String,
         classLoader: ClassLoader,
+        errors: MutableList<String>,
     ): List<CatalogueSource> {
+        val collected = mutableListOf<CatalogueSource>()
+
         // SourceFactory path
         val factoryClass = metadata.getString(METADATA_SOURCE_FACTORY)
         if (!factoryClass.isNullOrBlank()) {
             val resolved = resolveClassName(factoryClass.trim(), pkgName)
-            val factory = instantiateClass(classLoader, resolved)
-            if (factory is SourceFactory) {
-                return factory.createSources()
-                    .filterIsInstance<CatalogueSource>()
+            when (val result = instantiateClass(classLoader, resolved)) {
+                is InstantiationResult.Success -> {
+                    val instance = result.instance
+                    if (instance is SourceFactory) {
+                        collected += instance.createSources().filterIsInstance<CatalogueSource>()
+                        return collected
+                    } else {
+                        errors += "$resolved: declared as factory but is not a SourceFactory"
+                    }
+                }
+                is InstantiationResult.NotFound -> errors += "$resolved: ClassNotFoundException"
+                is InstantiationResult.Failure -> errors += "$resolved: ${result.reason}"
             }
         }
 
         // Direct source class(es)
-        val sourceClassEntry = metadata.getString(METADATA_SOURCE_CLASS) ?: return emptyList()
+        val sourceClassEntry = metadata.getString(METADATA_SOURCE_CLASS) ?: return collected
 
-        return sourceClassEntry
+        sourceClassEntry
             .split(";")
             .map { it.trim() }
             .filter { it.isNotEmpty() }
-            .flatMap { rawClass ->
+            .forEach { rawClass ->
                 val resolved = resolveClassName(rawClass, pkgName)
-                when (val instance = instantiateClass(classLoader, resolved)) {
-                    is SourceFactory -> instance.createSources().filterIsInstance<CatalogueSource>()
-                    is CatalogueSource -> listOf(instance)
-                    is Source -> emptyList() // non-catalogue sources not supported here
-                    else -> emptyList()
+                when (val result = instantiateClass(classLoader, resolved)) {
+                    is InstantiationResult.Success -> {
+                        when (val instance = result.instance) {
+                            is SourceFactory -> collected += instance.createSources().filterIsInstance<CatalogueSource>()
+                            is CatalogueSource -> collected += instance
+                            is Source -> errors += "$resolved: ${instance.javaClass.simpleName} is not a CatalogueSource"
+                            else -> errors += "$resolved: instantiated to ${instance.javaClass.simpleName}, not a Source or SourceFactory"
+                        }
+                    }
+                    is InstantiationResult.NotFound -> {
+                        // Routine for `;`-separated lists; don't pollute the error list.
+                    }
+                    is InstantiationResult.Failure -> errors += "$resolved: ${result.reason}"
                 }
             }
+
+        return collected
     }
 
     /** Expand a relative class name (starting with `.`) using the package name. */
@@ -253,37 +303,47 @@ class TachiyomiExtensionLoader(
         return if (className.startsWith(".")) pkgName + className else className
     }
 
-    /** Instantiate a class by name; returns null on any error. */
-    private fun instantiateClass(classLoader: ClassLoader, className: String): Any? {
-        if (className.isBlank()) return null
+    /**
+     * Instantiate a class by name. See the same-named function in
+     * [app.otakureader.core.extension.loader.ExtensionLoadingUtils] — the catch ladder
+     * is intentionally identical and any change here must be mirrored there.
+     */
+    private fun instantiateClass(classLoader: ClassLoader, className: String): InstantiationResult {
+        if (className.isBlank()) return InstantiationResult.Failure("blank class name", IllegalArgumentException("blank class name"))
 
         return try {
-            Class.forName(className, false, classLoader).getDeclaredConstructor().newInstance()
+            val instance = Class.forName(className, false, classLoader)
+                .getDeclaredConstructor().newInstance()
+            InstantiationResult.Success(instance)
         } catch (e: ClassNotFoundException) {
-            // Class not found in APK - expected for invalid/missing source classes
-            null
+            runCatching { Log.d(TAG, "Class not found: $className") }
+            InstantiationResult.NotFound
         } catch (e: NoSuchMethodException) {
-            // No parameterless constructor - expected for non-source classes
-            null
+            failure(className, "NoSuchMethodException (no no-arg constructor)", e)
         } catch (e: InstantiationException) {
-            // Cannot instantiate (abstract class/interface) - expected for invalid sources
-            null
+            failure(className, "InstantiationException (abstract class or interface)", e)
         } catch (e: IllegalAccessException) {
-            // Constructor not accessible - expected for inaccessible classes
-            null
+            failure(className, "IllegalAccessException (constructor not accessible)", e)
         } catch (e: SecurityException) {
-            // Security manager denies access - rare but expected
-            null
+            failure(className, "SecurityException", e)
         } catch (e: java.lang.reflect.InvocationTargetException) {
-            // Constructor threw an exception - expected for extension code with initialization errors
-            null
+            val cause = e.targetException ?: e
+            failure(className, "InvocationTargetException: ${cause.javaClass.simpleName}: ${cause.message}", cause)
         } catch (e: ExceptionInInitializerError) {
-            // Static initializer threw an exception - expected for extension code with init errors
-            null
+            val cause = e.cause ?: e
+            failure(className, "ExceptionInInitializerError: ${cause.javaClass.simpleName}: ${cause.message}", cause)
         } catch (e: LinkageError) {
-            // Class linking failed - expected for extensions with missing dependencies
-            null
+            // Typically NoClassDefFoundError → extension references a class the host
+            // (core/tachiyomi-compat) doesn't ship. The most common silent failure mode.
+            failure(className, "LinkageError: ${e.javaClass.simpleName}: ${e.message}", e)
+        } catch (e: RuntimeException) {
+            failure(className, "RuntimeException: ${e.javaClass.simpleName}: ${e.message}", e)
         }
+    }
+
+    private fun failure(className: String, reason: String, cause: Throwable): InstantiationResult.Failure {
+        runCatching { Log.w(TAG, "Failed to instantiate $className — $reason", cause) }
+        return InstantiationResult.Failure(reason, cause)
     }
 
     /**


### PR DESCRIPTION
## **User description**
## Why

User installed Keiyoushi + Komikku repos and tried to install
`eu.kanade.tachiyomi.extension.it.animegdrclub`. The install failed with:

> Failed to install: No valid sources found in extension eu.kanade.tachiyomi.extension.it.animegdrclub

User reports: *"I'm not sure what is wrong with the extension system."* That's
because the loader can't be debugged from the outside — `instantiateClass`
catches **eight** exception types and silently returns `null` from every
branch (only `RuntimeException` even logs). A missing host class
(`NoClassDefFoundError`), a no-arg-ctor mismatch, a constructor that threw,
or a static-init failure all produce the same opaque toast. There's no way
to tell from the UI or from logcat why the source list came back empty.

## What

Make the loader observable. No change to what it accepts — purely a
debuggability fix. The success path is identical for extensions that
already load.

- **`instantiateClass`** returns a sealed `InstantiationResult`:
  `Success(instance)` / `NotFound` / `Failure(reason, cause)`. `NotFound`
  stays silent (routine when walking `;`-separated class lists); every
  other failure logs at warn level under `ExtensionLoadingUtils` /
  `TachiyomiExtensionLoader`, so `adb logcat -s ExtensionLoadingUtils:* TachiyomiExtensionLoader:*` shows the cause.
- **`resolveSourcesFromMetadata`** returns `SourceResolution(sources, errors)` — one short
  string per class/factory that failed to instantiate.
- **`ExtensionLoader.loadFromPackageInfo`** includes those errors in the
  user-visible message. Example:
  > No valid sources found in extension X
  > (com.x.MainSource: LinkageError: NoClassDefFoundError: eu.kanade.tachiyomi.network.NetworkHelper)
- **`TachiyomiExtensionLoader`** (the sister loader in `core/tachiyomi-compat`,
  which can't import from `core/extension` without creating a cycle) gets
  a local copy of the same diagnostic. The catch ladder is identical and
  the file references the original so future changes stay in sync.

## Repo coverage

Repo-agnostic by construction — sits in the APK class-loading layer that
runs the same way for every install path:

| Path | Covered |
|---|---|
| Keiyoushi (`raw.githubusercontent.com/keiyoushi/extensions/repo`) | ✅ via `ExtensionLoader` |
| Komikku (`raw.githubusercontent.com/komikku-app/extensions/repo`) | ✅ via both loaders |
| Suwayomi | ✅ via `ExtensionLoader` |
| Sideloaded shared APK | ✅ via `ExtensionLoader` |
| Sideloaded private APK | ✅ via `ExtensionLoader` |

Known Komikku-adjacent liabilities **flagged but not fixed here** (gated
on what the new diagnostic reveals):

1. `LIB_VERSION_MAX = 1.5` in `ExtensionLoader.kt:94`. Komikku has shipped
   1.6.x extensions on parts of its catalog; if the failing APK is 1.6+
   it hits the existing `Unsupported lib version` branch (different
   error path). One-line bump candidate for the follow-up.
2. Extra Komikku-only manifest meta-data keys (`tachiyomi.extension.lang`
   etc.) aren't read. Currently harmless — `Source.lang` comes from the
   instance, not the manifest — but the new diagnostic will tell us if
   any extension *only* declares Komikku-only keys.

## How to use

User installs this build, retries `animegdrclub`, and captures **the new
toast** plus `adb logcat -s ExtensionLoadingUtils:* TachiyomiExtensionLoader:* ExtensionLoader:*`.
That output identifies the real cause and gates the follow-up fix
(probably adding the missing class to `core/tachiyomi-compat`).

## Test plan

- [x] `./gradlew :core:extension:testDebugUnitTest :core:tachiyomi-compat:testDebugUnitTest` — green locally.
- [x] `./gradlew detekt` — green locally.
- [x] `./gradlew ktlintCheck :app:compileDebugKotlin` — green locally (only pre-existing deprecation warnings).
- [x] Existing `ExtensionLoaderTest` assertions on `contains("No valid sources found")` still hold (prefix preserved).
- [ ] **Device repro** — install this build, re-attempt the failing extension, capture the toast + logcat. (Cannot do this from the container.)
- [ ] Verify the new diagnostic appears for both Keiyoushi-served and Komikku-served install paths.

## Scope

One small PR. Draft — user has said merges aren't imminent. The real fix
(likely a `tachiyomi-compat` class addition) is gated on what the
diagnostic shows.

https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd)_


___

## **CodeAnt-AI Description**
Show the real reason an extension source failed to load

### What Changed
- Failed extension installs now show the specific cause, such as a missing class, missing constructor, constructor crash, or dependency error, instead of only saying “No valid sources found”
- When an extension declares multiple source classes, the loader keeps checking the rest and includes each failure reason in the final error message
- The same failure details are now written to logcat so install problems can be diagnosed from the device
- Extensions that already load successfully behave the same as before

### Impact
`✅ Clearer extension install errors`
`✅ Fewer opaque “no valid sources” failures`
`✅ Easier debugging for sideloaded extensions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extension loading now provides detailed error messages when sources cannot be resolved, including per-class failure information for improved troubleshooting.
  * Improved diagnostic logging for extension instantiation failures.

* **Tests**
  * Added comprehensive test coverage for extension instantiation error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Heartless-Veteran/Otaku-Reader/pull/967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->