### PR TITLE
feat(library): surface completed/dropped marker actions and badges (#946)

### DIFF
--- a/core/ui/src/main/java/app/otakureader/core/ui/components/MangaCard.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/components/MangaCard.kt
@@ -61,6 +61,7 @@ fun MangaCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     badge: @Composable (() -> Unit)? = null,
+    statusBadge: @Composable (() -> Unit)? = null,
     contentDescription: String? = null,
     isSelected: Boolean = false,
     readProgress: Float? = null,
@@ -140,6 +141,17 @@ fun MangaCard(
                 Box(
                     modifier = Modifier
                         .align(Alignment.TopEnd)
+                        .padding(4.dp)
+                ) {
+                    it()
+                }
+            }
+
+            // Status badge (e.g., completed / dropped marker), top-start corner
+            statusBadge?.let {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
                         .padding(4.dp)
                 ) {
                     it()

--- a/core/ui/src/main/java/app/otakureader/core/ui/components/StatusBadge.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/components/StatusBadge.kt
@@ -1,0 +1,56 @@
+package app.otakureader.core.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CompletedBadge(modifier: Modifier = Modifier) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .background(
+                color = MaterialTheme.colorScheme.primary,
+                shape = RoundedCornerShape(4.dp),
+            )
+            .padding(3.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Filled.CheckCircle,
+            contentDescription = "Completed",
+            tint = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.size(14.dp),
+        )
+    }
+}
+
+@Composable
+fun DroppedBadge(modifier: Modifier = Modifier) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .background(
+                color = MaterialTheme.colorScheme.error,
+                shape = RoundedCornerShape(4.dp),
+            )
+            .padding(3.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Cancel,
+            contentDescription = "Dropped",
+            tint = MaterialTheme.colorScheme.onError,
+            modifier = Modifier.size(14.dp),
+        )
+    }
+}

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
@@ -194,6 +194,10 @@ object DetailsContract {
         data object ToggleNotifications : Event
         data object OpenTracking : Event
 
+        // Completed / Dropped user-state toggles (#946)
+        data object ToggleUserCompleted : Event
+        data object ToggleUserDropped : Event
+
         // Per-manga reader settings (#260)
         data class SetReaderDirection(val direction: Int?) : Event
         data class SetReaderMode(val mode: Int?) : Event

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -199,6 +199,36 @@ fun DetailsScreen(
                                 overflowExpanded = false
                             }
                         )
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    if (state.manga?.userCompleted == true) {
+                                        stringResource(R.string.details_unmark_completed)
+                                    } else {
+                                        stringResource(R.string.details_mark_completed)
+                                    }
+                                )
+                            },
+                            onClick = {
+                                viewModel.onEvent(DetailsContract.Event.ToggleUserCompleted)
+                                overflowExpanded = false
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    if (state.manga?.userDropped == true) {
+                                        stringResource(R.string.details_unmark_dropped)
+                                    } else {
+                                        stringResource(R.string.details_mark_dropped)
+                                    }
+                                )
+                            },
+                            onClick = {
+                                viewModel.onEvent(DetailsContract.Event.ToggleUserDropped)
+                                overflowExpanded = false
+                            }
+                        )
                     }
                 }
             )

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -115,6 +115,8 @@ class DetailsViewModel @Inject constructor(
             is DetailsContract.Event.MarkSelectedAsUnread -> markSelectedAsUnread()
             is DetailsContract.Event.BookmarkSelectedChapters -> bookmarkSelectedChapters()
             is DetailsContract.Event.ToggleNotifications -> toggleNotifications()
+            is DetailsContract.Event.ToggleUserCompleted -> toggleUserCompleted()
+            is DetailsContract.Event.ToggleUserDropped -> toggleUserDropped()
 
             // Per-manga reader settings (#260)
             is DetailsContract.Event.SetReaderDirection -> setReaderDirection(event.direction)
@@ -326,6 +328,36 @@ class DetailsViewModel @Inject constructor(
                 throw e
             } catch (e: Exception) {
                 _effect.send(DetailsContract.Effect.ShowError("Failed to update library: ${e.message}"))
+            }
+        }
+    }
+
+    private fun toggleUserCompleted() {
+        viewModelScope.launch {
+            val current = _state.value.manga?.userCompleted ?: false
+            try {
+                mangaRepository.markUserCompleted(mangaId, !current)
+                val message = if (!current) "Marked as completed" else "Removed completed mark"
+                _effect.send(DetailsContract.Effect.ShowSnackbar(message))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(DetailsContract.Effect.ShowError("Failed to update: ${e.message}"))
+            }
+        }
+    }
+
+    private fun toggleUserDropped() {
+        viewModelScope.launch {
+            val current = _state.value.manga?.userDropped ?: false
+            try {
+                mangaRepository.markUserDropped(mangaId, !current)
+                val message = if (!current) "Marked as dropped" else "Removed dropped mark"
+                _effect.send(DetailsContract.Effect.ShowSnackbar(message))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(DetailsContract.Effect.ShowError("Failed to update: ${e.message}"))
             }
         }
     }

