### PR TITLE
feat(feed): discovery modes — Latest / Trending / Random (#944)

### DIFF
--- a/feature/feed/src/main/java/app/otakureader/feature/feed/FeedMvi.kt
+++ b/feature/feed/src/main/java/app/otakureader/feature/feed/FeedMvi.kt
@@ -6,6 +6,14 @@ import app.otakureader.core.common.mvi.UiState
 import app.otakureader.domain.model.FeedItem
 import app.otakureader.domain.model.FeedSource
 
+/**
+ * Discovery presentation mode for the feed (#944).
+ *  - LATEST: chronological by timestamp DESC (default)
+ *  - TRENDING: unread first, then chronological — a "what's hot" proxy that doesn't need server-side view counts
+ *  - RANDOM:  shuffled, for serendipitous discovery
+ */
+enum class FeedDiscoveryMode { LATEST, TRENDING, RANDOM }
+
 data class FeedState(
     val isLoading: Boolean = false,
     val feedItems: List<FeedItem> = emptyList(),
@@ -13,6 +21,8 @@ data class FeedState(
     val error: String? = null,
     /** IDs of manga currently in the library. Used to indicate favorite status on long-click. */
     val favoritedMangaIds: Set<Long> = emptySet(),
+    /** Active discovery mode — drives ordering of [feedItems]. */
+    val discoveryMode: FeedDiscoveryMode = FeedDiscoveryMode.LATEST,
 ) : UiState
 
 sealed interface FeedEvent : UiEvent {
@@ -24,6 +34,7 @@ sealed interface FeedEvent : UiEvent {
     /** Long-click on a feed item: quickly add to or remove from the library. */
     data class LongClickManga(val mangaId: Long) : FeedEvent
     data object ManageSources : FeedEvent
+    data class SetDiscoveryMode(val mode: FeedDiscoveryMode) : FeedEvent
 }
 
 sealed interface FeedEffect : UiEffect {

--- a/feature/feed/src/main/java/app/otakureader/feature/feed/FeedScreen.kt
+++ b/feature/feed/src/main/java/app/otakureader/feature/feed/FeedScreen.kt
@@ -161,6 +161,12 @@ fun FeedScreen(
                     .fillMaxSize()
                     .padding(paddingValues)
             ) {
+                item(key = "discovery_chips") {
+                    DiscoveryModeChips(
+                        selected = state.discoveryMode,
+                        onSelect = { viewModel.onEvent(FeedEvent.SetDiscoveryMode(it)) },
+                    )
+                }
                 items(
                     items = state.feedItems,
                     key = { it.id }
@@ -250,6 +256,35 @@ private fun FeedItemRow(
                     tint = MaterialTheme.colorScheme.primary
                 )
             }
+        }
+    }
+}
+
+@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+@Composable
+private fun DiscoveryModeChips(
+    selected: FeedDiscoveryMode,
+    onSelect: (FeedDiscoveryMode) -> Unit,
+) {
+    androidx.compose.foundation.lazy.LazyRow(
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        items(FeedDiscoveryMode.entries.toList()) { mode ->
+            androidx.compose.material3.FilterChip(
+                selected = selected == mode,
+                onClick = { onSelect(mode) },
+                label = {
+                    Text(
+                        when (mode) {
+                            FeedDiscoveryMode.LATEST -> stringResource(R.string.feed_mode_latest)
+                            FeedDiscoveryMode.TRENDING -> stringResource(R.string.feed_mode_trending)
+                            FeedDiscoveryMode.RANDOM -> stringResource(R.string.feed_mode_random)
+                        }
+                    )
+                },
+            )
         }
     }
 }

--- a/feature/feed/src/main/java/app/otakureader/feature/feed/FeedViewModel.kt
+++ b/feature/feed/src/main/java/app/otakureader/feature/feed/FeedViewModel.kt
@@ -33,20 +33,23 @@ class FeedViewModel @Inject constructor(
     private val _isLoading = MutableStateFlow(false)
     private val _error = MutableStateFlow<String?>(null)
     private val _favoritedMangaIds = MutableStateFlow<Set<Long>>(emptySet())
+    private val _discoveryMode = MutableStateFlow(FeedDiscoveryMode.LATEST)
 
     val state = combine(
         feedRepository.getFeedItems(limit = FEED_ITEMS_LIMIT),
         feedRepository.getFeedSources(),
         _isLoading,
         _error,
-        _favoritedMangaIds,
-    ) { feedItems, sources, isLoading, error, favoritedIds ->
+        // Bundle the two single-value flows together so we stay under combine's 5-arg overload.
+        combine(_favoritedMangaIds, _discoveryMode) { ids, mode -> ids to mode },
+    ) { feedItems, sources, isLoading, error, (favoritedIds, mode) ->
         FeedState(
             isLoading = isLoading,
-            feedItems = feedItems,
+            feedItems = applyDiscoveryMode(feedItems, mode),
             feedSources = sources,
             error = error,
             favoritedMangaIds = favoritedIds,
+            discoveryMode = mode,
         )
     }.catch { e ->
         // Emit an error state so the UI can display the error message.
@@ -56,6 +59,22 @@ class FeedViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5_000),
         initialValue = FeedState(isLoading = true)
     )
+
+    /**
+     * Apply the chosen discovery mode to the raw feed list.
+     * LATEST is the default natural ordering from the repo (timestamp DESC).
+     */
+    private fun applyDiscoveryMode(
+        items: List<app.otakureader.domain.model.FeedItem>,
+        mode: FeedDiscoveryMode,
+    ): List<app.otakureader.domain.model.FeedItem> = when (mode) {
+        FeedDiscoveryMode.LATEST -> items
+        FeedDiscoveryMode.TRENDING -> items.sortedWith(
+            compareBy<app.otakureader.domain.model.FeedItem> { it.isRead }
+                .thenByDescending { it.timestamp }
+        )
+        FeedDiscoveryMode.RANDOM -> items.shuffled()
+    }
 
     private val _effect = Channel<FeedEffect>()
     val effect = _effect.receiveAsFlow()
@@ -73,6 +92,7 @@ class FeedViewModel @Inject constructor(
             is FeedEvent.ClearHistory -> clearHistory()
             is FeedEvent.LongClickManga -> quickToggleFavorite(event.mangaId)
             is FeedEvent.ManageSources -> viewModelScope.launch { _effect.send(FeedEffect.NavigateToFeedManagement) }
+            is FeedEvent.SetDiscoveryMode -> _discoveryMode.update { event.mode }
         }
     }
 

--- a/feature/feed/src/main/res/values/strings.xml
+++ b/feature/feed/src/main/res/values/strings.xml
@@ -19,4 +19,8 @@
     <string name="feed_add">Add</string>
     <string name="feed_no_sources_title">No feed sources</string>
     <string name="feed_no_sources_message">Add sources to customize your feed</string>
+    <!-- Discovery modes (#944) -->
+    <string name="feed_mode_latest">Latest</string>
+    <string name="feed_mode_trending">Trending</string>
+    <string name="feed_mode_random">Random</string>
 </resources>


### PR DESCRIPTION
## **User description**
## Summary

Closes #944 (partially). Adds a per-user **discovery presentation mode** to the Feed via a horizontal chip row at the top of the list.

### Modes
| Mode | Behavior |
|---|---|
| **LATEST** | Chronological by `timestamp DESC` (default; existing behavior) |
| **TRENDING** | Unread items first, then chronological — a "what's hot" proxy that works with data we already have (no server-side view counts needed) |
| **RANDOM** | Shuffled, for serendipitous discovery |

### Wiring
- `FeedDiscoveryMode` enum in `FeedMvi.kt`
- `FeedState.discoveryMode` + `FeedEvent.SetDiscoveryMode`
- `FeedViewModel.applyDiscoveryMode()` applied inside the existing `combine`; the two single-value flows (`_favoritedMangaIds` + new `_discoveryMode`) are bundled with an inner combine so we stay within Kotlin's 5-arg `combine` overload.
- `FeedScreen` prepends a `LazyRow` of `FilterChip`s above the items.

### Deferred from this issue (separate follow-up)
- **SEASONAL** discovery mode — semantics ill-defined without series-season metadata (we'd be filtering by chapter upload date, which is mostly redundant with LATEST).
- **Genre filter** — requires joining `FeedItem` → `Manga` at query time to pull genres; a data-layer change worth its own PR.
- **Per-source toggle** is already wired (`OnToggleSource` event + `feed_sources.isEnabled` column).

## Test plan
- [ ] Open Feed → chips row appears: Latest (selected by default) / Trending / Random.
- [ ] Tap **Trending** → all unread items move to the top; read items follow.
- [ ] Tap **Random** → list reshuffles each time the underlying data changes (e.g., on refresh).
- [ ] Tap **Latest** → reverts to timestamp-DESC order.
- [ ] Toggling a source off in feed management → items disappear regardless of mode.

### Build sanity
- `./gradlew :feature:feed:compileDebugKotlin :feature:feed:testDebugUnitTest` ✅
- `./gradlew detekt :app:assembleDebug` ✅

https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd)_


___

## **CodeAnt-AI Description**
Add feed discovery modes for Latest, Trending, and Random

### What Changed
- Added a row of chips at the top of the feed so users can switch how items are ordered
- Latest keeps the normal chronological order, Trending puts unread items first, and Random reshuffles the feed for discovery
- The selected mode stays visible while browsing the feed

### Impact
`✅ Faster access to unread feed items`
`✅ Easier content discovery from the feed`
`✅ Less manual scrolling through the same order`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
