### PR TITLE
feat(widget): large home-screen widget with cover-art carousel (#949)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -220,6 +220,20 @@
                 android:resource="@xml/recent_updates_widget_info" />
         </receiver>
 
+        <!-- Large Home Widget — cover-art carousel (#949) -->
+        <receiver
+            android:name=".widget.HomeWidgetReceiver"
+            android:exported="true"
+            android:label="@string/home_widget_label"
+            android:permission="android.permission.BIND_APPWIDGET">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/home_widget_info" />
+        </receiver>
+
         <!--
             WorkManager foreground service: declare dataSync type so that library-update
             and backup workers can run as foreground services on Android 14+ without

--- a/app/src/main/java/app/otakureader/widget/HomeWidget.kt
+++ b/app/src/main/java/app/otakureader/widget/HomeWidget.kt
@@ -1,0 +1,261 @@
+package app.otakureader.widget
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.ImageProvider
+import androidx.glance.Image
+import androidx.glance.action.actionParametersOf
+import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.LinearProgressIndicator
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.ContentScale
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.size
+import androidx.glance.layout.width
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import app.otakureader.MainActivity
+import app.otakureader.R
+import app.otakureader.domain.repository.ChapterRepository
+import app.otakureader.domain.repository.MangaRepository
+import coil3.ImageLoader
+import coil3.asDrawable
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.request.allowHardware
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+/**
+ * Large home-screen widget showing a vertical carousel of the user's most-recently-read manga
+ * with cover art, reading-progress bar, and tap-to-resume. (#949)
+ *
+ * Pulls the top [MAX_ITEMS] favourites by `lastRead` and loads their covers up-front via Coil
+ * so Glance can render bitmaps directly (Glance has no built-in async image loader).
+ */
+class HomeWidget : GlanceAppWidget() {
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface HomeWidgetEntryPoint {
+        fun mangaRepository(): MangaRepository
+        fun chapterRepository(): ChapterRepository
+    }
+
+    private companion object {
+        const val MAX_ITEMS = 5
+        const val COVER_PX = 256
+    }
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val entryPoint = EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            HomeWidgetEntryPoint::class.java,
+        )
+        val mangaRepository = entryPoint.mangaRepository()
+        val chapterRepository = entryPoint.chapterRepository()
+
+        val items = try {
+            buildItems(context, mangaRepository, chapterRepository)
+        } catch (_: Exception) {
+            emptyList()
+        }
+
+        val title = context.getString(R.string.widget_home_title)
+        val emptyText = context.getString(R.string.widget_no_manga_in_progress)
+
+        provideContent {
+            GlanceTheme {
+                HomeWidgetContent(title = title, items = items, emptyText = emptyText)
+            }
+        }
+    }
+
+    private suspend fun buildItems(
+        context: Context,
+        mangaRepository: MangaRepository,
+        chapterRepository: ChapterRepository,
+    ): List<HomeWidgetItem> {
+        val candidates = mangaRepository.getLibraryManga().first()
+            .filter { it.favorite && it.lastRead != null }
+            .sortedByDescending { it.lastRead }
+            .take(MAX_ITEMS)
+        return coroutineScope {
+            candidates.map { manga ->
+                async {
+                    val nextChapter = chapterRepository.getNextUnreadChapter(manga.id)
+                    val cover = loadCoverBitmap(context, manga.thumbnailUrl)
+                    val progress = if (manga.totalChapters > 0) {
+                        val read = (manga.totalChapters - manga.unreadCount).coerceAtLeast(0)
+                        read.toFloat() / manga.totalChapters
+                    } else null
+                    HomeWidgetItem(
+                        mangaId = manga.id,
+                        chapterId = nextChapter?.id,
+                        title = manga.title,
+                        subtitle = when {
+                            nextChapter != null -> context.getString(
+                                R.string.widget_home_next_chapter,
+                                nextChapter.chapterNumber,
+                            )
+                            manga.unreadCount == 0 -> context.getString(R.string.widget_up_to_date)
+                            else -> context.getString(R.string.widget_chapters_remaining, manga.unreadCount)
+                        },
+                        cover = cover,
+                        progress = progress,
+                    )
+                }
+            }.map { it.await() }
+        }
+    }
+
+    private suspend fun loadCoverBitmap(context: Context, url: String?): Bitmap? {
+        if (url.isNullOrBlank()) return null
+        return withContext(Dispatchers.IO) {
+            try {
+                val request = ImageRequest.Builder(context)
+                    .data(url)
+                    .allowHardware(false)
+                    .size(COVER_PX, COVER_PX)
+                    .build()
+                val loader: ImageLoader = context.imageLoader
+                val result = loader.execute(request)
+                if (result is SuccessResult) {
+                    val drawable = result.image.asDrawable(context.resources)
+                    (drawable as? BitmapDrawable)?.bitmap
+                } else null
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
+}
+
+private data class HomeWidgetItem(
+    val mangaId: Long,
+    val chapterId: Long?,
+    val title: String,
+    val subtitle: String,
+    val cover: Bitmap?,
+    val progress: Float?,
+)
+
+@Composable
+private fun HomeWidgetContent(
+    title: String,
+    items: List<HomeWidgetItem>,
+    emptyText: String,
+) {
+    Box(
+        modifier = GlanceModifier
+            .fillMaxSize()
+            .background(GlanceTheme.colors.surface)
+            .padding(12.dp),
+    ) {
+        Column(modifier = GlanceModifier.fillMaxSize()) {
+            Text(
+                text = title,
+                style = TextStyle(color = GlanceTheme.colors.onSurface, fontSize = 16.sp),
+                modifier = GlanceModifier.fillMaxWidth(),
+            )
+            Spacer(modifier = GlanceModifier.height(8.dp))
+
+            if (items.isEmpty()) {
+                Text(
+                    text = emptyText,
+                    style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 12.sp),
+                )
+            } else {
+                items.forEach { item ->
+                    HomeWidgetRow(item)
+                    Spacer(modifier = GlanceModifier.height(6.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomeWidgetRow(item: HomeWidgetItem) {
+    Row(
+        modifier = GlanceModifier
+            .fillMaxWidth()
+            .clickable(
+                actionStartActivity<MainActivity>(
+                    parameters = if (item.chapterId != null) {
+                        actionParametersOf(
+                            WidgetKeys.MANGA_ID_KEY to item.mangaId,
+                            WidgetKeys.CHAPTER_ID_KEY to item.chapterId,
+                        )
+                    } else {
+                        actionParametersOf(WidgetKeys.MANGA_ID_KEY to item.mangaId)
+                    },
+                ),
+            ),
+        verticalAlignment = Alignment.Vertical.CenterVertically,
+    ) {
+        Box(
+            modifier = GlanceModifier
+                .size(width = 36.dp, height = 48.dp)
+                .cornerRadius(4.dp)
+                .background(GlanceTheme.colors.surfaceVariant),
+        ) {
+            if (item.cover != null) {
+                Image(
+                    provider = ImageProvider(item.cover),
+                    contentDescription = item.title,
+                    contentScale = ContentScale.Crop,
+                    modifier = GlanceModifier.fillMaxSize(),
+                )
+            }
+        }
+        Spacer(modifier = GlanceModifier.width(8.dp))
+        Column(modifier = GlanceModifier.fillMaxWidth()) {
+            Text(
+                text = item.title,
+                style = TextStyle(color = GlanceTheme.colors.onSurface, fontSize = 13.sp),
+                maxLines = 1,
+            )
+            Text(
+                text = item.subtitle,
+                style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 11.sp),
+                maxLines = 1,
+            )
+            if (item.progress != null && item.progress > 0f) {
+                Spacer(modifier = GlanceModifier.height(2.dp))
+                LinearProgressIndicator(
+                    progress = item.progress.coerceIn(0f, 1f),
+                    modifier = GlanceModifier.fillMaxWidth().height(3.dp),
+                    color = GlanceTheme.colors.primary,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/otakureader/widget/HomeWidgetReceiver.kt
+++ b/app/src/main/java/app/otakureader/widget/HomeWidgetReceiver.kt
@@ -1,0 +1,9 @@
+package app.otakureader.widget
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+/** Widget receiver for the large Home (cover-art carousel) widget (#949). */
+class HomeWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = HomeWidget()
+}

--- a/app/src/main/res/values/widget_strings.xml
+++ b/app/src/main/res/values/widget_strings.xml
@@ -29,5 +29,11 @@
     <string name="widget_up_to_date">Up to date</string>
     <!-- Recent Updates widget: new chapters count -->
     <string name="widget_new_chapters">%1$d new chapter(s)</string>
-    
+
+    <!-- Large Home Widget (#949) -->
+    <string name="home_widget_label">Home (Large)</string>
+    <string name="home_widget_description">Cover-art carousel of your most-recently-read manga with progress</string>
+    <string name="widget_home_title">Recently Read</string>
+    <string name="widget_home_next_chapter">Next: Ch. %1$.1f</string>
+
 </resources>

--- a/app/src/main/res/xml/home_widget_info.xml
+++ b/app/src/main/res/xml/home_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/home_widget_description"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:minWidth="250dp"
+    android:minHeight="180dp"
+    android:previewLayout="@layout/glance_default_loading_layout"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellWidth="4"
+    android:targetCellHeight="3"
+    android:updatePeriodMillis="1800000"
+    android:widgetCategory="home_screen" />


### PR DESCRIPTION
## **User description**
## Summary

Closes #949. Adds a 4×3 Glance widget that complements the existing three small widgets with a richer, cover-art-driven surface for recently-read manga.

### What each row renders
- **36×48dp cover thumbnail** — loaded synchronously in `provideGlance` via Coil 3 (Glance has no built-in async image loader), then passed via `ImageProvider(bitmap)`.
- **Manga title**.
- **Subtitle**: next chapter number (`Next: Ch. 12.5`), or `X remaining` / `Up to date`.
- **Linear progress bar** tinted with the Material primary color, derived from `(totalChapters − unreadCount) / totalChapters`.

Tapping a row deep-links into `MainActivity` with `MANGA_ID_KEY` + `CHAPTER_ID_KEY` (existing pattern from `ContinueReadingWidget`), which the existing nav handler turns into a `Reader` navigation when both are present, or a `MangaDetails` navigation when only the manga ID is known.

### Pieces
- `app/.../widget/HomeWidget.kt` — Glance composable + Coil cover loading
- `app/.../widget/HomeWidgetReceiver.kt` — `GlanceAppWidgetReceiver` glue
- `res/xml/home_widget_info.xml` — 4×3, resizable, 30-min update
- `AndroidManifest.xml` — new receiver below the existing three
- `widget_strings.xml` — new labels + format strings

### Deferred to follow-up
- **Configurable update interval** — currently fixed at 30 min via XML; would need a `WidgetConfiguration` screen entry.
- **True swipeable carousel** — Glance `LazyRow` exists but doesn't fit a 4-cell-wide widget well; vertical list works better. If the user really wants horizontal swipe, that's a separate redesign.

## Test plan
- [ ] Long-press home screen → Widgets → Otaku Reader → "Home (Large)" appears with description "Cover-art carousel…"
- [ ] Drop it onto a 4×3 area; it loads with up to 5 most-recently-read favorited manga.
- [ ] Each row shows a cover + title + "Next: Ch. X.X" + progress bar.
- [ ] Tap a row → reader opens at the right chapter (or details if no chapter exists).
- [ ] Wait 30 min or pull the widget down and re-add: data refreshes.
- [ ] Dark mode + light mode both render readably (GlanceTheme.colors honors system).

### Build sanity
- `./gradlew :app:compileDebugKotlin` ✅
- `./gradlew detekt :app:assembleDebug` ✅

https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd)_


___

## **CodeAnt-AI Description**
**Add a large home-screen widget for recently read manga**

### What Changed
- Added a new 4×3 home widget that shows the manga you recently read, with cover art, title, next chapter or remaining chapters, and a progress bar
- Tapping an item opens the manga or resumes reading from the next chapter when available
- The widget now appears as a separate home-screen option with its own name and description

### Impact
`✅ Faster resume from the home screen`
`✅ Clearer at-a-glance reading progress`
`✅ Easier access to recently read manga`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