--- a/feature/details/src/main/res/values/strings.xml
+++ b/feature/details/src/main/res/values/strings.xml
@@ -156,4 +156,8 @@
     <string name="details_filter_apply">Apply</string>
     <string name="details_filter_reset">Reset</string>
     <string name="details_filter_cancel">Cancel</string>
+    <string name="details_mark_completed">Mark as completed</string>
+    <string name="details_unmark_completed">Unmark completed</string>
+    <string name="details_mark_dropped">Mark as dropped</string>
+    <string name="details_unmark_dropped">Unmark dropped</string>
 </resources>

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -42,7 +42,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import app.otakureader.core.ui.components.CompletedBadge
 import app.otakureader.core.ui.components.DownloadBadge
+import app.otakureader.core.ui.components.DroppedBadge
 import app.otakureader.core.ui.components.MangaCard
 import app.otakureader.core.ui.components.ManhwaCard
 import app.otakureader.core.ui.theme.LocalOtakuColors
@@ -218,6 +220,11 @@ internal fun MangaGrid(
                                 }
                                 else -> null
                             },
+                            statusBadge = when {
+                                manga.userCompleted -> { { CompletedBadge() } }
+                                manga.userDropped -> { { DroppedBadge() } }
+                                else -> null
+                            },
                             modifier = Modifier.fillMaxWidth()
                         )
                     }
@@ -289,6 +296,11 @@ internal fun MangaGrid(
                             state.showDownloadBadge && downloadCount > 0 -> {
                                 { DownloadBadge(count = downloadCount) }
                             }
+                            else -> null
+                        },
+                        statusBadge = when {
+                            manga.userCompleted -> { { CompletedBadge() } }
+                            manga.userDropped -> { { DroppedBadge() } }
                             else -> null
                         },
                         modifier = Modifier.fillMaxWidth()

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -115,6 +115,8 @@ sealed class LibraryEvent {
     data object MarkSelectedAsUnread : LibraryEvent()
     data object RemoveSelectedFromLibrary : LibraryEvent()
     data object DownloadSelected : LibraryEvent()
+    data object MarkSelectedAsCompleted : LibraryEvent()
+    data object MarkSelectedAsDropped : LibraryEvent()
     // Continue Reading
     data class ContinueReadingClick(val mangaId: Long, val chapterId: Long) : LibraryEvent()
     // Reading list filter (null = clear/show all)

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -125,6 +125,32 @@ fun LibraryScreen(
                         IconButton(onClick = { viewModel.onEvent(LibraryEvent.RemoveSelectedFromLibrary) }) {
                             Icon(Icons.Default.DeleteForever, contentDescription = stringResource(R.string.library_remove_selected))
                         }
+                        var selectionOverflowExpanded by remember { mutableStateOf(false) }
+                        IconButton(onClick = { selectionOverflowExpanded = true }) {
+                            Icon(
+                                Icons.Default.MoreVert,
+                                contentDescription = stringResource(R.string.library_more_actions),
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = selectionOverflowExpanded,
+                            onDismissRequest = { selectionOverflowExpanded = false },
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.library_mark_selected_completed)) },
+                                onClick = {
+                                    viewModel.onEvent(LibraryEvent.MarkSelectedAsCompleted)
+                                    selectionOverflowExpanded = false
+                                },
+                            )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.library_mark_selected_dropped)) },
+                                onClick = {
+                                    viewModel.onEvent(LibraryEvent.MarkSelectedAsDropped)
+                                    selectionOverflowExpanded = false
+                                },
+                            )
+                        }
                     }
                 )
                 state.showSearchBar -> TopAppBar(

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -8,6 +8,7 @@ import app.otakureader.core.preferences.ReadingGoalPreferences
 import app.otakureader.core.ui.selection.SelectionManager
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
+import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.ReaderSettingsRepository
 import app.otakureader.domain.repository.ReadingListRepository
 import app.otakureader.domain.repository.StatisticsRepository
@@ -51,6 +52,7 @@ class LibraryViewModel @Inject constructor(
     private val libraryPreferences: LibraryPreferences,
     private val generalPreferences: GeneralPreferences,
     private val chapterRepository: ChapterRepository,
+    private val mangaRepository: MangaRepository,
     private val downloadRepository: DownloadRepository,
     private val settingsRepository: ReaderSettingsRepository,
     private val trackRepository: TrackRepository,
@@ -111,7 +113,8 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.DismissRecommendation -> dismissRecommendation(event.mangaId)
             is LibraryEvent.ToggleFavorite, is LibraryEvent.MarkSelectedAsRead,
             is LibraryEvent.MarkSelectedAsUnread, is LibraryEvent.RemoveSelectedFromLibrary,
-            is LibraryEvent.DownloadSelected -> handleActionEvent(event)
+            is LibraryEvent.DownloadSelected, is LibraryEvent.MarkSelectedAsCompleted,
+            is LibraryEvent.MarkSelectedAsDropped -> handleActionEvent(event)
         }
     }
 
