### PR TITLE
fix(ux): two more silent-no-op user actions surface feedback (saved-search delete, batch mark-as-read)

### DIFF
--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
@@ -19,6 +19,7 @@ import app.otakureader.sourceapi.MangaSource
 import app.otakureader.sourceapi.SourceManga
 import app.otakureader.sourceapi.toSourceId
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -472,9 +473,16 @@ class BrowseViewModel @Inject constructor(
 
     private fun deleteSavedSearch(searchId: Long) {
         viewModelScope.launch {
-            runCatching { feedRepository.removeSavedSearch(searchId) }
-                .onSuccess { _effect.send(BrowseEffect.ShowSnackbar("Search deleted")) }
-                .onFailure { _effect.send(BrowseEffect.ShowSnackbar("Failed to delete search")) }
+            // try/catch with explicit CancellationException rethrow so coroutine cancellation
+            // (e.g. ViewModel cleared mid-delete) doesn't get routed through the failure snackbar.
+            try {
+                feedRepository.removeSavedSearch(searchId)
+                _effect.send(BrowseEffect.ShowSnackbar("Search deleted"))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                _effect.send(BrowseEffect.ShowSnackbar("Failed to delete search"))
+            }
         }
     }
 

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
@@ -473,6 +473,8 @@ class BrowseViewModel @Inject constructor(
     private fun deleteSavedSearch(searchId: Long) {
         viewModelScope.launch {
             runCatching { feedRepository.removeSavedSearch(searchId) }
+                .onSuccess { _effect.send(BrowseEffect.ShowSnackbar("Search deleted")) }
+                .onFailure { _effect.send(BrowseEffect.ShowSnackbar("Failed to delete search")) }
         }
     }
 

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
@@ -155,11 +155,18 @@ class UpdatesViewModel @Inject constructor(
     private fun markSelectedAsRead() {
         val selected = _state.value.selectedItems
         if (selected.isEmpty()) return
+        val count = selected.size
         viewModelScope.launch {
             runCatching {
                 chapterRepository.updateChapterProgress(selected, read = true, lastPageRead = 0)
+            }.onSuccess {
+                // Only clear selection on success — if the DB write threw, keep the items
+                // selected so the user can retry instead of silently losing their selection.
+                _state.update { it.copy(selectedItems = emptySet()) }
+                _effect.send(UpdatesEffect.ShowSnackbar("Marked $count chapter(s) as read"))
+            }.onFailure {
+                _effect.send(UpdatesEffect.ShowSnackbar("Failed to mark as read"))
             }
-            _state.update { it.copy(selectedItems = emptySet()) }
         }
     }
 

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
@@ -157,14 +157,17 @@ class UpdatesViewModel @Inject constructor(
         if (selected.isEmpty()) return
         val count = selected.size
         viewModelScope.launch {
-            runCatching {
+            // try/catch with explicit CancellationException rethrow — coroutine cancellation
+            // (e.g. ViewModel cleared mid-update) shouldn't surface as "Failed to mark as read".
+            try {
                 chapterRepository.updateChapterProgress(selected, read = true, lastPageRead = 0)
-            }.onSuccess {
                 // Only clear selection on success — if the DB write threw, keep the items
                 // selected so the user can retry instead of silently losing their selection.
                 _state.update { it.copy(selectedItems = emptySet()) }
                 _effect.send(UpdatesEffect.ShowSnackbar("Marked $count chapter(s) as read"))
-            }.onFailure {
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
                 _effect.send(UpdatesEffect.ShowSnackbar("Failed to mark as read"))
             }
         }

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
@@ -161,14 +161,19 @@ class UpdatesViewModel @Inject constructor(
             // (e.g. ViewModel cleared mid-update) shouldn't surface as "Failed to mark as read".
             try {
                 chapterRepository.updateChapterProgress(selected, read = true, lastPageRead = 0)
-                // Only clear selection on success — if the DB write threw, keep the items
-                // selected so the user can retry instead of silently losing their selection.
-                _state.update { it.copy(selectedItems = emptySet()) }
-                _effect.send(UpdatesEffect.ShowSnackbar("Marked $count chapter(s) as read"))
+                // Subtract only the IDs we actually processed from the current selection.
+                // Clearing wholesale would also wipe any new selections the user made while
+                // the DB write was in flight — losing UI state they expect to keep.
+                _state.update { it.copy(selectedItems = it.selectedItems - selected) }
+                _effect.send(
+                    UpdatesEffect.ShowSnackbar(
+                        context.resources.getQuantityString(R.plurals.updates_marked_as_read, count, count)
+                    )
+                )
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Exception) {
-                _effect.send(UpdatesEffect.ShowSnackbar("Failed to mark as read"))
+                _effect.send(UpdatesEffect.ShowSnackbar(context.getString(R.string.updates_mark_as_read_failed)))
             }
         }
     }

--- a/feature/updates/src/main/res/values/strings.xml
+++ b/feature/updates/src/main/res/values/strings.xml
@@ -61,6 +61,11 @@
     <string name="updates_download_failed">Failed to queue download: %1$s</string>
     <string name="updates_bulk_download_queued">%1$d chapter(s) queued for download</string>
     <string name="updates_bulk_download_partial">%1$d queued, %2$d failed</string>
+    <plurals name="updates_marked_as_read">
+        <item quantity="one">Marked %1$d chapter as read</item>
+        <item quantity="other">Marked %1$d chapters as read</item>
+    </plurals>
+    <string name="updates_mark_as_read_failed">Failed to mark as read</string>
     <string name="updates_library_update_started">Library update started</string>
     <!-- Date group headers -->
     <string name="updates_date_today">Today</string>


### PR DESCRIPTION
## **User description**
## Why

Follow-up forensic sweep after PR #970 (delete-repo bug). An Explore agent did an exhaustive hunt across **all 15 feature modules** for the same anti-pattern — `runCatching {}` with no `onSuccess` / `onFailure`, where user actions succeed (or silently fail) with no Snackbar feedback. Two real bugs found.

## What

### 1. `BrowseViewModel.deleteSavedSearch()` — Critical

The delete icon on a saved-search chip behaved identically to the original delete-repo bug — bare `runCatching {}`, no `onSuccess`, no `onFailure`. User tap → nothing visible happens. Now:
- `onSuccess` → `ShowSnackbar("Search deleted")`
- `onFailure` → `ShowSnackbar("Failed to delete search")`

(The matching `saveSavedSearch` at line 467 was already doing this; this brings delete to parity.)

### 2. `UpdatesViewModel.markSelectedAsRead()` — Major

Was silent on success AND wiped the selection unconditionally — so if the DB write threw, the user lost their selection without any error feedback and couldn't retry. Two changes:
- Capture `count` before `launch` so the snackbar can report it.
- Only clear selection on `onSuccess`. On `onFailure`, **keep the selection intact** so the user can retry, plus emit `ShowSnackbar("Failed to mark as read")`.

## Skipped from the audit (explained in commit message)

- **`LibraryViewModel`'s four `else -> Unit` arms** — false positive. The events are routed through several handler methods, and each `else` catches events the *other* handlers own. Not a silent failure.
- **`ExtensionsBottomSheet.kt:232` `onInstall = {}`** — intentional. The Install button only renders on the Available tab; the no-op on the Installed tab is invisible to the user.

## Test plan

- [x] `./gradlew :feature:browse:testDebugUnitTest :feature:updates:testDebugUnitTest detekt` — green.
- [ ] Manual on-device:
  1. Browse → save a search → delete it → "Search deleted" Snackbar.
  2. Updates → select N chapters → batch mark-as-read → "Marked N chapter(s) as read" Snackbar.
  3. Disconnect/break DB temporarily → batch mark-as-read → selection STAYS and "Failed to mark as read" shows.

## Related

Part of the alpha stabilisation sweep: PR #970 (delete-repo), PR #971 (brand assets), this PR (no-op hunt).

https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd)_


___

## **CodeAnt-AI Description**
**Show feedback when deleting a saved search or marking items as read**

### What Changed
- Deleting a saved search now shows a confirmation message when it succeeds and an error message if it fails
- Marking selected chapters as read now keeps the selection if the update fails, so the action can be retried
- Marking chapters as read now shows how many items were updated on success, or a failure message if it did not work

### Impact
`✅ Clearer saved-search deletion feedback`
`✅ Fewer lost selections after failed mark-as-read actions`
`✅ Easier retry after update errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and user feedback for search deletion and mark-as-read operations with clearer messages.
  * Success notifications now display the count of affected items with proper plural forms.
  * Fixed erroneous error messages during app navigation and background task handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Heartless-Veteran/Otaku-Reader/pull/972?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->