### PR TITLE
feat(crash): optional Sentry-backed crash reporting (#952)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -183,6 +183,9 @@ dependencies {
     // Encrypted SharedPreferences for crash log storage
     implementation(libs.androidx.security.crypto)
 
+    // Crash reporting (#952) — Sentry SDK, configured at runtime via user-supplied DSN
+    implementation(libs.sentry.android)
+
     // Debug tools (LeakCanary — no-op in release builds)
     debugImplementation(libs.leakcanary)
 

--- a/app/src/main/java/app/otakureader/OtakuReaderApplication.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderApplication.kt
@@ -5,8 +5,10 @@ import android.content.ComponentCallbacks2
 import android.content.Context
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import app.otakureader.core.preferences.CrashReportingStore
 import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.crash.CrashHandler
+import app.otakureader.crash.CrashReporter
 import app.otakureader.shortcut.AppShortcutManager
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
@@ -53,9 +55,15 @@ class OtakuReaderApplication : Application(), Configuration.Provider, SingletonI
             .build()
 
     override fun onCreate() {
+        // Read crash-reporting prefs directly (no Hilt) since CrashHandler installs BEFORE
+        // super.onCreate() and the Hilt graph isn't constructed yet at that point. The store
+        // is keystore-backed encrypted SharedPreferences, safe to instantiate here. (#952)
+        val crashReportingStore = CrashReportingStore(this)
+        // Init Sentry first so the captureException() inside CrashHandler has a live SDK.
+        CrashReporter.initialize(this, crashReportingStore)
         // Install the crash handler first so failures during Hilt graph construction
         // or any other startup code are captured and shown on the next launch.
-        CrashHandler.install(this)
+        CrashHandler.install(this, crashReportingStore)
         super.onCreate()
         // Enable Material You dynamic colors on Android 12+ (API 31+)
         DynamicColors.applyToActivitiesIfAvailable(this)

--- a/app/src/main/java/app/otakureader/crash/CrashHandler.kt
+++ b/app/src/main/java/app/otakureader/crash/CrashHandler.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import app.otakureader.core.preferences.CrashReportingStore
 
 /**
  * Custom [Thread.UncaughtExceptionHandler] that captures fatal crashes, writes the
@@ -28,12 +29,16 @@ object CrashHandler {
      * Must be called early in [app.otakureader.OtakuReaderApplication.onCreate] so
      * crashes during Hilt graph construction or any other startup code are captured.
      */
-    fun install(context: Context) {
+    fun install(context: Context, crashReportingStore: CrashReportingStore? = null) {
         val appContext = context.applicationContext
         val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
 
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             try {
+                // Forward to Sentry first (synchronously flushes) so the report leaves the
+                // device before the system kills the process. Falls back to the local-only
+                // path when no store is wired or the user hasn't opted in (#952).
+                crashReportingStore?.let { CrashReporter.captureIfEnabled(it, throwable) }
                 saveReport(appContext, buildReport(thread, throwable))
             } catch (_: Throwable) {
                 // Never allow the crash handler itself to throw – always fall through.

--- a/app/src/main/java/app/otakureader/crash/CrashReporter.kt
+++ b/app/src/main/java/app/otakureader/crash/CrashReporter.kt
@@ -1,0 +1,81 @@
+package app.otakureader.crash
+
+import android.content.Context
+import app.otakureader.core.preferences.CrashReportingStore
+import io.sentry.Sentry
+import io.sentry.android.core.SentryAndroid
+
+/**
+ * Thin façade around the Sentry SDK (#952).
+ *
+ * - Initialization is opt-in: the SDK is only started when the user has both supplied a DSN
+ *   and flipped the opt-in toggle in Settings → Privacy. With no DSN the SDK stays inert and
+ *   no events leave the device.
+ * - Forwarding [Throwable]s goes through [Sentry.captureException]; we deliberately do NOT
+ *   install Sentry's own uncaught-exception handler. The existing [CrashHandler] keeps writing
+ *   the local encrypted report (used for the on-device "previous-run crash" surface) and
+ *   simply CC's Sentry when reporting is enabled.
+ * - PII redaction continues to happen via [CrashHandler.sanitizeTrace] for the local report.
+ *   Sentry's own scrubbing handles in-flight redaction of common patterns (tokens, emails)
+ *   before transmission, but callers should still avoid passing user-identifying breadcrumbs.
+ */
+object CrashReporter {
+
+    @Volatile
+    private var initialized = false
+
+    /**
+     * Initialize Sentry if the user has opted in and supplied a DSN.
+     * Safe to call multiple times — re-initialization with the same config is a no-op.
+     */
+    fun initialize(context: Context, store: CrashReportingStore) {
+        if (initialized) return
+        if (!store.isReportingEnabled()) return
+        val dsn = store.dsn
+        try {
+            val appContext = context.applicationContext
+            val packageInfo = try {
+                appContext.packageManager.getPackageInfo(appContext.packageName, 0)
+            } catch (_: Throwable) {
+                null
+            }
+            val versionName = packageInfo?.versionName ?: "unknown"
+            val isDebuggable = (
+                appContext.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE
+                ) != 0
+            SentryAndroid.init(appContext) { options ->
+                options.dsn = dsn
+                options.environment = if (isDebuggable) "debug" else "release"
+                options.release = "${appContext.packageName}@$versionName"
+                // We forward via captureException() ourselves; don't double-report.
+                options.isEnableUncaughtExceptionHandler = false
+                // Don't attach the user's device ID — keep crash data minimal.
+                options.isSendDefaultPii = false
+                // No NDK / ANR uploads in the first phase — bring those in once the
+                // baseline DSN-only flow is validated against the user's chosen backend.
+                options.isAnrEnabled = false
+            }
+            initialized = true
+        } catch (_: Throwable) {
+            // Sentry init must never crash the app. A bad DSN just keeps reporting disabled.
+            initialized = false
+        }
+    }
+
+    /**
+     * Forward a captured exception to Sentry if reporting is initialized and currently enabled.
+     * No-op when disabled — safe to call unconditionally from [CrashHandler].
+     */
+    fun captureIfEnabled(store: CrashReportingStore, throwable: Throwable) {
+        if (!initialized || !store.isReportingEnabled()) return
+        try {
+            Sentry.captureException(throwable)
+            // Flush synchronously so the report survives the imminent process death.
+            Sentry.flush(FLUSH_TIMEOUT_MS)
+        } catch (_: Throwable) {
+            // Never propagate Sentry failures up from the crash path.
+        }
+    }
+
+    private const val FLUSH_TIMEOUT_MS = 2_000L
+}

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/CrashReportingStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/CrashReportingStore.kt
@@ -1,0 +1,54 @@
+package app.otakureader.core.preferences
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Encrypted storage for crash-reporting credentials and the user's opt-in toggle (#952).
+ *
+ * The DSN is treated like a tracker token — keystore-backed AES-GCM so it never lives in
+ * plain SharedPreferences. Both fields default to "disabled" so a fresh install never
+ * sends anything until the user explicitly turns it on.
+ */
+@Singleton
+class CrashReportingStore @Inject constructor(context: Context) {
+
+    private val prefs: SharedPreferences by lazy {
+        EncryptedSharedPreferences.create(
+            context.applicationContext,
+            STORE_NAME,
+            MasterKey.Builder(context.applicationContext)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build(),
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+    }
+
+    /** Sentry DSN supplied by the user. Empty/blank → reporting cannot start regardless of opt-in. */
+    var dsn: String
+        get() = prefs.getString(KEY_DSN, "").orEmpty()
+        set(value) {
+            prefs.edit().putString(KEY_DSN, value.trim()).apply()
+        }
+
+    /** User has explicitly opted in to crash reporting. Defaults to false. */
+    var optedIn: Boolean
+        get() = prefs.getBoolean(KEY_OPTED_IN, false)
+        set(value) {
+            prefs.edit().putBoolean(KEY_OPTED_IN, value).apply()
+        }
+
+    /** True when both a DSN is configured and the user has opted in. */
+    fun isReportingEnabled(): Boolean = optedIn && dsn.isNotBlank()
+
+    private companion object {
+        const val STORE_NAME = "crash_reporting_prefs"
+        const val KEY_DSN = "sentry_dsn"
+        const val KEY_OPTED_IN = "opted_in"
+    }
+}

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/CrashReportingSection.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/CrashReportingSection.kt
@@ -1,0 +1,118 @@
+@file:Suppress("MaxLineLength")
+package app.otakureader.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import app.otakureader.core.preferences.CrashReportingStore
+
+/**
+ * Settings UI for the optional Sentry-backed crash reporting feature (#952).
+ *
+ * Holds its own minimal state via [remember] + a directly-instantiated [CrashReportingStore]
+ * so it doesn't ripple into [SettingsViewModel] (which would force test-mock updates across
+ * every existing setting). The store is keystore-backed, so direct instantiation is safe.
+ *
+ * The DSN field is empty by default and reporting stays off until the user supplies a DSN
+ * AND flips the opt-in switch — until then no events leave the device.
+ */
+@Composable
+internal fun CrashReportingSection(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val store = remember { CrashReportingStore(context) }
+
+    var dsn by remember { mutableStateOf(store.dsn) }
+    var optedIn by remember { mutableStateOf(store.optedIn) }
+    var savedHintVisible by remember { mutableStateOf(false) }
+
+    // Clear the "Saved" hint after a moment so it doesn't linger forever on the settings page.
+    LaunchedEffect(savedHintVisible) {
+        if (savedHintVisible) {
+            kotlinx.coroutines.delay(SAVED_HINT_VISIBLE_MS)
+            savedHintVisible = false
+        }
+    }
+
+    Column(modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
+        SectionHeader(title = stringResource(R.string.settings_crash_reporting))
+
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.settings_crash_opt_in)) },
+            supportingContent = {
+                Text(
+                    text = stringResource(R.string.settings_crash_opt_in_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
+            trailingContent = {
+                Switch(
+                    checked = optedIn,
+                    onCheckedChange = { newValue ->
+                        optedIn = newValue
+                        store.optedIn = newValue
+                        savedHintVisible = true
+                    },
+                )
+            },
+        )
+
+        OutlinedTextField(
+            value = dsn,
+            onValueChange = { dsn = it },
+            label = { Text(stringResource(R.string.settings_crash_dsn_label)) },
+            placeholder = { Text("https://<key>@<host>/<project>") },
+            singleLine = true,
+            supportingText = {
+                Text(stringResource(R.string.settings_crash_dsn_helper))
+            },
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+        )
+
+        androidx.compose.foundation.layout.Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+            horizontalArrangement = Arrangement.End,
+        ) {
+            if (savedHintVisible) {
+                Text(
+                    text = stringResource(R.string.settings_crash_saved),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(end = 8.dp).align(androidx.compose.ui.Alignment.CenterVertically),
+                )
+            }
+            TextButton(onClick = {
+                store.dsn = dsn
+                savedHintVisible = true
+            }) {
+                Text(stringResource(R.string.settings_crash_save_dsn))
+            }
+        }
+
+        Text(
+            text = stringResource(R.string.settings_crash_restart_hint),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+    }
+}
+
+private const val SAVED_HINT_VISIBLE_MS = 2_500L

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsScreen.kt
@@ -164,6 +164,10 @@ fun SettingsScreen(
             HorizontalDivider()
             ReadingGoalsSection(state = state, onEvent = viewModel::onEvent)
 
+            // ── Crash reporting (#952) ────────────────────────────────
+            HorizontalDivider()
+            CrashReportingSection()
+
             // ── Data management ───────────────────────────────────────
             HorizontalDivider()
             DataManagementSection(state = state, onEvent = viewModel::onEvent)

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -181,6 +181,16 @@
     <string name="settings_migrate_manga">Migrate manga</string>
     <string name="settings_migrate_manga_description">Move manga from one source to another</string>
 
+    <!-- Crash reporting (#952) — Sentry SDK, opt-in only -->
+    <string name="settings_crash_reporting">Crash Reporting</string>
+    <string name="settings_crash_opt_in">Send crash reports</string>
+    <string name="settings_crash_opt_in_description">Off by default. When on, fatal crashes are reported to the Sentry instance configured below. Disable at any time to stop reporting.</string>
+    <string name="settings_crash_dsn_label">Sentry DSN</string>
+    <string name="settings_crash_dsn_helper">Paste your Sentry project DSN. No DSN = no reporting, regardless of the switch above.</string>
+    <string name="settings_crash_save_dsn">Save DSN</string>
+    <string name="settings_crash_saved">Saved</string>
+    <string name="settings_crash_restart_hint">DSN changes take effect on the next app launch.</string>
+
     <!-- Data management -->
     <string name="settings_data_management">Data Management</string>
     <string name="settings_image_cache_size">Image cache size</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,8 @@ okhttp = "4.12.0"
 netty = "4.2.12.Final"
 retrofit = "3.0.0"
 kotlinx-serialization = "1.11.0"
+# Crash reporting (#952) — Sentry SDK; user-supplied DSN, no upload until both DSN + opt-in set
+sentry = "7.18.1"
 
 # Image Loading
 coil = "3.4.0"
@@ -126,6 +128,7 @@ androidx-material = { group = "com.google.android.material", name = "material", 
 androidx-palette = { group = "androidx.palette", name = "palette", version.ref = "palette" }
 androidx-workmanager = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workmanager" }
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "security-crypto" }
+sentry-android = { group = "io.sentry", name = "sentry-android-core", version.ref = "sentry" }
 androidx-glance = { group = "androidx.glance", name = "glance", version.ref = "glance" }
 androidx-glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glance" }
 androidx-glance-material3 = { group = "androidx.glance", name = "glance-material3", version.ref = "glance" }


### PR DESCRIPTION
## **User description**
## Summary

Closes #952. Adds **opt-in remote crash reporting through Sentry**, without contradicting CLAUDE.md's anti-Firebase note: the SDK only starts when the user supplies a DSN and explicitly flips the opt-in toggle. With no DSN it stays inert and zero events leave the device.

### Pieces
- **`io.sentry:sentry-android-core` 7.18.1** dep
- **`CrashReportingStore`** (`core/preferences`) — keystore-backed `EncryptedSharedPreferences` for the DSN + opt-in toggle, same pattern as `TrackerTokenStore`. Defaults to **disabled**.
- **`CrashReporter`** façade (`app/crash`) — wraps `SentryAndroid.init` (network deliberately gated on `isReportingEnabled`) and `captureException` with a synchronous 2 s flush so the report survives process death.
- **`CrashHandler.install`** now takes an optional store; when present and opt-in, it forwards to Sentry **before** writing the local encrypted report — keeps the existing on-device "previous-run crash" surface unchanged.
- **`OtakuReaderApplication`** wires the store + Sentry init **before** `super.onCreate` so failures during Hilt graph construction are still captured.
- **`CrashReportingSection`** settings UI (above Data Management) — DSN text field + opt-in switch + "DSN changes take effect on next app launch" hint.

### Notable knobs left off
- `isEnableUncaughtExceptionHandler = false` — we don't want Sentry double-installing its own handler over ours.
- `isSendDefaultPii = false` — don't attach device/user IDs.
- `isAnrEnabled = false` — defer ANR uploads until the baseline DSN-only flow is validated against the chosen backend.

### Why Sentry over Firebase
- CLAUDE.md line 263: "Do not add Firebase analytics or crash tooling unless explicitly requested." This PR uses Sentry per the explicit user decision in the rollout plan: **no Google Play Services dep**, GDPR-friendly, can be pointed at a self-hosted Sentry later just by changing the DSN.

## Test plan
- [ ] **Default off**: fresh install → Settings → Crash Reporting section visible; DSN field empty; switch off; force a crash via debug menu → only the local encrypted report saves, no network traffic.
- [ ] **DSN with switch off**: paste a valid DSN, leave switch off → still no Sentry traffic on next crash.
- [ ] **DSN + switch on**: paste DSN, flip switch, kill+relaunch the app, force a crash → event appears in the Sentry project within ~1 minute.
- [ ] **Toggle off after enabling**: flip switch off → next crash does NOT appear in Sentry (local report still saves).
- [ ] **Bad DSN**: paste garbage → init silently fails, no events upload, app does not crash.

### Build sanity
- `./gradlew :core:preferences:compileDebugKotlin :feature:settings:compileDebugKotlin :app:compileDebugKotlin` ✅
- `./gradlew detekt :app:assembleDebug` ✅

https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd

_Generated by [Claude Code](https://claude.ai/code/session_01BkSfea7Q7QSLBRRnU8hahd)_


___

## **CodeAnt-AI Description**
**Add optional Sentry crash reporting**

### What Changed
- Adds a new Crash Reporting section in Settings where users can paste a Sentry DSN and turn crash reporting on or off
- Crash reports are only sent when both the DSN is saved and the user has opted in; otherwise crashes stay local
- Crash reporting now starts during app launch so startup crashes can be captured, while the app still keeps its existing on-device crash record
- The DSN and opt-in choice are stored securely, and changes to the DSN take effect after the next app launch

### Impact
`✅ Opt-in crash reporting`
`✅ Fewer missed startup crash reports`
`✅ Clearer crash handling without automatic uploads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