@@ -166,6 +169,8 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.MarkSelectedAsUnread -> markSelectedAsUnread()
             is LibraryEvent.RemoveSelectedFromLibrary -> removeSelectedFromLibrary()
             is LibraryEvent.DownloadSelected -> downloadSelected()
+            is LibraryEvent.MarkSelectedAsCompleted -> markSelectedAsCompleted()
+            is LibraryEvent.MarkSelectedAsDropped -> markSelectedAsDropped()
             else -> Unit
         }
     }
@@ -454,6 +459,22 @@ class LibraryViewModel @Inject constructor(
                     )
                 }
             }
+        }
+    }
+
+    private fun markSelectedAsCompleted() {
+        val mangaIds = selection.snapshotAndClear()
+        if (mangaIds.isEmpty()) return
+        viewModelScope.launch {
+            mangaIds.forEach { mangaRepository.markUserCompleted(it, completed = true) }
+        }
+    }
+
+    private fun markSelectedAsDropped() {
+        val mangaIds = selection.snapshotAndClear()
+        if (mangaIds.isEmpty()) return
+        viewModelScope.launch {
+            mangaIds.forEach { mangaRepository.markUserDropped(it, dropped = true) }
         }
     }
 

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -79,6 +79,9 @@
     <string name="library_mark_selected_unread">Mark as unread</string>
     <string name="library_download_selected">Download selected</string>
     <string name="library_remove_selected">Remove from library</string>
+    <string name="library_more_actions">More actions</string>
+    <string name="library_mark_selected_completed">Mark as completed</string>
+    <string name="library_mark_selected_dropped">Mark as dropped</string>
     <!-- Daily goal banner -->
     <string name="library_daily_goal_label">Daily Reading Goal</string>
     <string name="library_daily_goal_complete">Daily goal reached! 🎉</string>

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -12,6 +12,7 @@ import app.otakureader.domain.model.ReadingListMangaItem
 import app.otakureader.domain.model.DownloadItem
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
+import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.ReaderSettingsRepository
 import app.otakureader.domain.repository.ReadingListRepository
 import app.otakureader.domain.repository.StatisticsRepository
