### PR TITLE
feat(library): reading list collections CRUD screens (#945)

### DIFF
--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -24,6 +24,8 @@ import app.otakureader.feature.feed.navigation.feedScreen
 import app.otakureader.feature.history.navigation.historyScreen
 import app.otakureader.feature.library.category.navigation.categoryManagementScreen
 import app.otakureader.feature.library.navigation.libraryScreen
+import app.otakureader.feature.library.readinglist.navigation.readingListDetailScreen
+import app.otakureader.feature.library.readinglist.navigation.readingListsScreen
 import app.otakureader.feature.migration.navigation.migrationEntryScreen
 import app.otakureader.feature.migration.navigation.migrationScreen
 import app.otakureader.feature.more.navigation.moreScreen
@@ -419,6 +421,19 @@ fun OtakuReaderNavHost(
             onNavigateToBackup = {
                 navController.navigate(Route.SettingsBackup)
             },
+            onNavigateToReadingLists = {
+                navController.navigate(Route.ReadingLists)
+            },
+        )
+
+        // Reading List Collections (#945)
+        readingListsScreen(
+            onNavigateBack = { navController.popBackStack() },
+            onNavigateToList = { listId -> navController.navigate(Route.ReadingListDetail(listId)) },
+        )
+        readingListDetailScreen(
+            onNavigateBack = { navController.popBackStack() },
+            onNavigateToManga = { mangaId -> navController.navigate(Route.MangaDetails(mangaId)) },
         )
 
         // QR Library Sharing

--- a/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
+++ b/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
@@ -188,6 +188,19 @@ sealed interface Route {
     @Serializable
     data object CategoryManagement : Route
 
+    // ─── Reading Lists ───
+
+    /** User-defined reading list collections — top-level CRUD screen. */
+    @Serializable
+    data object ReadingLists : Route
+
+    /**
+     * A single reading list's detail/manga-grid screen.
+     * @param listId The reading list's database ID.
+     */
+    @Serializable
+    data class ReadingListDetail(val listId: Long) : Route
+
     // ─── OPDS (Phase 3) ───
 
     /**

--- a/feature/library/src/main/java/app/otakureader/feature/library/readinglist/ReadingListDetailScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/readinglist/ReadingListDetailScreen.kt
@@ -1,0 +1,142 @@
+package app.otakureader.feature.library.readinglist
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.otakureader.core.ui.components.MangaCard
+import app.otakureader.feature.library.R
+import kotlinx.coroutines.flow.collectLatest
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReadingListDetailScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToManga: (Long) -> Unit,
+    viewModel: ReadingListDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(viewModel.effect) {
+        viewModel.effect.collectLatest { effect ->
+            when (effect) {
+                is ReadingListDetailEffect.ShowSnackbar -> snackbarHostState.showSnackbar(effect.message)
+                is ReadingListDetailEffect.NavigateToManga -> onNavigateToManga(effect.mangaId)
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = state.list?.name ?: stringResource(R.string.reading_lists_detail_fallback_title),
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.reading_lists_back),
+                        )
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when {
+                state.isLoading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                state.manga.isEmpty() -> EmptyDetail(modifier = Modifier.align(Alignment.Center))
+                else -> LazyVerticalGrid(
+                    columns = GridCells.Fixed(3),
+                    contentPadding = PaddingValues(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    items(state.manga, key = { it.manga.id }) { item ->
+                        var menuExpanded by remember { mutableStateOf(false) }
+                        Box(modifier = Modifier.fillMaxWidth()) {
+                            MangaCard(
+                                title = item.manga.title,
+                                coverUrl = item.manga.thumbnailUrl,
+                                onClick = { viewModel.onEvent(ReadingListDetailEvent.OpenManga(item.manga.id)) },
+                                onLongClick = { menuExpanded = true },
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                            DropdownMenu(
+                                expanded = menuExpanded,
+                                onDismissRequest = { menuExpanded = false },
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.reading_lists_remove_from_list)) },
+                                    leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                                    onClick = {
+                                        viewModel.onEvent(ReadingListDetailEvent.RemoveManga(item.manga.id))
+                                        menuExpanded = false
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyDetail(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.reading_lists_detail_empty_title),
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Text(
+            text = stringResource(R.string.reading_lists_detail_empty_subtitle),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/feature/library/src/main/java/app/otakureader/feature/library/readinglist/ReadingListDetailViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/readinglist/ReadingListDetailViewModel.kt
@@ -1,0 +1,65 @@
+package app.otakureader.feature.library.readinglist
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.otakureader.core.navigation.Route
+import app.otakureader.domain.repository.ReadingListRepository
+import androidx.navigation.toRoute
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ReadingListDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val readingListRepository: ReadingListRepository,
+) : ViewModel() {
+
+    private val listId: Long = savedStateHandle.toRoute<Route.ReadingListDetail>().listId
+
+    private val _state = MutableStateFlow(ReadingListDetailState())
+    val state: StateFlow<ReadingListDetailState> = _state.asStateFlow()
+
+    private val _effect = Channel<ReadingListDetailEffect>(Channel.BUFFERED)
+    val effect: Flow<ReadingListDetailEffect> = _effect.receiveAsFlow()
+
+    init {
+        readingListRepository.getListWithManga(listId)
+            .onEach { (list, manga) ->
+                _state.update { it.copy(list = list, manga = manga, isLoading = false) }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    fun onEvent(event: ReadingListDetailEvent) {
+        when (event) {
+            is ReadingListDetailEvent.RemoveManga -> removeManga(event.mangaId)
+            is ReadingListDetailEvent.OpenManga ->
+                viewModelScope.launch { _effect.send(ReadingListDetailEffect.NavigateToManga(event.mangaId)) }
+        }
+    }
+
+    private fun removeManga(mangaId: Long) {
+        viewModelScope.launch {
+            try {
+                readingListRepository.removeMangaFromList(listId, mangaId)
+                _effect.send(ReadingListDetailEffect.ShowSnackbar("Removed from list"))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(ReadingListDetailEffect.ShowSnackbar("Failed to remove: ${e.message}"))
+            }
+        }
+    }
+}

--- a/feature/library/src/main/java/app/otakureader/feature/library/readinglist/ReadingListsMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/readinglist/ReadingListsMvi.kt
@@ -1,0 +1,41 @@
+package app.otakureader.feature.library.readinglist
+
+import app.otakureader.core.common.mvi.UiEffect
+import app.otakureader.core.common.mvi.UiEvent
+import app.otakureader.core.common.mvi.UiState
+import app.otakureader.domain.model.ReadingList
+import app.otakureader.domain.model.ReadingListMangaItem
+
+data class ReadingListsState(
+    val lists: List<ReadingList> = emptyList(),
+    val isLoading: Boolean = true,
+) : UiState
+
+sealed interface ReadingListsEvent : UiEvent {
+    data class CreateList(val name: String, val description: String?) : ReadingListsEvent
+    data class RenameList(val listId: Long, val name: String, val description: String?) : ReadingListsEvent
+    data class DeleteList(val listId: Long) : ReadingListsEvent
+    data class OpenList(val listId: Long) : ReadingListsEvent
+}
+
+sealed interface ReadingListsEffect : UiEffect {
+    data class ShowSnackbar(val message: String) : ReadingListsEffect
+    data class NavigateToListDetail(val listId: Long) : ReadingListsEffect
+}
+
+/** Detail-screen state: the list's metadata plus its manga grid. */
+data class ReadingListDetailState(
+    val list: ReadingList? = null,
+    val manga: List<ReadingListMangaItem> = emptyList(),
+    val isLoading: Boolean = true,
+) : UiState
+
+sealed interface ReadingListDetailEvent : UiEvent {
+    data class RemoveManga(val mangaId: Long) : ReadingListDetailEvent
+    data class OpenManga(val mangaId: Long) : ReadingListDetailEvent
+}
+
+sealed interface ReadingListDetailEffect : UiEffect {
+    data class ShowSnackbar(val message: String) : ReadingListDetailEffect
+    data class NavigateToManga(val mangaId: Long) : ReadingListDetailEffect
+}

--- a/feature/library/src/main/java/app/otakureader/feature/library/readinglist/ReadingListsScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/readinglist/ReadingListsScreen.kt
@@ -1,0 +1,254 @@
+package app.otakureader.feature.library.readinglist
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.otakureader.domain.model.ReadingList
+import app.otakureader.feature.library.R
+import kotlinx.coroutines.flow.collectLatest
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReadingListsScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToList: (Long) -> Unit,
+    viewModel: ReadingListsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showCreateDialog by remember { mutableStateOf(false) }
+    var editingList by remember { mutableStateOf<ReadingList?>(null) }
+    var listPendingDeletion by remember { mutableStateOf<ReadingList?>(null) }
+
+    LaunchedEffect(viewModel.effect) {
+        viewModel.effect.collectLatest { effect ->
+            when (effect) {
+                is ReadingListsEffect.ShowSnackbar -> snackbarHostState.showSnackbar(effect.message)
+                is ReadingListsEffect.NavigateToListDetail -> onNavigateToList(effect.listId)
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.reading_lists_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.reading_lists_back))
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showCreateDialog = true }) {
+                Icon(Icons.Default.Add, contentDescription = stringResource(R.string.reading_lists_create))
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when {
+                state.isLoading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                state.lists.isEmpty() -> EmptyReadingLists(modifier = Modifier.align(Alignment.Center))
+                else -> LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(state.lists, key = { it.id }) { list ->
+                        ListRow(
+                            list = list,
+                            onClick = { viewModel.onEvent(ReadingListsEvent.OpenList(list.id)) },
+                            onEdit = { editingList = list },
+                            onDelete = { listPendingDeletion = list },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (showCreateDialog) {
+        ReadingListEditorDialog(
+            initial = null,
+            onDismiss = { showCreateDialog = false },
+            onConfirm = { name, desc ->
+                viewModel.onEvent(ReadingListsEvent.CreateList(name, desc))
+                showCreateDialog = false
+            },
+        )
+    }
+
+    editingList?.let { list ->
+        ReadingListEditorDialog(
+            initial = list,
+            onDismiss = { editingList = null },
+            onConfirm = { name, desc ->
+                viewModel.onEvent(ReadingListsEvent.RenameList(list.id, name, desc))
+                editingList = null
+            },
+        )
+    }
+
+    listPendingDeletion?.let { list ->
+        AlertDialog(
+            onDismissRequest = { listPendingDeletion = null },
+            title = { Text(stringResource(R.string.reading_lists_delete_title)) },
+            text = { Text(stringResource(R.string.reading_lists_delete_confirm, list.name)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.onEvent(ReadingListsEvent.DeleteList(list.id))
+                    listPendingDeletion = null
+                }) { Text(stringResource(R.string.reading_lists_delete_confirm_button)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { listPendingDeletion = null }) {
+                    Text(stringResource(R.string.reading_lists_cancel))
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun ListRow(
+    list: ReadingList,
+    onClick: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    ListItem(
+        headlineContent = { Text(list.name) },
+        supportingContent = {
+            Column {
+                if (!list.description.isNullOrBlank()) {
+                    Text(
+                        text = list.description!!,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.reading_lists_item_count, list.itemCount),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        trailingContent = {
+            androidx.compose.foundation.layout.Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                IconButton(onClick = onEdit) {
+                    Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.reading_lists_edit))
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.reading_lists_delete))
+                }
+            }
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+    )
+}
+
+@Composable
+private fun EmptyReadingLists(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.reading_lists_empty_title),
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Text(
+            text = stringResource(R.string.reading_lists_empty_subtitle),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ReadingListEditorDialog(
+    initial: ReadingList?,
+    onDismiss: () -> Unit,
+    onConfirm: (name: String, description: String?) -> Unit,
+) {
+    var name by remember { mutableStateOf(initial?.name.orEmpty()) }
+    var description by remember { mutableStateOf(initial?.description.orEmpty()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                if (initial == null) stringResource(R.string.reading_lists_create_title)
+                else stringResource(R.string.reading_lists_edit_title),
+            )
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(stringResource(R.string.reading_lists_name_label)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    label = { Text(stringResource(R.string.reading_lists_description_label)) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(name, description.ifBlank { null }) }) {
+                Text(stringResource(R.string.reading_lists_save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.reading_lists_cancel))
+            }
+        },
+    )
+}

--- a/feature/library/src/main/java/app/otakureader/feature/library/readinglist/ReadingListsViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/readinglist/ReadingListsViewModel.kt
@@ -1,0 +1,119 @@
+package app.otakureader.feature.library.readinglist
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.otakureader.domain.model.ReadingList
+import app.otakureader.domain.repository.ReadingListRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class ReadingListsViewModel @Inject constructor(
+    private val readingListRepository: ReadingListRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ReadingListsState())
+    val state: StateFlow<ReadingListsState> = _state.asStateFlow()
+
+    private val _effect = Channel<ReadingListsEffect>(Channel.BUFFERED)
+    val effect: Flow<ReadingListsEffect> = _effect.receiveAsFlow()
+
+    init {
+        readingListRepository.getAllLists()
+            .flatMapLatest { lists ->
+                if (lists.isEmpty()) {
+                    flowOf(emptyList<ReadingList>())
+                } else {
+                    // Combine each list with its item count so the badge stays reactive.
+                    combine(lists.map { list -> readingListRepository.getItemCount(list.id) }) { counts ->
+                        lists.mapIndexed { i, list -> list.copy(itemCount = counts[i]) }
+                    }
+                }
+            }
+            .onEach { enriched ->
+                _state.update { it.copy(lists = enriched, isLoading = false) }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    fun onEvent(event: ReadingListsEvent) {
+        when (event) {
+            is ReadingListsEvent.CreateList -> createList(event.name, event.description)
+            is ReadingListsEvent.RenameList -> renameList(event.listId, event.name, event.description)
+            is ReadingListsEvent.DeleteList -> deleteList(event.listId)
+            is ReadingListsEvent.OpenList -> openList(event.listId)
+        }
+    }
+
+    private fun createList(name: String, description: String?) {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) {
+            viewModelScope.launch { _effect.send(ReadingListsEffect.ShowSnackbar("Name cannot be empty")) }
+            return
+        }
+        viewModelScope.launch {
+            try {
+                readingListRepository.createList(name = trimmed, description = description?.takeIf { it.isNotBlank() }, color = null)
+                _effect.send(ReadingListsEffect.ShowSnackbar("List created"))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(ReadingListsEffect.ShowSnackbar("Failed to create list: ${e.message}"))
+            }
+        }
+    }
+
+    private fun renameList(listId: Long, name: String, description: String?) {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) {
+            viewModelScope.launch { _effect.send(ReadingListsEffect.ShowSnackbar("Name cannot be empty")) }
+            return
+        }
+        viewModelScope.launch {
+            try {
+                val current = readingListRepository.getListById(listId) ?: return@launch
+                readingListRepository.updateList(
+                    current.copy(name = trimmed, description = description?.takeIf { it.isNotBlank() })
+                )
+                _effect.send(ReadingListsEffect.ShowSnackbar("List updated"))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(ReadingListsEffect.ShowSnackbar("Failed to update list: ${e.message}"))
+            }
+        }
+    }
+
+    private fun deleteList(listId: Long) {
+        viewModelScope.launch {
+            try {
+                readingListRepository.deleteList(listId)
+                _effect.send(ReadingListsEffect.ShowSnackbar("List deleted"))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(ReadingListsEffect.ShowSnackbar("Failed to delete list: ${e.message}"))
+            }
+        }
+    }
+
+    private fun openList(listId: Long) {
+        viewModelScope.launch { _effect.send(ReadingListsEffect.NavigateToListDetail(listId)) }
+    }
+}

--- a/feature/library/src/main/java/app/otakureader/feature/library/readinglist/navigation/ReadingListsNavigation.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/readinglist/navigation/ReadingListsNavigation.kt
@@ -1,0 +1,31 @@
+package app.otakureader.feature.library.readinglist.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import app.otakureader.core.navigation.Route
+import app.otakureader.feature.library.readinglist.ReadingListDetailScreen
+import app.otakureader.feature.library.readinglist.ReadingListsScreen
+
+fun NavGraphBuilder.readingListsScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToList: (Long) -> Unit,
+) {
+    composable<Route.ReadingLists> {
+        ReadingListsScreen(
+            onNavigateBack = onNavigateBack,
+            onNavigateToList = onNavigateToList,
+        )
+    }
+}
+
+fun NavGraphBuilder.readingListDetailScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToManga: (Long) -> Unit,
+) {
+    composable<Route.ReadingListDetail> {
+        ReadingListDetailScreen(
+            onNavigateBack = onNavigateBack,
+            onNavigateToManga = onNavigateToManga,
+        )
+    }
+}

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -141,4 +141,27 @@
     <string name="browse_scope_sources">Sources</string>
     <string name="browse_search_history">Recent searches</string>
     <string name="browse_search_history_empty">No recent searches</string>
+    <!-- Reading Lists (#945) -->
+    <string name="reading_lists_title">Reading Lists</string>
+    <string name="reading_lists_back">Back</string>
+    <string name="reading_lists_create">Create list</string>
+    <string name="reading_lists_create_title">Create reading list</string>
+    <string name="reading_lists_edit">Edit</string>
+    <string name="reading_lists_edit_title">Edit reading list</string>
+    <string name="reading_lists_delete">Delete</string>
+    <string name="reading_lists_delete_title">Delete reading list?</string>
+    <string name="reading_lists_delete_confirm">Permanently delete "%1$s" and all its entries?</string>
+    <string name="reading_lists_delete_confirm_button">Delete</string>
+    <string name="reading_lists_cancel">Cancel</string>
+    <string name="reading_lists_save">Save</string>
+    <string name="reading_lists_name_label">Name</string>
+    <string name="reading_lists_description_label">Description (optional)</string>
+    <string name="reading_lists_item_count">%1$d entries</string>
+    <string name="reading_lists_open">Open</string>
+    <string name="reading_lists_empty_title">No reading lists yet</string>
+    <string name="reading_lists_empty_subtitle">Create one to group manga across categories.</string>
+    <string name="reading_lists_detail_fallback_title">Reading list</string>
+    <string name="reading_lists_detail_empty_title">List is empty</string>
+    <string name="reading_lists_detail_empty_subtitle">Add manga from their details screen.</string>
+    <string name="reading_lists_remove_from_list">Remove from list</string>
 </resources>

--- a/feature/more/src/main/java/app/otakureader/feature/more/MoreScreen.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/MoreScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.automirrored.filled.LibraryBooks
 import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.QrCode
 import androidx.compose.material.icons.filled.QueryStats
@@ -69,6 +70,7 @@ fun MoreScreen(
     onNavigateToShareLibrary: () -> Unit = {},
     onNavigateToScanLibrary: () -> Unit = {},
     onNavigateToUpdateErrors: () -> Unit = {},
+    onNavigateToReadingLists: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -121,6 +123,17 @@ fun MoreScreen(
                 headline = stringResource(R.string.more_extensions),
                 supporting = stringResource(R.string.more_extensions_desc),
                 onClick = onNavigateToExtensions
+            )
+
+            HorizontalDivider()
+
+            MoreListItem(
+                icon = Icons.AutoMirrored.Filled.LibraryBooks,
+                iconContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                iconTint = MaterialTheme.colorScheme.onPrimaryContainer,
+                headline = stringResource(R.string.more_reading_lists),
+                supporting = stringResource(R.string.more_reading_lists_desc),
+                onClick = onNavigateToReadingLists,
             )
 
             HorizontalDivider()

--- a/feature/more/src/main/java/app/otakureader/feature/more/navigation/MoreNavigation.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/navigation/MoreNavigation.kt
@@ -20,6 +20,7 @@ fun NavGraphBuilder.moreScreen(
     onNavigateToScanLibrary: () -> Unit = {},
     onNavigateToBackup: () -> Unit = {},
     onNavigateToUpdateErrors: () -> Unit = {},
+    onNavigateToReadingLists: () -> Unit = {},
 ) {
     composable<Route.More> {
         MoreScreen(
@@ -33,6 +34,7 @@ fun NavGraphBuilder.moreScreen(
             onNavigateToScanLibrary = onNavigateToScanLibrary,
             onNavigateToBackup = onNavigateToBackup,
             onNavigateToUpdateErrors = onNavigateToUpdateErrors,
+            onNavigateToReadingLists = onNavigateToReadingLists,
         )
     }
 }

--- a/feature/more/src/main/res/values/strings.xml
+++ b/feature/more/src/main/res/values/strings.xml
@@ -24,6 +24,10 @@
     <string name="more_extensions">Extensions</string>
     <string name="more_extensions_desc">Manage installed manga sources</string>
 
+    <!-- Reading Lists (#945) -->
+    <string name="more_reading_lists">Reading Lists</string>
+    <string name="more_reading_lists_desc">Organize manga into custom collections</string>
+
     <!-- Backup & Restore -->
     <string name="more_backup">Backup &amp; Restore</string>
     <string name="more_backup_desc">Back up and restore your library data</string>


### PR DESCRIPTION
## **User description**
## Summary

Closes #945. Adds the missing UI surface for the already-implemented `ReadingListRepository`: a top-level list of user-defined reading lists, plus a per-list detail screen showing the manga grid.

### Pieces
- `Route.ReadingLists` / `Route.ReadingListDetail(listId)` in `core/navigation`.
- `ReadingListsMvi`: separate state/event/effect contracts for the list screen (CRUD over reading lists) and the detail screen (manga grid + remove action).
- `ReadingListsViewModel`: reactive `flatMapLatest` over `getAllLists` + per-list `getItemCount` so the entry badge stays in sync.
- `ReadingListDetailViewModel`: subscribes to `getListWithManga(listId)`.
- `ReadingListsScreen`: create/rename/delete dialogs, empty state, per-row Edit + Delete + Open click.
- `ReadingListDetailScreen`: 3-column manga grid using existing `MangaCard` with long-press → "Remove from list" overflow.
- New "Reading Lists" entry in the More tab.
- Navigation wired through `OtakuReaderNavHost`.

### Why this is mostly glue
The data + domain stack (entity, junction, DAO, `ReadingListRepository`, domain models) was all already in place — this PR is purely the missing UI + navigation.

### Out of scope (follow-up)
- **Add manga to a reading list from details** — needs an "Add to list" overflow item on `DetailsScreen` that opens a list-picker bottom sheet. Backend `addMangaToList(listId, mangaId)` already exists; UI deferred to a focused follow-up.
- **Reorder lists / reorder items within a list** — `reorderItem(listId, mangaId, sortOrder)` is in the repo but not surfaced here.
- **Color/icon per list** — `ReadingList.color` exists in the model; UI selector deferred.

## Test plan
- [ ] **More tab**: new "Reading Lists" entry appears below Extensions, opens to an empty-state screen.
- [ ] **Create**: tap FAB → enter name + (optional) description → confirm → list appears in the screen.
- [ ] **Edit**: tap pencil → change name → save → row updates.
- [ ] **Delete**: tap trash → confirm in dialog → row disappears + snackbar "List deleted".
- [ ] **Open detail**: tap row → detail screen opens; empty state shown since no manga added yet.
- [ ] **Item count badge** updates when a manga is added (via the future "Add to list" flow, or by manually inserting via DB tests).
- [ ] **Remove from list**: long-press manga card in detail → "Remove from list" → manga disappears + snackbar.

### Build sanity
- `./gradlew :feature:library:compileDebugKotlin :feature:more:compileDebugKotlin :app:compileDebugKotlin` ✅
- `./gradlew :feature:library:testDebugUnitTest :feature:more:testDebugUnitTest` ✅
- `./gradlew detekt :app:assembleDebug` ✅

https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd)_


___

## **CodeAnt-AI Description**
**Add reading list management screens and navigation**

### What Changed
- Added a new Reading Lists entry in the More tab so users can open their custom collections from the app menu
- Users can create, rename, and delete reading lists, with an empty state when no lists exist
- Each reading list now opens to a detail screen that shows its manga in a grid, lets users open a manga, and remove it from the list
- List counts stay up to date on the main Reading Lists screen

### Impact
`✅ Easier access to custom manga collections`
`✅ Faster list management from one screen`
`✅ Clearer view of what’s inside each reading list`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
