### PR TITLE
fix(extensions): delete-repository button now actually removes the row

### DIFF
--- a/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepoRepositoryImpl.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepoRepositoryImpl.kt
@@ -52,9 +52,12 @@ class ExtensionRepoRepositoryImpl(
     }
 
     override suspend fun ensureDefaultRepository() {
+        // Seed the default repo ONLY when the key has never been written (truly first launch).
+        // An empty Set means the user has deliberately deleted everything — preserve that across
+        // restarts, otherwise the delete-last-repo flow looks broken: relaunch silently re-adds
+        // the default and the user's "no repos" state evaporates.
         dataStore.edit { preferences ->
-            val currentRepos = preferences[REPOSITORIES_KEY]
-            if (currentRepos.isNullOrEmpty()) {
+            if (preferences[REPOSITORIES_KEY] == null) {
                 preferences[REPOSITORIES_KEY] = setOf(DEFAULT_REPO_URL)
             }
         }

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepoRepositoryImpl.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepoRepositoryImpl.kt
@@ -23,9 +23,13 @@ class ExtensionRepoRepositoryImpl(
     }
 
     override fun getRepositories(): Flow<List<String>> {
+        // Return exactly what's in DataStore. The previous `if (repos.isEmpty()) DEFAULT_REPO_URL`
+        // substitution meant deleting the last repo silently re-emitted the default, which made
+        // the delete button look broken — the row snapped back instantly. First-launch defaulting
+        // is handled by `ensureDefaultRepository()` (called from ExtensionsViewModel.init), so a
+        // truly-empty list here is the user's deliberate state.
         return dataStore.data.map { preferences ->
-            val repos = preferences[REPOSITORIES_KEY]?.toList() ?: emptyList()
-            if (repos.isEmpty()) listOf(DEFAULT_REPO_URL) else repos
+            preferences[REPOSITORIES_KEY]?.toList() ?: emptyList()
         }
     }
 

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsViewModel.kt
@@ -301,11 +301,18 @@ class ExtensionsViewModel @Inject constructor(
 
     private fun removeRepository(url: String) {
         viewModelScope.launch {
-            runCatching { extensionRepoRepository.removeRepository(url) }
-                .onSuccess { _effect.send(ExtensionsEffect.ShowSnackbar("Repository removed")) }
-                .onFailure { e ->
-                    _effect.send(ExtensionsEffect.ShowError("Couldn't remove repository: ${e.message}"))
-                }
+            // try/catch with explicit CancellationException rethrow instead of `runCatching`,
+            // matching the pattern used by toggleExtension / doInstallExtension / uninstallExtension
+            // in this VM. `runCatching` catches Throwable including CancellationException, which
+            // would route normal coroutine cancellation through the error snackbar.
+            try {
+                extensionRepoRepository.removeRepository(url)
+                _effect.send(ExtensionsEffect.ShowSnackbar("Repository removed"))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(ExtensionsEffect.ShowError("Couldn't remove repository: ${e.message}"))
+            }
         }
     }
 

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsViewModel.kt
@@ -302,6 +302,10 @@ class ExtensionsViewModel @Inject constructor(
     private fun removeRepository(url: String) {
         viewModelScope.launch {
             runCatching { extensionRepoRepository.removeRepository(url) }
+                .onSuccess { _effect.send(ExtensionsEffect.ShowSnackbar("Repository removed")) }
+                .onFailure { e ->
+                    _effect.send(ExtensionsEffect.ShowError("Couldn't remove repository: ${e.message}"))
+                }
         }
     }
 


### PR DESCRIPTION
## **User description**
## Why

User reported the trash icon next to a repo URL in the Extensions screen "does nothing." Investigation found **two stacked silent failures**:

1. **`ExtensionRepoRepositoryImpl.getRepositories()`** had a hidden `if (repos.isEmpty()) listOf(DEFAULT_REPO_URL)` substitution inside the Flow's `map`. When the user deleted their last repo, DataStore was correctly emptied, but the next emission silently re-added Keiyoushi — the row "snapped back" instantly and delete looked broken.
2. **`ExtensionsViewModel.removeRepository()`** used `runCatching {}` with **no `onSuccess`, no `onFailure`** — even when the underlying delete worked, the user got zero Snackbar feedback. So `delete` on a non-last repo (Komikku in the user's screenshot) also appeared to "do nothing" because there was no visual confirmation that anything happened.

## What

- **`ExtensionRepoRepositoryImpl.kt`** — Remove the auto-refill from `getRepositories()`. First-launch defaulting is already handled by `ensureDefaultRepository()` (called from `ExtensionsViewModel.init` line 147), so the auto-refill was both **redundant** and **actively wrong** when the user deliberately emptied the list.
- **`ExtensionsViewModel.kt`** — Add `onSuccess { ShowSnackbar("Repository removed") }` and `onFailure { ShowError(...) }` to mirror `addRepository`'s feedback shape.

## Test plan

- [x] `./gradlew :core:extension:testDebugUnitTest :feature:browse:testDebugUnitTest detekt` — green.
- [ ] Manual on-device:
  1. Open Extensions → Repositories.
  2. Tap trash next to Komikku → row disappears + "Repository removed" Snackbar.
  3. Tap trash next to Keiyoushi (now last remaining) → row disappears (no auto-refill) + Snackbar.
  4. Force-quit and relaunch → repo list still empty (verifies `ensureDefaultRepository()` doesn't undo the user's choice; first-launch path only re-adds when the *key* is missing, not when it's an empty set).

https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd)_


___

## **CodeAnt-AI Description**
**Make repository deletion remove the row and show confirmation**

### What Changed
- Deleting a repository now removes it from the Extensions list without it immediately reappearing
- The app now keeps an empty repository list when the user removes the last entry instead of restoring the default automatically
- Removing a repository now shows a success message, and failures now show a clear error message

### Impact
`✅ Repositories stay deleted`
`✅ Clearer delete confirmation`
`✅ Fewer confusing "nothing happened" moments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