@@ -53,6 +54,7 @@ class LibraryViewModelTest {
     private lateinit var libraryPreferences: LibraryPreferences
     private lateinit var generalPreferences: GeneralPreferences
     private lateinit var chapterRepository: ChapterRepository
+    private lateinit var mangaRepository: MangaRepository
     private lateinit var downloadRepository: DownloadRepository
     private lateinit var settingsRepository: ReaderSettingsRepository
     private lateinit var trackRepository: TrackRepository
@@ -91,9 +93,8 @@ class LibraryViewModelTest {
             every { lastUpdatesViewedAt } returns flowOf(0L)
             every { visualEffectsEnabled } returns flowOf(true)
         }
-        chapterRepository = mockk {
-            every { countNewUpdatesSince(any()) } returns flowOf(0)
-        }
+        chapterRepository = mockk { every { countNewUpdatesSince(any()) } returns flowOf(0) }
+        mangaRepository = mockk(relaxed = true)
         downloadRepository = mockk {
             coEvery { hasMangaDownloads(any(), any()) } returns false
             every { observeDownloads() } returns flowOf(emptyList())
@@ -143,6 +144,7 @@ class LibraryViewModelTest {
             libraryPreferences,
             generalPreferences,
             chapterRepository,
+            mangaRepository,
             downloadRepository,
             settingsRepository,
             trackRepository,


### PR DESCRIPTION
## **User description**
## Summary

Closes #946. Surfaces the existing `userCompleted` / `userDropped` flags through three new UI affordances:

- **Details overflow menu** — "Mark as completed" / "Mark as dropped" (and their unmark variants when already set), wired through new `ToggleUserCompleted` / `ToggleUserDropped` events to existing `MangaRepository.markUserCompleted` / `markUserDropped`.
- **Library selection top-app-bar overflow** — bulk mark-as-completed / mark-as-dropped for the current selection (`MarkSelectedAsCompleted` / `MarkSelectedAsDropped` events; new `MoreVert` overflow keeps the icon row from getting crowded).
- **Manga grid cards** — small badge in the top-left corner showing a checkmark (completed) or X (dropped). New `statusBadge` slot on `MangaCard` keeps the existing unread/download badge slot in the top-right corner undisturbed.

### Why this is small
The data layer (`Manga.userCompleted` / `Manga.userDropped`), domain repository (`markUserCompleted` / `markUserDropped`), and library filter logic (`LibraryFilterMode.COMPLETED` / `DROPPED` already filtering in `applyFilterMode`) were all already in place — this PR is purely the missing UI surface.

### Acceptance criteria mapping
- [x] "Completed" library filter/section — *already in the filter sheet*; chip stays visible via existing `state.filterMode != ALL` indicator
- [x] "Dropped" library filter/section — same
- [x] Mark as completed/dropped actions in manga details — new overflow items
- [x] Visual badge on manga cards — new `StatusBadge` (CompletedBadge / DroppedBadge) shown in top-left
- [x] Bulk mark-as-completed/dropped in multi-select — new selection-bar overflow menu items
- [ ] Option to hide completed manga from main library — deferred; would require a new pref + behavioral change to `ALL` mode. Open question, separate PR if wanted.

## Test plan
- [ ] **Details**: open any manga → overflow → "Mark as completed" → snackbar "Marked as completed"; reopen overflow → label is now "Unmark completed"; tap → reverts.
- [ ] **Details (dropped)**: same flow for "Mark as dropped" / "Unmark dropped".
- [ ] **Grid badges**: open Library → manga marked completed shows green checkmark badge top-left; dropped shows red X.
- [ ] **Bulk completed**: Library → long-press to select 2+ manga → overflow → "Mark as completed" → both move to Completed filter (via filter sheet); selection clears.
- [ ] **Bulk dropped**: same flow for "Mark as dropped".
- [ ] **Existing filter still works**: filter sheet → COMPLETED → only marked manga show.

### Build sanity
- `./gradlew :feature:library:compileDebugKotlin :feature:details:compileDebugKotlin :core:ui:compileDebugKotlin` ✅
- `./gradlew :feature:library:testDebugUnitTest :feature:details:testDebugUnitTest :core:ui:testDebugUnitTest` ✅
- `./gradlew detekt :app:assembleDebug` ✅

https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd)_


___

## **CodeAnt-AI Description**
**Show completed and dropped markers in more places**

### What Changed
- Manga details now include actions to mark or unmark a series as completed or dropped, with confirmation messages after the change.
- Library multi-select now adds a separate overflow menu for marking selected manga as completed or dropped.
- Manga cards in the library now show a top-left badge for completed or dropped titles, making their status visible at a glance.

### Impact
`✅ Faster marking of finished series`
`✅ Quicker bulk status updates from the library`
`✅ Clearer library status at a glance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual status badges (Completed, Dropped) displayed on manga cards in the library
  * Added per-manga actions to mark/unmark items as completed or dropped in the details screen
  * Added bulk actions to mark multiple selected library items as completed or dropped simultaneously

* **Tests**
  * Updated unit tests to support new repository dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->