### PR TITLE
feat(browse): dedicated extension repositories management screen (#953)

### DIFF
--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -15,6 +15,7 @@ import app.otakureader.feature.about.navigation.aboutScreen
 import app.otakureader.feature.browse.navigation.browseScreen
 import app.otakureader.feature.browse.navigation.extensionInstallScreen
 import app.otakureader.feature.browse.navigation.extensionsBottomSheet
+import app.otakureader.feature.browse.repos.navigation.extensionRepositoriesScreen
 import app.otakureader.feature.browse.navigation.globalSearchScreen
 import app.otakureader.feature.browse.navigation.sourceMangaDetailScreen
 import app.otakureader.feature.browse.navigation.sourceDetailScreen
@@ -236,7 +237,15 @@ fun OtakuReaderNavHost(
             },
             onNavigateToSettings = {
                 navController.navigate(Route.Settings)
-            }
+            },
+            onNavigateToRepositories = {
+                navController.navigate(Route.ExtensionRepositories)
+            },
+        )
+
+        // Extension repositories management screen (#953)
+        extensionRepositoriesScreen(
+            onNavigateBack = { navController.popBackStack() },
         )
 
         // Extension install screen

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepoRepositoryImpl.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepoRepositoryImpl.kt
@@ -19,7 +19,6 @@ class ExtensionRepoRepositoryImpl(
 
     companion object {
         private val REPOSITORIES_KEY = stringSetPreferencesKey("extension_repositories")
-        private const val DEFAULT_REPO_URL = "https://raw.githubusercontent.com/keiyoushi/extensions/repo"
     }
 
     override fun getRepositories(): Flow<List<String>> {
@@ -58,7 +57,7 @@ class ExtensionRepoRepositoryImpl(
         // the default and the user's "no repos" state evaporates.
         dataStore.edit { preferences ->
             if (preferences[REPOSITORIES_KEY] == null) {
-                preferences[REPOSITORIES_KEY] = setOf(DEFAULT_REPO_URL)
+                preferences[REPOSITORIES_KEY] = setOf(ExtensionRepoRepository.DEFAULT_REPO_URL)
             }
         }
     }

--- a/core/extension/src/main/java/app/otakureader/core/extension/domain/repository/ExtensionRepoRepository.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/domain/repository/ExtensionRepoRepository.kt
@@ -17,6 +17,11 @@ import kotlinx.coroutines.flow.Flow
  */
 interface ExtensionRepoRepository {
 
+    companion object {
+        /** The bundled default Tachiyomi/Komikku-compatible extensions repository. */
+        const val DEFAULT_REPO_URL = "https://raw.githubusercontent.com/keiyoushi/extensions/repo"
+    }
+
     /**
      * Get all configured repository URLs. All returned URLs are treated as active.
      */

--- a/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
+++ b/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
@@ -83,6 +83,12 @@ sealed interface Route {
     data object ExtensionInstall : Route
 
     /**
+     * Manage custom extension repository URLs (#953).
+     */
+    @Serializable
+    data object ExtensionRepositories : Route
+
+    /**
      * Source manga detail — browse a manga from a source before adding to library.
      * @param sourceId Source extension ID.
      * @param mangaUrl URL slug from the source.

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
@@ -82,6 +82,7 @@ import kotlinx.coroutines.launch
 fun ExtensionsBottomSheet(
     onDismiss: () -> Unit,
     onNavigateToSettings: () -> Unit = {},
+    onNavigateToRepositories: () -> Unit = {},
     viewModel: ExtensionsViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -116,6 +117,7 @@ fun ExtensionsBottomSheet(
                 }
             },
             onNavigateToSettings = onNavigateToSettings,
+            onNavigateToRepositories = onNavigateToRepositories,
         )
     }
 }
@@ -128,6 +130,7 @@ private fun ExtensionsContent(
     snackbarHostState: SnackbarHostState,
     onClose: () -> Unit,
     onNavigateToSettings: () -> Unit = {},
+    onNavigateToRepositories: () -> Unit = {},
 ) {
     val selectedTab = state.selectedTab
     val tabs = listOf("Installed", "Available", "Updates")
@@ -189,7 +192,8 @@ private fun ExtensionsContent(
             RepositoryManager(
                 repositories = state.repositories,
                 onAdd = { onEvent(ExtensionsEvent.AddRepository(it)) },
-                onRemove = { onEvent(ExtensionsEvent.RemoveRepository(it)) }
+                onRemove = { onEvent(ExtensionsEvent.RemoveRepository(it)) },
+                onOpenFullManager = onNavigateToRepositories,
             )
 
             // Tabs
@@ -620,7 +624,8 @@ private fun UpdateAllButton(
 private fun RepositoryManager(
     repositories: List<String>,
     onAdd: (String) -> Unit,
-    onRemove: (String) -> Unit
+    onRemove: (String) -> Unit,
+    onOpenFullManager: () -> Unit = {},
 ) {
     var repoInput by remember { mutableStateOf("") }
 
@@ -660,8 +665,12 @@ private fun RepositoryManager(
 
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
+            TextButton(onClick = onOpenFullManager) {
+                Text(stringResource(R.string.extensions_manage_repositories))
+            }
             TextButton(
                 onClick = {
                     onAdd(repoInput)

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
@@ -67,6 +67,7 @@ fun NavGraphBuilder.sourceMangaDetailScreen(
 fun NavGraphBuilder.extensionsBottomSheet(
     onDismiss: () -> Unit,
     onNavigateToSettings: () -> Unit = {},
+    onNavigateToRepositories: () -> Unit = {},
 ) {
     composable<Route.ExtensionCatalog>(
         enterTransition = { fadeIn(animationSpec = tween(200)) },
@@ -77,6 +78,7 @@ fun NavGraphBuilder.extensionsBottomSheet(
         ExtensionsBottomSheet(
             onDismiss = onDismiss,
             onNavigateToSettings = onNavigateToSettings,
+            onNavigateToRepositories = onNavigateToRepositories,
         )
     }
 }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/repos/ExtensionRepositoriesMvi.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/repos/ExtensionRepositoriesMvi.kt
@@ -1,0 +1,29 @@
+package app.otakureader.feature.browse.repos
+
+import app.otakureader.core.common.mvi.UiEffect
+import app.otakureader.core.common.mvi.UiEvent
+import app.otakureader.core.common.mvi.UiState
+
+data class RepositoryItem(
+    val url: String,
+    /** True when this is the bundled default repo (per ExtensionRepoRepository.DEFAULT_REPO_URL). */
+    val isDefault: Boolean,
+)
+
+data class ExtensionRepositoriesState(
+    val repositories: List<RepositoryItem> = emptyList(),
+    val isLoading: Boolean = true,
+    /** Active validation error for the add-URL field; null when input is acceptable. */
+    val urlValidationError: String? = null,
+) : UiState
+
+sealed interface ExtensionRepositoriesEvent : UiEvent {
+    data class AddRepository(val url: String) : ExtensionRepositoriesEvent
+    data class RemoveRepository(val url: String) : ExtensionRepositoriesEvent
+    /** Live validation as the user types; populates state.urlValidationError. */
+    data class ValidateUrl(val url: String) : ExtensionRepositoriesEvent
+}
+
+sealed interface ExtensionRepositoriesEffect : UiEffect {
+    data class ShowSnackbar(val message: String) : ExtensionRepositoriesEffect
+}

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/repos/ExtensionRepositoriesScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/repos/ExtensionRepositoriesScreen.kt
@@ -1,0 +1,208 @@
+package app.otakureader.feature.browse.repos
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.otakureader.feature.browse.R
+import kotlinx.coroutines.flow.collectLatest
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExtensionRepositoriesScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: ExtensionRepositoriesViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var urlInput by remember { mutableStateOf("") }
+
+    LaunchedEffect(viewModel.effect) {
+        viewModel.effect.collectLatest { effect ->
+            when (effect) {
+                is ExtensionRepositoriesEffect.ShowSnackbar -> snackbarHostState.showSnackbar(effect.message)
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.repos_screen_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.repos_back),
+                        )
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when {
+                state.isLoading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                else -> Column(modifier = Modifier.fillMaxSize()) {
+                    AddRepositoryRow(
+                        url = urlInput,
+                        validationError = state.urlValidationError,
+                        onUrlChange = {
+                            urlInput = it
+                            viewModel.onEvent(ExtensionRepositoriesEvent.ValidateUrl(it))
+                        },
+                        onAdd = {
+                            viewModel.onEvent(ExtensionRepositoriesEvent.AddRepository(urlInput))
+                            if (state.urlValidationError == null) urlInput = ""
+                        },
+                    )
+                    if (state.repositories.isEmpty()) {
+                        EmptyRepos(modifier = Modifier.weight(1f))
+                    } else {
+                        LazyColumn(modifier = Modifier.weight(1f)) {
+                            items(state.repositories, key = { it.url }) { repo ->
+                                RepositoryRow(
+                                    item = repo,
+                                    onRemove = {
+                                        viewModel.onEvent(ExtensionRepositoriesEvent.RemoveRepository(repo.url))
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddRepositoryRow(
+    url: String,
+    validationError: String?,
+    onUrlChange: (String) -> Unit,
+    onAdd: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        OutlinedTextField(
+            value = url,
+            onValueChange = onUrlChange,
+            label = { Text(stringResource(R.string.repos_add_url_label)) },
+            placeholder = { Text(stringResource(R.string.repos_add_url_placeholder)) },
+            supportingText = {
+                Text(validationError ?: stringResource(R.string.repos_add_url_helper))
+            },
+            isError = validationError != null,
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+        ) {
+            TextButton(
+                onClick = onAdd,
+                enabled = url.isNotBlank() && validationError == null,
+            ) {
+                Icon(Icons.Default.Add, contentDescription = null)
+                Text(stringResource(R.string.repos_add_button))
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RepositoryRow(
+    item: RepositoryItem,
+    onRemove: () -> Unit,
+) {
+    ListItem(
+        headlineContent = {
+            Text(text = item.url, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        },
+        supportingContent = if (item.isDefault) {
+            {
+                AssistChip(
+                    onClick = {},
+                    label = { Text(stringResource(R.string.repos_default_badge)) },
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        labelColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    ),
+                )
+            }
+        } else null,
+        trailingContent = {
+            IconButton(onClick = onRemove) {
+                Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.repos_remove))
+            }
+        },
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+private fun EmptyRepos(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(24.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.repos_empty_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = stringResource(R.string.repos_empty_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/repos/ExtensionRepositoriesViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/repos/ExtensionRepositoriesViewModel.kt
@@ -1,0 +1,111 @@
+package app.otakureader.feature.browse.repos
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.otakureader.core.extension.domain.repository.ExtensionRepoRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import javax.inject.Inject
+
+@HiltViewModel
+class ExtensionRepositoriesViewModel @Inject constructor(
+    private val extensionRepoRepository: ExtensionRepoRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ExtensionRepositoriesState())
+    val state: StateFlow<ExtensionRepositoriesState> = _state.asStateFlow()
+
+    private val _effect = Channel<ExtensionRepositoriesEffect>(Channel.BUFFERED)
+    val effect: Flow<ExtensionRepositoriesEffect> = _effect.receiveAsFlow()
+
+    init {
+        extensionRepoRepository.getRepositories()
+            .onEach { urls ->
+                _state.update {
+                    it.copy(
+                        repositories = urls.map { url ->
+                            RepositoryItem(url = url, isDefault = url == ExtensionRepoRepository.DEFAULT_REPO_URL)
+                        },
+                        isLoading = false,
+                    )
+                }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    fun onEvent(event: ExtensionRepositoriesEvent) {
+        when (event) {
+            is ExtensionRepositoriesEvent.AddRepository -> addRepository(event.url)
+            is ExtensionRepositoriesEvent.RemoveRepository -> removeRepository(event.url)
+            is ExtensionRepositoriesEvent.ValidateUrl -> {
+                _state.update { it.copy(urlValidationError = validate(event.url)) }
+            }
+        }
+    }
+
+    private fun addRepository(url: String) {
+        val trimmed = url.trim()
+        val err = validate(trimmed, requireNonEmpty = true)
+        if (err != null) {
+            _state.update { it.copy(urlValidationError = err) }
+            return
+        }
+        viewModelScope.launch {
+            try {
+                extensionRepoRepository.addRepository(trimmed)
+                _state.update { it.copy(urlValidationError = null) }
+                _effect.send(ExtensionRepositoriesEffect.ShowSnackbar("Repository added"))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(ExtensionRepositoriesEffect.ShowSnackbar("Failed to add: ${e.message}"))
+            }
+        }
+    }
+
+    private fun removeRepository(url: String) {
+        viewModelScope.launch {
+            try {
+                extensionRepoRepository.removeRepository(url)
+                _effect.send(ExtensionRepositoriesEffect.ShowSnackbar("Repository removed"))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(ExtensionRepositoriesEffect.ShowSnackbar("Failed to remove: ${e.message}"))
+            }
+        }
+    }
+
+    /**
+     * Validate the candidate URL. Returns an error string or null when acceptable.
+     * Empty input returns null unless [requireNonEmpty] is set (so live validation while typing
+     * doesn't shout at the user before they've finished).
+     */
+    private fun validate(url: String, requireNonEmpty: Boolean = false): String? {
+        val trimmed = url.trim()
+        if (trimmed.isEmpty()) return if (requireNonEmpty) "URL cannot be empty" else null
+        val parsed = trimmed.toHttpUrlOrNull()
+            ?: return "Not a valid http(s) URL"
+        if (parsed.scheme != "https" && parsed.scheme != "http") {
+            return "URL must start with http:// or https://"
+        }
+        // Repos point at a directory; the loader appends index.min.json/index.json itself.
+        // We just check the URL doesn't itself end with one of those filenames.
+        val path = parsed.encodedPath
+        if (path.endsWith("/index.json") || path.endsWith("/index.min.json")) {
+            return "Drop the trailing /index.json — point to the directory"
+        }
+        return null
+    }
+}

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/repos/navigation/ExtensionRepositoriesNavigation.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/repos/navigation/ExtensionRepositoriesNavigation.kt
@@ -1,0 +1,14 @@
+package app.otakureader.feature.browse.repos.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import app.otakureader.core.navigation.Route
+import app.otakureader.feature.browse.repos.ExtensionRepositoriesScreen
+
+fun NavGraphBuilder.extensionRepositoriesScreen(
+    onNavigateBack: () -> Unit,
+) {
+    composable<Route.ExtensionRepositories> {
+        ExtensionRepositoriesScreen(onNavigateBack = onNavigateBack)
+    }
+}

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -104,6 +104,18 @@
     <string name="extensions_repo_url_placeholder">https://raw.githubusercontent.com/komikku-app/extensions/repo</string>
     <string name="extensions_add_repository">Add repository</string>
     <string name="extensions_repositories_title">Repositories</string>
+    <string name="extensions_manage_repositories">Manage repositories</string>
+    <!-- Repository management screen (#953) -->
+    <string name="repos_screen_title">Extension Repositories</string>
+    <string name="repos_back">Back</string>
+    <string name="repos_add_url_label">Repository URL</string>
+    <string name="repos_add_url_placeholder">https://example.com/extensions/repo</string>
+    <string name="repos_add_url_helper">Point to the directory containing index.min.json or index.json</string>
+    <string name="repos_add_button">Add</string>
+    <string name="repos_remove">Remove repository</string>
+    <string name="repos_default_badge">Default</string>
+    <string name="repos_empty_title">No repositories configured</string>
+    <string name="repos_empty_subtitle">Add a URL above to discover community-maintained sources.</string>
     <string name="extensions_search_cd">Search</string>
     <string name="extensions_icon_cd">Extension icon</string>
     <string name="extensions_language_cd">Language</string>


### PR DESCRIPTION
## **User description**
## Summary

Closes #953. Adds a full-screen repository manager that complements the inline `RepositoryManager` added in #970 — easier to find, with URL validation and a **Default** badge for the bundled Keiyoushi repo.

### Pieces
- `Route.ExtensionRepositories` in `core/navigation`.
- `ExtensionRepoRepository.DEFAULT_REPO_URL` hoisted to the interface companion (was a private const in the impl) so UI can flag the default visually.
- `ExtensionRepositoriesMvi`: state with `RepositoryItem(url, isDefault)` + add/remove/validate events.
- `ExtensionRepositoriesViewModel`: live URL validation using OkHttp's `toHttpUrlOrNull()`; rejects non-http(s) and URLs that end with `/index.json` (common user mistake — they should point to the parent directory).
- `ExtensionRepositoriesScreen`: `OutlinedTextField` with helper text + `isError` + add button gated on validation; `LazyColumn` of repos with a "Default" `AssistChip` on the bundled URL; empty-state.
- Existing in-bottom-sheet `RepositoryManager` now also has an "Open full repository manager" `TextButton`, so both surfaces stay in sync.

### Acceptance criteria mapping
- [x] Repository management screen — new `ExtensionRepositoriesScreen`
- [x] Add repository by URL — with live validation
- [x] Repository validation — well-formed http(s) + helpful "Drop the trailing /index.json" hint
- [ ] **Enable/disable toggle per repo** — deferred; needs `Set<String>` → richer model migration
- [x] Delete repository option — trash icon per row
- [x] Visual indicator for custom vs official — "Default" chip on the bundled URL

### Out of scope (deferred)
- **Enable/disable toggle**: needs a DataStore schema migration from `Set<String>` to a richer model — separate PR.
- **HEAD-request reachability check**: should run on a worker rather than blocking the add button; separate PR.

## Test plan
- [ ] Browse → Extensions → bottom sheet → scroll to the Repositories section → tap **Manage repositories** → new screen opens.
- [ ] Type `not-a-url` → supporting text shows "Not a valid http(s) URL"; add button stays disabled.
- [ ] Type `ftp://example.com` → "URL must start with http:// or https://".
- [ ] Type `https://example.com/repo/index.json` → "Drop the trailing /index.json — point to the directory".
- [ ] Type `https://raw.githubusercontent.com/komikku-app/extensions/repo` → no error → add → row appears + snackbar.
- [ ] Bundled Keiyoushi row shows a teal "Default" chip; custom rows do not.
- [ ] Tap trash on a custom repo → it disappears + snackbar.

### Build sanity
- `./gradlew :feature:browse:compileDebugKotlin :app:compileDebugKotlin` ✅
- `./gradlew :feature:browse:testDebugUnitTest` ✅
- `./gradlew detekt :app:assembleDebug` ✅

https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd)_


___

## **CodeAnt-AI Description**
**Add a dedicated screen for managing extension repositories**

### What Changed
- Added a full-screen repository manager for viewing, adding, and removing extension repository URLs
- The Extensions sheet now includes a shortcut to open the full repository manager
- New repository entries are checked as you type, with clear errors for invalid URLs, non-http(s) links, and links ending in `/index.json`
- The bundled default repository is now marked with a visible `Default` badge
- Added empty-state messaging and add/remove feedback so users know when repository changes succeed or fail

### Impact
`✅ Easier repository management`
`✅ Fewer invalid repository URLs`
`✅ Clearer default repository identification`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
