### PR TITLE
ci(ruflo): persistent bootstrap — fresh containers come up with ruflo wired

### DIFF
--- a/.claude-flow/.gitignore
+++ b/.claude-flow/.gitignore
@@ -1,0 +1,7 @@
+# Claude Flow runtime files
+data/
+logs/
+sessions/
+neural/
+*.log
+*.tmp

--- a/.claude-flow/CAPABILITIES.md
+++ b/.claude-flow/CAPABILITIES.md
@@ -1,0 +1,403 @@
+# RuFlo V3 - Complete Capabilities Reference
+> Generated: 2026-05-30T11:38:35.183Z
+> Full documentation: https://github.com/ruvnet/claude-flow
+
+## 📋 Table of Contents
+
+1. [Overview](#overview)
+2. [Swarm Orchestration](#swarm-orchestration)
+3. [Available Agents (60+)](#available-agents)
+4. [CLI Commands (26 Commands, 140+ Subcommands)](#cli-commands)
+5. [Hooks System (27 Hooks + 12 Workers)](#hooks-system)
+6. [Memory & Intelligence (RuVector)](#memory--intelligence)
+7. [Hive-Mind Consensus](#hive-mind-consensus)
+8. [Performance Targets](#performance-targets)
+9. [Integration Ecosystem](#integration-ecosystem)
+
+---
+
+## Overview
+
+RuFlo V3 is a domain-driven design architecture for multi-agent AI coordination with:
+
+- **15-Agent Swarm Coordination** with hierarchical and mesh topologies
+- **HNSW Vector Search** - 150x-12,500x faster pattern retrieval
+- **SONA Neural Learning** - Self-optimizing with <0.05ms adaptation
+- **Byzantine Fault Tolerance** - Queen-led consensus mechanisms
+- **MCP Server Integration** - Model Context Protocol support
+
+### Current Configuration
+| Setting | Value |
+|---------|-------|
+| Topology | mesh |
+| Max Agents | 5 |
+| Memory Backend | memory |
+| HNSW Indexing | Disabled |
+| Neural Learning | Disabled |
+| LearningBridge | Disabled |
+| Knowledge Graph | Disabled |
+| Agent Scopes | Disabled |
+
+---
+
+## Swarm Orchestration
+
+### Topologies
+| Topology | Description | Best For |
+|----------|-------------|----------|
+| `hierarchical` | Queen controls workers directly | Anti-drift, tight control |
+| `mesh` | Fully connected peer network | Distributed tasks |
+| `hierarchical-mesh` | V3 hybrid (recommended) | 10+ agents |
+| `ring` | Circular communication | Sequential workflows |
+| `star` | Central coordinator | Simple coordination |
+| `adaptive` | Dynamic based on load | Variable workloads |
+
+### Strategies
+- `balanced` - Even distribution across agents
+- `specialized` - Clear roles, no overlap (anti-drift)
+- `adaptive` - Dynamic task routing
+
+### Quick Commands
+```bash
+# Initialize swarm
+npx @claude-flow/cli@latest swarm init --topology hierarchical --max-agents 8 --strategy specialized
+
+# Check status
+npx @claude-flow/cli@latest swarm status
+
+# Monitor activity
+npx @claude-flow/cli@latest swarm monitor
+```
+
+---
+
+## Available Agents
+
+### Core Development (5)
+`coder`, `reviewer`, `tester`, `planner`, `researcher`
+
+### V3 Specialized (4)
+`security-architect`, `security-auditor`, `memory-specialist`, `performance-engineer`
+
+### Swarm Coordination (5)
+`hierarchical-coordinator`, `mesh-coordinator`, `adaptive-coordinator`, `collective-intelligence-coordinator`, `swarm-memory-manager`
+
+### Consensus & Distributed (7)
+`byzantine-coordinator`, `raft-manager`, `gossip-coordinator`, `consensus-builder`, `crdt-synchronizer`, `quorum-manager`, `security-manager`
+
+### Performance & Optimization (5)
+`perf-analyzer`, `performance-benchmarker`, `task-orchestrator`, `memory-coordinator`, `smart-agent`
+
+### GitHub & Repository (9)
+`github-modes`, `pr-manager`, `code-review-swarm`, `issue-tracker`, `release-manager`, `workflow-automation`, `project-board-sync`, `repo-architect`, `multi-repo-swarm`
+
+### SPARC Methodology (6)
+`sparc-coord`, `sparc-coder`, `specification`, `pseudocode`, `architecture`, `refinement`
+
+### Specialized Development (8)
+`backend-dev`, `mobile-dev`, `ml-developer`, `cicd-engineer`, `api-docs`, `system-architect`, `code-analyzer`, `base-template-generator`
+
+### Testing & Validation (2)
+`tdd-london-swarm`, `production-validator`
+
+### Agent Routing by Task
+| Task Type | Recommended Agents | Topology |
+|-----------|-------------------|----------|
+| Bug Fix | researcher, coder, tester | mesh |
+| New Feature | coordinator, architect, coder, tester, reviewer | hierarchical |
+| Refactoring | architect, coder, reviewer | mesh |
+| Performance | researcher, perf-engineer, coder | hierarchical |
+| Security | security-architect, auditor, reviewer | hierarchical |
+| Docs | researcher, api-docs | mesh |
+
+---
+
+## CLI Commands
+
+### Core Commands (12)
+| Command | Subcommands | Description |
+|---------|-------------|-------------|
+| `init` | 4 | Project initialization |
+| `agent` | 8 | Agent lifecycle management |
+| `swarm` | 6 | Multi-agent coordination |
+| `memory` | 11 | AgentDB with HNSW search |
+| `mcp` | 9 | MCP server management |
+| `task` | 6 | Task assignment |
+| `session` | 7 | Session persistence |
+| `config` | 7 | Configuration |
+| `status` | 3 | System monitoring |
+| `workflow` | 6 | Workflow templates |
+| `hooks` | 17 | Self-learning hooks |
+| `hive-mind` | 6 | Consensus coordination |
+
+### Advanced Commands (14)
+| Command | Subcommands | Description |
+|---------|-------------|-------------|
+| `daemon` | 5 | Background workers |
+| `neural` | 5 | Pattern training |
+| `security` | 6 | Security scanning |
+| `performance` | 5 | Profiling & benchmarks |
+| `providers` | 5 | AI provider config |
+| `plugins` | 5 | Plugin management |
+| `deployment` | 5 | Deploy management |
+| `embeddings` | 4 | Vector embeddings |
+| `claims` | 4 | Authorization |
+| `migrate` | 5 | V2→V3 migration |
+| `process` | 4 | Process management |
+| `doctor` | 1 | Health diagnostics |
+| `completions` | 4 | Shell completions |
+
+### Example Commands
+```bash
+# Initialize
+npx @claude-flow/cli@latest init --wizard
+
+# Spawn agent
+npx @claude-flow/cli@latest agent spawn -t coder --name my-coder
+
+# Memory operations
+npx @claude-flow/cli@latest memory store --key "pattern" --value "data" --namespace patterns
+npx @claude-flow/cli@latest memory search --query "authentication"
+
+# Diagnostics
+npx @claude-flow/cli@latest doctor --fix
+```
+
+---
+
+## Hooks System
+
+### 27 Available Hooks
+
+#### Core Hooks (6)
+| Hook | Description |
+|------|-------------|
+| `pre-edit` | Context before file edits |
+| `post-edit` | Record edit outcomes |
+| `pre-command` | Risk assessment |
+| `post-command` | Command metrics |
+| `pre-task` | Task start + agent suggestions |
+| `post-task` | Task completion learning |
+
+#### Session Hooks (4)
+| Hook | Description |
+|------|-------------|
+| `session-start` | Start/restore session |
+| `session-end` | Persist state |
+| `session-restore` | Restore previous |
+| `notify` | Cross-agent notifications |
+
+#### Intelligence Hooks (5)
+| Hook | Description |
+|------|-------------|
+| `route` | Optimal agent routing |
+| `explain` | Routing decisions |
+| `pretrain` | Bootstrap intelligence |
+| `build-agents` | Generate configs |
+| `transfer` | Pattern transfer |
+
+#### Coverage Hooks (3)
+| Hook | Description |
+|------|-------------|
+| `coverage-route` | Coverage-based routing |
+| `coverage-suggest` | Improvement suggestions |
+| `coverage-gaps` | Gap analysis |
+
+### 12 Background Workers
+| Worker | Priority | Purpose |
+|--------|----------|---------|
+| `ultralearn` | normal | Deep knowledge |
+| `optimize` | high | Performance |
+| `consolidate` | low | Memory consolidation |
+| `predict` | normal | Predictive preload |
+| `audit` | critical | Security |
+| `map` | normal | Codebase mapping |
+| `preload` | low | Resource preload |
+| `deepdive` | normal | Deep analysis |
+| `document` | normal | Auto-docs |
+| `refactor` | normal | Suggestions |
+| `benchmark` | normal | Benchmarking |
+| `testgaps` | normal | Coverage gaps |
+
+---
+
+## Memory & Intelligence
+
+### RuVector Intelligence System
+- **SONA**: Self-Optimizing Neural Architecture (<0.05ms)
+- **MoE**: Mixture of Experts routing
+- **HNSW**: 150x-12,500x faster search
+- **EWC++**: Prevents catastrophic forgetting
+- **Flash Attention**: 2.49x-7.47x speedup
+- **Int8 Quantization**: 3.92x memory reduction
+
+### 4-Step Intelligence Pipeline
+1. **RETRIEVE** - HNSW pattern search
+2. **JUDGE** - Success/failure verdicts
+3. **DISTILL** - LoRA learning extraction
+4. **CONSOLIDATE** - EWC++ preservation
+
+### Self-Learning Memory (ADR-049)
+
+| Component | Status | Description |
+|-----------|--------|-------------|
+| **LearningBridge** | ⏸ Disabled | Connects insights to SONA/ReasoningBank neural pipeline |
+| **MemoryGraph** | ⏸ Disabled | PageRank knowledge graph + community detection |
+| **AgentMemoryScope** | ⏸ Disabled | 3-scope agent memory (project/local/user) |
+
+**LearningBridge** - Insights trigger learning trajectories. Confidence evolves: +0.03 on access, -0.005/hour decay. Consolidation runs the JUDGE/DISTILL/CONSOLIDATE pipeline.
+
+**MemoryGraph** - Builds a knowledge graph from entry references. PageRank identifies influential insights. Communities group related knowledge. Graph-aware ranking blends vector + structural scores.
+
+**AgentMemoryScope** - Maps Claude Code 3-scope directories:
+- `project`: `<gitRoot>/.claude/agent-memory/<agent>/`
+- `local`: `<gitRoot>/.claude/agent-memory-local/<agent>/`
+- `user`: `~/.claude/agent-memory/<agent>/`
+
+High-confidence insights (>0.8) can transfer between agents.
+
+### Memory Commands
+```bash
+# Store pattern
+npx @claude-flow/cli@latest memory store --key "name" --value "data" --namespace patterns
+
+# Semantic search
+npx @claude-flow/cli@latest memory search --query "authentication"
+
+# List entries
+npx @claude-flow/cli@latest memory list --namespace patterns
+
+# Initialize database
+npx @claude-flow/cli@latest memory init --force
+```
+
+---
+
+## Hive-Mind Consensus
+
+### Queen Types
+| Type | Role |
+|------|------|
+| Strategic Queen | Long-term planning |
+| Tactical Queen | Execution coordination |
+| Adaptive Queen | Dynamic optimization |
+
+### Worker Types (8)
+`researcher`, `coder`, `analyst`, `tester`, `architect`, `reviewer`, `optimizer`, `documenter`
+
+### Consensus Mechanisms
+| Mechanism | Fault Tolerance | Use Case |
+|-----------|-----------------|----------|
+| `byzantine` | f < n/3 faulty | Adversarial |
+| `raft` | f < n/2 failed | Leader-based |
+| `gossip` | Eventually consistent | Large scale |
+| `crdt` | Conflict-free | Distributed |
+| `quorum` | Configurable | Flexible |
+
+### Hive-Mind Commands
+```bash
+# Initialize
+npx @claude-flow/cli@latest hive-mind init --queen-type strategic
+
+# Status
+npx @claude-flow/cli@latest hive-mind status
+
+# Spawn workers
+npx @claude-flow/cli@latest hive-mind spawn --count 5 --type worker
+
+# Consensus
+npx @claude-flow/cli@latest hive-mind consensus --propose "task"
+```
+
+---
+
+## Performance Targets
+
+| Metric | Target | Status |
+|--------|--------|--------|
+| HNSW Search | 150x-12,500x faster | ✅ Implemented |
+| Memory Reduction | 50-75% | ✅ Implemented (3.92x) |
+| SONA Integration | Pattern learning | ✅ Implemented |
+| Flash Attention | 2.49x-7.47x | 🔄 In Progress |
+| MCP Response | <100ms | ✅ Achieved |
+| CLI Startup | <500ms | ✅ Achieved |
+| SONA Adaptation | <0.05ms | 🔄 In Progress |
+| Graph Build (1k) | <200ms | ✅ 2.78ms (71.9x headroom) |
+| PageRank (1k) | <100ms | ✅ 12.21ms (8.2x headroom) |
+| Insight Recording | <5ms/each | ✅ 0.12ms (41x headroom) |
+| Consolidation | <500ms | ✅ 0.26ms (1,955x headroom) |
+| Knowledge Transfer | <100ms | ✅ 1.25ms (80x headroom) |
+
+---
+
+## Integration Ecosystem
+
+### Integrated Packages
+| Package | Version | Purpose |
+|---------|---------|---------|
+| agentic-flow | 3.0.0-alpha.1 | Core coordination + ReasoningBank + Router |
+| agentdb | 3.0.0-alpha.10 | Vector database + 8 controllers |
+| @ruvector/attention | 0.1.3 | Flash attention |
+| @ruvector/sona | 0.1.5 | Neural learning |
+
+### Optional Integrations
+| Package | Command |
+|---------|---------|
+| ruv-swarm | `npx ruv-swarm mcp start` |
+| flow-nexus | `npx flow-nexus@latest mcp start` |
+| agentic-jujutsu | `npx agentic-jujutsu@latest` |
+
+### MCP Server Setup
+```bash
+# Add Ruflo MCP
+claude mcp add ruflo -- npx -y ruflo@latest
+
+# Optional servers
+claude mcp add ruv-swarm -- npx -y ruv-swarm mcp start
+claude mcp add flow-nexus -- npx -y flow-nexus@latest mcp start
+```
+
+---
+
+## Quick Reference
+
+### Essential Commands
+```bash
+# Setup
+npx ruflo@latest init --wizard
+npx ruflo@latest daemon start
+npx ruflo@latest doctor --fix
+
+# Swarm
+npx ruflo@latest swarm init --topology hierarchical --max-agents 8
+npx ruflo@latest swarm status
+
+# Agents
+npx ruflo@latest agent spawn -t coder
+npx ruflo@latest agent list
+
+# Memory
+npx ruflo@latest memory search --query "patterns"
+
+# Hooks
+npx ruflo@latest hooks pre-task --description "task"
+npx ruflo@latest hooks worker dispatch --trigger optimize
+```
+
+### File Structure
+```
+.claude-flow/
+├── config.yaml      # Runtime configuration
+├── CAPABILITIES.md  # This file
+├── data/            # Memory storage
+├── logs/            # Operation logs
+├── sessions/        # Session state
+├── hooks/           # Custom hooks
+├── agents/          # Agent configs
+└── workflows/       # Workflow templates
+```
+
+---
+
+**Full Documentation**: https://github.com/ruvnet/claude-flow
+**Issues**: https://github.com/ruvnet/claude-flow/issues

--- a/.claude-flow/config.yaml
+++ b/.claude-flow/config.yaml
@@ -1,0 +1,43 @@
+# RuFlo V3 Runtime Configuration
+# Generated: 2026-05-30T11:38:35.183Z
+
+version: "3.0.0"
+
+swarm:
+  topology: mesh
+  maxAgents: 5
+  autoScale: true
+  coordinationStrategy: consensus
+
+memory:
+  backend: memory
+  enableHNSW: false
+  persistPath: .claude-flow/data
+  cacheSize: 100
+  # ADR-049: Self-Learning Memory
+  learningBridge:
+    enabled: false
+    sonaMode: balanced
+    confidenceDecayRate: 0.005
+    accessBoostAmount: 0.03
+    consolidationThreshold: 10
+  memoryGraph:
+    enabled: false
+    pageRankDamping: 0.85
+    maxNodes: 5000
+    similarityThreshold: 0.8
+  agentScopes:
+    enabled: false
+    defaultScope: project
+
+neural:
+  enabled: false
+  modelPath: .claude-flow/neural
+
+hooks:
+  enabled: true
+  autoExecute: true
+
+mcp:
+  autoStart: false
+  port: 3000

--- a/.claude/hooks/ruflo-bootstrap.sh
+++ b/.claude/hooks/ruflo-bootstrap.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SessionStart hook: ensure ruflo is initialised in this container.
+#
+# Why this exists: remote-execution containers are ephemeral. The repo carries the *config
+# skeleton* (.mcp.json, .claude/settings.json, .claude/hooks/, .claude-flow/config.yaml),
+# but ruflo's runtime stores (.claude-flow/data/, sessions/, logs/) and the agents/commands/
+# helpers scaffolding are .gitignored and have to be regenerated on each fresh container.
+# This hook does that regeneration idempotently: if the runtime is already present, it's a
+# no-op fast path; otherwise it runs `ruflo init` to recreate everything before the user's
+# first request lands.
+#
+# Output goes to stderr only (so it doesn't pollute hook capture). One "ruflo: ready" line
+# on success, full error block on failure.
+
+set -euo pipefail
+
+# Allow override for testing.
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)}"
+cd "$REPO_ROOT"
+
+log() { printf '[ruflo-bootstrap] %s\n' "$*" >&2; }
+
+# Fast path: ruflo is initialised when both of these are present. Matches the markers
+# ruflo's own "already initialized" check uses (see `ruflo init` output).
+if [[ -f .claude/settings.json && -f .claude-flow/config.yaml ]]; then
+    log "ruflo: ready (cached)"
+    exit 0
+fi
+
+log "ruflo: runtime missing, initialising…"
+
+# npx itself is the typical failure mode. Prefer the in-cache binary if it's still intact
+# (faster, survives the stale-rename `ENOTEMPTY` case where `npx -y` would fight the cache);
+# otherwise fall back to a `--yes` npx that re-fetches.
+RUFLO_CACHED_BIN=""
+for candidate in /root/.npm/_npx/*/node_modules/ruflo/bin/ruflo.js; do
+    if [[ -f "$candidate" ]]; then
+        RUFLO_CACHED_BIN="$candidate"
+        break
+    fi
+done
+
+# ruflo init exits non-zero when it detects an existing init (without --force) — treat that
+# as success because the hook is idempotent by design.
+INIT_EXIT=0
+if [[ -n "$RUFLO_CACHED_BIN" ]]; then
+    log "using cached ruflo at $RUFLO_CACHED_BIN"
+    node "$RUFLO_CACHED_BIN" init --minimal --no-global --skip-claude >&2 || INIT_EXIT=$?
+else
+    log "no cached ruflo; falling back to npx -y ruflo@latest"
+    npx -y ruflo@latest init --minimal --no-global --skip-claude >&2 || INIT_EXIT=$?
+fi
+
+if [[ "$INIT_EXIT" -ne 0 ]] && [[ ! -f .claude-flow/config.yaml ]]; then
+    log "ruflo: init failed (exit $INIT_EXIT) and no config present — escalate"
+    exit "$INIT_EXIT"
+fi
+
+log "ruflo: ready"

--- a/.claude/hooks/ruflo-bootstrap.sh
+++ b/.claude/hooks/ruflo-bootstrap.sh
@@ -33,7 +33,7 @@ log "ruflo: runtime missing, initialising…"
 # (faster, survives the stale-rename `ENOTEMPTY` case where `npx -y` would fight the cache);
 # otherwise fall back to a `--yes` npx that re-fetches.
 RUFLO_CACHED_BIN=""
-for candidate in /root/.npm/_npx/*/node_modules/ruflo/bin/ruflo.js; do
+for candidate in "${HOME:-/root}/.npm/_npx"/*/node_modules/ruflo/bin/ruflo.js; do
     if [[ -f "$candidate" ]]; then
         RUFLO_CACHED_BIN="$candidate"
         break

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,143 @@
+{
+  "statusLine": {
+    "type": "command",
+    "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/statusline.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/statusline.cjs\"'"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(npx @claude-flow*)",
+      "Bash(npx claude-flow*)",
+      "Bash(npx -y ruflo*)",
+      "Bash(node .claude/*)",
+      "Bash(.claude/hooks/*)",
+      "mcp__claude-flow__:*",
+      "mcp__ruflo__:*"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/ruflo-bootstrap.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_FLOW_V3_ENABLED": "true",
+    "CLAUDE_FLOW_HOOKS_ENABLED": "true"
+  },
+  "claudeFlow": {
+    "version": "3.0.0",
+    "enabled": true,
+    "platform": {
+      "os": "linux",
+      "arch": "x64",
+      "shell": "bash"
+    },
+    "modelPreferences": {
+      "default": "claude-opus-4-8",
+      "routing": "claude-haiku-4-5-20251001"
+    },
+    "agentTeams": {
+      "enabled": true,
+      "teammateMode": "auto",
+      "taskListEnabled": true,
+      "mailboxEnabled": true,
+      "coordination": {
+        "autoAssignOnIdle": true,
+        "trainPatternsOnComplete": true,
+        "notifyLeadOnComplete": true,
+        "sharedMemoryNamespace": "agent-teams"
+      },
+      "hooks": {
+        "teammateIdle": {
+          "enabled": true,
+          "autoAssign": true,
+          "checkTaskList": true
+        },
+        "taskCompleted": {
+          "enabled": true,
+          "trainPatterns": true,
+          "notifyLead": true
+        }
+      }
+    },
+    "swarm": {
+      "topology": "mesh",
+      "maxAgents": 5
+    },
+    "memory": {
+      "backend": "memory",
+      "enableHNSW": false,
+      "learningBridge": {
+        "enabled": false
+      },
+      "memoryGraph": {
+        "enabled": false
+      },
+      "agentScopes": {
+        "enabled": false
+      }
+    },
+    "neural": {
+      "enabled": false
+    },
+    "daemon": {
+      "autoStart": false,
+      "workers": [
+        "map",
+        "audit",
+        "optimize"
+      ],
+      "schedules": {
+        "audit": {
+          "interval": "4h",
+          "priority": "critical"
+        },
+        "optimize": {
+          "interval": "2h",
+          "priority": "high"
+        }
+      }
+    },
+    "learning": {
+      "enabled": true,
+      "autoTrain": true,
+      "patterns": [
+        "coordination",
+        "optimization",
+        "prediction"
+      ],
+      "retention": {
+        "shortTerm": "24h",
+        "longTerm": "30d"
+      }
+    },
+    "adr": {
+      "autoGenerate": true,
+      "directory": "/docs/adr",
+      "template": "madr"
+    },
+    "ddd": {
+      "trackDomains": true,
+      "validateBoundedContexts": true,
+      "directory": "/docs/ddd"
+    },
+    "security": {
+      "autoScan": true,
+      "scanOnEdit": true,
+      "cveCheck": true,
+      "threatModel": true
+    }
+  }
+}

--- a/.claude/skills/hooks-automation/SKILL.md
+++ b/.claude/skills/hooks-automation/SKILL.md
@@ -1,0 +1,1201 @@
+---
+name: Hooks Automation
+description: Automated coordination, formatting, and learning from Claude Code operations using intelligent hooks with MCP integration. Includes pre/post task hooks, session management, Git integration, memory coordination, and neural pattern training for enhanced development workflows.
+---
+
+# Hooks Automation
+
+Intelligent automation system that coordinates, validates, and learns from Claude Code operations through hooks integrated with MCP tools and neural pattern training.
+
+## What This Skill Does
+
+This skill provides a comprehensive hook system that automatically manages development operations, coordinates swarm agents, maintains session state, and continuously learns from coding patterns. It enables automated agent assignment, code formatting, performance tracking, and cross-session memory persistence.
+
+**Key Capabilities:**
+- **Pre-Operation Hooks**: Validate, prepare, and auto-assign agents before operations
+- **Post-Operation Hooks**: Format, analyze, and train patterns after operations
+- **Session Management**: Persist state, restore context, generate summaries
+- **Memory Coordination**: Synchronize knowledge across swarm agents
+- **Git Integration**: Automated commit hooks with quality verification
+- **Neural Training**: Continuous learning from successful patterns
+- **MCP Integration**: Seamless coordination with swarm tools
+
+## Prerequisites
+
+**Required:**
+- Claude Flow CLI installed (`npm install -g claude-flow@alpha`)
+- Claude Code with hooks enabled
+- `.claude/settings.json` with hook configurations
+
+**Optional:**
+- MCP servers configured (claude-flow, ruv-swarm, flow-nexus)
+- Git repository for version control
+- Testing framework for quality verification
+
+## Quick Start
+
+### Initialize Hooks System
+
+```bash
+# Initialize with default hooks configuration
+npx claude-flow init --hooks
+```
+
+This creates:
+- `.claude/settings.json` with pre-configured hooks
+- Hook command documentation in `.claude/commands/hooks/`
+- Default hook handlers for common operations
+
+### Basic Hook Usage
+
+```bash
+# Pre-task hook (auto-spawns agents)
+npx claude-flow hook pre-task --description "Implement authentication"
+
+# Post-edit hook (auto-formats and stores in memory)
+npx claude-flow hook post-edit --file "src/auth.js" --memory-key "auth/login"
+
+# Session end hook (saves state and metrics)
+npx claude-flow hook session-end --session-id "dev-session" --export-metrics
+```
+
+---
+
+## Complete Guide
+
+### Available Hooks
+
+#### Pre-Operation Hooks
+
+Hooks that execute BEFORE operations to prepare and validate:
+
+**pre-edit** - Validate and assign agents before file modifications
+```bash
+npx claude-flow hook pre-edit [options]
+
+Options:
+  --file, -f <path>         File path to be edited
+  --auto-assign-agent       Automatically assign best agent (default: true)
+  --validate-syntax         Pre-validate syntax before edit
+  --check-conflicts         Check for merge conflicts
+  --backup-file             Create backup before editing
+
+Examples:
+  npx claude-flow hook pre-edit --file "src/auth/login.js"
+  npx claude-flow hook pre-edit -f "config/db.js" --validate-syntax
+  npx claude-flow hook pre-edit -f "production.env" --backup-file --check-conflicts
+```
+
+**Features:**
+- Auto agent assignment based on file type
+- Syntax validation to prevent broken code
+- Conflict detection for concurrent edits
+- Automatic file backups for safety
+
+**pre-bash** - Check command safety and resource requirements
+```bash
+npx claude-flow hook pre-bash --command <cmd>
+
+Options:
+  --command, -c <cmd>       Command to validate
+  --check-safety            Verify command safety (default: true)
+  --estimate-resources      Estimate resource usage
+  --require-confirmation    Request user confirmation for risky commands
+
+Examples:
+  npx claude-flow hook pre-bash -c "rm -rf /tmp/cache"
+  npx claude-flow hook pre-bash --command "docker build ." --estimate-resources
+```
+
+**Features:**
+- Command safety validation
+- Resource requirement estimation
+- Destructive command confirmation
+- Permission checks
+
+**pre-task** - Auto-spawn agents and prepare for complex tasks
+```bash
+npx claude-flow hook pre-task [options]
+
+Options:
+  --description, -d <text>  Task description for context
+  --auto-spawn-agents       Automatically spawn required agents (default: true)
+  --load-memory             Load relevant memory from previous sessions
+  --optimize-topology       Select optimal swarm topology
+  --estimate-complexity     Analyze task complexity
+
+Examples:
+  npx claude-flow hook pre-task --description "Implement user authentication"
+  npx claude-flow hook pre-task -d "Continue API dev" --load-memory
+  npx claude-flow hook pre-task -d "Refactor codebase" --optimize-topology
+```
+
+**Features:**
+- Automatic agent spawning based on task analysis
+- Memory loading for context continuity
+- Topology optimization for task structure
+- Complexity estimation and time prediction
+
+**pre-search** - Prepare and optimize search operations
+```bash
+npx claude-flow hook pre-search --query <query>
+
+Options:
+  --query, -q <text>        Search query
+  --check-cache             Check cache first (default: true)
+  --optimize-query          Optimize search pattern
+
+Examples:
+  npx claude-flow hook pre-search -q "authentication middleware"
+```
+
+**Features:**
+- Cache checking for faster results
+- Query optimization
+- Search pattern improvement
+
+#### Post-Operation Hooks
+
+Hooks that execute AFTER operations to process and learn:
+
+**post-edit** - Auto-format, validate, and update memory
+```bash
+npx claude-flow hook post-edit [options]
+
+Options:
+  --file, -f <path>         File path that was edited
+  --auto-format             Automatically format code (default: true)
+  --memory-key, -m <key>    Store edit context in memory
+  --train-patterns          Train neural patterns from edit
+  --validate-output         Validate edited file
+
+Examples:
+  npx claude-flow hook post-edit --file "src/components/Button.jsx"
+  npx claude-flow hook post-edit -f "api/auth.js" --memory-key "auth/login"
+  npx claude-flow hook post-edit -f "utils/helpers.ts" --train-patterns
+```
+
+**Features:**
+- Language-specific auto-formatting (Prettier, Black, gofmt)
+- Memory storage for edit context and decisions
+- Neural pattern training for continuous improvement
+- Output validation with linting
+
+**post-bash** - Log execution and update metrics
+```bash
+npx claude-flow hook post-bash --command <cmd>
+
+Options:
+  --command, -c <cmd>       Command that was executed
+  --log-output              Log command output (default: true)
+  --update-metrics          Update performance metrics
+  --store-result            Store result in memory
+
+Examples:
+  npx claude-flow hook post-bash -c "npm test" --update-metrics
+```
+
+**Features:**
+- Command execution logging
+- Performance metric tracking
+- Result storage for analysis
+- Error pattern detection
+
+**post-task** - Performance analysis and decision storage
+```bash
+npx claude-flow hook post-task [options]
+
+Options:
+  --task-id, -t <id>        Task identifier for tracking
+  --analyze-performance     Generate performance metrics (default: true)
+  --store-decisions         Save task decisions to memory
+  --export-learnings        Export neural pattern learnings
+  --generate-report         Create task completion report
+
+Examples:
+  npx claude-flow hook post-task --task-id "auth-implementation"
+  npx claude-flow hook post-task -t "api-refactor" --analyze-performance
+  npx claude-flow hook post-task -t "bug-fix-123" --store-decisions
+```
+
+**Features:**
+- Execution time and token usage measurement
+- Decision and implementation choice recording
+- Neural learning pattern export
+- Completion report generation
+
+**post-search** - Cache results and improve patterns
+```bash
+npx claude-flow hook post-search --query <query> --results <path>
+
+Options:
+  --query, -q <text>        Original search query
+  --results, -r <path>      Results file path
+  --cache-results           Cache for future use (default: true)
+  --train-patterns          Improve search patterns
+
+Examples:
+  npx claude-flow hook post-search -q "auth" -r "results.json" --train-patterns
+```
+
+**Features:**
+- Result caching for faster subsequent searches
+- Search pattern improvement
+- Relevance scoring
+
+#### MCP Integration Hooks
+
+Hooks that coordinate with MCP swarm tools:
+
+**mcp-initialized** - Persist swarm configuration
+```bash
+npx claude-flow hook mcp-initialized --swarm-id <id>
+
+Features:
+- Save swarm topology and configuration
+- Store agent roster in memory
+- Initialize coordination namespace
+```
+
+**agent-spawned** - Update agent roster and memory
+```bash
+npx claude-flow hook agent-spawned --agent-id <id> --type <type>
+
+Features:
+- Register agent in coordination memory
+- Update agent roster
+- Initialize agent-specific memory namespace
+```
+
+**task-orchestrated** - Monitor task progress
+```bash
+npx claude-flow hook task-orchestrated --task-id <id>
+
+Features:
+- Track task progress through memory
+- Monitor agent assignments
+- Update coordination state
+```
+
+**neural-trained** - Save pattern improvements
+```bash
+npx claude-flow hook neural-trained --pattern <name>
+
+Features:
+- Export trained neural patterns
+- Update coordination models
+- Share learning across agents
+```
+
+#### Memory Coordination Hooks
+
+**memory-write** - Triggered when agents write to coordination memory
+```bash
+Features:
+- Validate memory key format
+- Update cross-agent indexes
+- Trigger dependent hooks
+- Notify subscribed agents
+```
+
+**memory-read** - Triggered when agents read from coordination memory
+```bash
+Features:
+- Log access patterns
+- Update popularity metrics
+- Preload related data
+- Track usage statistics
+```
+
+**memory-sync** - Synchronize memory across swarm agents
+```bash
+npx claude-flow hook memory-sync --namespace <ns>
+
+Features:
+- Sync memory state across agents
+- Resolve conflicts
+- Propagate updates
+- Maintain consistency
+```
+
+#### Session Hooks
+
+**session-start** - Initialize new session
+```bash
+npx claude-flow hook session-start --session-id <id>
+
+Options:
+  --session-id, -s <id>     Session identifier
+  --load-context            Load context from previous session
+  --init-agents             Initialize required agents
+
+Features:
+- Create session directory
+- Initialize metrics tracking
+- Load previous context
+- Set up coordination namespace
+```
+
+**session-restore** - Load previous session state
+```bash
+npx claude-flow hook session-restore --session-id <id>
+
+Options:
+  --session-id, -s <id>     Session to restore
+  --restore-memory          Restore memory state (default: true)
+  --restore-agents          Restore agent configurations
+
+Examples:
+  npx claude-flow hook session-restore --session-id "swarm-20241019"
+  npx claude-flow hook session-restore -s "feature-auth" --restore-memory
+```
+
+**Features:**
+- Load previous session context
+- Restore memory state and decisions
+- Reconfigure agents to previous state
+- Resume in-progress tasks
+
+**session-end** - Cleanup and persist session state
+```bash
+npx claude-flow hook session-end [options]
+
+Options:
+  --session-id, -s <id>     Session identifier to end
+  --save-state              Save current session state (default: true)
+  --export-metrics          Export session metrics
+  --generate-summary        Create session summary
+  --cleanup-temp            Remove temporary files
+
+Examples:
+  npx claude-flow hook session-end --session-id "dev-session-2024"
+  npx claude-flow hook session-end -s "feature-auth" --export-metrics --generate-summary
+  npx claude-flow hook session-end -s "quick-fix" --cleanup-temp
+```
+
+**Features:**
+- Save current context and progress
+- Export session metrics (duration, commands, tokens, files)
+- Generate work summary with decisions and next steps
+- Cleanup temporary files and optimize storage
+
+**notify** - Custom notifications with swarm status
+```bash
+npx claude-flow hook notify --message <msg>
+
+Options:
+  --message, -m <text>      Notification message
+  --level <level>           Notification level (info|warning|error)
+  --swarm-status            Include swarm status (default: true)
+  --broadcast               Send to all agents
+
+Examples:
+  npx claude-flow hook notify -m "Task completed" --level info
+  npx claude-flow hook notify -m "Critical error" --level error --broadcast
+```
+
+**Features:**
+- Send notifications to coordination system
+- Include swarm status and metrics
+- Broadcast to all agents
+- Log important events
+
+### Configuration
+
+#### Basic Configuration
+
+Edit `.claude/settings.json` to configure hooks:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^(Write|Edit|MultiEdit)$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow hook pre-edit --file '${tool.params.file_path}' --memory-key 'swarm/editor/current'"
+        }]
+      },
+      {
+        "matcher": "^Bash$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow hook pre-bash --command '${tool.params.command}'"
+        }]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^(Write|Edit|MultiEdit)$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow hook post-edit --file '${tool.params.file_path}' --memory-key 'swarm/editor/complete' --auto-format --train-patterns"
+        }]
+      },
+      {
+        "matcher": "^Bash$",
+        "hooks": [{
+          "type": "command",
+          "command": "npx claude-flow hook post-bash --command '${tool.params.command}' --update-metrics"
+        }]
+      }
+    ]
+  }
+}
+```
+
+#### Advanced Configuration
+
+Complete hook configuration with all features:
+
+```json
+{
+  "hooks": {
+    "enabled": true,
+    "debug": false,
+    "timeout": 5000,
+
+    "PreToolUse": [
+      {
+        "matcher": "^(Write|Edit|MultiEdit)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hook pre-edit --file '${tool.params.file_path}' --auto-assign-agent --validate-syntax",
+            "timeout": 3000,
+            "continueOnError": true
+          }
+        ]
+      },
+      {
+        "matcher": "^Task$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hook pre-task --description '${tool.params.task}' --auto-spawn-agents --load-memory",
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "^Grep$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hook pre-search --query '${tool.params.pattern}' --check-cache"
+          }
+        ]
+      }
+    ],
+
+    "PostToolUse": [
+      {
+        "matcher": "^(Write|Edit|MultiEdit)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hook post-edit --file '${tool.params.file_path}' --memory-key 'edits/${tool.params.file_path}' --auto-format --train-patterns",
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "^Task$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hook post-task --task-id '${result.task_id}' --analyze-performance --store-decisions --export-learnings",
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "^Grep$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hook post-search --query '${tool.params.pattern}' --cache-results --train-patterns"
+          }
+        ]
+      }
+    ],
+
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hook session-start --session-id '${session.id}' --load-context"
+          }
+        ]
+      }
+    ],
+
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hook session-end --session-id '${session.id}' --export-metrics --generate-summary --cleanup-temp"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### Protected File Patterns
+
+Add protection for sensitive files:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^(Write|Edit|MultiEdit)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx claude-flow hook check-protected --file '${tool.params.file_path}'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### Automatic Testing
+
+Run tests after file modifications:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "^Write$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test -f '${tool.params.file_path%.js}.test.js' && npm test '${tool.params.file_path%.js}.test.js'",
+            "continueOnError": true
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### MCP Tool Integration
+
+Hooks automatically integrate with MCP tools for coordination:
+
+#### Pre-Task Hook with Agent Spawning
+
+```javascript
+// Hook command
+npx claude-flow hook pre-task --description "Build REST API"
+
+// Internally calls MCP tools:
+mcp__claude-flow__agent_spawn {
+  type: "backend-dev",
+  capabilities: ["api", "database", "testing"]
+}
+
+mcp__claude-flow__memory_usage {
+  action: "store",
+  key: "swarm/task/api-build/context",
+  namespace: "coordination",
+  value: JSON.stringify({
+    description: "Build REST API",
+    agents: ["backend-dev"],
+    started: Date.now()
+  })
+}
+```
+
+#### Post-Edit Hook with Memory Storage
+
+```javascript
+// Hook command
+npx claude-flow hook post-edit --file "api/auth.js"
+
+// Internally calls MCP tools:
+mcp__claude-flow__memory_usage {
+  action: "store",
+  key: "swarm/edits/api/auth.js",
+  namespace: "coordination",
+  value: JSON.stringify({
+    file: "api/auth.js",
+    timestamp: Date.now(),
+    changes: { added: 45, removed: 12 },
+    formatted: true,
+    linted: true
+  })
+}
+
+mcp__claude-flow__neural_train {
+  pattern_type: "coordination",
+  training_data: { /* edit patterns */ }
+}
+```
+
+#### Session End Hook with State Persistence
+
+```javascript
+// Hook command
+npx claude-flow hook session-end --session-id "dev-2024"
+
+// Internally calls MCP tools:
+mcp__claude-flow__memory_persist {
+  sessionId: "dev-2024"
+}
+
+mcp__claude-flow__swarm_status {
+  swarmId: "current"
+}
+
+// Generates metrics and summary
+```
+
+### Memory Coordination Protocol
+
+All hooks follow a standardized memory coordination pattern:
+
+#### Three-Phase Memory Protocol
+
+**Phase 1: STATUS** - Hook starts
+```javascript
+mcp__claude-flow__memory_usage {
+  action: "store",
+  key: "swarm/hooks/pre-edit/status",
+  namespace: "coordination",
+  value: JSON.stringify({
+    status: "running",
+    hook: "pre-edit",
+    file: "src/auth.js",
+    timestamp: Date.now()
+  })
+}
+```
+
+**Phase 2: PROGRESS** - Hook processes
+```javascript
+mcp__claude-flow__memory_usage {
+  action: "store",
+  key: "swarm/hooks/pre-edit/progress",
+  namespace: "coordination",
+  value: JSON.stringify({
+    progress: 50,
+    action: "validating syntax",
+    file: "src/auth.js"
+  })
+}
+```
+
+**Phase 3: COMPLETE** - Hook finishes
+```javascript
+mcp__claude-flow__memory_usage {
+  action: "store",
+  key: "swarm/hooks/pre-edit/complete",
+  namespace: "coordination",
+  value: JSON.stringify({
+    status: "complete",
+    result: "success",
+    agent_assigned: "backend-dev",
+    syntax_valid: true,
+    backup_created: true
+  })
+}
+```
+
+### Hook Response Format
+
+Hooks return JSON responses to control operation flow:
+
+#### Continue Response
+```json
+{
+  "continue": true,
+  "reason": "All validations passed",
+  "metadata": {
+    "agent_assigned": "backend-dev",
+    "syntax_valid": true,
+    "file": "src/auth.js"
+  }
+}
+```
+
+#### Block Response
+```json
+{
+  "continue": false,
+  "reason": "Protected file - manual review required",
+  "metadata": {
+    "file": ".env.production",
+    "protection_level": "high",
+    "requires": "manual_approval"
+  }
+}
+```
+
+#### Warning Response
+```json
+{
+  "continue": true,
+  "reason": "Syntax valid but complexity high",
+  "warnings": [
+    "Cyclomatic complexity: 15 (threshold: 10)",
+    "Consider refactoring for better maintainability"
+  ],
+  "metadata": {
+    "complexity": 15,
+    "threshold": 10
+  }
+}
+```
+
+### Git Integration
+
+Hooks can integrate with Git operations for quality control:
+
+#### Pre-Commit Hook
+```bash
+# Add to .git/hooks/pre-commit or use husky
+
+#!/bin/bash
+# Run quality checks before commit
+
+# Get staged files
+FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+for FILE in $FILES; do
+  # Run pre-edit hook for validation
+  npx claude-flow hook pre-edit --file "$FILE" --validate-syntax
+
+  if [ $? -ne 0 ]; then
+    echo "Validation failed for $FILE"
+    exit 1
+  fi
+
+  # Run post-edit hook for formatting
+  npx claude-flow hook post-edit --file "$FILE" --auto-format
+done
+
+# Run tests
+npm test
+
+exit $?
+```
+
+#### Post-Commit Hook
+```bash
+# Add to .git/hooks/post-commit
+
+#!/bin/bash
+# Track commit metrics
+
+COMMIT_HASH=$(git rev-parse HEAD)
+COMMIT_MSG=$(git log -1 --pretty=%B)
+
+npx claude-flow hook notify \
+  --message "Commit completed: $COMMIT_MSG" \
+  --level info \
+  --swarm-status
+```
+
+#### Pre-Push Hook
+```bash
+# Add to .git/hooks/pre-push
+
+#!/bin/bash
+# Quality gate before push
+
+# Run full test suite
+npm run test:all
+
+# Run quality checks
+npx claude-flow hook session-end \
+  --generate-report \
+  --export-metrics
+
+# Verify quality thresholds
+TRUTH_SCORE=$(npx claude-flow metrics score --format json | jq -r '.truth_score')
+
+if (( $(echo "$TRUTH_SCORE < 0.95" | bc -l) )); then
+  echo "Truth score below threshold: $TRUTH_SCORE < 0.95"
+  exit 1
+fi
+
+exit 0
+```
+
+### Agent Coordination Workflow
+
+How agents use hooks for coordination:
+
+#### Agent Workflow Example
+
+```bash
+# Agent 1: Backend Developer
+# STEP 1: Pre-task preparation
+npx claude-flow hook pre-task \
+  --description "Implement user authentication API" \
+  --auto-spawn-agents \
+  --load-memory
+
+# STEP 2: Work begins - pre-edit validation
+npx claude-flow hook pre-edit \
+  --file "api/auth.js" \
+  --auto-assign-agent \
+  --validate-syntax
+
+# STEP 3: Edit file (via Claude Code Edit tool)
+# ... code changes ...
+
+# STEP 4: Post-edit processing
+npx claude-flow hook post-edit \
+  --file "api/auth.js" \
+  --memory-key "swarm/backend/auth-api" \
+  --auto-format \
+  --train-patterns
+
+# STEP 5: Notify coordination system
+npx claude-flow hook notify \
+  --message "Auth API implementation complete" \
+  --swarm-status \
+  --broadcast
+
+# STEP 6: Task completion
+npx claude-flow hook post-task \
+  --task-id "auth-api" \
+  --analyze-performance \
+  --store-decisions \
+  --export-learnings
+```
+
+```bash
+# Agent 2: Test Engineer (receives notification)
+# STEP 1: Check memory for API details
+npx claude-flow hook session-restore \
+  --session-id "swarm-current" \
+  --restore-memory
+
+# Memory contains: swarm/backend/auth-api with implementation details
+
+# STEP 2: Generate tests
+npx claude-flow hook pre-task \
+  --description "Write tests for auth API" \
+  --load-memory
+
+# STEP 3: Create test file
+npx claude-flow hook post-edit \
+  --file "api/auth.test.js" \
+  --memory-key "swarm/testing/auth-api-tests" \
+  --train-patterns
+
+# STEP 4: Share test results
+npx claude-flow hook notify \
+  --message "Auth API tests complete - 100% coverage" \
+  --broadcast
+```
+
+### Custom Hook Creation
+
+Create custom hooks for specific workflows:
+
+#### Custom Hook Template
+
+```javascript
+// .claude/hooks/custom-quality-check.js
+
+module.exports = {
+  name: 'custom-quality-check',
+  type: 'pre',
+  matcher: /\.(ts|js)$/,
+
+  async execute(context) {
+    const { file, content } = context;
+
+    // Custom validation logic
+    const complexity = await analyzeComplexity(content);
+    const securityIssues = await scanSecurity(content);
+
+    // Store in memory
+    await storeInMemory({
+      key: `quality/${file}`,
+      value: { complexity, securityIssues }
+    });
+
+    // Return decision
+    if (complexity > 15 || securityIssues.length > 0) {
+      return {
+        continue: false,
+        reason: 'Quality checks failed',
+        warnings: [
+          `Complexity: ${complexity} (max: 15)`,
+          `Security issues: ${securityIssues.length}`
+        ]
+      };
+    }
+
+    return {
+      continue: true,
+      reason: 'Quality checks passed',
+      metadata: { complexity, securityIssues: 0 }
+    };
+  }
+};
+```
+
+#### Register Custom Hook
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^(Write|Edit)$",
+        "hooks": [
+          {
+            "type": "script",
+            "script": ".claude/hooks/custom-quality-check.js"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Real-World Examples
+
+#### Example 1: Full-Stack Development Workflow
+
+```bash
+# Session start - initialize coordination
+npx claude-flow hook session-start --session-id "fullstack-feature"
+
+# Pre-task planning
+npx claude-flow hook pre-task \
+  --description "Build user profile feature - frontend + backend + tests" \
+  --auto-spawn-agents \
+  --optimize-topology
+
+# Backend work
+npx claude-flow hook pre-edit --file "api/profile.js"
+# ... implement backend ...
+npx claude-flow hook post-edit \
+  --file "api/profile.js" \
+  --memory-key "profile/backend" \
+  --train-patterns
+
+# Frontend work (reads backend details from memory)
+npx claude-flow hook pre-edit --file "components/Profile.jsx"
+# ... implement frontend ...
+npx claude-flow hook post-edit \
+  --file "components/Profile.jsx" \
+  --memory-key "profile/frontend" \
+  --train-patterns
+
+# Testing (reads both backend and frontend from memory)
+npx claude-flow hook pre-task \
+  --description "Test profile feature" \
+  --load-memory
+
+# Session end - export everything
+npx claude-flow hook session-end \
+  --session-id "fullstack-feature" \
+  --export-metrics \
+  --generate-summary
+```
+
+#### Example 2: Debugging with Hooks
+
+```bash
+# Start debugging session
+npx claude-flow hook session-start --session-id "debug-memory-leak"
+
+# Pre-task: analyze issue
+npx claude-flow hook pre-task \
+  --description "Debug memory leak in event handlers" \
+  --load-memory \
+  --estimate-complexity
+
+# Search for event emitters
+npx claude-flow hook pre-search --query "EventEmitter"
+# ... search executes ...
+npx claude-flow hook post-search \
+  --query "EventEmitter" \
+  --cache-results
+
+# Fix the issue
+npx claude-flow hook pre-edit \
+  --file "services/events.js" \
+  --backup-file
+# ... fix code ...
+npx claude-flow hook post-edit \
+  --file "services/events.js" \
+  --memory-key "debug/memory-leak-fix" \
+  --validate-output
+
+# Verify fix
+npx claude-flow hook post-task \
+  --task-id "memory-leak-fix" \
+  --analyze-performance \
+  --generate-report
+
+# End session
+npx claude-flow hook session-end \
+  --session-id "debug-memory-leak" \
+  --export-metrics
+```
+
+#### Example 3: Multi-Agent Refactoring
+
+```bash
+# Initialize swarm for refactoring
+npx claude-flow hook pre-task \
+  --description "Refactor legacy codebase to modern patterns" \
+  --auto-spawn-agents \
+  --optimize-topology
+
+# Agent 1: Code Analyzer
+npx claude-flow hook pre-task --description "Analyze code complexity"
+# ... analysis ...
+npx claude-flow hook post-task \
+  --task-id "analysis" \
+  --store-decisions
+
+# Agent 2: Refactoring (reads analysis from memory)
+npx claude-flow hook session-restore \
+  --session-id "swarm-refactor" \
+  --restore-memory
+
+for file in src/**/*.js; do
+  npx claude-flow hook pre-edit --file "$file" --backup-file
+  # ... refactor ...
+  npx claude-flow hook post-edit \
+    --file "$file" \
+    --memory-key "refactor/$file" \
+    --auto-format \
+    --train-patterns
+done
+
+# Agent 3: Testing (reads refactored code from memory)
+npx claude-flow hook pre-task \
+  --description "Generate tests for refactored code" \
+  --load-memory
+
+# Broadcast completion
+npx claude-flow hook notify \
+  --message "Refactoring complete - all tests passing" \
+  --broadcast
+```
+
+### Performance Tips
+
+1. **Keep Hooks Lightweight** - Target < 100ms execution time
+2. **Use Async for Heavy Operations** - Don't block the main flow
+3. **Cache Aggressively** - Store frequently accessed data
+4. **Batch Related Operations** - Combine multiple actions
+5. **Use Memory Wisely** - Set appropriate TTLs
+6. **Monitor Hook Performance** - Track execution times
+7. **Parallelize When Possible** - Run independent hooks concurrently
+
+### Debugging Hooks
+
+Enable debug mode for troubleshooting:
+
+```bash
+# Enable debug output
+export CLAUDE_FLOW_DEBUG=true
+
+# Test specific hook with verbose output
+npx claude-flow hook pre-edit --file "test.js" --debug
+
+# Check hook execution logs
+cat .claude-flow/logs/hooks-$(date +%Y-%m-%d).log
+
+# Validate configuration
+npx claude-flow hook validate-config
+```
+
+### Benefits
+
+- **Automatic Agent Assignment**: Right agent for every file type
+- **Consistent Code Formatting**: Language-specific formatters
+- **Continuous Learning**: Neural patterns improve over time
+- **Cross-Session Memory**: Context persists between sessions
+- **Performance Tracking**: Comprehensive metrics and analytics
+- **Automatic Coordination**: Agents sync via memory
+- **Smart Agent Spawning**: Task-based agent selection
+- **Quality Gates**: Pre-commit validation and verification
+- **Error Prevention**: Syntax validation before edits
+- **Knowledge Sharing**: Decisions stored and shared
+- **Reduced Manual Work**: Automation of repetitive tasks
+- **Better Collaboration**: Seamless multi-agent coordination
+
+### Best Practices
+
+1. **Configure Hooks Early** - Set up during project initialization
+2. **Use Memory Keys Strategically** - Organize with clear namespaces
+3. **Enable Auto-Formatting** - Maintain code consistency
+4. **Train Patterns Continuously** - Learn from successful operations
+5. **Monitor Performance** - Track hook execution times
+6. **Validate Configuration** - Test hooks before production use
+7. **Document Custom Hooks** - Maintain hook documentation
+8. **Set Appropriate Timeouts** - Prevent hanging operations
+9. **Handle Errors Gracefully** - Use continueOnError when appropriate
+10. **Review Metrics Regularly** - Optimize based on usage patterns
+
+### Troubleshooting
+
+#### Hooks Not Executing
+- Verify `.claude/settings.json` syntax
+- Check hook matcher patterns
+- Enable debug mode
+- Review permission settings
+- Ensure claude-flow CLI is in PATH
+
+#### Hook Timeouts
+- Increase timeout values in configuration
+- Make hooks asynchronous for heavy operations
+- Optimize hook logic
+- Check network connectivity for MCP tools
+
+#### Memory Issues
+- Set appropriate TTLs for memory keys
+- Clean up old memory entries
+- Use memory namespaces effectively
+- Monitor memory usage
+
+#### Performance Problems
+- Profile hook execution times
+- Use caching for repeated operations
+- Batch operations when possible
+- Reduce hook complexity
+
+### Related Commands
+
+- `npx claude-flow init --hooks` - Initialize hooks system
+- `npx claude-flow hook --list` - List available hooks
+- `npx claude-flow hook --test <hook>` - Test specific hook
+- `npx claude-flow memory usage` - Manage memory
+- `npx claude-flow agent spawn` - Spawn agents
+- `npx claude-flow swarm init` - Initialize swarm
+
+### Integration with Other Skills
+
+This skill works seamlessly with:
+- **SPARC Methodology** - Hooks enhance SPARC workflows
+- **Pair Programming** - Automated quality in pairing sessions
+- **Verification Quality** - Truth-score validation in hooks
+- **GitHub Workflows** - Git integration for commits/PRs
+- **Performance Analysis** - Metrics collection in hooks
+- **Swarm Advanced** - Multi-agent coordination via hooks

--- a/.claude/skills/pair-programming/SKILL.md
+++ b/.claude/skills/pair-programming/SKILL.md
@@ -1,0 +1,1202 @@
+---
+name: Pair Programming
+description: AI-assisted pair programming with multiple modes (driver/navigator/switch), real-time verification, quality monitoring, and comprehensive testing. Supports TDD, debugging, refactoring, and learning sessions. Features automatic role switching, continuous code review, security scanning, and performance optimization with truth-score verification.
+---
+
+# Pair Programming
+
+Collaborative AI pair programming with intelligent role management, real-time quality monitoring, and comprehensive development workflows.
+
+## What This Skill Does
+
+This skill provides professional pair programming capabilities with AI assistance, supporting multiple collaboration modes, continuous verification, and integrated testing. It manages driver/navigator roles, performs real-time code review, tracks quality metrics, and ensures high standards through truth-score verification.
+
+**Key Capabilities:**
+- **Multiple Modes**: Driver, Navigator, Switch, TDD, Review, Mentor, Debug
+- **Real-Time Verification**: Automatic quality scoring with rollback on failures
+- **Role Management**: Seamless switching between driver/navigator roles
+- **Testing Integration**: Auto-generate tests, track coverage, continuous testing
+- **Code Review**: Security scanning, performance analysis, best practice enforcement
+- **Session Persistence**: Auto-save, recovery, export, and sharing
+
+## Prerequisites
+
+**Required:**
+- Claude Flow CLI installed (`npm install -g claude-flow@alpha`)
+- Git repository (optional but recommended)
+
+**Recommended:**
+- Testing framework (Jest, pytest, etc.)
+- Linter configured (ESLint, pylint, etc.)
+- Code formatter (Prettier, Black, etc.)
+
+## Quick Start
+
+### Basic Session
+```bash
+# Start simple pair programming
+claude-flow pair --start
+```
+
+### TDD Session
+```bash
+# Test-driven development
+claude-flow pair --start \
+  --mode tdd \
+  --test-first \
+  --coverage 90
+```
+
+---
+
+## Complete Guide
+
+### Session Control Commands
+
+#### Starting Sessions
+```bash
+# Basic start
+claude-flow pair --start
+
+# Expert refactoring session
+claude-flow pair --start \
+  --agent senior-dev \
+  --focus refactor \
+  --verify \
+  --threshold 0.98
+
+# Debugging session
+claude-flow pair --start \
+  --agent debugger-expert \
+  --focus debug \
+  --review
+
+# Learning session
+claude-flow pair --start \
+  --mode mentor \
+  --pace slow \
+  --examples
+```
+
+#### Session Management
+```bash
+# Check status
+claude-flow pair --status
+
+# View history
+claude-flow pair --history
+
+# Pause session
+/pause [--reason <reason>]
+
+# Resume session
+/resume
+
+# End session
+claude-flow pair --end [--save] [--report]
+```
+
+### Available Modes
+
+#### Driver Mode
+You write code while AI provides guidance.
+
+```bash
+claude-flow pair --start --mode driver
+```
+
+**Your Responsibilities:**
+- Write actual code
+- Implement solutions
+- Make immediate decisions
+- Handle syntax and structure
+
+**AI Navigator:**
+- Strategic guidance
+- Spot potential issues
+- Suggest improvements
+- Real-time review
+- Track overall direction
+
+**Best For:**
+- Learning new patterns
+- Implementing familiar features
+- Quick iterations
+- Hands-on debugging
+
+**Commands:**
+```
+/suggest     - Get implementation suggestions
+/review      - Request code review
+/explain     - Ask for explanations
+/optimize    - Request optimization ideas
+/patterns    - Get pattern recommendations
+```
+
+#### Navigator Mode
+AI writes code while you provide direction.
+
+```bash
+claude-flow pair --start --mode navigator
+```
+
+**Your Responsibilities:**
+- Provide high-level direction
+- Review generated code
+- Make architectural decisions
+- Ensure business requirements
+
+**AI Driver:**
+- Write implementation code
+- Handle syntax details
+- Implement your guidance
+- Manage boilerplate
+- Execute refactoring
+
+**Best For:**
+- Rapid prototyping
+- Boilerplate generation
+- Learning from AI patterns
+- Exploring solutions
+
+**Commands:**
+```
+/implement   - Direct implementation
+/refactor    - Request refactoring
+/test        - Generate tests
+/document    - Add documentation
+/alternate   - See alternative approaches
+```
+
+#### Switch Mode
+Automatically alternates roles at intervals.
+
+```bash
+# Default 10-minute intervals
+claude-flow pair --start --mode switch
+
+# 5-minute intervals (rapid)
+claude-flow pair --start --mode switch --interval 5m
+
+# 15-minute intervals (deep focus)
+claude-flow pair --start --mode switch --interval 15m
+```
+
+**Handoff Process:**
+1. 30-second warning before switch
+2. Current driver completes thought
+3. Context summary generated
+4. Roles swap smoothly
+5. New driver continues
+
+**Best For:**
+- Balanced collaboration
+- Knowledge sharing
+- Complex features
+- Extended sessions
+
+#### Specialized Modes
+
+**TDD Mode** - Test-Driven Development:
+```bash
+claude-flow pair --start \
+  --mode tdd \
+  --test-first \
+  --coverage 100
+```
+Workflow: Write failing test → Implement → Refactor → Repeat
+
+**Review Mode** - Continuous code review:
+```bash
+claude-flow pair --start \
+  --mode review \
+  --strict \
+  --security
+```
+Features: Real-time feedback, security scanning, performance analysis
+
+**Mentor Mode** - Learning-focused:
+```bash
+claude-flow pair --start \
+  --mode mentor \
+  --explain-all \
+  --pace slow
+```
+Features: Detailed explanations, step-by-step guidance, pattern teaching
+
+**Debug Mode** - Problem-solving:
+```bash
+claude-flow pair --start \
+  --mode debug \
+  --verbose \
+  --trace
+```
+Features: Issue identification, root cause analysis, fix suggestions
+
+### In-Session Commands
+
+#### Code Commands
+```
+/explain [--level basic|detailed|expert]
+  Explain the current code or selection
+
+/suggest [--type refactor|optimize|security|style]
+  Get improvement suggestions
+
+/implement <description>
+  Request implementation (navigator mode)
+
+/refactor [--pattern <pattern>] [--scope function|file|module]
+  Refactor selected code
+
+/optimize [--target speed|memory|both]
+  Optimize code for performance
+
+/document [--format jsdoc|markdown|inline]
+  Add documentation to code
+
+/comment [--verbose]
+  Add inline comments
+
+/pattern <pattern-name> [--example]
+  Apply a design pattern
+```
+
+#### Testing Commands
+```
+/test [--watch] [--coverage] [--only <pattern>]
+  Run test suite
+
+/test-gen [--type unit|integration|e2e]
+  Generate tests for current code
+
+/coverage [--report html|json|terminal]
+  Check test coverage
+
+/mock <target> [--realistic]
+  Generate mock data or functions
+
+/test-watch [--on-save]
+  Enable test watching
+
+/snapshot [--update]
+  Create test snapshots
+```
+
+#### Review Commands
+```
+/review [--scope current|file|changes] [--strict]
+  Perform code review
+
+/security [--deep] [--fix]
+  Security analysis
+
+/perf [--profile] [--suggestions]
+  Performance analysis
+
+/quality [--detailed]
+  Check code quality metrics
+
+/lint [--fix] [--config <config>]
+  Run linters
+
+/complexity [--threshold <value>]
+  Analyze code complexity
+```
+
+#### Navigation Commands
+```
+/goto <file>[:line[:column]]
+  Navigate to file or location
+
+/find <pattern> [--regex] [--case-sensitive]
+  Search in project
+
+/recent [--limit <n>]
+  Show recent files
+
+/bookmark [add|list|goto|remove] [<name>]
+  Manage bookmarks
+
+/history [--limit <n>] [--filter <pattern>]
+  Show command history
+
+/tree [--depth <n>] [--filter <pattern>]
+  Show project structure
+```
+
+#### Git Commands
+```
+/diff [--staged] [--file <file>]
+  Show git diff
+
+/commit [--message <msg>] [--amend]
+  Commit with verification
+
+/branch [create|switch|delete|list] [<name>]
+  Branch operations
+
+/stash [save|pop|list|apply] [<message>]
+  Stash operations
+
+/log [--oneline] [--limit <n>]
+  View git log
+
+/blame [<file>]
+  Show git blame
+```
+
+#### AI Partner Commands
+```
+/agent [switch|info|config] [<agent-name>]
+  Manage AI agent
+
+/teach <preference>
+  Teach the AI your preferences
+
+/feedback [positive|negative] <message>
+  Provide feedback to AI
+
+/personality [professional|friendly|concise|verbose]
+  Adjust AI personality
+
+/expertise [add|remove|list] [<domain>]
+  Set AI expertise focus
+```
+
+#### Metrics Commands
+```
+/metrics [--period today|session|week|all]
+  Show session metrics
+
+/score [--breakdown]
+  Show quality scores
+
+/productivity [--chart]
+  Show productivity metrics
+
+/leaderboard [--personal|team]
+  Show improvement leaderboard
+```
+
+#### Role & Mode Commands
+```
+/switch [--immediate]
+  Switch driver/navigator roles
+
+/mode <type>
+  Change mode (driver|navigator|switch|tdd|review|mentor|debug)
+
+/role
+  Show current role
+
+/handoff
+  Prepare role handoff
+```
+
+### Command Shortcuts
+
+| Alias | Full Command |
+|-------|-------------|
+| `/s` | `/suggest` |
+| `/e` | `/explain` |
+| `/t` | `/test` |
+| `/r` | `/review` |
+| `/c` | `/commit` |
+| `/g` | `/goto` |
+| `/f` | `/find` |
+| `/h` | `/help` |
+| `/sw` | `/switch` |
+| `/st` | `/status` |
+
+### Configuration
+
+#### Basic Configuration
+Create `.claude-flow/pair-config.json`:
+
+```json
+{
+  "pair": {
+    "enabled": true,
+    "defaultMode": "switch",
+    "defaultAgent": "auto",
+    "autoStart": false,
+    "theme": "professional"
+  }
+}
+```
+
+#### Complete Configuration
+
+```json
+{
+  "pair": {
+    "general": {
+      "enabled": true,
+      "defaultMode": "switch",
+      "defaultAgent": "senior-dev",
+      "language": "javascript",
+      "timezone": "UTC"
+    },
+
+    "modes": {
+      "driver": {
+        "enabled": true,
+        "suggestions": true,
+        "realTimeReview": true,
+        "autoComplete": false
+      },
+      "navigator": {
+        "enabled": true,
+        "codeGeneration": true,
+        "explanations": true,
+        "alternatives": true
+      },
+      "switch": {
+        "enabled": true,
+        "interval": "10m",
+        "warning": "30s",
+        "autoSwitch": true,
+        "pauseOnIdle": true
+      }
+    },
+
+    "verification": {
+      "enabled": true,
+      "threshold": 0.95,
+      "autoRollback": true,
+      "preCommitCheck": true,
+      "continuousMonitoring": true,
+      "blockOnFailure": true
+    },
+
+    "testing": {
+      "enabled": true,
+      "autoRun": true,
+      "framework": "jest",
+      "onSave": true,
+      "coverage": {
+        "enabled": true,
+        "minimum": 80,
+        "enforce": true,
+        "reportFormat": "html"
+      }
+    },
+
+    "review": {
+      "enabled": true,
+      "continuous": true,
+      "preCommit": true,
+      "security": true,
+      "performance": true,
+      "style": true,
+      "complexity": {
+        "maxComplexity": 10,
+        "maxDepth": 4,
+        "maxLines": 100
+      }
+    },
+
+    "git": {
+      "enabled": true,
+      "autoCommit": false,
+      "commitTemplate": "feat: {message}",
+      "signCommits": false,
+      "pushOnEnd": false,
+      "branchProtection": true
+    },
+
+    "session": {
+      "autoSave": true,
+      "saveInterval": "5m",
+      "maxDuration": "4h",
+      "idleTimeout": "15m",
+      "breakReminder": "45m",
+      "metricsInterval": "1m"
+    },
+
+    "ai": {
+      "model": "advanced",
+      "temperature": 0.7,
+      "maxTokens": 4000,
+      "personality": "professional",
+      "expertise": ["backend", "testing", "security"],
+      "learningEnabled": true
+    }
+  }
+}
+```
+
+#### Built-in Agents
+
+```json
+{
+  "agents": {
+    "senior-dev": {
+      "expertise": ["architecture", "patterns", "optimization"],
+      "style": "thorough",
+      "reviewLevel": "strict"
+    },
+    "tdd-specialist": {
+      "expertise": ["testing", "mocks", "coverage"],
+      "style": "test-first",
+      "reviewLevel": "comprehensive"
+    },
+    "debugger-expert": {
+      "expertise": ["debugging", "profiling", "tracing"],
+      "style": "analytical",
+      "reviewLevel": "focused"
+    },
+    "junior-dev": {
+      "expertise": ["learning", "basics", "documentation"],
+      "style": "questioning",
+      "reviewLevel": "educational"
+    }
+  }
+}
+```
+
+#### CLI Configuration
+```bash
+# Set configuration
+claude-flow pair config set defaultMode switch
+claude-flow pair config set verification.threshold 0.98
+
+# Get configuration
+claude-flow pair config get
+claude-flow pair config get defaultMode
+
+# Export/Import
+claude-flow pair config export > config.json
+claude-flow pair config import config.json
+
+# Reset
+claude-flow pair config reset
+```
+
+#### Profile Management
+
+Create reusable profiles:
+
+```bash
+# Create profile
+claude-flow pair profile create refactoring \
+  --mode driver \
+  --verify true \
+  --threshold 0.98 \
+  --focus refactor
+
+# Use profile
+claude-flow pair --start --profile refactoring
+
+# List profiles
+claude-flow pair profile list
+```
+
+Profile configuration:
+```json
+{
+  "profiles": {
+    "refactoring": {
+      "mode": "driver",
+      "verification": {
+        "enabled": true,
+        "threshold": 0.98
+      },
+      "focus": "refactor"
+    },
+    "debugging": {
+      "mode": "navigator",
+      "agent": "debugger-expert",
+      "trace": true,
+      "verbose": true
+    },
+    "learning": {
+      "mode": "mentor",
+      "pace": "slow",
+      "explanations": "detailed",
+      "examples": true
+    }
+  }
+}
+```
+
+### Real-World Examples
+
+#### Example 1: Feature Implementation
+
+Implementing user authentication with JWT tokens:
+
+```bash
+# Session setup
+claude-flow pair --start \
+  --mode switch \
+  --agent senior-dev \
+  --focus implement \
+  --verify \
+  --test
+```
+
+**Session Flow:**
+```
+👥 Starting pair programming for authentication feature...
+
+[DRIVER: You - 10 minutes]
+/explain JWT authentication flow
+> AI explains JWT concepts and best practices
+
+/suggest implementation approach
+> AI suggests using middleware pattern with refresh tokens
+
+# You write the basic auth middleware structure
+
+[SWITCH TO NAVIGATOR]
+
+[NAVIGATOR: AI - 10 minutes]
+/implement JWT token generation with refresh tokens
+> AI generates secure token implementation
+
+/test-gen
+> AI creates comprehensive test suite
+
+[SWITCH TO DRIVER]
+
+[DRIVER: You - 10 minutes]
+# You refine the implementation
+/review --security
+> AI performs security review, suggests improvements
+
+/commit --message "feat: JWT authentication with refresh tokens"
+✅ Truth Score: 0.98 - Committed successfully
+```
+
+#### Example 2: Bug Fixing
+
+Debugging a memory leak in Node.js:
+
+```bash
+# Session setup
+claude-flow pair --start \
+  --mode navigator \
+  --agent debugger-expert \
+  --focus debug \
+  --trace
+```
+
+**Session Flow:**
+```
+👥 Starting debugging session...
+
+/status
+> Analyzing application for memory issues...
+
+/perf --profile
+> Memory usage growing: 150MB → 450MB over 10 minutes
+
+/find "new EventEmitter" --regex
+> Found 3 instances of EventEmitter creation
+
+/inspect eventEmitters --deep
+> Discovering listeners not being removed
+
+/suggest fix for memory leak
+> AI suggests: "Add removeListener in cleanup functions"
+
+/implement cleanup functions for all event emitters
+> AI generates proper cleanup code
+
+/test
+> Memory stable at 150MB ✅
+
+/commit --message "fix: memory leak in event emitters"
+```
+
+#### Example 3: TDD Session
+
+Building shopping cart with test-driven development:
+
+```bash
+# Session setup
+claude-flow pair --start \
+  --mode tdd \
+  --agent tdd-specialist \
+  --test-first
+```
+
+**Session Flow:**
+```
+👥 TDD Session: Shopping Cart Feature
+
+[RED PHASE]
+/test-gen "add item to cart"
+> AI writes failing test:
+  ✗ should add item to cart
+  ✗ should update quantity for existing item
+  ✗ should calculate total price
+
+[GREEN PHASE]
+/implement minimal cart functionality
+> You write just enough code to pass tests
+
+/test
+> Tests passing: 3/3 ✅
+
+[REFACTOR PHASE]
+/refactor --pattern repository
+> AI refactors to repository pattern
+
+/test
+> Tests still passing: 3/3 ✅
+
+[NEXT CYCLE]
+/test-gen "remove item from cart"
+> AI writes new failing tests...
+```
+
+#### Example 4: Code Refactoring
+
+Modernizing legacy code:
+
+```bash
+# Session setup
+claude-flow pair --start \
+  --mode driver \
+  --focus refactor \
+  --verify \
+  --threshold 0.98
+```
+
+**Session Flow:**
+```
+👥 Refactoring Session: Modernizing UserService
+
+/analyze UserService.js
+> AI identifies:
+  - Callback hell (5 levels deep)
+  - No error handling
+  - Tight coupling
+  - No tests
+
+/suggest refactoring plan
+> AI suggests:
+  1. Convert callbacks to async/await
+  2. Add error boundaries
+  3. Extract dependencies
+  4. Add unit tests
+
+/test-gen --before-refactor
+> AI generates tests for current behavior
+
+/refactor callbacks to async/await
+# You refactor with AI guidance
+
+/test
+> All tests passing ✅
+
+/review --compare
+> AI shows before/after comparison
+> Code complexity: 35 → 12
+> Truth score: 0.99 ✅
+
+/commit --message "refactor: modernize UserService with async/await"
+```
+
+#### Example 5: Performance Optimization
+
+Optimizing slow React application:
+
+```bash
+# Session setup
+claude-flow pair --start \
+  --mode switch \
+  --agent performance-expert \
+  --focus optimize \
+  --profile
+```
+
+**Session Flow:**
+```
+👥 Performance Optimization Session
+
+/perf --profile
+> React DevTools Profiler Results:
+  - ProductList: 450ms render
+  - CartSummary: 200ms render
+  - Unnecessary re-renders: 15
+
+/suggest optimizations for ProductList
+> AI suggests:
+  1. Add React.memo
+  2. Use useMemo for expensive calculations
+  3. Implement virtualization for long lists
+
+/implement React.memo and useMemo
+# You implement with AI guidance
+
+/perf --profile
+> ProductList: 45ms render (90% improvement!) ✅
+
+/implement virtualization with react-window
+> AI implements virtual scrolling
+
+/perf --profile
+> ProductList: 12ms render (97% improvement!) ✅
+> FPS: 60 stable ✅
+
+/commit --message "perf: optimize ProductList with memoization and virtualization"
+```
+
+#### Example 6: API Development
+
+Building RESTful API with Express:
+
+```bash
+# Session setup
+claude-flow pair --start \
+  --mode navigator \
+  --agent backend-expert \
+  --focus implement \
+  --test
+```
+
+**Session Flow:**
+```
+👥 API Development Session
+
+/design REST API for blog platform
+> AI designs endpoints:
+  POST   /api/posts
+  GET    /api/posts
+  GET    /api/posts/:id
+  PUT    /api/posts/:id
+  DELETE /api/posts/:id
+
+/implement CRUD endpoints with validation
+> AI implements with Express + Joi validation
+
+/test-gen --integration
+> AI generates integration tests
+
+/security --api
+> AI adds:
+  - Rate limiting
+  - Input sanitization
+  - JWT authentication
+  - CORS configuration
+
+/document --openapi
+> AI generates OpenAPI documentation
+
+/test --integration
+> All endpoints tested: 15/15 ✅
+```
+
+### Session Templates
+
+#### Quick Start Templates
+
+```bash
+# Refactoring template
+claude-flow pair --template refactor
+# Focus: Code improvement
+# Verification: High (0.98)
+# Testing: After each change
+# Review: Continuous
+
+# Feature template
+claude-flow pair --template feature
+# Focus: Implementation
+# Verification: Standard (0.95)
+# Testing: On completion
+# Review: Pre-commit
+
+# Debug template
+claude-flow pair --template debug
+# Focus: Problem solving
+# Verification: Moderate (0.90)
+# Testing: Regression tests
+# Review: Root cause
+
+# Learning template
+claude-flow pair --template learn
+# Mode: Mentor
+# Pace: Slow
+# Explanations: Detailed
+# Examples: Many
+```
+
+### Session Management
+
+#### Session Status
+
+```bash
+claude-flow pair --status
+```
+
+**Output:**
+```
+👥 Pair Programming Session
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Session ID: pair_1755021234567
+Duration: 45 minutes
+Status: Active
+
+Partner: senior-dev
+Current Role: DRIVER (you)
+Mode: Switch (10m intervals)
+Next Switch: in 3 minutes
+
+📊 Metrics:
+├── Truth Score: 0.982 ✅
+├── Lines Changed: 234
+├── Files Modified: 5
+├── Tests Added: 12
+├── Coverage: 87% ↑3%
+└── Commits: 3
+
+🎯 Focus: Implementation
+📝 Current File: src/auth/login.js
+```
+
+#### Session History
+
+```bash
+claude-flow pair --history
+```
+
+**Output:**
+```
+📚 Session History
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. 2024-01-15 14:30 - 16:45 (2h 15m)
+   Partner: expert-coder
+   Focus: Refactoring
+   Truth Score: 0.975
+   Changes: +340 -125 lines
+
+2. 2024-01-14 10:00 - 11:30 (1h 30m)
+   Partner: tdd-specialist
+   Focus: Testing
+   Truth Score: 0.991
+   Tests Added: 24
+
+3. 2024-01-13 15:00 - 17:00 (2h)
+   Partner: debugger-expert
+   Focus: Bug Fixing
+   Truth Score: 0.968
+   Issues Fixed: 5
+```
+
+#### Session Persistence
+
+```bash
+# Save session
+claude-flow pair --save [--name <name>]
+
+# Load session
+claude-flow pair --load <session-id>
+
+# Export session
+claude-flow pair --export <session-id> [--format json|md]
+
+# Generate report
+claude-flow pair --report <session-id>
+```
+
+#### Background Sessions
+
+```bash
+# Start in background
+claude-flow pair --start --background
+
+# Monitor background session
+claude-flow pair --monitor
+
+# Attach to background session
+claude-flow pair --attach <session-id>
+
+# End background session
+claude-flow pair --end <session-id>
+```
+
+### Advanced Features
+
+#### Custom Commands
+
+Define in configuration:
+
+```json
+{
+  "customCommands": {
+    "tdd": "/test-gen && /test --watch",
+    "full-review": "/lint --fix && /test && /review --strict",
+    "quick-fix": "/suggest --type fix && /implement && /test"
+  }
+}
+```
+
+Use custom commands:
+```
+/custom tdd
+/custom full-review
+```
+
+#### Command Chaining
+
+```
+/test && /commit && /push
+/lint --fix && /test && /review --strict
+```
+
+#### Session Recording
+
+```bash
+# Start with recording
+claude-flow pair --start --record
+
+# Replay session
+claude-flow pair --replay <session-id>
+
+# Session analytics
+claude-flow pair --analytics <session-id>
+```
+
+#### Integration Options
+
+**With Git:**
+```bash
+claude-flow pair --start --git --auto-commit
+```
+
+**With CI/CD:**
+```bash
+claude-flow pair --start --ci --non-interactive
+```
+
+**With IDE:**
+```bash
+claude-flow pair --start --ide vscode
+```
+
+### Best Practices
+
+#### Session Practices
+1. **Clear Goals** - Define session objectives upfront
+2. **Appropriate Mode** - Choose based on task type
+3. **Enable Verification** - For critical code paths
+4. **Regular Testing** - Maintain quality continuously
+5. **Session Notes** - Document important decisions
+6. **Regular Breaks** - Take breaks every 45-60 minutes
+
+#### Code Practices
+1. **Test Early** - Run tests after each change
+2. **Verify Before Commit** - Check truth scores
+3. **Review Security** - Always for sensitive code
+4. **Profile Performance** - Use `/perf` for optimization
+5. **Save Sessions** - For complex work
+6. **Learn from AI** - Ask questions frequently
+
+#### Mode Selection
+- **Driver Mode**: When learning, controlling implementation
+- **Navigator Mode**: For rapid prototyping, generation
+- **Switch Mode**: Long sessions, balanced collaboration
+- **TDD Mode**: Building with tests
+- **Review Mode**: Quality focus
+- **Mentor Mode**: Learning priority
+- **Debug Mode**: Fixing issues
+
+### Troubleshooting
+
+#### Session Won't Start
+- Check agent availability
+- Verify configuration file syntax
+- Ensure clean workspace
+- Review log files
+
+#### Session Disconnected
+- Use `--recover` to restore
+- Check network connection
+- Verify background processes
+- Review auto-save files
+
+#### Poor Performance
+- Reduce verification threshold
+- Disable continuous testing
+- Check system resources
+- Use lighter AI model
+
+#### Configuration Issues
+- Validate JSON syntax
+- Check file permissions
+- Review priority order (CLI > env > project > user > global)
+- Run `claude-flow pair config validate`
+
+### Quality Metrics
+
+#### Truth Score Thresholds
+```
+Error:   < 0.90 ❌
+Warning: 0.90 - 0.95 ⚠️
+Good:    0.95 - 0.98 ✅
+Excellent: > 0.98 🌟
+```
+
+#### Coverage Thresholds
+```
+Error:   < 70% ❌
+Warning: 70% - 80% ⚠️
+Good:    80% - 90% ✅
+Excellent: > 90% 🌟
+```
+
+#### Complexity Thresholds
+```
+Error:   > 15 ❌
+Warning: 10 - 15 ⚠️
+Good:    5 - 10 ✅
+Excellent: < 5 🌟
+```
+
+### Environment Variables
+
+Override configuration via environment:
+
+```bash
+export CLAUDE_PAIR_MODE=driver
+export CLAUDE_PAIR_VERIFY=true
+export CLAUDE_PAIR_THRESHOLD=0.98
+export CLAUDE_PAIR_AGENT=senior-dev
+export CLAUDE_PAIR_AUTO_TEST=true
+```
+
+### Command History
+
+Navigate history:
+- `↑/↓` - Navigate through command history
+- `Ctrl+R` - Search command history
+- `!!` - Repeat last command
+- `!<n>` - Run command n from history
+
+### Keyboard Shortcuts (Configurable)
+
+Default shortcuts:
+```json
+{
+  "shortcuts": {
+    "switch": "ctrl+shift+s",
+    "suggest": "ctrl+space",
+    "review": "ctrl+r",
+    "test": "ctrl+t"
+  }
+}
+```
+
+### Related Commands
+
+- `claude-flow pair --help` - Show help
+- `claude-flow pair config` - Manage configuration
+- `claude-flow pair profile` - Manage profiles
+- `claude-flow pair templates` - List templates
+- `claude-flow pair agents` - List available agents

--- a/.claude/skills/skill-builder/SKILL.md
+++ b/.claude/skills/skill-builder/SKILL.md
@@ -1,0 +1,910 @@
+---
+name: "Skill Builder"
+description: "Create new Claude Code Skills with proper YAML frontmatter, progressive disclosure structure, and complete directory organization. Use when you need to build custom skills for specific workflows, generate skill templates, or understand the Claude Skills specification."
+---
+
+# Skill Builder
+
+## What This Skill Does
+
+Creates production-ready Claude Code Skills with proper YAML frontmatter, progressive disclosure architecture, and complete file/folder structure. This skill guides you through building skills that Claude can autonomously discover and use across all surfaces (Claude.ai, Claude Code, SDK, API).
+
+## Prerequisites
+
+- Claude Code 2.0+ or Claude.ai with Skills support
+- Basic understanding of Markdown and YAML
+- Text editor or IDE
+
+## Quick Start
+
+### Creating Your First Skill
+
+```bash
+# 1. Create skill directory (MUST be at top level, NOT in subdirectories!)
+mkdir -p ~/.claude/skills/my-first-skill
+
+# 2. Create SKILL.md with proper format
+cat > ~/.claude/skills/my-first-skill/SKILL.md << 'EOF'
+---
+name: "My First Skill"
+description: "Brief description of what this skill does and when Claude should use it. Maximum 1024 characters."
+---
+
+# My First Skill
+
+## What This Skill Does
+[Your instructions here]
+
+## Quick Start
+[Basic usage]
+EOF
+
+# 3. Verify skill is detected
+# Restart Claude Code or refresh Claude.ai
+```
+
+---
+
+## Complete Specification
+
+### 📋 YAML Frontmatter (REQUIRED)
+
+Every SKILL.md **must** start with YAML frontmatter containing exactly two required fields:
+
+```yaml
+---
+name: "Skill Name"                    # REQUIRED: Max 64 chars
+description: "What this skill does    # REQUIRED: Max 1024 chars
+and when Claude should use it."       # Include BOTH what & when
+---
+```
+
+#### Field Requirements
+
+**`name`** (REQUIRED):
+- **Type**: String
+- **Max Length**: 64 characters
+- **Format**: Human-friendly display name
+- **Usage**: Shown in skill lists, UI, and loaded into Claude's system prompt
+- **Best Practice**: Use Title Case, be concise and descriptive
+- **Examples**:
+  - ✅ "API Documentation Generator"
+  - ✅ "React Component Builder"
+  - ✅ "Database Schema Designer"
+  - ❌ "skill-1" (not descriptive)
+  - ❌ "This is a very long skill name that exceeds sixty-four characters" (too long)
+
+**`description`** (REQUIRED):
+- **Type**: String
+- **Max Length**: 1024 characters
+- **Format**: Plain text or minimal markdown
+- **Content**: MUST include:
+  1. **What** the skill does (functionality)
+  2. **When** Claude should invoke it (trigger conditions)
+- **Usage**: Loaded into Claude's system prompt for autonomous matching
+- **Best Practice**: Front-load key trigger words, be specific about use cases
+- **Examples**:
+  - ✅ "Generate OpenAPI 3.0 documentation from Express.js routes. Use when creating API docs, documenting endpoints, or building API specifications."
+  - ✅ "Create React functional components with TypeScript, hooks, and tests. Use when scaffolding new components or converting class components."
+  - ❌ "A comprehensive guide to API documentation" (no "when" clause)
+  - ❌ "Documentation tool" (too vague)
+
+#### YAML Formatting Rules
+
+```yaml
+---
+# ✅ CORRECT: Simple string
+name: "API Builder"
+description: "Creates REST APIs with Express and TypeScript."
+
+# ✅ CORRECT: Multi-line description
+name: "Full-Stack Generator"
+description: "Generates full-stack applications with React frontend and Node.js backend. Use when starting new projects or scaffolding applications."
+
+# ✅ CORRECT: Special characters quoted
+name: "JSON:API Builder"
+description: "Creates JSON:API compliant endpoints: pagination, filtering, relationships."
+
+# ❌ WRONG: Missing quotes with special chars
+name: API:Builder  # YAML parse error!
+
+# ❌ WRONG: Extra fields (ignored but discouraged)
+name: "My Skill"
+description: "My description"
+version: "1.0.0"       # NOT part of spec
+author: "Me"           # NOT part of spec
+tags: ["dev", "api"]   # NOT part of spec
+---
+```
+
+**Critical**: Only `name` and `description` are used by Claude. Additional fields are ignored.
+
+---
+
+### 📂 Directory Structure
+
+#### Minimal Skill (Required)
+```
+~/.claude/skills/                    # Personal skills location
+└── my-skill/                        # Skill directory (MUST be at top level!)
+    └── SKILL.md                     # REQUIRED: Main skill file
+```
+
+**IMPORTANT**: Skills MUST be directly under `~/.claude/skills/[skill-name]/`.
+Claude Code does NOT support nested subdirectories or namespaces!
+
+#### Full-Featured Skill (Recommended)
+```
+~/.claude/skills/
+└── my-skill/                        # Top-level skill directory
+        ├── SKILL.md                 # REQUIRED: Main skill file
+        ├── README.md                # Optional: Human-readable docs
+        ├── scripts/                 # Optional: Executable scripts
+        │   ├── setup.sh
+        │   ├── validate.js
+        │   └── deploy.py
+        ├── resources/               # Optional: Supporting files
+        │   ├── templates/
+        │   │   ├── api-template.js
+        │   │   └── component.tsx
+        │   ├── examples/
+        │   │   └── sample-output.json
+        │   └── schemas/
+        │       └── config-schema.json
+        └── docs/                    # Optional: Additional documentation
+            ├── ADVANCED.md
+            ├── TROUBLESHOOTING.md
+            └── API_REFERENCE.md
+```
+
+#### Skills Locations
+
+**Personal Skills** (available across all projects):
+```
+~/.claude/skills/
+└── [your-skills]/
+```
+- **Path**: `~/.claude/skills/` or `$HOME/.claude/skills/`
+- **Scope**: Available in all projects for this user
+- **Version Control**: NOT committed to git (outside repo)
+- **Use Case**: Personal productivity tools, custom workflows
+
+**Project Skills** (team-shared, version controlled):
+```
+<project-root>/.claude/skills/
+└── [team-skills]/
+```
+- **Path**: `.claude/skills/` in project root
+- **Scope**: Available only in this project
+- **Version Control**: SHOULD be committed to git
+- **Use Case**: Team workflows, project-specific tools, shared knowledge
+
+---
+
+### 🎯 Progressive Disclosure Architecture
+
+Claude Code uses a **3-level progressive disclosure system** to scale to 100+ skills without context penalty:
+
+#### Level 1: Metadata (Name + Description)
+**Loaded**: At Claude Code startup, always
+**Size**: ~200 chars per skill
+**Purpose**: Enable autonomous skill matching
+**Context**: Loaded into system prompt for ALL skills
+
+```yaml
+---
+name: "API Builder"                   # 11 chars
+description: "Creates REST APIs..."   # ~50 chars
+---
+# Total: ~61 chars per skill
+# 100 skills = ~6KB context (minimal!)
+```
+
+#### Level 2: SKILL.md Body
+**Loaded**: When skill is triggered/matched
+**Size**: ~1-10KB typically
+**Purpose**: Main instructions and procedures
+**Context**: Only loaded for ACTIVE skills
+
+```markdown
+# API Builder
+
+## What This Skill Does
+[Main instructions - loaded only when skill is active]
+
+## Quick Start
+[Basic procedures]
+
+## Step-by-Step Guide
+[Detailed instructions]
+```
+
+#### Level 3+: Referenced Files
+**Loaded**: On-demand as Claude navigates
+**Size**: Variable (KB to MB)
+**Purpose**: Deep reference, examples, schemas
+**Context**: Loaded only when Claude accesses specific files
+
+```markdown
+# In SKILL.md
+See [Advanced Configuration](docs/ADVANCED.md) for complex scenarios.
+See [API Reference](docs/API_REFERENCE.md) for complete documentation.
+Use template: `resources/templates/api-template.js`
+
+# Claude will load these files ONLY if needed
+```
+
+**Benefit**: Install 100+ skills with ~6KB context. Only active skill content (1-10KB) enters context.
+
+---
+
+### 📝 SKILL.md Content Structure
+
+#### Recommended 4-Level Structure
+
+```markdown
+---
+name: "Your Skill Name"
+description: "What it does and when to use it"
+---
+
+# Your Skill Name
+
+## Level 1: Overview (Always Read First)
+Brief 2-3 sentence description of the skill.
+
+## Prerequisites
+- Requirement 1
+- Requirement 2
+
+## What This Skill Does
+1. Primary function
+2. Secondary function
+3. Key benefit
+
+---
+
+## Level 2: Quick Start (For Fast Onboarding)
+
+### Basic Usage
+```bash
+# Simplest use case
+command --option value
+```
+
+### Common Scenarios
+1. **Scenario 1**: How to...
+2. **Scenario 2**: How to...
+
+---
+
+## Level 3: Detailed Instructions (For Deep Work)
+
+### Step-by-Step Guide
+
+#### Step 1: Initial Setup
+```bash
+# Commands
+```
+Expected output:
+```
+Success message
+```
+
+#### Step 2: Configuration
+- Configuration option 1
+- Configuration option 2
+
+#### Step 3: Execution
+- Run the main command
+- Verify results
+
+### Advanced Options
+
+#### Option 1: Custom Configuration
+```bash
+# Advanced usage
+```
+
+#### Option 2: Integration
+```bash
+# Integration steps
+```
+
+---
+
+## Level 4: Reference (Rarely Needed)
+
+### Troubleshooting
+
+#### Issue: Common Problem
+**Symptoms**: What you see
+**Cause**: Why it happens
+**Solution**: How to fix
+```bash
+# Fix command
+```
+
+#### Issue: Another Problem
+**Solution**: Steps to resolve
+
+### Complete API Reference
+See [API_REFERENCE.md](docs/API_REFERENCE.md)
+
+### Examples
+See [examples/](resources/examples/)
+
+### Related Skills
+- [Related Skill 1](#)
+- [Related Skill 2](#)
+
+### Resources
+- [External Link 1](https://example.com)
+- [Documentation](https://docs.example.com)
+```
+
+---
+
+### 🎨 Content Best Practices
+
+#### Writing Effective Descriptions
+
+**Front-Load Keywords**:
+```yaml
+# ✅ GOOD: Keywords first
+description: "Generate TypeScript interfaces from JSON schema. Use when converting schemas, creating types, or building API clients."
+
+# ❌ BAD: Keywords buried
+description: "This skill helps developers who need to work with JSON schemas by providing a way to generate TypeScript interfaces."
+```
+
+**Include Trigger Conditions**:
+```yaml
+# ✅ GOOD: Clear "when" clause
+description: "Debug React performance issues using Chrome DevTools. Use when components re-render unnecessarily, investigating slow updates, or optimizing bundle size."
+
+# ❌ BAD: No trigger conditions
+description: "Helps with React performance debugging."
+```
+
+**Be Specific**:
+```yaml
+# ✅ GOOD: Specific technologies
+description: "Create Express.js REST endpoints with Joi validation, Swagger docs, and Jest tests. Use when building new APIs or adding endpoints."
+
+# ❌ BAD: Too generic
+description: "Build API endpoints with proper validation and testing."
+```
+
+#### Progressive Disclosure Writing
+
+**Keep Level 1 Brief** (Overview):
+```markdown
+## What This Skill Does
+Creates production-ready React components with TypeScript, hooks, and tests in 3 steps.
+```
+
+**Level 2 for Common Paths** (Quick Start):
+```markdown
+## Quick Start
+```bash
+# Most common use case (80% of users)
+generate-component MyComponent
+```
+```
+
+**Level 3 for Details** (Step-by-Step):
+```markdown
+## Step-by-Step Guide
+
+### Creating a Basic Component
+1. Run generator
+2. Choose template
+3. Customize options
+[Detailed explanations]
+```
+
+**Level 4 for Edge Cases** (Reference):
+```markdown
+## Advanced Configuration
+For complex scenarios like HOCs, render props, or custom hooks, see [ADVANCED.md](docs/ADVANCED.md).
+```
+
+---
+
+### 🛠️ Adding Scripts and Resources
+
+#### Scripts Directory
+
+**Purpose**: Executable scripts that Claude can run
+**Location**: `scripts/` in skill directory
+**Usage**: Referenced from SKILL.md
+
+Example:
+```bash
+# In skill directory
+scripts/
+├── setup.sh          # Initialization script
+├── validate.js       # Validation logic
+├── generate.py       # Code generation
+└── deploy.sh         # Deployment script
+```
+
+Reference from SKILL.md:
+```markdown
+## Setup
+Run the setup script:
+```bash
+./scripts/setup.sh
+```
+
+## Validation
+Validate your configuration:
+```bash
+node scripts/validate.js config.json
+```
+```
+
+#### Resources Directory
+
+**Purpose**: Templates, examples, schemas, static files
+**Location**: `resources/` in skill directory
+**Usage**: Referenced or copied by scripts
+
+Example:
+```bash
+resources/
+├── templates/
+│   ├── component.tsx.template
+│   ├── test.spec.ts.template
+│   └── story.stories.tsx.template
+├── examples/
+│   ├── basic-example/
+│   ├── advanced-example/
+│   └── integration-example/
+└── schemas/
+    ├── config.schema.json
+    └── output.schema.json
+```
+
+Reference from SKILL.md:
+```markdown
+## Templates
+Use the component template:
+```bash
+cp resources/templates/component.tsx.template src/components/MyComponent.tsx
+```
+
+## Examples
+See working examples in `resources/examples/`:
+- `basic-example/` - Simple component
+- `advanced-example/` - With hooks and context
+```
+
+---
+
+### 🔗 File References and Navigation
+
+Claude can navigate to referenced files automatically. Use these patterns:
+
+#### Markdown Links
+```markdown
+See [Advanced Configuration](docs/ADVANCED.md) for complex scenarios.
+See [Troubleshooting Guide](docs/TROUBLESHOOTING.md) if you encounter errors.
+```
+
+#### Relative File Paths
+```markdown
+Use the template located at `resources/templates/api-template.js`
+See examples in `resources/examples/basic-usage/`
+```
+
+#### Inline File Content
+```markdown
+## Example Configuration
+See `resources/examples/config.json`:
+```json
+{
+  "option": "value"
+}
+```
+```
+
+**Best Practice**: Keep SKILL.md lean (~2-5KB). Move lengthy content to separate files and reference them. Claude will load only what's needed.
+
+---
+
+### ✅ Validation Checklist
+
+Before publishing a skill, verify:
+
+**YAML Frontmatter**:
+- [ ] Starts with `---`
+- [ ] Contains `name` field (max 64 chars)
+- [ ] Contains `description` field (max 1024 chars)
+- [ ] Description includes "what" and "when"
+- [ ] Ends with `---`
+- [ ] No YAML syntax errors
+
+**File Structure**:
+- [ ] SKILL.md exists in skill directory
+- [ ] Directory is DIRECTLY in `~/.claude/skills/[skill-name]/` or `.claude/skills/[skill-name]/`
+- [ ] Uses clear, descriptive directory name
+- [ ] **NO nested subdirectories** (Claude Code requires top-level structure)
+
+**Content Quality**:
+- [ ] Level 1 (Overview) is brief and clear
+- [ ] Level 2 (Quick Start) shows common use case
+- [ ] Level 3 (Details) provides step-by-step guide
+- [ ] Level 4 (Reference) links to advanced content
+- [ ] Examples are concrete and runnable
+- [ ] Troubleshooting section addresses common issues
+
+**Progressive Disclosure**:
+- [ ] Core instructions in SKILL.md (~2-5KB)
+- [ ] Advanced content in separate docs/
+- [ ] Large resources in resources/ directory
+- [ ] Clear navigation between levels
+
+**Testing**:
+- [ ] Skill appears in Claude's skill list
+- [ ] Description triggers on relevant queries
+- [ ] Instructions are clear and actionable
+- [ ] Scripts execute successfully (if included)
+- [ ] Examples work as documented
+
+---
+
+## Skill Builder Templates
+
+### Template 1: Basic Skill (Minimal)
+
+```markdown
+---
+name: "My Basic Skill"
+description: "One sentence what. One sentence when to use."
+---
+
+# My Basic Skill
+
+## What This Skill Does
+[2-3 sentences describing functionality]
+
+## Quick Start
+```bash
+# Single command to get started
+```
+
+## Step-by-Step Guide
+
+### Step 1: Setup
+[Instructions]
+
+### Step 2: Usage
+[Instructions]
+
+### Step 3: Verify
+[Instructions]
+
+## Troubleshooting
+- **Issue**: Problem description
+  - **Solution**: Fix description
+```
+
+### Template 2: Intermediate Skill (With Scripts)
+
+```markdown
+---
+name: "My Intermediate Skill"
+description: "Detailed what with key features. When to use with specific triggers: scaffolding, generating, building."
+---
+
+# My Intermediate Skill
+
+## Prerequisites
+- Requirement 1
+- Requirement 2
+
+## What This Skill Does
+1. Primary function
+2. Secondary function
+3. Integration capability
+
+## Quick Start
+```bash
+./scripts/setup.sh
+./scripts/generate.sh my-project
+```
+
+## Configuration
+Edit `config.json`:
+```json
+{
+  "option1": "value1",
+  "option2": "value2"
+}
+```
+
+## Step-by-Step Guide
+
+### Basic Usage
+[Steps for 80% use case]
+
+### Advanced Usage
+[Steps for complex scenarios]
+
+## Available Scripts
+- `scripts/setup.sh` - Initial setup
+- `scripts/generate.sh` - Code generation
+- `scripts/validate.sh` - Validation
+
+## Resources
+- Templates: `resources/templates/`
+- Examples: `resources/examples/`
+
+## Troubleshooting
+[Common issues and solutions]
+```
+
+### Template 3: Advanced Skill (Full-Featured)
+
+```markdown
+---
+name: "My Advanced Skill"
+description: "Comprehensive what with all features and integrations. Use when [trigger 1], [trigger 2], or [trigger 3]. Supports [technology stack]."
+---
+
+# My Advanced Skill
+
+## Overview
+[Brief 2-3 sentence description]
+
+## Prerequisites
+- Technology 1 (version X+)
+- Technology 2 (version Y+)
+- API keys or credentials
+
+## What This Skill Does
+1. **Core Feature**: Description
+2. **Integration**: Description
+3. **Automation**: Description
+
+---
+
+## Quick Start (60 seconds)
+
+### Installation
+```bash
+./scripts/install.sh
+```
+
+### First Use
+```bash
+./scripts/quickstart.sh
+```
+
+Expected output:
+```
+✓ Setup complete
+✓ Configuration validated
+→ Ready to use
+```
+
+---
+
+## Configuration
+
+### Basic Configuration
+Edit `config.json`:
+```json
+{
+  "mode": "production",
+  "features": ["feature1", "feature2"]
+}
+```
+
+### Advanced Configuration
+See [Configuration Guide](docs/CONFIGURATION.md)
+
+---
+
+## Step-by-Step Guide
+
+### 1. Initial Setup
+[Detailed steps]
+
+### 2. Core Workflow
+[Main procedures]
+
+### 3. Integration
+[Integration steps]
+
+---
+
+## Advanced Features
+
+### Feature 1: Custom Templates
+```bash
+./scripts/generate.sh --template custom
+```
+
+### Feature 2: Batch Processing
+```bash
+./scripts/batch.sh --input data.json
+```
+
+### Feature 3: CI/CD Integration
+See [CI/CD Guide](docs/CICD.md)
+
+---
+
+## Scripts Reference
+
+| Script | Purpose | Usage |
+|--------|---------|-------|
+| `install.sh` | Install dependencies | `./scripts/install.sh` |
+| `generate.sh` | Generate code | `./scripts/generate.sh [name]` |
+| `validate.sh` | Validate output | `./scripts/validate.sh` |
+| `deploy.sh` | Deploy to environment | `./scripts/deploy.sh [env]` |
+
+---
+
+## Resources
+
+### Templates
+- `resources/templates/basic.template` - Basic template
+- `resources/templates/advanced.template` - Advanced template
+
+### Examples
+- `resources/examples/basic/` - Simple example
+- `resources/examples/advanced/` - Complex example
+- `resources/examples/integration/` - Integration example
+
+### Schemas
+- `resources/schemas/config.schema.json` - Configuration schema
+- `resources/schemas/output.schema.json` - Output validation
+
+---
+
+## Troubleshooting
+
+### Issue: Installation Failed
+**Symptoms**: Error during `install.sh`
+**Cause**: Missing dependencies
+**Solution**:
+```bash
+# Install prerequisites
+npm install -g required-package
+./scripts/install.sh --force
+```
+
+### Issue: Validation Errors
+**Symptoms**: Validation script fails
+**Solution**: See [Troubleshooting Guide](docs/TROUBLESHOOTING.md)
+
+---
+
+## API Reference
+Complete API documentation: [API_REFERENCE.md](docs/API_REFERENCE.md)
+
+## Related Skills
+- [Related Skill 1](../related-skill-1/)
+- [Related Skill 2](../related-skill-2/)
+
+## Resources
+- [Official Documentation](https://example.com/docs)
+- [GitHub Repository](https://github.com/example/repo)
+- [Community Forum](https://forum.example.com)
+
+---
+
+**Created**: 2025-10-19
+**Category**: Advanced
+**Difficulty**: Intermediate
+**Estimated Time**: 15-30 minutes
+```
+
+---
+
+## Examples from the Wild
+
+### Example 1: Simple Documentation Skill
+
+```markdown
+---
+name: "README Generator"
+description: "Generate comprehensive README.md files for GitHub repositories. Use when starting new projects, documenting code, or improving existing READMEs."
+---
+
+# README Generator
+
+## What This Skill Does
+Creates well-structured README.md files with badges, installation, usage, and contribution sections.
+
+## Quick Start
+```bash
+# Answer a few questions
+./scripts/generate-readme.sh
+
+# README.md created with:
+# - Project title and description
+# - Installation instructions
+# - Usage examples
+# - Contribution guidelines
+```
+
+## Customization
+Edit sections in `resources/templates/sections/` before generating.
+```
+
+### Example 2: Code Generation Skill
+
+```markdown
+---
+name: "React Component Generator"
+description: "Generate React functional components with TypeScript, hooks, tests, and Storybook stories. Use when creating new components, scaffolding UI, or following component architecture patterns."
+---
+
+# React Component Generator
+
+## Prerequisites
+- Node.js 18+
+- React 18+
+- TypeScript 5+
+
+## Quick Start
+```bash
+./scripts/generate-component.sh MyComponent
+
+# Creates:
+# - src/components/MyComponent/MyComponent.tsx
+# - src/components/MyComponent/MyComponent.test.tsx
+# - src/components/MyComponent/MyComponent.stories.tsx
+# - src/components/MyComponent/index.ts
+```
+
+## Step-by-Step Guide
+
+### 1. Run Generator
+```bash
+./scripts/generate-component.sh ComponentName
+```
+
+### 2. Choose Template
+- Basic: Simple functional component
+- With State: useState hooks
+- With Context: useContext integration
+- With API: Data fetching component
+
+### 3. Customize
+Edit generated files in `src/components/ComponentName/`
+
+## Templates
+See `resources/templates/` for available component templates.
+```
+
+---
+
+## Learn More
+
+### Official Resources
+- [Anthropic Agent Skills Documentation](https://docs.claude.com/en/docs/agents-and-tools/agent-skills)
+- [GitHub Skills Repository](https://github.com/anthropics/skills)
+- [Claude Code Documentation](https://docs.claude.com/en/docs/claude-code)
+
+### Community
+- [Skills Marketplace](https://github.com/anthropics/skills) - Browse community skills
+- [Anthropic Discord](https://discord.gg/anthropic) - Get help from community
+
+### Advanced Topics
+- Multi-file skills with complex navigation
+- Skills that spawn other skills
+- Integration with MCP tools
+- Dynamic skill generation
+
+---
+
+**Created**: 2025-10-19
+**Version**: 1.0.0
+**Maintained By**: agentic-flow team
+**License**: MIT

--- a/.claude/skills/sparc-methodology/SKILL.md
+++ b/.claude/skills/sparc-methodology/SKILL.md
@@ -1,0 +1,1106 @@
+---
+name: sparc-methodology
+description: |
+  SPARC (Specification, Pseudocode, Architecture, Refinement, Completion) comprehensive development methodology with multi-agent orchestration
+---
+
+# SPARC Methodology - Comprehensive Development Framework
+
+## Overview
+
+SPARC (Specification, Pseudocode, Architecture, Refinement, Completion) is a systematic development methodology integrated with Claude Flow's multi-agent orchestration capabilities. It provides 17 specialized modes for comprehensive software development, from initial research through deployment and monitoring.
+
+## Table of Contents
+
+1. [Core Philosophy](#core-philosophy)
+2. [Development Phases](#development-phases)
+3. [Available Modes](#available-modes)
+4. [Activation Methods](#activation-methods)
+5. [Orchestration Patterns](#orchestration-patterns)
+6. [TDD Workflows](#tdd-workflows)
+7. [Best Practices](#best-practices)
+8. [Integration Examples](#integration-examples)
+9. [Common Workflows](#common-workflows)
+
+---
+
+## Core Philosophy
+
+SPARC methodology emphasizes:
+
+- **Systematic Approach**: Structured phases from specification to completion
+- **Test-Driven Development**: Tests written before implementation
+- **Parallel Execution**: Concurrent agent coordination for 2.8-4.4x speed improvements
+- **Memory Integration**: Persistent knowledge sharing across agents and sessions
+- **Quality First**: Comprehensive reviews, testing, and validation
+- **Modular Design**: Clean separation of concerns with clear interfaces
+
+### Key Principles
+
+1. **Specification Before Code**: Define requirements and constraints clearly
+2. **Design Before Implementation**: Plan architecture and components
+3. **Tests Before Features**: Write failing tests, then make them pass
+4. **Review Everything**: Code quality, security, and performance checks
+5. **Document Continuously**: Maintain current documentation throughout
+
+---
+
+## Development Phases
+
+### Phase 1: Specification
+**Goal**: Define requirements, constraints, and success criteria
+
+- Requirements analysis
+- User story mapping
+- Constraint identification
+- Success metrics definition
+- Pseudocode planning
+
+**Key Modes**: `researcher`, `analyzer`, `memory-manager`
+
+### Phase 2: Architecture
+**Goal**: Design system structure and component interfaces
+
+- System architecture design
+- Component interface definition
+- Database schema planning
+- API contract specification
+- Infrastructure planning
+
+**Key Modes**: `architect`, `designer`, `orchestrator`
+
+### Phase 3: Refinement (TDD Implementation)
+**Goal**: Implement features with test-first approach
+
+- Write failing tests
+- Implement minimum viable code
+- Make tests pass
+- Refactor for quality
+- Iterate until complete
+
+**Key Modes**: `tdd`, `coder`, `tester`
+
+### Phase 4: Review
+**Goal**: Ensure code quality, security, and performance
+
+- Code quality assessment
+- Security vulnerability scanning
+- Performance profiling
+- Best practices validation
+- Documentation review
+
+**Key Modes**: `reviewer`, `optimizer`, `debugger`
+
+### Phase 5: Completion
+**Goal**: Integration, deployment, and monitoring
+
+- System integration
+- Deployment automation
+- Monitoring setup
+- Documentation finalization
+- Knowledge capture
+
+**Key Modes**: `workflow-manager`, `documenter`, `memory-manager`
+
+---
+
+## Available Modes
+
+### Core Orchestration Modes
+
+#### `orchestrator`
+Multi-agent task orchestration with TodoWrite/Task/Memory coordination.
+
+**Capabilities**:
+- Task decomposition into manageable units
+- Agent coordination and resource allocation
+- Progress tracking and result synthesis
+- Adaptive strategy selection
+- Cross-agent communication
+
+**Usage**:
+```javascript
+mcp__claude-flow__sparc_mode {
+  mode: "orchestrator",
+  task_description: "coordinate feature development",
+  options: { parallel: true, monitor: true }
+}
+```
+
+#### `swarm-coordinator`
+Specialized swarm management for complex multi-agent workflows.
+
+**Capabilities**:
+- Topology optimization (mesh, hierarchical, ring, star)
+- Agent lifecycle management
+- Dynamic scaling based on workload
+- Fault tolerance and recovery
+- Performance monitoring
+
+#### `workflow-manager`
+Process automation and workflow orchestration.
+
+**Capabilities**:
+- Workflow definition and execution
+- Event-driven triggers
+- Sequential and parallel pipelines
+- State management
+- Error handling and retry logic
+
+#### `batch-executor`
+Parallel task execution for high-throughput operations.
+
+**Capabilities**:
+- Concurrent file operations
+- Batch processing optimization
+- Resource pooling
+- Load balancing
+- Progress aggregation
+
+---
+
+### Development Modes
+
+#### `coder`
+Autonomous code generation with batch file operations.
+
+**Capabilities**:
+- Feature implementation
+- Code refactoring
+- Bug fixes and patches
+- API development
+- Algorithm implementation
+
+**Quality Standards**:
+- ES2022+ standards
+- TypeScript type safety
+- Comprehensive error handling
+- Performance optimization
+- Security best practices
+
+**Usage**:
+```javascript
+mcp__claude-flow__sparc_mode {
+  mode: "coder",
+  task_description: "implement user authentication with JWT",
+  options: {
+    test_driven: true,
+    parallel_edits: true,
+    typescript: true
+  }
+}
+```
+
+#### `architect`
+System design with Memory-based coordination.
+
+**Capabilities**:
+- Microservices architecture
+- Event-driven design
+- Domain-driven design (DDD)
+- Hexagonal architecture
+- CQRS and Event Sourcing
+
+**Memory Integration**:
+- Store architectural decisions
+- Share component specifications
+- Maintain design consistency
+- Track architectural evolution
+
+**Design Patterns**:
+- Layered architecture
+- Microservices patterns
+- Event-driven patterns
+- Domain modeling
+- Infrastructure as Code
+
+**Usage**:
+```javascript
+mcp__claude-flow__sparc_mode {
+  mode: "architect",
+  task_description: "design scalable e-commerce platform",
+  options: {
+    detailed: true,
+    memory_enabled: true,
+    patterns: ["microservices", "event-driven"]
+  }
+}
+```
+
+#### `tdd`
+Test-driven development with comprehensive testing.
+
+**Capabilities**:
+- Test-first development
+- Red-green-refactor cycle
+- Test suite design
+- Coverage optimization (target: 90%+)
+- Continuous testing
+
+**TDD Workflow**:
+1. Write failing test (RED)
+2. Implement minimum code
+3. Make test pass (GREEN)
+4. Refactor for quality (REFACTOR)
+5. Repeat cycle
+
+**Testing Strategies**:
+- Unit testing (Jest, Mocha, Vitest)
+- Integration testing
+- End-to-end testing (Playwright, Cypress)
+- Performance testing
+- Security testing
+
+**Usage**:
+```javascript
+mcp__claude-flow__sparc_mode {
+  mode: "tdd",
+  task_description: "shopping cart feature with payment integration",
+  options: {
+    coverage_target: 90,
+    test_framework: "jest",
+    e2e_framework: "playwright"
+  }
+}
+```
+
+#### `reviewer`
+Code review using batch file analysis.
+
+**Capabilities**:
+- Code quality assessment
+- Security vulnerability detection
+- Performance analysis
+- Best practices validation
+- Documentation review
+
+**Review Criteria**:
+- Code correctness and logic
+- Design pattern adherence
+- Comprehensive error handling
+- Test coverage adequacy
+- Maintainability and readability
+- Security vulnerabilities
+- Performance bottlenecks
+
+**Batch Analysis**:
+- Parallel file review
+- Pattern detection
+- Dependency checking
+- Consistency validation
+- Automated reporting
+
+**Usage**:
+```javascript
+mcp__claude-flow__sparc_mode {
+  mode: "reviewer",
+  task_description: "review authentication module PR #123",
+  options: {
+    security_check: true,
+    performance_check: true,
+    test_coverage_check: true
+  }
+}
+```
+
+---
+
+### Analysis and Research Modes
+
+#### `researcher`
+Deep research with parallel WebSearch/WebFetch and Memory coordination.
+
+**Capabilities**:
+- Comprehensive information gathering
+- Source credibility evaluation
+- Trend analysis and forecasting
+- Competitive research
+- Technology assessment
+
+**Research Methods**:
+- Parallel web searches
+- Academic paper analysis
+- Industry report synthesis
+- Expert opinion gathering
+- Statistical data compilation
+
+**Memory Integration**:
+- Store research findings with citations
+- Build knowledge graphs
+- Track information sources
+- Cross-reference insights
+- Maintain research history
+
+**Usage**:
+```javascript
+mcp__claude-flow__sparc_mode {
+  mode: "researcher",
+  task_description: "research microservices best practices 2024",
+  options: {
+    depth: "comprehensive",
+    sources: ["academic", "industry", "news"],
+    citations: true
+  }
+}
+```
+
+#### `analyzer`
+Code and data analysis with pattern recognition.
+
+**Capabilities**:
+- Static code analysis
+- Dependency analysis
+- Performance profiling
+- Security scanning
+- Data pattern recognition
+
+#### `optimizer`
+Performance optimization and bottleneck resolution.
+
+**Capabilities**:
+- Algorithm optimization
+- Database query tuning
+- Caching strategy design
+- Bundle size reduction
+- Memory leak detection
+
+---
+
+### Creative and Support Modes
+
+#### `designer`
+UI/UX design with accessibility focus.
+
+**Capabilities**:
+- Interface design
+- User experience optimization
+- Accessibility compliance (WCAG 2.1)
+- Design system creation
+- Responsive layout design
+
+#### `innovator`
+Creative problem-solving and novel solutions.
+
+**Capabilities**:
+- Brainstorming and ideation
+- Alternative approach generation
+- Technology evaluation
+- Proof of concept development
+- Innovation feasibility analysis
+
+#### `documenter`
+Comprehensive documentation generation.
+
+**Capabilities**:
+- API documentation (OpenAPI/Swagger)
+- Architecture diagrams
+- User guides and tutorials
+- Code comments and JSDoc
+- README and changelog maintenance
+
+#### `debugger`
+Systematic debugging and issue resolution.
+
+**Capabilities**:
+- Bug reproduction
+- Root cause analysis
+- Fix implementation
+- Regression prevention
+- Debug logging optimization
+
+#### `tester`
+Comprehensive testing beyond TDD.
+
+**Capabilities**:
+- Test suite expansion
+- Edge case identification
+- Performance testing
+- Load testing
+- Chaos engineering
+
+#### `memory-manager`
+Knowledge management and context preservation.
+
+**Capabilities**:
+- Cross-session memory persistence
+- Knowledge graph construction
+- Context restoration
+- Learning pattern extraction
+- Decision tracking
+
+---
+
+## Activation Methods
+
+### Method 1: MCP Tools (Preferred in Claude Code)
+
+**Best for**: Integrated Claude Code workflows with full orchestration capabilities
+
+```javascript
+// Basic mode execution
+mcp__claude-flow__sparc_mode {
+  mode: "<mode-name>",
+  task_description: "<task description>",
+  options: {
+    // mode-specific options
+  }
+}
+
+// Initialize swarm for complex tasks
+mcp__claude-flow__swarm_init {
+  topology: "hierarchical",  // or "mesh", "ring", "star"
+  strategy: "auto",           // or "balanced", "specialized", "adaptive"
+  maxAgents: 8
+}
+
+// Spawn specialized agents
+mcp__claude-flow__agent_spawn {
+  type: "<agent-type>",
+  capabilities: ["<capability1>", "<capability2>"]
+}
+
+// Monitor execution
+mcp__claude-flow__swarm_monitor {
+  swarmId: "current",
+  interval: 5000
+}
+```
+
+### Method 2: NPX CLI (Fallback)
+
+**Best for**: Terminal usage or when MCP tools unavailable
+
+```bash
+# Execute specific mode
+npx claude-flow sparc run <mode> "task description"
+
+# Use alpha features
+npx claude-flow@alpha sparc run <mode> "task description"
+
+# List all available modes
+npx claude-flow sparc modes
+
+# Get help for specific mode
+npx claude-flow sparc help <mode>
+
+# Run with options
+npx claude-flow sparc run <mode> "task" --parallel --monitor
+
+# Execute TDD workflow
+npx claude-flow sparc tdd "feature description"
+
+# Batch execution
+npx claude-flow sparc batch <mode1,mode2,mode3> "task"
+
+# Pipeline execution
+npx claude-flow sparc pipeline "task description"
+```
+
+### Method 3: Local Installation
+
+**Best for**: Projects with local claude-flow installation
+
+```bash
+# If claude-flow is installed locally
+./claude-flow sparc run <mode> "task description"
+```
+
+---
+
+## Orchestration Patterns
+
+### Pattern 1: Hierarchical Coordination
+
+**Best for**: Complex projects with clear delegation hierarchy
+
+```javascript
+// Initialize hierarchical swarm
+mcp__claude-flow__swarm_init {
+  topology: "hierarchical",
+  maxAgents: 12
+}
+
+// Spawn coordinator
+mcp__claude-flow__agent_spawn {
+  type: "coordinator",
+  capabilities: ["planning", "delegation", "monitoring"]
+}
+
+// Spawn specialized workers
+mcp__claude-flow__agent_spawn { type: "architect" }
+mcp__claude-flow__agent_spawn { type: "coder" }
+mcp__claude-flow__agent_spawn { type: "tester" }
+mcp__claude-flow__agent_spawn { type: "reviewer" }
+```
+
+### Pattern 2: Mesh Coordination
+
+**Best for**: Collaborative tasks requiring peer-to-peer communication
+
+```javascript
+mcp__claude-flow__swarm_init {
+  topology: "mesh",
+  strategy: "balanced",
+  maxAgents: 6
+}
+```
+
+### Pattern 3: Sequential Pipeline
+
+**Best for**: Ordered workflow execution (spec → design → code → test → review)
+
+```javascript
+mcp__claude-flow__workflow_create {
+  name: "development-pipeline",
+  steps: [
+    { mode: "researcher", task: "gather requirements" },
+    { mode: "architect", task: "design system" },
+    { mode: "coder", task: "implement features" },
+    { mode: "tdd", task: "create tests" },
+    { mode: "reviewer", task: "review code" }
+  ],
+  triggers: ["on_step_complete"]
+}
+```
+
+### Pattern 4: Parallel Execution
+
+**Best for**: Independent tasks that can run concurrently
+
+```javascript
+mcp__claude-flow__task_orchestrate {
+  task: "build full-stack application",
+  strategy: "parallel",
+  dependencies: {
+    backend: [],
+    frontend: [],
+    database: [],
+    tests: ["backend", "frontend"]
+  }
+}
+```
+
+### Pattern 5: Adaptive Strategy
+
+**Best for**: Dynamic workloads with changing requirements
+
+```javascript
+mcp__claude-flow__swarm_init {
+  topology: "hierarchical",
+  strategy: "adaptive",  // Auto-adjusts based on workload
+  maxAgents: 20
+}
+```
+
+---
+
+## TDD Workflows
+
+### Complete TDD Workflow
+
+```javascript
+// Step 1: Initialize TDD swarm
+mcp__claude-flow__swarm_init {
+  topology: "hierarchical",
+  maxAgents: 8
+}
+
+// Step 2: Research and planning
+mcp__claude-flow__sparc_mode {
+  mode: "researcher",
+  task_description: "research testing best practices for feature X"
+}
+
+// Step 3: Architecture design
+mcp__claude-flow__sparc_mode {
+  mode: "architect",
+  task_description: "design testable architecture for feature X"
+}
+
+// Step 4: TDD implementation
+mcp__claude-flow__sparc_mode {
+  mode: "tdd",
+  task_description: "implement feature X with 90% coverage",
+  options: {
+    coverage_target: 90,
+    test_framework: "jest",
+    parallel_tests: true
+  }
+}
+
+// Step 5: Code review
+mcp__claude-flow__sparc_mode {
+  mode: "reviewer",
+  task_description: "review feature X implementation",
+  options: {
+    test_coverage_check: true,
+    security_check: true
+  }
+}
+
+// Step 6: Optimization
+mcp__claude-flow__sparc_mode {
+  mode: "optimizer",
+  task_description: "optimize feature X performance"
+}
+```
+
+### Red-Green-Refactor Cycle
+
+```javascript
+// RED: Write failing test
+mcp__claude-flow__sparc_mode {
+  mode: "tester",
+  task_description: "create failing test for shopping cart add item",
+  options: { expect_failure: true }
+}
+
+// GREEN: Minimal implementation
+mcp__claude-flow__sparc_mode {
+  mode: "coder",
+  task_description: "implement minimal code to pass test",
+  options: { minimal: true }
+}
+
+// REFACTOR: Improve code quality
+mcp__claude-flow__sparc_mode {
+  mode: "coder",
+  task_description: "refactor shopping cart implementation",
+  options: { maintain_tests: true }
+}
+```
+
+---
+
+## Best Practices
+
+### 1. Memory Integration
+
+**Always use Memory for cross-agent coordination**:
+
+```javascript
+// Store architectural decisions
+mcp__claude-flow__memory_usage {
+  action: "store",
+  namespace: "architecture",
+  key: "api-design-v1",
+  value: JSON.stringify(apiDesign),
+  ttl: 86400000  // 24 hours
+}
+
+// Retrieve in subsequent agents
+mcp__claude-flow__memory_usage {
+  action: "retrieve",
+  namespace: "architecture",
+  key: "api-design-v1"
+}
+```
+
+### 2. Parallel Operations
+
+**Batch all related operations in single message**:
+
+```javascript
+// ✅ CORRECT: All operations together
+[Single Message]:
+  mcp__claude-flow__agent_spawn { type: "researcher" }
+  mcp__claude-flow__agent_spawn { type: "coder" }
+  mcp__claude-flow__agent_spawn { type: "tester" }
+  TodoWrite { todos: [8-10 todos] }
+
+// ❌ WRONG: Multiple messages
+Message 1: mcp__claude-flow__agent_spawn { type: "researcher" }
+Message 2: mcp__claude-flow__agent_spawn { type: "coder" }
+Message 3: TodoWrite { todos: [...] }
+```
+
+### 3. Hook Integration
+
+**Every SPARC mode should use hooks**:
+
+```bash
+# Before work
+npx claude-flow@alpha hooks pre-task --description "implement auth"
+
+# During work
+npx claude-flow@alpha hooks post-edit --file "auth.js"
+
+# After work
+npx claude-flow@alpha hooks post-task --task-id "task-123"
+```
+
+### 4. Test Coverage
+
+**Maintain minimum 90% coverage**:
+
+- Unit tests for all functions
+- Integration tests for APIs
+- E2E tests for critical flows
+- Edge case coverage
+- Error path testing
+
+### 5. Documentation
+
+**Document as you build**:
+
+- API documentation (OpenAPI)
+- Architecture decision records (ADR)
+- Code comments for complex logic
+- README with setup instructions
+- Changelog for version tracking
+
+### 6. File Organization
+
+**Never save to root folder**:
+
+```
+project/
+├── src/           # Source code
+├── tests/         # Test files
+├── docs/          # Documentation
+├── config/        # Configuration
+├── scripts/       # Utility scripts
+└── examples/      # Example code
+```
+
+---
+
+## Integration Examples
+
+### Example 1: Full-Stack Development
+
+```javascript
+[Single Message - Parallel Agent Execution]:
+
+// Initialize swarm
+mcp__claude-flow__swarm_init {
+  topology: "hierarchical",
+  maxAgents: 10
+}
+
+// Architecture phase
+mcp__claude-flow__sparc_mode {
+  mode: "architect",
+  task_description: "design REST API with authentication",
+  options: { memory_enabled: true }
+}
+
+// Research phase
+mcp__claude-flow__sparc_mode {
+  mode: "researcher",
+  task_description: "research authentication best practices"
+}
+
+// Implementation phase
+mcp__claude-flow__sparc_mode {
+  mode: "coder",
+  task_description: "implement Express API with JWT auth",
+  options: { test_driven: true }
+}
+
+// Testing phase
+mcp__claude-flow__sparc_mode {
+  mode: "tdd",
+  task_description: "comprehensive API tests",
+  options: { coverage_target: 90 }
+}
+
+// Review phase
+mcp__claude-flow__sparc_mode {
+  mode: "reviewer",
+  task_description: "security and performance review",
+  options: { security_check: true }
+}
+
+// Batch todos
+TodoWrite {
+  todos: [
+    {content: "Design API schema", status: "completed"},
+    {content: "Research JWT implementation", status: "completed"},
+    {content: "Implement authentication", status: "in_progress"},
+    {content: "Write API tests", status: "pending"},
+    {content: "Security review", status: "pending"},
+    {content: "Performance optimization", status: "pending"},
+    {content: "API documentation", status: "pending"},
+    {content: "Deployment setup", status: "pending"}
+  ]
+}
+```
+
+### Example 2: Research-Driven Innovation
+
+```javascript
+// Research phase
+mcp__claude-flow__sparc_mode {
+  mode: "researcher",
+  task_description: "research AI-powered search implementations",
+  options: {
+    depth: "comprehensive",
+    sources: ["academic", "industry"]
+  }
+}
+
+// Innovation phase
+mcp__claude-flow__sparc_mode {
+  mode: "innovator",
+  task_description: "propose novel search algorithm",
+  options: { memory_enabled: true }
+}
+
+// Architecture phase
+mcp__claude-flow__sparc_mode {
+  mode: "architect",
+  task_description: "design scalable search system"
+}
+
+// Implementation phase
+mcp__claude-flow__sparc_mode {
+  mode: "coder",
+  task_description: "implement search algorithm",
+  options: { test_driven: true }
+}
+
+// Documentation phase
+mcp__claude-flow__sparc_mode {
+  mode: "documenter",
+  task_description: "document search system architecture and API"
+}
+```
+
+### Example 3: Legacy Code Refactoring
+
+```javascript
+// Analysis phase
+mcp__claude-flow__sparc_mode {
+  mode: "analyzer",
+  task_description: "analyze legacy codebase dependencies"
+}
+
+// Planning phase
+mcp__claude-flow__sparc_mode {
+  mode: "orchestrator",
+  task_description: "plan incremental refactoring strategy"
+}
+
+// Testing phase (create safety net)
+mcp__claude-flow__sparc_mode {
+  mode: "tester",
+  task_description: "create comprehensive test suite for legacy code",
+  options: { coverage_target: 80 }
+}
+
+// Refactoring phase
+mcp__claude-flow__sparc_mode {
+  mode: "coder",
+  task_description: "refactor module X with modern patterns",
+  options: { maintain_tests: true }
+}
+
+// Review phase
+mcp__claude-flow__sparc_mode {
+  mode: "reviewer",
+  task_description: "validate refactoring maintains functionality"
+}
+```
+
+---
+
+## Common Workflows
+
+### Workflow 1: Feature Development
+
+```bash
+# Step 1: Research and planning
+npx claude-flow sparc run researcher "authentication patterns"
+
+# Step 2: Architecture design
+npx claude-flow sparc run architect "design auth system"
+
+# Step 3: TDD implementation
+npx claude-flow sparc tdd "user authentication feature"
+
+# Step 4: Code review
+npx claude-flow sparc run reviewer "review auth implementation"
+
+# Step 5: Documentation
+npx claude-flow sparc run documenter "document auth API"
+```
+
+### Workflow 2: Bug Investigation
+
+```bash
+# Step 1: Analyze issue
+npx claude-flow sparc run analyzer "investigate bug #456"
+
+# Step 2: Debug systematically
+npx claude-flow sparc run debugger "fix memory leak in service X"
+
+# Step 3: Create tests
+npx claude-flow sparc run tester "regression tests for bug #456"
+
+# Step 4: Review fix
+npx claude-flow sparc run reviewer "validate bug fix"
+```
+
+### Workflow 3: Performance Optimization
+
+```bash
+# Step 1: Profile performance
+npx claude-flow sparc run analyzer "profile API response times"
+
+# Step 2: Identify bottlenecks
+npx claude-flow sparc run optimizer "optimize database queries"
+
+# Step 3: Implement improvements
+npx claude-flow sparc run coder "implement caching layer"
+
+# Step 4: Benchmark results
+npx claude-flow sparc run tester "performance benchmarks"
+```
+
+### Workflow 4: Complete Pipeline
+
+```bash
+# Execute full development pipeline
+npx claude-flow sparc pipeline "e-commerce checkout feature"
+
+# This automatically runs:
+# 1. researcher - Gather requirements
+# 2. architect - Design system
+# 3. coder - Implement features
+# 4. tdd - Create comprehensive tests
+# 5. reviewer - Code quality review
+# 6. optimizer - Performance tuning
+# 7. documenter - Documentation
+```
+
+---
+
+## Advanced Features
+
+### Neural Pattern Training
+
+```javascript
+// Train patterns from successful workflows
+mcp__claude-flow__neural_train {
+  pattern_type: "coordination",
+  training_data: "successful_tdd_workflow.json",
+  epochs: 50
+}
+```
+
+### Cross-Session Memory
+
+```javascript
+// Save session state
+mcp__claude-flow__memory_persist {
+  sessionId: "feature-auth-v1"
+}
+
+// Restore in new session
+mcp__claude-flow__context_restore {
+  snapshotId: "feature-auth-v1"
+}
+```
+
+### GitHub Integration
+
+```javascript
+// Analyze repository
+mcp__claude-flow__github_repo_analyze {
+  repo: "owner/repo",
+  analysis_type: "code_quality"
+}
+
+// Manage pull requests
+mcp__claude-flow__github_pr_manage {
+  repo: "owner/repo",
+  pr_number: 123,
+  action: "review"
+}
+```
+
+### Performance Monitoring
+
+```javascript
+// Real-time swarm monitoring
+mcp__claude-flow__swarm_monitor {
+  swarmId: "current",
+  interval: 5000
+}
+
+// Bottleneck analysis
+mcp__claude-flow__bottleneck_analyze {
+  component: "api-layer",
+  metrics: ["latency", "throughput", "errors"]
+}
+
+// Token usage tracking
+mcp__claude-flow__token_usage {
+  operation: "feature-development",
+  timeframe: "24h"
+}
+```
+
+---
+
+## Performance Benefits
+
+**Proven Results**:
+- **84.8%** SWE-Bench solve rate
+- **32.3%** token reduction through optimizations
+- **2.8-4.4x** speed improvement with parallel execution
+- **27+** neural models for pattern learning
+- **90%+** test coverage standard
+
+---
+
+## Support and Resources
+
+- **Documentation**: https://github.com/ruvnet/claude-flow
+- **Issues**: https://github.com/ruvnet/claude-flow/issues
+- **NPM Package**: https://www.npmjs.com/package/claude-flow
+- **Community**: Discord server (link in repository)
+
+---
+
+## Quick Reference
+
+### Most Common Commands
+
+```bash
+# List modes
+npx claude-flow sparc modes
+
+# Run specific mode
+npx claude-flow sparc run <mode> "task"
+
+# TDD workflow
+npx claude-flow sparc tdd "feature"
+
+# Full pipeline
+npx claude-flow sparc pipeline "task"
+
+# Batch execution
+npx claude-flow sparc batch <modes> "task"
+```
+
+### Most Common MCP Calls
+
+```javascript
+// Initialize swarm
+mcp__claude-flow__swarm_init { topology: "hierarchical" }
+
+// Execute mode
+mcp__claude-flow__sparc_mode { mode: "coder", task_description: "..." }
+
+// Monitor progress
+mcp__claude-flow__swarm_monitor { interval: 5000 }
+
+// Store in memory
+mcp__claude-flow__memory_usage { action: "store", key: "...", value: "..." }
+```
+
+---
+
+Remember: **SPARC = Systematic, Parallel, Agile, Refined, Complete**

--- a/.claude/skills/stream-chain/SKILL.md
+++ b/.claude/skills/stream-chain/SKILL.md
@@ -1,0 +1,560 @@
+---
+name: stream-chain
+description: Stream-JSON chaining for multi-agent pipelines, data transformation, and sequential workflows
+---
+
+# Stream-Chain Skill
+
+Execute sophisticated multi-step workflows where each agent's output flows into the next, enabling complex data transformations and sequential processing pipelines.
+
+## Overview
+
+Stream-Chain provides two powerful modes for orchestrating multi-agent workflows:
+
+1. **Custom Chains** (`run`): Execute custom prompt sequences with full control
+2. **Predefined Pipelines** (`pipeline`): Use battle-tested workflows for common tasks
+
+Each step in a chain receives the complete output from the previous step, enabling sophisticated multi-agent coordination through streaming data flow.
+
+---
+
+## Quick Start
+
+### Run a Custom Chain
+
+```bash
+claude-flow stream-chain run \
+  "Analyze codebase structure" \
+  "Identify improvement areas" \
+  "Generate action plan"
+```
+
+### Execute a Pipeline
+
+```bash
+claude-flow stream-chain pipeline analysis
+```
+
+---
+
+## Custom Chains (`run`)
+
+Execute custom stream chains with your own prompts for maximum flexibility.
+
+### Syntax
+
+```bash
+claude-flow stream-chain run <prompt1> <prompt2> [...] [options]
+```
+
+**Requirements:**
+- Minimum 2 prompts required
+- Each prompt becomes a step in the chain
+- Output flows sequentially through all steps
+
+### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--verbose` | Show detailed execution information | `false` |
+| `--timeout <seconds>` | Timeout per step | `30` |
+| `--debug` | Enable debug mode with full logging | `false` |
+
+### How Context Flows
+
+Each step receives the previous output as context:
+
+```
+Step 1: "Write a sorting function"
+Output: [function implementation]
+
+Step 2 receives:
+  "Previous step output:
+  [function implementation]
+
+  Next task: Add comprehensive tests"
+
+Step 3 receives:
+  "Previous steps output:
+  [function + tests]
+
+  Next task: Optimize performance"
+```
+
+### Examples
+
+#### Basic Development Chain
+
+```bash
+claude-flow stream-chain run \
+  "Write a user authentication function" \
+  "Add input validation and error handling" \
+  "Create unit tests with edge cases"
+```
+
+#### Security Audit Workflow
+
+```bash
+claude-flow stream-chain run \
+  "Analyze authentication system for vulnerabilities" \
+  "Identify and categorize security issues by severity" \
+  "Propose fixes with implementation priority" \
+  "Generate security test cases" \
+  --timeout 45 \
+  --verbose
+```
+
+#### Code Refactoring Chain
+
+```bash
+claude-flow stream-chain run \
+  "Identify code smells in src/ directory" \
+  "Create refactoring plan with specific changes" \
+  "Apply refactoring to top 3 priority items" \
+  "Verify refactored code maintains behavior" \
+  --debug
+```
+
+#### Data Processing Pipeline
+
+```bash
+claude-flow stream-chain run \
+  "Extract data from API responses" \
+  "Transform data into normalized format" \
+  "Validate data against schema" \
+  "Generate data quality report"
+```
+
+---
+
+## Predefined Pipelines (`pipeline`)
+
+Execute battle-tested workflows optimized for common development tasks.
+
+### Syntax
+
+```bash
+claude-flow stream-chain pipeline <type> [options]
+```
+
+### Available Pipelines
+
+#### 1. Analysis Pipeline
+
+Comprehensive codebase analysis and improvement identification.
+
+```bash
+claude-flow stream-chain pipeline analysis
+```
+
+**Workflow Steps:**
+1. **Structure Analysis**: Map directory structure and identify components
+2. **Issue Detection**: Find potential improvements and problems
+3. **Recommendations**: Generate actionable improvement report
+
+**Use Cases:**
+- New codebase onboarding
+- Technical debt assessment
+- Architecture review
+- Code quality audits
+
+#### 2. Refactor Pipeline
+
+Systematic code refactoring with prioritization.
+
+```bash
+claude-flow stream-chain pipeline refactor
+```
+
+**Workflow Steps:**
+1. **Candidate Identification**: Find code needing refactoring
+2. **Prioritization**: Create ranked refactoring plan
+3. **Implementation**: Provide refactored code for top priorities
+
+**Use Cases:**
+- Technical debt reduction
+- Code quality improvement
+- Legacy code modernization
+- Design pattern implementation
+
+#### 3. Test Pipeline
+
+Comprehensive test generation with coverage analysis.
+
+```bash
+claude-flow stream-chain pipeline test
+```
+
+**Workflow Steps:**
+1. **Coverage Analysis**: Identify areas lacking tests
+2. **Test Design**: Create test cases for critical functions
+3. **Implementation**: Generate unit tests with assertions
+
+**Use Cases:**
+- Increasing test coverage
+- TDD workflow support
+- Regression test creation
+- Quality assurance
+
+#### 4. Optimize Pipeline
+
+Performance optimization with profiling and implementation.
+
+```bash
+claude-flow stream-chain pipeline optimize
+```
+
+**Workflow Steps:**
+1. **Profiling**: Identify performance bottlenecks
+2. **Strategy**: Analyze and suggest optimization approaches
+3. **Implementation**: Provide optimized code
+
+**Use Cases:**
+- Performance improvement
+- Resource optimization
+- Scalability enhancement
+- Latency reduction
+
+### Pipeline Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--verbose` | Show detailed execution | `false` |
+| `--timeout <seconds>` | Timeout per step | `30` |
+| `--debug` | Enable debug mode | `false` |
+
+### Pipeline Examples
+
+#### Quick Analysis
+
+```bash
+claude-flow stream-chain pipeline analysis
+```
+
+#### Extended Refactoring
+
+```bash
+claude-flow stream-chain pipeline refactor --timeout 60 --verbose
+```
+
+#### Debug Test Generation
+
+```bash
+claude-flow stream-chain pipeline test --debug
+```
+
+#### Comprehensive Optimization
+
+```bash
+claude-flow stream-chain pipeline optimize --timeout 90 --verbose
+```
+
+### Pipeline Output
+
+Each pipeline execution provides:
+
+- **Progress**: Step-by-step execution status
+- **Results**: Success/failure per step
+- **Timing**: Total and per-step execution time
+- **Summary**: Consolidated results and recommendations
+
+---
+
+## Custom Pipeline Definitions
+
+Define reusable pipelines in `.claude-flow/config.json`:
+
+### Configuration Format
+
+```json
+{
+  "streamChain": {
+    "pipelines": {
+      "security": {
+        "name": "Security Audit Pipeline",
+        "description": "Comprehensive security analysis",
+        "prompts": [
+          "Scan codebase for security vulnerabilities",
+          "Categorize issues by severity (critical/high/medium/low)",
+          "Generate fixes with priority and implementation steps",
+          "Create security test suite"
+        ],
+        "timeout": 45
+      },
+      "documentation": {
+        "name": "Documentation Generation Pipeline",
+        "prompts": [
+          "Analyze code structure and identify undocumented areas",
+          "Generate API documentation with examples",
+          "Create usage guides and tutorials",
+          "Build architecture diagrams and flow charts"
+        ]
+      }
+    }
+  }
+}
+```
+
+### Execute Custom Pipeline
+
+```bash
+claude-flow stream-chain pipeline security
+claude-flow stream-chain pipeline documentation
+```
+
+---
+
+## Advanced Use Cases
+
+### Multi-Agent Coordination
+
+Chain different agent types for complex workflows:
+
+```bash
+claude-flow stream-chain run \
+  "Research best practices for API design" \
+  "Design REST API with discovered patterns" \
+  "Implement API endpoints with validation" \
+  "Generate OpenAPI specification" \
+  "Create integration tests" \
+  "Write deployment documentation"
+```
+
+### Data Transformation Pipeline
+
+Process and transform data through multiple stages:
+
+```bash
+claude-flow stream-chain run \
+  "Extract user data from CSV files" \
+  "Normalize and validate data format" \
+  "Enrich data with external API calls" \
+  "Generate analytics report" \
+  "Create visualization code"
+```
+
+### Code Migration Workflow
+
+Systematic code migration with validation:
+
+```bash
+claude-flow stream-chain run \
+  "Analyze legacy codebase dependencies" \
+  "Create migration plan with risk assessment" \
+  "Generate modernized code for high-priority modules" \
+  "Create migration tests" \
+  "Document migration steps and rollback procedures"
+```
+
+### Quality Assurance Chain
+
+Comprehensive code quality workflow:
+
+```bash
+claude-flow stream-chain pipeline analysis
+claude-flow stream-chain pipeline refactor
+claude-flow stream-chain pipeline test
+claude-flow stream-chain pipeline optimize
+```
+
+---
+
+## Best Practices
+
+### 1. Clear and Specific Prompts
+
+**Good:**
+```bash
+"Analyze authentication.js for SQL injection vulnerabilities"
+```
+
+**Avoid:**
+```bash
+"Check security"
+```
+
+### 2. Logical Progression
+
+Order prompts to build on previous outputs:
+```bash
+1. "Identify the problem"
+2. "Analyze root causes"
+3. "Design solution"
+4. "Implement solution"
+5. "Verify implementation"
+```
+
+### 3. Appropriate Timeouts
+
+- Simple tasks: 30 seconds (default)
+- Analysis tasks: 45-60 seconds
+- Implementation tasks: 60-90 seconds
+- Complex workflows: 90-120 seconds
+
+### 4. Verification Steps
+
+Include validation in your chains:
+```bash
+claude-flow stream-chain run \
+  "Implement feature X" \
+  "Write tests for feature X" \
+  "Verify tests pass and cover edge cases"
+```
+
+### 5. Iterative Refinement
+
+Use chains for iterative improvement:
+```bash
+claude-flow stream-chain run \
+  "Generate initial implementation" \
+  "Review and identify issues" \
+  "Refine based on issues found" \
+  "Final quality check"
+```
+
+---
+
+## Integration with Claude Flow
+
+### Combine with Swarm Coordination
+
+```bash
+# Initialize swarm for coordination
+claude-flow swarm init --topology mesh
+
+# Execute stream chain with swarm agents
+claude-flow stream-chain run \
+  "Agent 1: Research task" \
+  "Agent 2: Implement solution" \
+  "Agent 3: Test implementation" \
+  "Agent 4: Review and refine"
+```
+
+### Memory Integration
+
+Stream chains automatically store context in memory for cross-session persistence:
+
+```bash
+# Execute chain with memory
+claude-flow stream-chain run \
+  "Analyze requirements" \
+  "Design architecture" \
+  --verbose
+
+# Results stored in .claude-flow/memory/stream-chain/
+```
+
+### Neural Pattern Training
+
+Successful chains train neural patterns for improved performance:
+
+```bash
+# Enable neural training
+claude-flow stream-chain pipeline optimize --debug
+
+# Patterns learned and stored for future optimizations
+```
+
+---
+
+## Troubleshooting
+
+### Chain Timeout
+
+If steps timeout, increase timeout value:
+
+```bash
+claude-flow stream-chain run "complex task" --timeout 120
+```
+
+### Context Loss
+
+If context not flowing properly, use `--debug`:
+
+```bash
+claude-flow stream-chain run "step 1" "step 2" --debug
+```
+
+### Pipeline Not Found
+
+Verify pipeline name and custom definitions:
+
+```bash
+# Check available pipelines
+cat .claude-flow/config.json | grep -A 10 "streamChain"
+```
+
+---
+
+## Performance Characteristics
+
+- **Throughput**: 2-5 steps per minute (varies by complexity)
+- **Context Size**: Up to 100K tokens per step
+- **Memory Usage**: ~50MB per active chain
+- **Concurrency**: Supports parallel chain execution
+
+---
+
+## Related Skills
+
+- **SPARC Methodology**: Systematic development workflow
+- **Swarm Coordination**: Multi-agent orchestration
+- **Memory Management**: Persistent context storage
+- **Neural Patterns**: Adaptive learning
+
+---
+
+## Examples Repository
+
+### Complete Development Workflow
+
+```bash
+# Full feature development chain
+claude-flow stream-chain run \
+  "Analyze requirements for user profile feature" \
+  "Design database schema and API endpoints" \
+  "Implement backend with validation" \
+  "Create frontend components" \
+  "Write comprehensive tests" \
+  "Generate API documentation" \
+  --timeout 60 \
+  --verbose
+```
+
+### Code Review Pipeline
+
+```bash
+# Automated code review workflow
+claude-flow stream-chain run \
+  "Analyze recent git changes" \
+  "Identify code quality issues" \
+  "Check for security vulnerabilities" \
+  "Verify test coverage" \
+  "Generate code review report with recommendations"
+```
+
+### Migration Assistant
+
+```bash
+# Framework migration helper
+claude-flow stream-chain run \
+  "Analyze current Vue 2 codebase" \
+  "Identify Vue 3 breaking changes" \
+  "Create migration checklist" \
+  "Generate migration scripts" \
+  "Provide updated code examples"
+```
+
+---
+
+## Conclusion
+
+Stream-Chain enables sophisticated multi-step workflows by:
+
+- **Sequential Processing**: Each step builds on previous results
+- **Context Preservation**: Full output history flows through chain
+- **Flexible Orchestration**: Custom chains or predefined pipelines
+- **Agent Coordination**: Natural multi-agent collaboration pattern
+- **Data Transformation**: Complex processing through simple steps
+
+Use `run` for custom workflows and `pipeline` for battle-tested solutions.

--- a/.claude/skills/swarm-advanced/SKILL.md
+++ b/.claude/skills/swarm-advanced/SKILL.md
@@ -1,0 +1,970 @@
+---
+name: swarm-advanced
+description: |
+  Advanced swarm orchestration patterns for research, development, testing, and complex distributed workflows
+---
+
+# Advanced Swarm Orchestration
+
+Master advanced swarm patterns for distributed research, development, and testing workflows. This skill covers comprehensive orchestration strategies using both MCP tools and CLI commands.
+
+## Quick Start
+
+### Prerequisites
+```bash
+# Ensure Claude Flow is installed
+npm install -g claude-flow@alpha
+
+# Add MCP server (if using MCP tools)
+claude mcp add claude-flow npx claude-flow@alpha mcp start
+```
+
+### Basic Pattern
+```javascript
+// 1. Initialize swarm topology
+mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 6 })
+
+// 2. Spawn specialized agents
+mcp__claude-flow__agent_spawn({ type: "researcher", name: "Agent 1" })
+
+// 3. Orchestrate tasks
+mcp__claude-flow__task_orchestrate({ task: "...", strategy: "parallel" })
+```
+
+## Core Concepts
+
+### Swarm Topologies
+
+**Mesh Topology** - Peer-to-peer communication, best for research and analysis
+- All agents communicate directly
+- High flexibility and resilience
+- Use for: Research, analysis, brainstorming
+
+**Hierarchical Topology** - Coordinator with subordinates, best for development
+- Clear command structure
+- Sequential workflow support
+- Use for: Development, structured workflows
+
+**Star Topology** - Central coordinator, best for testing
+- Centralized control and monitoring
+- Parallel execution with coordination
+- Use for: Testing, validation, quality assurance
+
+**Ring Topology** - Sequential processing chain
+- Step-by-step processing
+- Pipeline workflows
+- Use for: Multi-stage processing, data pipelines
+
+### Agent Strategies
+
+**Adaptive** - Dynamic adjustment based on task complexity
+**Balanced** - Equal distribution of work across agents
+**Specialized** - Task-specific agent assignment
+**Parallel** - Maximum concurrent execution
+
+## Pattern 1: Research Swarm
+
+### Purpose
+Deep research through parallel information gathering, analysis, and synthesis.
+
+### Architecture
+```javascript
+// Initialize research swarm
+mcp__claude-flow__swarm_init({
+  "topology": "mesh",
+  "maxAgents": 6,
+  "strategy": "adaptive"
+})
+
+// Spawn research team
+const researchAgents = [
+  {
+    type: "researcher",
+    name: "Web Researcher",
+    capabilities: ["web-search", "content-extraction", "source-validation"]
+  },
+  {
+    type: "researcher",
+    name: "Academic Researcher",
+    capabilities: ["paper-analysis", "citation-tracking", "literature-review"]
+  },
+  {
+    type: "analyst",
+    name: "Data Analyst",
+    capabilities: ["data-processing", "statistical-analysis", "visualization"]
+  },
+  {
+    type: "analyst",
+    name: "Pattern Analyzer",
+    capabilities: ["trend-detection", "correlation-analysis", "outlier-detection"]
+  },
+  {
+    type: "documenter",
+    name: "Report Writer",
+    capabilities: ["synthesis", "technical-writing", "formatting"]
+  }
+]
+
+// Spawn all agents
+researchAgents.forEach(agent => {
+  mcp__claude-flow__agent_spawn({
+    type: agent.type,
+    name: agent.name,
+    capabilities: agent.capabilities
+  })
+})
+```
+
+### Research Workflow
+
+#### Phase 1: Information Gathering
+```javascript
+// Parallel information collection
+mcp__claude-flow__parallel_execute({
+  "tasks": [
+    {
+      "id": "web-search",
+      "command": "search recent publications and articles"
+    },
+    {
+      "id": "academic-search",
+      "command": "search academic databases and papers"
+    },
+    {
+      "id": "data-collection",
+      "command": "gather relevant datasets and statistics"
+    },
+    {
+      "id": "expert-search",
+      "command": "identify domain experts and thought leaders"
+    }
+  ]
+})
+
+// Store research findings in memory
+mcp__claude-flow__memory_usage({
+  "action": "store",
+  "key": "research-findings-" + Date.now(),
+  "value": JSON.stringify(findings),
+  "namespace": "research",
+  "ttl": 604800 // 7 days
+})
+```
+
+#### Phase 2: Analysis and Validation
+```javascript
+// Pattern recognition in findings
+mcp__claude-flow__pattern_recognize({
+  "data": researchData,
+  "patterns": ["trend", "correlation", "outlier", "emerging-pattern"]
+})
+
+// Cognitive analysis
+mcp__claude-flow__cognitive_analyze({
+  "behavior": "research-synthesis"
+})
+
+// Quality assessment
+mcp__claude-flow__quality_assess({
+  "target": "research-sources",
+  "criteria": ["credibility", "relevance", "recency", "authority"]
+})
+
+// Cross-reference validation
+mcp__claude-flow__neural_patterns({
+  "action": "analyze",
+  "operation": "fact-checking",
+  "metadata": { "sources": sourcesArray }
+})
+```
+
+#### Phase 3: Knowledge Management
+```javascript
+// Search existing knowledge base
+mcp__claude-flow__memory_search({
+  "pattern": "topic X",
+  "namespace": "research",
+  "limit": 20
+})
+
+// Create knowledge graph connections
+mcp__claude-flow__neural_patterns({
+  "action": "learn",
+  "operation": "knowledge-graph",
+  "metadata": {
+    "topic": "X",
+    "connections": relatedTopics,
+    "depth": 3
+  }
+})
+
+// Store connections for future use
+mcp__claude-flow__memory_usage({
+  "action": "store",
+  "key": "knowledge-graph-X",
+  "value": JSON.stringify(knowledgeGraph),
+  "namespace": "research/graphs",
+  "ttl": 2592000 // 30 days
+})
+```
+
+#### Phase 4: Report Generation
+```javascript
+// Orchestrate report generation
+mcp__claude-flow__task_orchestrate({
+  "task": "generate comprehensive research report",
+  "strategy": "sequential",
+  "priority": "high",
+  "dependencies": ["gather", "analyze", "validate", "synthesize"]
+})
+
+// Monitor research progress
+mcp__claude-flow__swarm_status({
+  "swarmId": "research-swarm"
+})
+
+// Generate final report
+mcp__claude-flow__workflow_execute({
+  "workflowId": "research-report-generation",
+  "params": {
+    "findings": findings,
+    "format": "comprehensive",
+    "sections": ["executive-summary", "methodology", "findings", "analysis", "conclusions", "references"]
+  }
+})
+```
+
+### CLI Fallback
+```bash
+# Quick research swarm
+npx claude-flow swarm "research AI trends in 2025" \
+  --strategy research \
+  --mode distributed \
+  --max-agents 6 \
+  --parallel \
+  --output research-report.md
+```
+
+## Pattern 2: Development Swarm
+
+### Purpose
+Full-stack development through coordinated specialist agents.
+
+### Architecture
+```javascript
+// Initialize development swarm with hierarchy
+mcp__claude-flow__swarm_init({
+  "topology": "hierarchical",
+  "maxAgents": 8,
+  "strategy": "balanced"
+})
+
+// Spawn development team
+const devTeam = [
+  { type: "architect", name: "System Architect", role: "coordinator" },
+  { type: "coder", name: "Backend Developer", capabilities: ["node", "api", "database"] },
+  { type: "coder", name: "Frontend Developer", capabilities: ["react", "ui", "ux"] },
+  { type: "coder", name: "Database Engineer", capabilities: ["sql", "nosql", "optimization"] },
+  { type: "tester", name: "QA Engineer", capabilities: ["unit", "integration", "e2e"] },
+  { type: "reviewer", name: "Code Reviewer", capabilities: ["security", "performance", "best-practices"] },
+  { type: "documenter", name: "Technical Writer", capabilities: ["api-docs", "guides", "tutorials"] },
+  { type: "monitor", name: "DevOps Engineer", capabilities: ["ci-cd", "deployment", "monitoring"] }
+]
+
+// Spawn all team members
+devTeam.forEach(member => {
+  mcp__claude-flow__agent_spawn({
+    type: member.type,
+    name: member.name,
+    capabilities: member.capabilities,
+    swarmId: "dev-swarm"
+  })
+})
+```
+
+### Development Workflow
+
+#### Phase 1: Architecture and Design
+```javascript
+// System architecture design
+mcp__claude-flow__task_orchestrate({
+  "task": "design system architecture for REST API",
+  "strategy": "sequential",
+  "priority": "critical",
+  "assignTo": "System Architect"
+})
+
+// Store architecture decisions
+mcp__claude-flow__memory_usage({
+  "action": "store",
+  "key": "architecture-decisions",
+  "value": JSON.stringify(architectureDoc),
+  "namespace": "development/design"
+})
+```
+
+#### Phase 2: Parallel Implementation
+```javascript
+// Parallel development tasks
+mcp__claude-flow__parallel_execute({
+  "tasks": [
+    {
+      "id": "backend-api",
+      "command": "implement REST API endpoints",
+      "assignTo": "Backend Developer"
+    },
+    {
+      "id": "frontend-ui",
+      "command": "build user interface components",
+      "assignTo": "Frontend Developer"
+    },
+    {
+      "id": "database-schema",
+      "command": "design and implement database schema",
+      "assignTo": "Database Engineer"
+    },
+    {
+      "id": "api-documentation",
+      "command": "create API documentation",
+      "assignTo": "Technical Writer"
+    }
+  ]
+})
+
+// Monitor development progress
+mcp__claude-flow__swarm_monitor({
+  "swarmId": "dev-swarm",
+  "interval": 5000
+})
+```
+
+#### Phase 3: Testing and Validation
+```javascript
+// Comprehensive testing
+mcp__claude-flow__batch_process({
+  "items": [
+    { type: "unit", target: "all-modules" },
+    { type: "integration", target: "api-endpoints" },
+    { type: "e2e", target: "user-flows" },
+    { type: "performance", target: "critical-paths" }
+  ],
+  "operation": "execute-tests"
+})
+
+// Quality assessment
+mcp__claude-flow__quality_assess({
+  "target": "codebase",
+  "criteria": ["coverage", "complexity", "maintainability", "security"]
+})
+```
+
+#### Phase 4: Review and Deployment
+```javascript
+// Code review workflow
+mcp__claude-flow__workflow_execute({
+  "workflowId": "code-review-process",
+  "params": {
+    "reviewers": ["Code Reviewer"],
+    "criteria": ["security", "performance", "best-practices"]
+  }
+})
+
+// CI/CD pipeline
+mcp__claude-flow__pipeline_create({
+  "config": {
+    "stages": ["build", "test", "security-scan", "deploy"],
+    "environment": "production"
+  }
+})
+```
+
+### CLI Fallback
+```bash
+# Quick development swarm
+npx claude-flow swarm "build REST API with authentication" \
+  --strategy development \
+  --mode hierarchical \
+  --monitor \
+  --output sqlite
+```
+
+## Pattern 3: Testing Swarm
+
+### Purpose
+Comprehensive quality assurance through distributed testing.
+
+### Architecture
+```javascript
+// Initialize testing swarm with star topology
+mcp__claude-flow__swarm_init({
+  "topology": "star",
+  "maxAgents": 7,
+  "strategy": "parallel"
+})
+
+// Spawn testing team
+const testingTeam = [
+  {
+    type: "tester",
+    name: "Unit Test Coordinator",
+    capabilities: ["unit-testing", "mocking", "coverage", "tdd"]
+  },
+  {
+    type: "tester",
+    name: "Integration Tester",
+    capabilities: ["integration", "api-testing", "contract-testing"]
+  },
+  {
+    type: "tester",
+    name: "E2E Tester",
+    capabilities: ["e2e", "ui-testing", "user-flows", "selenium"]
+  },
+  {
+    type: "tester",
+    name: "Performance Tester",
+    capabilities: ["load-testing", "stress-testing", "benchmarking"]
+  },
+  {
+    type: "monitor",
+    name: "Security Tester",
+    capabilities: ["security-testing", "penetration-testing", "vulnerability-scanning"]
+  },
+  {
+    type: "analyst",
+    name: "Test Analyst",
+    capabilities: ["coverage-analysis", "test-optimization", "reporting"]
+  },
+  {
+    type: "documenter",
+    name: "Test Documenter",
+    capabilities: ["test-documentation", "test-plans", "reports"]
+  }
+]
+
+// Spawn all testers
+testingTeam.forEach(tester => {
+  mcp__claude-flow__agent_spawn({
+    type: tester.type,
+    name: tester.name,
+    capabilities: tester.capabilities,
+    swarmId: "testing-swarm"
+  })
+})
+```
+
+### Testing Workflow
+
+#### Phase 1: Test Planning
+```javascript
+// Analyze test coverage requirements
+mcp__claude-flow__quality_assess({
+  "target": "test-coverage",
+  "criteria": [
+    "line-coverage",
+    "branch-coverage",
+    "function-coverage",
+    "edge-cases"
+  ]
+})
+
+// Identify test scenarios
+mcp__claude-flow__pattern_recognize({
+  "data": testScenarios,
+  "patterns": [
+    "edge-case",
+    "boundary-condition",
+    "error-path",
+    "happy-path"
+  ]
+})
+
+// Store test plan
+mcp__claude-flow__memory_usage({
+  "action": "store",
+  "key": "test-plan-" + Date.now(),
+  "value": JSON.stringify(testPlan),
+  "namespace": "testing/plans"
+})
+```
+
+#### Phase 2: Parallel Test Execution
+```javascript
+// Execute all test suites in parallel
+mcp__claude-flow__parallel_execute({
+  "tasks": [
+    {
+      "id": "unit-tests",
+      "command": "npm run test:unit",
+      "assignTo": "Unit Test Coordinator"
+    },
+    {
+      "id": "integration-tests",
+      "command": "npm run test:integration",
+      "assignTo": "Integration Tester"
+    },
+    {
+      "id": "e2e-tests",
+      "command": "npm run test:e2e",
+      "assignTo": "E2E Tester"
+    },
+    {
+      "id": "performance-tests",
+      "command": "npm run test:performance",
+      "assignTo": "Performance Tester"
+    },
+    {
+      "id": "security-tests",
+      "command": "npm run test:security",
+      "assignTo": "Security Tester"
+    }
+  ]
+})
+
+// Batch process test suites
+mcp__claude-flow__batch_process({
+  "items": testSuites,
+  "operation": "execute-test-suite"
+})
+```
+
+#### Phase 3: Performance and Security
+```javascript
+// Run performance benchmarks
+mcp__claude-flow__benchmark_run({
+  "suite": "comprehensive-performance"
+})
+
+// Bottleneck analysis
+mcp__claude-flow__bottleneck_analyze({
+  "component": "application",
+  "metrics": ["response-time", "throughput", "memory", "cpu"]
+})
+
+// Security scanning
+mcp__claude-flow__security_scan({
+  "target": "application",
+  "depth": "comprehensive"
+})
+
+// Vulnerability analysis
+mcp__claude-flow__error_analysis({
+  "logs": securityScanLogs
+})
+```
+
+#### Phase 4: Monitoring and Reporting
+```javascript
+// Real-time test monitoring
+mcp__claude-flow__swarm_monitor({
+  "swarmId": "testing-swarm",
+  "interval": 2000
+})
+
+// Generate comprehensive test report
+mcp__claude-flow__performance_report({
+  "format": "detailed",
+  "timeframe": "current-run"
+})
+
+// Get test results
+mcp__claude-flow__task_results({
+  "taskId": "test-execution-001"
+})
+
+// Trend analysis
+mcp__claude-flow__trend_analysis({
+  "metric": "test-coverage",
+  "period": "30d"
+})
+```
+
+### CLI Fallback
+```bash
+# Quick testing swarm
+npx claude-flow swarm "test application comprehensively" \
+  --strategy testing \
+  --mode star \
+  --parallel \
+  --timeout 600
+```
+
+## Pattern 4: Analysis Swarm
+
+### Purpose
+Deep code and system analysis through specialized analyzers.
+
+### Architecture
+```javascript
+// Initialize analysis swarm
+mcp__claude-flow__swarm_init({
+  "topology": "mesh",
+  "maxAgents": 5,
+  "strategy": "adaptive"
+})
+
+// Spawn analysis specialists
+const analysisTeam = [
+  {
+    type: "analyst",
+    name: "Code Analyzer",
+    capabilities: ["static-analysis", "complexity-analysis", "dead-code-detection"]
+  },
+  {
+    type: "analyst",
+    name: "Security Analyzer",
+    capabilities: ["security-scan", "vulnerability-detection", "dependency-audit"]
+  },
+  {
+    type: "analyst",
+    name: "Performance Analyzer",
+    capabilities: ["profiling", "bottleneck-detection", "optimization"]
+  },
+  {
+    type: "analyst",
+    name: "Architecture Analyzer",
+    capabilities: ["dependency-analysis", "coupling-detection", "modularity-assessment"]
+  },
+  {
+    type: "documenter",
+    name: "Analysis Reporter",
+    capabilities: ["reporting", "visualization", "recommendations"]
+  }
+]
+
+// Spawn all analysts
+analysisTeam.forEach(analyst => {
+  mcp__claude-flow__agent_spawn({
+    type: analyst.type,
+    name: analyst.name,
+    capabilities: analyst.capabilities
+  })
+})
+```
+
+### Analysis Workflow
+```javascript
+// Parallel analysis execution
+mcp__claude-flow__parallel_execute({
+  "tasks": [
+    { "id": "analyze-code", "command": "analyze codebase structure and quality" },
+    { "id": "analyze-security", "command": "scan for security vulnerabilities" },
+    { "id": "analyze-performance", "command": "identify performance bottlenecks" },
+    { "id": "analyze-architecture", "command": "assess architectural patterns" }
+  ]
+})
+
+// Generate comprehensive analysis report
+mcp__claude-flow__performance_report({
+  "format": "detailed",
+  "timeframe": "current"
+})
+
+// Cost analysis
+mcp__claude-flow__cost_analysis({
+  "timeframe": "30d"
+})
+```
+
+## Advanced Techniques
+
+### Error Handling and Fault Tolerance
+
+```javascript
+// Setup fault tolerance for all agents
+mcp__claude-flow__daa_fault_tolerance({
+  "agentId": "all",
+  "strategy": "auto-recovery"
+})
+
+// Error handling pattern
+try {
+  await mcp__claude-flow__task_orchestrate({
+    "task": "complex operation",
+    "strategy": "parallel",
+    "priority": "high"
+  })
+} catch (error) {
+  // Check swarm health
+  const status = await mcp__claude-flow__swarm_status({})
+
+  // Analyze error patterns
+  await mcp__claude-flow__error_analysis({
+    "logs": [error.message]
+  })
+
+  // Auto-recovery attempt
+  if (status.healthy) {
+    await mcp__claude-flow__task_orchestrate({
+      "task": "retry failed operation",
+      "strategy": "sequential"
+    })
+  }
+}
+```
+
+### Memory and State Management
+
+```javascript
+// Cross-session persistence
+mcp__claude-flow__memory_persist({
+  "sessionId": "swarm-session-001"
+})
+
+// Namespace management for different swarms
+mcp__claude-flow__memory_namespace({
+  "namespace": "research-swarm",
+  "action": "create"
+})
+
+// Create state snapshot
+mcp__claude-flow__state_snapshot({
+  "name": "development-checkpoint-1"
+})
+
+// Restore from snapshot if needed
+mcp__claude-flow__context_restore({
+  "snapshotId": "development-checkpoint-1"
+})
+
+// Backup memory stores
+mcp__claude-flow__memory_backup({
+  "path": "/workspaces/claude-code-flow/backups/swarm-memory.json"
+})
+```
+
+### Neural Pattern Learning
+
+```javascript
+// Train neural patterns from successful workflows
+mcp__claude-flow__neural_train({
+  "pattern_type": "coordination",
+  "training_data": JSON.stringify(successfulWorkflows),
+  "epochs": 50
+})
+
+// Adaptive learning from experience
+mcp__claude-flow__learning_adapt({
+  "experience": {
+    "workflow": "research-to-report",
+    "success": true,
+    "duration": 3600,
+    "quality": 0.95
+  }
+})
+
+// Pattern recognition for optimization
+mcp__claude-flow__pattern_recognize({
+  "data": workflowMetrics,
+  "patterns": ["bottleneck", "optimization-opportunity", "efficiency-gain"]
+})
+```
+
+### Workflow Automation
+
+```javascript
+// Create reusable workflow
+mcp__claude-flow__workflow_create({
+  "name": "full-stack-development",
+  "steps": [
+    { "phase": "design", "agents": ["architect"] },
+    { "phase": "implement", "agents": ["backend-dev", "frontend-dev"], "parallel": true },
+    { "phase": "test", "agents": ["tester", "security-tester"], "parallel": true },
+    { "phase": "review", "agents": ["reviewer"] },
+    { "phase": "deploy", "agents": ["devops"] }
+  ],
+  "triggers": ["on-commit", "scheduled-daily"]
+})
+
+// Setup automation rules
+mcp__claude-flow__automation_setup({
+  "rules": [
+    {
+      "trigger": "file-changed",
+      "pattern": "*.js",
+      "action": "run-tests"
+    },
+    {
+      "trigger": "PR-created",
+      "action": "code-review-swarm"
+    }
+  ]
+})
+
+// Event-driven triggers
+mcp__claude-flow__trigger_setup({
+  "events": ["code-commit", "PR-merge", "deployment"],
+  "actions": ["test", "analyze", "document"]
+})
+```
+
+### Performance Optimization
+
+```javascript
+// Topology optimization
+mcp__claude-flow__topology_optimize({
+  "swarmId": "current-swarm"
+})
+
+// Load balancing
+mcp__claude-flow__load_balance({
+  "swarmId": "development-swarm",
+  "tasks": taskQueue
+})
+
+// Agent coordination sync
+mcp__claude-flow__coordination_sync({
+  "swarmId": "development-swarm"
+})
+
+// Auto-scaling
+mcp__claude-flow__swarm_scale({
+  "swarmId": "development-swarm",
+  "targetSize": 12
+})
+```
+
+### Monitoring and Metrics
+
+```javascript
+// Real-time swarm monitoring
+mcp__claude-flow__swarm_monitor({
+  "swarmId": "active-swarm",
+  "interval": 3000
+})
+
+// Collect comprehensive metrics
+mcp__claude-flow__metrics_collect({
+  "components": ["agents", "tasks", "memory", "performance"]
+})
+
+// Health monitoring
+mcp__claude-flow__health_check({
+  "components": ["swarm", "agents", "neural", "memory"]
+})
+
+// Usage statistics
+mcp__claude-flow__usage_stats({
+  "component": "swarm-orchestration"
+})
+
+// Trend analysis
+mcp__claude-flow__trend_analysis({
+  "metric": "agent-performance",
+  "period": "7d"
+})
+```
+
+## Best Practices
+
+### 1. Choosing the Right Topology
+
+- **Mesh**: Research, brainstorming, collaborative analysis
+- **Hierarchical**: Structured development, sequential workflows
+- **Star**: Testing, validation, centralized coordination
+- **Ring**: Pipeline processing, staged workflows
+
+### 2. Agent Specialization
+
+- Assign specific capabilities to each agent
+- Avoid overlapping responsibilities
+- Use coordination agents for complex workflows
+- Leverage memory for agent communication
+
+### 3. Parallel Execution
+
+- Identify independent tasks for parallelization
+- Use sequential execution for dependent tasks
+- Monitor resource usage during parallel execution
+- Implement proper error handling
+
+### 4. Memory Management
+
+- Use namespaces to organize memory
+- Set appropriate TTL values
+- Create regular backups
+- Implement state snapshots for checkpoints
+
+### 5. Monitoring and Optimization
+
+- Monitor swarm health regularly
+- Collect and analyze metrics
+- Optimize topology based on performance
+- Use neural patterns to learn from success
+
+### 6. Error Recovery
+
+- Implement fault tolerance strategies
+- Use auto-recovery mechanisms
+- Analyze error patterns
+- Create fallback workflows
+
+## Real-World Examples
+
+### Example 1: AI Research Project
+```javascript
+// Research AI trends, analyze findings, generate report
+mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 6 })
+// Spawn: 2 researchers, 2 analysts, 1 synthesizer, 1 documenter
+// Parallel gather → Analyze patterns → Synthesize → Report
+```
+
+### Example 2: Full-Stack Application
+```javascript
+// Build complete web application with testing
+mcp__claude-flow__swarm_init({ topology: "hierarchical", maxAgents: 8 })
+// Spawn: 1 architect, 2 devs, 1 db engineer, 2 testers, 1 reviewer, 1 devops
+// Design → Parallel implement → Test → Review → Deploy
+```
+
+### Example 3: Security Audit
+```javascript
+// Comprehensive security analysis
+mcp__claude-flow__swarm_init({ topology: "star", maxAgents: 5 })
+// Spawn: 1 coordinator, 1 code analyzer, 1 security scanner, 1 penetration tester, 1 reporter
+// Parallel scan → Vulnerability analysis → Penetration test → Report
+```
+
+### Example 4: Performance Optimization
+```javascript
+// Identify and fix performance bottlenecks
+mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 4 })
+// Spawn: 1 profiler, 1 bottleneck analyzer, 1 optimizer, 1 tester
+// Profile → Identify bottlenecks → Optimize → Validate
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**Issue**: Swarm agents not coordinating properly
+**Solution**: Check topology selection, verify memory usage, enable monitoring
+
+**Issue**: Parallel execution failing
+**Solution**: Verify task dependencies, check resource limits, implement error handling
+
+**Issue**: Memory persistence not working
+**Solution**: Verify namespaces, check TTL settings, ensure backup configuration
+
+**Issue**: Performance degradation
+**Solution**: Optimize topology, reduce agent count, analyze bottlenecks
+
+## Related Skills
+
+- `sparc-methodology` - Systematic development workflow
+- `github-integration` - Repository management and automation
+- `neural-patterns` - AI-powered coordination optimization
+- `memory-management` - Cross-session state persistence
+
+## References
+
+- [Claude Flow Documentation](https://github.com/ruvnet/claude-flow)
+- [Swarm Orchestration Guide](https://github.com/ruvnet/claude-flow/wiki/swarm)
+- [MCP Tools Reference](https://github.com/ruvnet/claude-flow/wiki/mcp)
+- [Performance Optimization](https://github.com/ruvnet/claude-flow/wiki/performance)
+
+---
+
+**Version**: 2.0.0
+**Last Updated**: 2025-10-19
+**Skill Level**: Advanced
+**Estimated Learning Time**: 2-3 hours

--- a/.claude/skills/swarm-orchestration/SKILL.md
+++ b/.claude/skills/swarm-orchestration/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: "Swarm Orchestration"
+description: "Orchestrate multi-agent swarms with agentic-flow for parallel task execution, dynamic topology, and intelligent coordination. Use when scaling beyond single agents, implementing complex workflows, or building distributed AI systems."
+---
+
+# Swarm Orchestration
+
+## What This Skill Does
+
+Orchestrates multi-agent swarms using agentic-flow's advanced coordination system. Supports mesh, hierarchical, and adaptive topologies with automatic task distribution, load balancing, and fault tolerance.
+
+## Prerequisites
+
+- agentic-flow v1.5.11+
+- Node.js 18+
+- Understanding of distributed systems (helpful)
+
+## Quick Start
+
+```bash
+# Initialize swarm
+npx agentic-flow hooks swarm-init --topology mesh --max-agents 5
+
+# Spawn agents
+npx agentic-flow hooks agent-spawn --type coder
+npx agentic-flow hooks agent-spawn --type tester
+npx agentic-flow hooks agent-spawn --type reviewer
+
+# Orchestrate task
+npx agentic-flow hooks task-orchestrate \
+  --task "Build REST API with tests" \
+  --mode parallel
+```
+
+## Topology Patterns
+
+### 1. Mesh (Peer-to-Peer)
+```typescript
+// Equal peers, distributed decision-making
+await swarm.init({
+  topology: 'mesh',
+  agents: ['coder', 'tester', 'reviewer'],
+  communication: 'broadcast'
+});
+```
+
+### 2. Hierarchical (Queen-Worker)
+```typescript
+// Centralized coordination, specialized workers
+await swarm.init({
+  topology: 'hierarchical',
+  queen: 'architect',
+  workers: ['backend-dev', 'frontend-dev', 'db-designer']
+});
+```
+
+### 3. Adaptive (Dynamic)
+```typescript
+// Automatically switches topology based on task
+await swarm.init({
+  topology: 'adaptive',
+  optimization: 'task-complexity'
+});
+```
+
+## Task Orchestration
+
+### Parallel Execution
+```typescript
+// Execute tasks concurrently
+const results = await swarm.execute({
+  tasks: [
+    { agent: 'coder', task: 'Implement API endpoints' },
+    { agent: 'frontend', task: 'Build UI components' },
+    { agent: 'tester', task: 'Write test suite' }
+  ],
+  mode: 'parallel',
+  timeout: 300000 // 5 minutes
+});
+```
+
+### Pipeline Execution
+```typescript
+// Sequential pipeline with dependencies
+await swarm.pipeline([
+  { stage: 'design', agent: 'architect' },
+  { stage: 'implement', agent: 'coder', after: 'design' },
+  { stage: 'test', agent: 'tester', after: 'implement' },
+  { stage: 'review', agent: 'reviewer', after: 'test' }
+]);
+```
+
+### Adaptive Execution
+```typescript
+// Let swarm decide execution strategy
+await swarm.autoOrchestrate({
+  goal: 'Build production-ready API',
+  constraints: {
+    maxTime: 3600,
+    maxAgents: 8,
+    quality: 'high'
+  }
+});
+```
+
+## Memory Coordination
+
+```typescript
+// Share state across swarm
+await swarm.memory.store('api-schema', {
+  endpoints: [...],
+  models: [...]
+});
+
+// Agents read shared memory
+const schema = await swarm.memory.retrieve('api-schema');
+```
+
+## Advanced Features
+
+### Load Balancing
+```typescript
+// Automatic work distribution
+await swarm.enableLoadBalancing({
+  strategy: 'dynamic',
+  metrics: ['cpu', 'memory', 'task-queue']
+});
+```
+
+### Fault Tolerance
+```typescript
+// Handle agent failures
+await swarm.setResiliency({
+  retry: { maxAttempts: 3, backoff: 'exponential' },
+  fallback: 'reassign-task'
+});
+```
+
+### Performance Monitoring
+```typescript
+// Track swarm metrics
+const metrics = await swarm.getMetrics();
+// { throughput, latency, success_rate, agent_utilization }
+```
+
+## Integration with Hooks
+
+```bash
+# Pre-task coordination
+npx agentic-flow hooks pre-task --description "Build API"
+
+# Post-task synchronization
+npx agentic-flow hooks post-task --task-id "task-123"
+
+# Session restore
+npx agentic-flow hooks session-restore --session-id "swarm-001"
+```
+
+## Best Practices
+
+1. **Start small**: Begin with 2-3 agents, scale up
+2. **Use memory**: Share context through swarm memory
+3. **Monitor metrics**: Track performance and bottlenecks
+4. **Enable hooks**: Automatic coordination and sync
+5. **Set timeouts**: Prevent hung tasks
+
+## Troubleshooting
+
+### Issue: Agents not coordinating
+**Solution**: Verify memory access and enable hooks
+
+### Issue: Poor performance
+**Solution**: Check topology (use adaptive) and enable load balancing
+
+## Learn More
+
+- Swarm Guide: docs/swarm/orchestration.md
+- Topology Patterns: docs/swarm/topologies.md
+- Hooks Integration: docs/hooks/coordination.md

--- a/.claude/skills/verification-quality/SKILL.md
+++ b/.claude/skills/verification-quality/SKILL.md
@@ -1,0 +1,691 @@
+---
+name: "Verification & Quality Assurance"
+description: |
+  Comprehensive truth scoring, code quality verification, and automatic rollback system with 0.95 accuracy threshold for ensuring high-quality agent outputs and codebase reliability.
+---
+
+# Verification & Quality Assurance Skill
+
+## What This Skill Does
+
+This skill provides a comprehensive verification and quality assurance system that ensures code quality and correctness through:
+
+- **Truth Scoring**: Real-time reliability metrics (0.0-1.0 scale) for code, agents, and tasks
+- **Verification Checks**: Automated code correctness, security, and best practices validation
+- **Automatic Rollback**: Instant reversion of changes that fail verification (default threshold: 0.95)
+- **Quality Metrics**: Statistical analysis with trends, confidence intervals, and improvement tracking
+- **CI/CD Integration**: Export capabilities for continuous integration pipelines
+- **Real-time Monitoring**: Live dashboards and watch modes for ongoing verification
+
+> **Shipped vs. aspirational.** The *concrete, in-CI* verification stack — the 6 regression-guard jobs + the witness manifest + the tool-discoverability audit — is real and runs on every push. The truth-scoring / auto-rollback / WebSocket-dashboard surface described later in this doc is partly shipped (`ruflo verify` runs the witness checks) and partly design — treat the "CI Guards" section below as the authoritative current state.
+
+## CI Guards — what's actually shipped (current state)
+
+Ruflo's regression protection is three layers, all gated before publish. Authoritative reference: [`verification/README.md`](../../../verification/README.md).
+
+| Layer | What | CI job(s) in `.github/workflows/v3-ci.yml` | ADR |
+|---|---|---|---|
+| **1 — install/behavioral smoke** | Exercise user-visible failure modes against a real build | `smoke-install-no-bsqlite` (npm install on platforms w/o prebuilds), `plugin-hooks-smoke` (#1859/#1862 — hook flag parsing), `mcp-protocol-smoke` (#1874 — HTTP MCP wire format), `memory-import-smoke` (#1883/#1884 — WSL path + key sanitization), `mcp-roundtrip-smoke` (#1889 paired-tool round-trip + #1863 cli-no-crash + ADR-095 G2 consensus-transport) | ADR-102 |
+| **1 — discoverability gate** | Every MCP tool description must answer "use this over native when?" | `tool-descriptions-audit` — `scripts/audit-tool-descriptions.mjs`, baseline at `verification/mcp-tool-baseline.json` (monotone-decreasing: noGuidance / tooShort / duplicates) | ADR-112 |
+| **2 — cryptographic witness** | Every documented fix's load-bearing marker must still be present in dist; Ed25519-signed, per-OS bundles | `witness-verify` (ubuntu/macos/windows) — `plugins/ruflo-core/scripts/witness/verify.mjs` against `verification/<os>/manifest.md.json` | ADR-103 |
+| **3 — temporal history** | When was a regression introduced | `verification/<os>/history.jsonl` + `history.mjs` (`summary` / `regressions` / `timeline`) | ADR-103 |
+
+### Run the guards locally
+
+```bash
+# Tool-description discoverability audit (ADR-112)
+node scripts/audit-tool-descriptions.mjs                       # fails if any baseline count rises
+node scripts/audit-tool-descriptions.mjs --update-baseline     # lock the new floor after a fix lands
+
+# Behavioral smokes (each builds what it needs; safe to run individually)
+node plugins/ruflo-core/scripts/test-hooks.mjs "node $PWD/v3/@claude-flow/cli/bin/cli.js"
+node plugins/ruflo-core/scripts/test-mcp-protocol.mjs
+node plugins/ruflo-core/scripts/test-memory-import.mjs
+node plugins/ruflo-core/scripts/test-mcp-roundtrips.mjs        # #1889 paired-tool round-trip
+node plugins/ruflo-core/scripts/test-cli-no-crash.mjs          # #1863 unhandled-exception class
+node plugins/ruflo-core/scripts/test-consensus-transport.mjs   # ADR-095 G2 consensus transport
+
+# Witness manifest — regenerate + verify
+node scripts/regen-witness.mjs
+node plugins/ruflo-core/scripts/witness/verify.mjs --manifest verification/macos/manifest.md.json
+
+# Temporal history
+node plugins/ruflo-core/scripts/witness/history.mjs --history verification/macos/history.jsonl summary
+node plugins/ruflo-core/scripts/witness/history.mjs --history verification/macos/history.jsonl regressions
+```
+
+### Adding a new guard
+
+1. **Behavioral smoke** → write `plugins/ruflo-core/scripts/test-<name>.mjs`. Pattern: static dist-scan first (fast, always completes), behavioral probe second with an internal timeout + a process-level watchdog so CI never hangs. Add a step to the relevant job in `v3-ci.yml`.
+2. **Static gate with a baseline** → write `scripts/audit-<name>.mjs` that scans, counts violations, and fails if the count exceeds a monotone-decreasing baseline in `verification/<name>-baseline.json`. Support `--update-baseline`. Add a CI job; wire it into `witness-verify` `needs[]` if it should gate `publish`.
+3. **Documented-fix marker** → append `{ id, desc, file, marker }` to `verification/witness-fixes.json`, run `node scripts/regen-witness.mjs`. The marker must be a substring the fix specifically creates (not a generic pattern like `'function'`).
+
+## Prerequisites
+
+- Ruflo installed (`npx ruflo@alpha`)
+- Git repository (for rollback features)
+- Node.js 18+ (for dashboard features)
+- `@noble/ed25519` (for the witness verifier — a single runtime dep, `npm i @noble/ed25519`)
+
+## Quick Start
+
+```bash
+# View current truth scores
+npx ruflo@alpha truth
+
+# Run verification check
+npx ruflo@alpha verify check
+
+# Verify specific file with custom threshold
+npx ruflo@alpha verify check --file src/app.js --threshold 0.98
+
+# Rollback last failed verification
+npx ruflo@alpha verify rollback --last-good
+```
+
+---
+
+## Complete Guide
+
+### Truth Scoring System
+
+#### View Truth Metrics
+
+Display comprehensive quality and reliability metrics for your codebase and agent tasks.
+
+**Basic Usage:**
+```bash
+# View current truth scores (default: table format)
+npx ruflo@alpha truth
+
+# View scores for specific time period
+npx ruflo@alpha truth --period 7d
+
+# View scores for specific agent
+npx ruflo@alpha truth --agent coder --period 24h
+
+# Find files/tasks below threshold
+npx ruflo@alpha truth --threshold 0.8
+```
+
+**Output Formats:**
+```bash
+# Table format (default)
+npx ruflo@alpha truth --format table
+
+# JSON for programmatic access
+npx ruflo@alpha truth --format json
+
+# CSV for spreadsheet analysis
+npx ruflo@alpha truth --format csv
+
+# HTML report with visualizations
+npx ruflo@alpha truth --format html --export report.html
+```
+
+**Real-time Monitoring:**
+```bash
+# Watch mode with live updates
+npx ruflo@alpha truth --watch
+
+# Export metrics automatically
+npx ruflo@alpha truth --export .claude-flow/metrics/truth-$(date +%Y%m%d).json
+```
+
+#### Truth Score Dashboard
+
+Example dashboard output:
+```
+📊 Truth Metrics Dashboard
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Overall Truth Score: 0.947 ✅
+Trend: ↗️ +2.3% (7d)
+
+Top Performers:
+  verification-agent   0.982 ⭐
+  code-analyzer       0.971 ⭐
+  test-generator      0.958 ✅
+
+Needs Attention:
+  refactor-agent      0.821 ⚠️
+  docs-generator      0.794 ⚠️
+
+Recent Tasks:
+  task-456  0.991 ✅  "Implement auth"
+  task-455  0.967 ✅  "Add tests"
+  task-454  0.743 ❌  "Refactor API"
+```
+
+#### Metrics Explained
+
+**Truth Scores (0.0-1.0):**
+- `1.0-0.95`: Excellent ⭐ (production-ready)
+- `0.94-0.85`: Good ✅ (acceptable quality)
+- `0.84-0.75`: Warning ⚠️ (needs attention)
+- `<0.75`: Critical ❌ (requires immediate action)
+
+**Trend Indicators:**
+- ↗️ Improving (positive trend)
+- → Stable (consistent performance)
+- ↘️ Declining (quality regression detected)
+
+**Statistics:**
+- **Mean Score**: Average truth score across all measurements
+- **Median Score**: Middle value (less affected by outliers)
+- **Standard Deviation**: Consistency of scores (lower = more consistent)
+- **Confidence Interval**: Statistical reliability of measurements
+
+### Verification Checks
+
+#### Run Verification
+
+Execute comprehensive verification checks on code, tasks, or agent outputs.
+
+**File Verification:**
+```bash
+# Verify single file
+npx ruflo@alpha verify check --file src/app.js
+
+# Verify directory recursively
+npx ruflo@alpha verify check --directory src/
+
+# Verify with auto-fix enabled
+npx ruflo@alpha verify check --file src/utils.js --auto-fix
+
+# Verify current working directory
+npx ruflo@alpha verify check
+```
+
+**Task Verification:**
+```bash
+# Verify specific task output
+npx ruflo@alpha verify check --task task-123
+
+# Verify with custom threshold
+npx ruflo@alpha verify check --task task-456 --threshold 0.99
+
+# Verbose output for debugging
+npx ruflo@alpha verify check --task task-789 --verbose
+```
+
+**Batch Verification:**
+```bash
+# Verify multiple files in parallel
+npx ruflo@alpha verify batch --files "*.js" --parallel
+
+# Verify with pattern matching
+npx ruflo@alpha verify batch --pattern "src/**/*.ts"
+
+# Integration test suite
+npx ruflo@alpha verify integration --test-suite full
+```
+
+#### Verification Criteria
+
+The verification system evaluates:
+
+1. **Code Correctness**
+   - Syntax validation
+   - Type checking (TypeScript)
+   - Logic flow analysis
+   - Error handling completeness
+
+2. **Best Practices**
+   - Code style adherence
+   - SOLID principles
+   - Design patterns usage
+   - Modularity and reusability
+
+3. **Security**
+   - Vulnerability scanning
+   - Secret detection
+   - Input validation
+   - Authentication/authorization checks
+
+4. **Performance**
+   - Algorithmic complexity
+   - Memory usage patterns
+   - Database query optimization
+   - Bundle size impact
+
+5. **Documentation**
+   - JSDoc/TypeDoc completeness
+   - README accuracy
+   - API documentation
+   - Code comments quality
+
+#### JSON Output for CI/CD
+
+```bash
+# Get structured JSON output
+npx ruflo@alpha verify check --json > verification.json
+
+# Example JSON structure:
+{
+  "overallScore": 0.947,
+  "passed": true,
+  "threshold": 0.95,
+  "checks": [
+    {
+      "name": "code-correctness",
+      "score": 0.98,
+      "passed": true
+    },
+    {
+      "name": "security",
+      "score": 0.91,
+      "passed": false,
+      "issues": [...]
+    }
+  ]
+}
+```
+
+### Automatic Rollback
+
+#### Rollback Failed Changes
+
+Automatically revert changes that fail verification checks.
+
+**Basic Rollback:**
+```bash
+# Rollback to last known good state
+npx ruflo@alpha verify rollback --last-good
+
+# Rollback to specific commit
+npx ruflo@alpha verify rollback --to-commit abc123
+
+# Interactive rollback with preview
+npx ruflo@alpha verify rollback --interactive
+```
+
+**Smart Rollback:**
+```bash
+# Rollback only failed files (preserve good changes)
+npx ruflo@alpha verify rollback --selective
+
+# Rollback with automatic backup
+npx ruflo@alpha verify rollback --backup-first
+
+# Dry-run mode (preview without executing)
+npx ruflo@alpha verify rollback --dry-run
+```
+
+**Rollback Performance:**
+- Git-based rollback: <1 second
+- Selective file rollback: <500ms
+- Backup creation: Automatic before rollback
+
+### Verification Reports
+
+#### Generate Reports
+
+Create detailed verification reports with metrics and visualizations.
+
+**Report Formats:**
+```bash
+# JSON report
+npx ruflo@alpha verify report --format json
+
+# HTML report with charts
+npx ruflo@alpha verify report --export metrics.html --format html
+
+# CSV for data analysis
+npx ruflo@alpha verify report --format csv --export metrics.csv
+
+# Markdown summary
+npx ruflo@alpha verify report --format markdown
+```
+
+**Time-based Reports:**
+```bash
+# Last 24 hours
+npx ruflo@alpha verify report --period 24h
+
+# Last 7 days
+npx ruflo@alpha verify report --period 7d
+
+# Last 30 days with trends
+npx ruflo@alpha verify report --period 30d --include-trends
+
+# Custom date range
+npx ruflo@alpha verify report --from 2025-01-01 --to 2025-01-31
+```
+
+**Report Content:**
+- Overall truth scores
+- Per-agent performance metrics
+- Task completion quality
+- Verification pass/fail rates
+- Rollback frequency
+- Quality improvement trends
+- Statistical confidence intervals
+
+### Interactive Dashboard
+
+#### Launch Dashboard
+
+Run interactive web-based verification dashboard with real-time updates.
+
+```bash
+# Launch dashboard on default port (3000)
+npx ruflo@alpha verify dashboard
+
+# Custom port
+npx ruflo@alpha verify dashboard --port 8080
+
+# Export dashboard data
+npx ruflo@alpha verify dashboard --export
+
+# Dashboard with auto-refresh
+npx ruflo@alpha verify dashboard --refresh 5s
+```
+
+**Dashboard Features:**
+- Real-time truth score updates (WebSocket)
+- Interactive charts and graphs
+- Agent performance comparison
+- Task history timeline
+- Rollback history viewer
+- Export to PDF/HTML
+- Filter by time period/agent/score
+
+### Configuration
+
+#### Default Configuration
+
+Set verification preferences in `.claude-flow/config.json`:
+
+```json
+{
+  "verification": {
+    "threshold": 0.95,
+    "autoRollback": true,
+    "gitIntegration": true,
+    "hooks": {
+      "preCommit": true,
+      "preTask": true,
+      "postEdit": true
+    },
+    "checks": {
+      "codeCorrectness": true,
+      "security": true,
+      "performance": true,
+      "documentation": true,
+      "bestPractices": true
+    }
+  },
+  "truth": {
+    "defaultFormat": "table",
+    "defaultPeriod": "24h",
+    "warningThreshold": 0.85,
+    "criticalThreshold": 0.75,
+    "autoExport": {
+      "enabled": true,
+      "path": ".claude-flow/metrics/truth-daily.json"
+    }
+  }
+}
+```
+
+#### Threshold Configuration
+
+**Adjust verification strictness:**
+```bash
+# Strict mode (99% accuracy required)
+npx ruflo@alpha verify check --threshold 0.99
+
+# Lenient mode (90% acceptable)
+npx ruflo@alpha verify check --threshold 0.90
+
+# Set default threshold
+npx ruflo@alpha config set verification.threshold 0.98
+```
+
+**Per-environment thresholds:**
+```json
+{
+  "verification": {
+    "thresholds": {
+      "production": 0.99,
+      "staging": 0.95,
+      "development": 0.90
+    }
+  }
+}
+```
+
+### Integration Examples
+
+#### CI/CD Integration
+
+**GitHub Actions:**
+```yaml
+name: Quality Verification
+
+on: [push, pull_request]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Run Verification
+        run: |
+          npx ruflo@alpha verify check --json > verification.json
+
+      - name: Check Truth Score
+        run: |
+          score=$(jq '.overallScore' verification.json)
+          if (( $(echo "$score < 0.95" | bc -l) )); then
+            echo "Truth score too low: $score"
+            exit 1
+          fi
+
+      - name: Upload Report
+        uses: actions/upload-artifact@v3
+        with:
+          name: verification-report
+          path: verification.json
+```
+
+**GitLab CI:**
+```yaml
+verify:
+  stage: test
+  script:
+    - npx ruflo@alpha verify check --threshold 0.95 --json > verification.json
+    - |
+      score=$(jq '.overallScore' verification.json)
+      if [ $(echo "$score < 0.95" | bc) -eq 1 ]; then
+        echo "Verification failed with score: $score"
+        exit 1
+      fi
+  artifacts:
+    paths:
+      - verification.json
+    reports:
+      junit: verification.json
+```
+
+#### Swarm Integration
+
+Run verification automatically during swarm operations:
+
+```bash
+# Swarm with verification enabled
+npx ruflo@alpha swarm --verify --threshold 0.98
+
+# Hive Mind with auto-rollback
+npx ruflo@alpha hive-mind --verify --rollback-on-fail
+
+# Training pipeline with verification
+npx ruflo@alpha train --verify --threshold 0.99
+```
+
+#### Pair Programming Integration
+
+Enable real-time verification during collaborative development:
+
+```bash
+# Pair with verification
+npx ruflo@alpha pair --verify --real-time
+
+# Pair with custom threshold
+npx ruflo@alpha pair --verify --threshold 0.97 --auto-fix
+```
+
+### Advanced Workflows
+
+#### Continuous Verification
+
+Monitor codebase continuously during development:
+
+```bash
+# Watch directory for changes
+npx ruflo@alpha verify watch --directory src/
+
+# Watch with auto-fix
+npx ruflo@alpha verify watch --directory src/ --auto-fix
+
+# Watch with notifications
+npx ruflo@alpha verify watch --notify --threshold 0.95
+```
+
+#### Monitoring Integration
+
+Send metrics to external monitoring systems:
+
+```bash
+# Export to Prometheus
+npx ruflo@alpha truth --format json | \
+  curl -X POST https://pushgateway.example.com/metrics/job/claude-flow \
+  -d @-
+
+# Send to DataDog
+npx ruflo@alpha verify report --format json | \
+  curl -X POST "https://api.datadoghq.com/api/v1/series?api_key=${DD_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d @-
+
+# Custom webhook
+npx ruflo@alpha truth --format json | \
+  curl -X POST https://metrics.example.com/api/truth \
+  -H "Content-Type: application/json" \
+  -d @-
+```
+
+#### Pre-commit Hooks
+
+Automatically verify before commits:
+
+```bash
+# Install pre-commit hook
+npx ruflo@alpha verify install-hook --pre-commit
+
+# .git/hooks/pre-commit example:
+#!/bin/bash
+npx ruflo@alpha verify check --threshold 0.95 --json > /tmp/verify.json
+
+score=$(jq '.overallScore' /tmp/verify.json)
+if (( $(echo "$score < 0.95" | bc -l) )); then
+  echo "❌ Verification failed with score: $score"
+  echo "Run 'npx ruflo@alpha verify check --verbose' for details"
+  exit 1
+fi
+
+echo "✅ Verification passed with score: $score"
+```
+
+### Performance Metrics
+
+**Verification Speed:**
+- Single file check: <100ms
+- Directory scan: <500ms (per 100 files)
+- Full codebase analysis: <5s (typical project)
+- Truth score calculation: <50ms
+
+**Rollback Speed:**
+- Git-based rollback: <1s
+- Selective file rollback: <500ms
+- Backup creation: <2s
+
+**Dashboard Performance:**
+- Initial load: <1s
+- Real-time updates: <100ms latency (WebSocket)
+- Chart rendering: 60 FPS
+
+### Troubleshooting
+
+#### Common Issues
+
+**Low Truth Scores:**
+```bash
+# Get detailed breakdown
+npx ruflo@alpha truth --verbose --threshold 0.0
+
+# Check specific criteria
+npx ruflo@alpha verify check --verbose
+
+# View agent-specific issues
+npx ruflo@alpha truth --agent <agent-name> --format json
+```
+
+**Rollback Failures:**
+```bash
+# Check git status
+git status
+
+# View rollback history
+npx ruflo@alpha verify rollback --history
+
+# Manual rollback
+git reset --hard HEAD~1
+```
+
+**Verification Timeouts:**
+```bash
+# Increase timeout
+npx ruflo@alpha verify check --timeout 60s
+
+# Verify in batches
+npx ruflo@alpha verify batch --batch-size 10
+```
+
+### Exit Codes
+
+Verification commands return standard exit codes:
+
+- `0`: Verification passed (score ≥ threshold)
+- `1`: Verification failed (score < threshold)
+- `2`: Error during verification (invalid input, system error)
+
+### Related Commands
+
+- `npx ruflo@alpha pair` - Collaborative development with verification
+- `npx ruflo@alpha train` - Training with verification feedback
+- `npx ruflo@alpha swarm` - Multi-agent coordination with quality checks
+- `npx ruflo@alpha report` - Generate comprehensive project reports
+
+### Best Practices
+
+1. **Set Appropriate Thresholds**: Use 0.99 for critical code, 0.95 for standard, 0.90 for experimental
+2. **Enable Auto-rollback**: Prevent bad code from persisting
+3. **Monitor Trends**: Track improvement over time, not just current scores
+4. **Integrate with CI/CD**: Make verification part of your pipeline
+5. **Use Watch Mode**: Get immediate feedback during development
+6. **Export Metrics**: Track quality metrics in your monitoring system
+7. **Review Rollbacks**: Understand why changes were rejected
+8. **Train Agents**: Use verification feedback to improve agent performance
+
+### Additional Resources
+
+- Truth Scoring Algorithm: See `/docs/truth-scoring.md`
+- Verification Criteria: See `/docs/verification-criteria.md`
+- Integration Examples: See `/examples/verification/`
+- API Reference: See `/docs/api/verification.md`

--- a/.gitignore
+++ b/.gitignore
@@ -37,13 +37,19 @@ server/.env
 .env
 
 # Ruflo / Claude orchestration runtime files
-.claude-flow/
+# The CONFIG skeleton (.mcp.json, .claude/settings.json, .claude/hooks/) is committed so
+# fresh remote containers come up with ruflo already wired — see .claude/hooks/ruflo-bootstrap.sh.
+# Only runtime / generated / secret bits are ignored below.
+.claude-flow/data/
+.claude-flow/logs/
+.claude-flow/sessions/
+.claude-flow/neural/
+.claude-flow/*.log
+.claude-flow/*.tmp
 .claude/agents/
 .claude/commands/
 .claude/helpers/
 .claude/memory.db
-.claude/settings.json
-.mcp.json
 .swarm/
 .hive-mind/
 ruvector.db

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "ruflo": {
+      "command": "npx",
+      "args": ["-y", "ruflo@latest", "mcp", "start"]
+    }
+  }
+}


### PR DESCRIPTION
## **User description**
## Why

For multiple sessions ruflo has been "registered but not connecting" because remote-execution containers are ephemeral. Three concrete causes were stacking:

1. The previous `.gitignore` **explicitly blocked** ruflo's config skeleton (`.mcp.json`, `.claude/settings.json`, `.claude-flow/`) from being committed — so every fresh container started with zero ruflo config.
2. The MCP-server registration was `npx ruflo@latest mcp start` — **without `-y`**. In non-interactive containers npx hangs on the "install y/N?" prompt, Claude Code times out, the server is marked `✗ Failed to connect`.
3. Even when init had run, the `npx ruflo` install left a stale rename target in the npx cache (`ENOTEMPTY`), poisoning the next `npx -y` for a few minutes.

End result: ruflo never delivered its `mcp__ruflo__*` tools to Claude Code, and we were re-paying API tokens every session to do work ruflo's swarms would have orchestrated.

## What

- **`.mcp.json`** — project-scoped MCP server registration using `npx -y ruflo@latest mcp start`. The `-y` is the critical fix for the npx-hangs-in-non-interactive-shell case.
- **`.gitignore`** — inverted the previous rule. The *config skeleton* (`.mcp.json`, `.claude/settings.json`, `.claude/hooks/`, `.claude-flow/config.yaml`, `.claude-flow/CAPABILITIES.md`, `.claude/skills/`) is now tracked. Only *runtime / generated / secret* paths (`.claude-flow/data/`, `logs/`, `sessions/`, `neural/`, `.claude/memory.db`, `.swarm/`, `.hive-mind/`, `ruvector.db`) stay ignored.
- **`.claude/settings.json`** — ruflo's project config (model preferences, agent-team coordination, hooks enablement) + a SessionStart hook entry + `permissions.allow` for `mcp__ruflo__*` so Claude doesn't prompt for every ruflo MCP call.
- **`.claude/hooks/ruflo-bootstrap.sh`** — idempotent SessionStart hook. Fast path (~6ms) when `.claude/settings.json` + `.claude-flow/config.yaml` are both present; otherwise prefers the cached ruflo binary at `/root/.npm/_npx/*/node_modules/ruflo/` and falls back to `npx -y ruflo@latest init` if the cache is gone. Treats "already initialized" exit codes as success.
- **`.claude-flow/config.yaml` + `CAPABILITIES.md`** — minimal ruflo runtime config; small enough to commit; also serves as the marker for the hook's fast path.
- **`.claude/skills/<8 ruflo skills>`** — `sparc-methodology`, `swarm-advanced`, `swarm-orchestration`, `hooks-automation`, `pair-programming`, `skill-builder`, `stream-chain`, `verification-quality`. Stock ruflo orchestration personas; committing them makes behaviour reproducible.

## Verification

Locally on this branch:
- `claude mcp list` → `ruflo: npx -y ruflo@latest mcp start - ⏸ Pending approval` (was: `✗ Failed to connect`).
- `.claude/hooks/ruflo-bootstrap.sh` fast-path measured at 6ms.
- `node /root/.npm/_npx/.../ruflo/bin/ruflo.js mcp start` returns a proper MCP `initialize` response with 27 tools registered.

## One thing you have to do

The new registration is **project-scoped**, which Claude Code requires you to **approve once** per workspace. After the next session opens this repo, you'll see a prompt — accept it, and the `mcp__ruflo__*` tools will appear in `ToolSearch` from that session forward.

## Honest caveat

Ruflo's actual tools won't appear in the session where this PR merges — Claude Code snapshots MCP tool schemas at session start, and the connection happens mid-session. First practical use is the **next** session.

https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd)_


___

## **CodeAnt-AI Description**
**Keep ruflo available in fresh containers and add project skills**

### What Changed
- Fresh sessions now restore ruflo automatically at startup, so the tools are ready without manual reinitialization
- The project now includes a working MCP setup that starts ruflo in non-interactive environments
- Previously missing Claude config, hooks, and skill files are now tracked so they survive new container builds
- Added several project skills for workflow automation, pair programming, swarm coordination, verification, and stream chaining

### Impact
`✅ Fewer "registered but not connecting" sessions`
`✅ Faster startup in new containers`
`✅ More reliable access to ruflo tools`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
