### PR TITLE
feat(recommendations): score non-library candidates, exclude favorites (#943)

### DIFF
--- a/core/database/src/main/java/app/otakureader/core/database/dao/MangaDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/MangaDao.kt
@@ -110,6 +110,13 @@ interface MangaDao {
     @Query("SELECT genre FROM manga WHERE favorite = 1 AND genre IS NOT NULL")
     fun getFavoriteMangaGenres(): Flow<List<String>>
 
+    /**
+     * Browsed-but-not-in-library manga: candidates for the recommendation engine (#943).
+     * Includes only entries with a non-empty genre, since the scorer needs genres to compare.
+     */
+    @Query("SELECT * FROM manga WHERE favorite = 0 AND genre IS NOT NULL AND genre != '' LIMIT :limit")
+    suspend fun getRecommendationCandidates(limit: Int = 500): List<MangaEntity>
+
     @Query("""
         SELECT m.*, COALESCE(SUM(CASE WHEN c.read = 0 THEN 1 ELSE 0 END), 0) as unreadCount
         FROM manga m

--- a/data/src/main/java/app/otakureader/data/repository/RecommendationRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/RecommendationRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package app.otakureader.data.repository
 
+import app.otakureader.core.database.dao.MangaDao
 import app.otakureader.core.database.dao.RecommendationDao
 import app.otakureader.core.database.entity.RecommendationEntity
 import app.otakureader.domain.model.Manga
@@ -16,6 +17,7 @@ import kotlin.math.sqrt
 @Singleton
 class RecommendationRepositoryImpl @Inject constructor(
     private val recommendationDao: RecommendationDao,
+    private val mangaDao: MangaDao,
 ) : RecommendationRepository {
 
     override fun getRecommendations(): Flow<List<Recommendation>> =
@@ -29,26 +31,37 @@ class RecommendationRepositoryImpl @Inject constructor(
         val profile = buildGenreProfile(libraryManga)
         if (profile.isEmpty()) return
 
-        // Score non-library manga sourced from genre metadata already in the library manga list.
-        // In Phase 1 we score the library manga themselves (excluding identity) as candidates
-        // to prove the algorithm, since non-library source browsing is async.
-        val candidates = libraryManga.filter { it.genre.isNotEmpty() }
+        // Candidates are browsed-but-not-favorited manga from the local manga table —
+        // these are sources the user has at least glanced at, which keeps recommendations
+        // grounded in their actual extension ecosystem rather than blind catalog crawls.
+        val libraryIds = libraryManga.mapTo(mutableSetOf()) { it.id }
+        val now = System.currentTimeMillis()
 
-        val scored = candidates.mapNotNull { manga ->
-            val genreVector = manga.genre.associateWith { 1f }
-            val score = cosineSimilarity(profile, genreVector)
-            if (score > 0f) {
+        val scored = mangaDao.getRecommendationCandidates(limit = CANDIDATE_POOL_LIMIT)
+            .asSequence()
+            .filter { it.id !in libraryIds }
+            .mapNotNull { entity ->
+                val genres = entity.genre?.split('|', ',', ';')
+                    ?.map { it.trim() }
+                    ?.filter { it.isNotEmpty() }
+                    ?: return@mapNotNull null
+                if (genres.isEmpty()) return@mapNotNull null
+                val genreVector = genres.associateWith { 1f }
+                val score = cosineSimilarity(profile, genreVector)
+                if (score <= 0f) return@mapNotNull null
                 RecommendationEntity(
-                    mangaId = manga.id,
-                    title = manga.title,
-                    thumbnailUrl = manga.thumbnailUrl,
-                    sourceId = manga.sourceId,
-                    genresJson = Json.encodeToString(manga.genre),
+                    mangaId = entity.id,
+                    title = entity.title,
+                    thumbnailUrl = entity.thumbnailUrl,
+                    sourceId = entity.sourceId,
+                    genresJson = Json.encodeToString(genres),
                     score = score,
-                    lastComputed = System.currentTimeMillis(),
+                    lastComputed = now,
                 )
-            } else null
-        }.sortedByDescending { it.score }.take(MAX_RECOMMENDATIONS)
+            }
+            .sortedByDescending { it.score }
+            .take(MAX_RECOMMENDATIONS)
+            .toList()
 
         recommendationDao.deleteAll()
         if (scored.isNotEmpty()) recommendationDao.upsertAll(scored)
@@ -90,5 +103,6 @@ class RecommendationRepositoryImpl @Inject constructor(
     companion object {
         private const val MIN_LIBRARY_SIZE = 5
         private const val MAX_RECOMMENDATIONS = 20
+        private const val CANDIDATE_POOL_LIMIT = 500
     }
 }


### PR DESCRIPTION
## **User description**
## Summary

Closes #943 (Phase 2 of the recommendation engine). The Phase-1 algorithm shipped earlier scored library manga themselves against the user's genre profile — useful to prove the cosine-similarity scoring worked, but didn't satisfy the issue's "**Exclude already-in-library manga**" acceptance criterion.

### What's in this PR
- **`MangaDao.getRecommendationCandidates(limit)`** — a `SELECT` for browsed-but-not-favorited entries (`favorite = 0 AND genre IS NOT NULL`). These are sources the user has at least visited from an extension, which keeps recommendations grounded in their actual ecosystem rather than catalog crawls.

- **Rewrote `RecommendationRepositoryImpl.refreshRecommendations`** to:
  1. Build the genre profile from the user's library (unchanged).
  2. Pull up to 500 candidates from `MangaDao` (the `|`/`,`/`;` split matches the same delimiter the genre column uses elsewhere in the codebase).
  3. Filter out any candidate whose id appears in the library set.
  4. Score with the existing cosine-similarity function, take the top 20, replace the cache.

### Wired through
- Injected `MangaDao` into `RecommendationRepositoryImpl` (both DAOs live in `core/database`, same pattern as `StatisticsRepositoryImpl`).
- The existing periodic `RecommendationWorker` (7-day repeat, network-unmetered + battery-not-low constraints) picks the new algorithm up automatically; **no scheduling change**.
- `LibraryRecommendations` carousel already consumes the cache via `getRecommendations()`; **no UI change**.

### Deferred to a follow-up
- **"Thumbs up/down feedback"** criterion — needs a new feedback table + integration into the scoring weights.
- **True collaborative filtering** — out of scope for the local-only core (CLAUDE.md restricts cloud features to a separate repo).

## Test plan
- [ ] Library has ≥5 favorited manga, all with genres → after the next refresh worker tick (or a manual cold-start), the "For You" carousel populates.
- [ ] Every item in the carousel has `favorite = false` — i.e., none are already in the library.
- [ ] Add one of the recommended manga to the library → on next refresh it's gone from the carousel.
- [ ] Library with no manga or no genres → carousel stays empty (existing behavior preserved).
- [ ] Dismiss a recommendation → it disappears (existing behavior preserved).

### Build sanity
- `./gradlew :data:compileDebugKotlin :core:database:compileDebugKotlin` ✅
- `./gradlew :data:testDebugUnitTest :core:database:testDebugUnitTest` ✅
- `./gradlew detekt :app:assembleDebug` ✅

https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd)_


___

## **CodeAnt-AI Description**
**Recommendation results now come from browsed manga outside your library and skip favorites**

### What Changed
- Recommendations are now built from manga you’ve browsed but not added to your library, instead of scoring library items themselves.
- Favorites and other already-owned manga are excluded from recommendation results.
- Manga without genre data are skipped, so the recommendation list only shows items that can be meaningfully matched.
- The recommendation cache still refreshes automatically and keeps the top 20 matches.

### Impact
`✅ Fewer duplicate recommendations`
`✅ Recommendations based on browsed manga`
`✅ Cleaner recommendation lists`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
