### PR TITLE
feat(details): total estimated read time remaining in chapter header (#951)

### DIFF
--- a/data/src/main/java/app/otakureader/data/repository/StatisticsRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/StatisticsRepositoryImpl.kt
@@ -58,6 +58,13 @@ class StatisticsRepositoryImpl @Inject constructor(
         )
     }
     
+    override fun getAverageChapterDurationMs(): Flow<Long> = readingHistoryDao.observeHistory().map { history ->
+        // Only count sessions with a recorded duration so an early-exit (0ms) read doesn't drag the average to zero.
+        val timed = history.filter { it.readDurationMs > 0L }
+        if (timed.isEmpty()) DEFAULT_AVG_CHAPTER_DURATION_MS
+        else timed.sumOf { it.readDurationMs } / timed.size
+    }
+
     @Suppress("MaxLineLength")
     override fun getReadingGoalProgress(dailyGoal: Int, weeklyGoal: Int): Flow<ReadingGoal> = readingHistoryDao.observeHistory().map { history ->
         val today = LocalDate.now()
@@ -117,6 +124,11 @@ class StatisticsRepositoryImpl @Inject constructor(
         return streak
     }
     
+    private companion object {
+        // 5 minutes — a reasonable default for an "average" manga chapter when the user has no history yet.
+        const val DEFAULT_AVG_CHAPTER_DURATION_MS = 5L * 60L * 1000L
+    }
+
     private fun calculateBestStreak(readingDays: List<LocalDate>): Int {
         if (readingDays.isEmpty()) return 0
         

--- a/domain/src/main/java/app/otakureader/domain/repository/StatisticsRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/StatisticsRepository.kt
@@ -7,4 +7,10 @@ import kotlinx.coroutines.flow.Flow
 interface StatisticsRepository {
     fun getReadingStats(): Flow<ReadingStats>
     fun getReadingGoalProgress(dailyGoal: Int, weeklyGoal: Int): Flow<ReadingGoal>
+
+    /**
+     * Average per-chapter reading duration in milliseconds derived from the user's history.
+     * Emits the user's running average; emits the fallback (5 min) when no history exists.
+     */
+    fun getAverageChapterDurationMs(): Flow<Long>
 }

--- a/feature/details/src/main/java/app/otakureader/feature/details/ChapterSection.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/ChapterSection.kt
@@ -37,6 +37,7 @@ internal fun ChapterListHeader(
     chapterCount: Int,
     sortOrder: DetailsContract.ChapterSortOrder,
     isFilterActive: Boolean = false,
+    estimatedRemainingTimeMs: Long = 0L,
     onToggleSort: () -> Unit,
     onShowFilter: () -> Unit = {},
     modifier: Modifier = Modifier
@@ -46,10 +47,23 @@ internal fun ChapterListHeader(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(
-            text = pluralStringResource(R.plurals.details_chapter_count, chapterCount, chapterCount),
-            style = MaterialTheme.typography.titleMedium
-        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = pluralStringResource(R.plurals.details_chapter_count, chapterCount, chapterCount),
+                style = MaterialTheme.typography.titleMedium
+            )
+            if (estimatedRemainingTimeMs > 0L) {
+                val minutes = (estimatedRemainingTimeMs / 60_000L).toInt()
+                Text(
+                    text = stringResource(
+                        R.string.details_remaining_read_time,
+                        app.otakureader.core.common.formatReadTime(minutes),
+                    ),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
 
         Row(verticalAlignment = Alignment.CenterVertically) {
             IconButton(onClick = onShowFilter) {

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
@@ -48,8 +48,14 @@ object DetailsContract {
         /** Whether to show panorama cover (wide banner) instead of square thumbnail. */
         val showPanoramaCover: Boolean = false,
         /** Whether automatic theme color extraction from cover is enabled. */
-        val autoThemeEnabled: Boolean = true
+        val autoThemeEnabled: Boolean = true,
+        /** User's average per-chapter reading duration in milliseconds; used to estimate remaining time. */
+        val averageChapterDurationMs: Long = 0L
     ) : UiState {
+
+        /** Estimated time remaining to finish all unread chapters of this manga. */
+        val estimatedRemainingTimeMs: Long
+            get() = averageChapterDurationMs * chapters.count { !it.read }
         
         val canStartReading: Boolean
             get() = chapters.isNotEmpty()

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -403,6 +403,7 @@ private fun LazyListScope.detailsChapterItems(
             chapterCount = state.chapters.size,
             sortOrder = state.chapterSortOrder,
             isFilterActive = state.chapterFilter.isActive,
+            estimatedRemainingTimeMs = state.estimatedRemainingTimeMs,
             onToggleSort = { onEvent(DetailsContract.Event.ToggleSortOrder) },
             onShowFilter = { onEvent(DetailsContract.Event.ShowChapterFilter) }
         )

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -9,6 +9,7 @@ import app.otakureader.domain.model.Manga
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.MangaRepository
+import app.otakureader.domain.repository.StatisticsRepository
 import app.otakureader.core.preferences.DeleteAfterReadMode
 import app.otakureader.core.preferences.DownloadPreferences
 import app.otakureader.core.preferences.GeneralPreferences
@@ -50,6 +51,7 @@ class DetailsViewModel @Inject constructor(
     private val generalPreferences: GeneralPreferences,
     private val updateMangaNote: UpdateMangaNoteUseCase,
     private val setMangaNotifications: SetMangaNotificationsUseCase,
+    private val statisticsRepository: StatisticsRepository,
 ) : ViewModel() {
 
     private val mangaId: Long = savedStateHandle.get<Long>(MANGA_ID_ARG) 
@@ -295,6 +297,10 @@ class DetailsViewModel @Inject constructor(
             .onEach { enabled ->
                 _state.update { it.copy(autoThemeEnabled = enabled) }
             }
+            .launchIn(viewModelScope)
+
+        statisticsRepository.getAverageChapterDurationMs()
+            .onEach { ms -> _state.update { it.copy(averageChapterDurationMs = ms) } }
             .launchIn(viewModelScope)
     }
 

--- a/feature/details/src/main/res/values/strings.xml
+++ b/feature/details/src/main/res/values/strings.xml
@@ -156,4 +156,5 @@
     <string name="details_filter_apply">Apply</string>
     <string name="details_filter_reset">Reset</string>
     <string name="details_filter_cancel">Cancel</string>
+    <string name="details_remaining_read_time">About %1$s remaining</string>
 </resources>

--- a/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
+++ b/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
@@ -47,6 +47,7 @@ class DetailsViewModelTest {
     private lateinit var generalPreferences: GeneralPreferences
     private lateinit var updateMangaNote: UpdateMangaNoteUseCase
     private lateinit var setMangaNotifications: SetMangaNotificationsUseCase
+    private lateinit var statisticsRepository: app.otakureader.domain.repository.StatisticsRepository
     private lateinit var savedStateHandle: SavedStateHandle
 
     private val sampleManga = Manga(
@@ -76,6 +77,7 @@ class DetailsViewModelTest {
         generalPreferences = mockk(relaxed = true)
         updateMangaNote = mockk()
         setMangaNotifications = mockk()
+        statisticsRepository = mockk(relaxed = true)
         savedStateHandle = SavedStateHandle(mapOf(DetailsViewModel.MANGA_ID_ARG to mangaId))
     }
 
@@ -95,6 +97,7 @@ class DetailsViewModelTest {
             generalPreferences,
             updateMangaNote,
             setMangaNotifications,
+            statisticsRepository,
         )
     }
 


### PR DESCRIPTION
## **User description**
## Summary

Closes #951. Surfaces the user's existing reading-history time data as an actionable manga-level "About 2h 30m remaining" subtitle under the chapter count in the details screen.

### Pieces
- `StatisticsRepository.getAverageChapterDurationMs(): Flow<Long>` — derives a user-specific per-chapter average from `ReadingHistoryEntity.readDurationMs`. Filters out 0-duration sessions so an early-exit read doesn't drag the average to zero. Falls back to 5 min/chapter when no history yet exists.
- `DetailsContract.State.averageChapterDurationMs` + computed `estimatedRemainingTimeMs = avg × unread chapter count`.
- `DetailsViewModel` observes the average and updates state.
- `ChapterListHeader` (`ChapterSection.kt`) takes an optional `estimatedRemainingTimeMs` and renders it under the chapter count using the existing `core.common.formatReadTime()` helper.

### Out of scope (deferred to a follow-up)
- **Per-chapter row time using user history**: a `~5 min read` estimate already exists in `ChapterListItem` via the page-count heuristic. Rewiring it to the user-history-derived speed needs more invasive plumbing — better as its own follow-up so this change stays focused.
- **Reader-overlay remaining time**: also in the issue's acceptance list, deferred for the same reason.

## Test plan
- [ ] Open a manga you've never read — header shows "About 5h 0m remaining" (5 min × 60 chapters) since there's no history yet (default fallback).
- [ ] Read 2–3 chapters of any manga; reopen the details — header now shows a duration derived from those sessions.
- [ ] Mark all chapters as read — the "remaining" subtitle disappears (because `estimatedRemainingTimeMs == 0`).
- [ ] Open a manga with only one unread chapter — estimate roughly matches the user's average for one chapter.

### Build sanity
- `./gradlew :feature:details:compileDebugKotlin :data:compileDebugKotlin :domain:compileKotlin` ✅
- `./gradlew :feature:details:testDebugUnitTest :data:testDebugUnitTest :domain:test` ✅
- `./gradlew detekt :app:assembleDebug` ✅

https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd)_


___

## **CodeAnt-AI Description**
**Show an estimated remaining read time in the manga details header**

### What Changed
- The chapter header now shows an "About X remaining" line when the manga still has unread chapters
- The estimate is based on the user's past reading speed, with a 5-minute-per-chapter fallback when there is no history yet
- Chapters marked as read no longer count toward the remaining time, so the estimate disappears once everything is finished

### Impact
`✅ Clearer progress estimates`
`✅ Faster decisions on what to read next`
`✅ Fewer surprises when picking up a manga`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
