### PR TITLE
feat(sync): reader progress sync via self-hosted server (#958)

### DIFF
--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -340,6 +340,9 @@ fun OtakuReaderNavHost(
             onNavigateToCloudBackup = {
                 navController.navigate(Route.SettingsCloudBackup)
             },
+            onNavigateToSync = {
+                navController.navigate(Route.SettingsSync)
+            },
         )
 
         downloadsScreen(

--- a/core/database/schemas/app.otakureader.core.database.OtakuReaderDatabase/31.json
+++ b/core/database/schemas/app.otakureader.core.database.OtakuReaderDatabase/31.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 30,
+    "version": 31,
     "identityHash": "9271f738342beb8d10c9b0a781d886a8",
     "entities": [
       {
@@ -1629,6 +1629,59 @@
           "autoGenerate": false,
           "columnNames": [
             "mangaId"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `chapterId` INTEGER NOT NULL, `mangaId` INTEGER NOT NULL, `payload` TEXT NOT NULL, `attempts` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `lastError` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "lastError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
           ]
         }
       }

--- a/core/database/schemas/app.otakureader.core.database.OtakuReaderDatabase/31.json
+++ b/core/database/schemas/app.otakureader.core.database.OtakuReaderDatabase/31.json
@@ -1683,7 +1683,18 @@
           "columnNames": [
             "id"
           ]
-        }
+        },
+        "indices": [
+          {
+            "name": "index_sync_queue_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_queue_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
       }
     ],
     "setupQueries": [

--- a/core/database/src/main/java/app/otakureader/core/database/OtakuReaderDatabase.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/OtakuReaderDatabase.kt
@@ -17,6 +17,7 @@ import app.otakureader.core.database.dao.ReadingHistoryDao
 import app.otakureader.core.database.dao.ReadingListDao
 import app.otakureader.core.database.dao.ReadingStreakDao
 import app.otakureader.core.database.dao.RecommendationDao
+import app.otakureader.core.database.dao.SyncQueueDao
 import app.otakureader.core.database.dao.TrackEntryDao
 import app.otakureader.core.database.dao.TrackerSyncDao
 import app.otakureader.core.database.entity.AchievementEntity
@@ -37,6 +38,7 @@ import app.otakureader.core.database.entity.ReadingListItemEntity
 import app.otakureader.core.database.entity.ReadingStreakEntity
 import app.otakureader.core.database.entity.RecommendationEntity
 import app.otakureader.core.database.entity.SyncConfigurationEntity
+import app.otakureader.core.database.entity.SyncQueueEntity
 import app.otakureader.core.database.entity.TrackEntryEntity
 import app.otakureader.core.database.entity.TrackerSyncStateEntity
 
@@ -71,8 +73,10 @@ import app.otakureader.core.database.entity.TrackerSyncStateEntity
         RecommendationEntity::class,
         // Reading achievements (#955)
         AchievementEntity::class,
+        // Reader progress sync queue (#958)
+        SyncQueueEntity::class,
     ],
-    version = 30,
+    version = 31,
     exportSchema = true
 )
 @TypeConverters(DatabaseConverters::class)
@@ -95,6 +99,7 @@ abstract class OtakuReaderDatabase : RoomDatabase() {
     abstract fun dynamicCategoryRuleDao(): DynamicCategoryRuleDao
     abstract fun recommendationDao(): RecommendationDao
     abstract fun achievementDao(): AchievementDao
+    abstract fun syncQueueDao(): SyncQueueDao
 
     companion object {
         const val DATABASE_NAME = "otakureader.db"

--- a/core/database/src/main/java/app/otakureader/core/database/dao/SyncQueueDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/SyncQueueDao.kt
@@ -29,7 +29,15 @@ interface SyncQueueDao {
      * already exceeded [maxAttempts] to avoid re-queuing permanently failed entries.
      */
     @Query("SELECT * FROM sync_queue WHERE attempts < :maxAttempts ORDER BY createdAt ASC LIMIT :limit")
-    fun getPending(limit: Int = 50, maxAttempts: Int = 5): Flow<List<SyncQueueEntity>>
+    fun getPending(
+        limit: Int = DEFAULT_BATCH_SIZE,
+        maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
+    ): Flow<List<SyncQueueEntity>>
+
+    companion object {
+        const val DEFAULT_BATCH_SIZE = 50
+        const val DEFAULT_MAX_ATTEMPTS = 5
+    }
 
     @Delete
     suspend fun delete(entity: SyncQueueEntity)

--- a/core/database/src/main/java/app/otakureader/core/database/dao/SyncQueueDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/SyncQueueDao.kt
@@ -24,9 +24,12 @@ interface SyncQueueDao {
     @Query("SELECT * FROM sync_queue ORDER BY createdAt ASC")
     fun observePending(): Flow<List<SyncQueueEntity>>
 
-    /** Fetch up to [limit] pending items to drain in one batch. */
-    @Query("SELECT * FROM sync_queue ORDER BY createdAt ASC LIMIT :limit")
-    suspend fun getPending(limit: Int = 50): List<SyncQueueEntity>
+    /**
+     * Observe up to [limit] pending items ordered oldest-first, skipping items that have
+     * already exceeded [maxAttempts] to avoid re-queuing permanently failed entries.
+     */
+    @Query("SELECT * FROM sync_queue WHERE attempts < :maxAttempts ORDER BY createdAt ASC LIMIT :limit")
+    fun getPending(limit: Int = 50, maxAttempts: Int = 5): Flow<List<SyncQueueEntity>>
 
     @Delete
     suspend fun delete(entity: SyncQueueEntity)

--- a/core/database/src/main/java/app/otakureader/core/database/dao/SyncQueueDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/SyncQueueDao.kt
@@ -1,0 +1,44 @@
+package app.otakureader.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import app.otakureader.core.database.entity.SyncQueueEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * DAO for the [SyncQueueEntity] table.
+ *
+ * All reads that need to react to queue changes are exposed as [Flow]; one-shot
+ * reads and writes are plain suspend functions.
+ */
+@Dao
+interface SyncQueueDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: SyncQueueEntity): Long
+
+    /** Observe all pending items ordered oldest-first (for UI badge). */
+    @Query("SELECT * FROM sync_queue ORDER BY createdAt ASC")
+    fun observePending(): Flow<List<SyncQueueEntity>>
+
+    /** Fetch up to [limit] pending items to drain in one batch. */
+    @Query("SELECT * FROM sync_queue ORDER BY createdAt ASC LIMIT :limit")
+    suspend fun getPending(limit: Int = 50): List<SyncQueueEntity>
+
+    @Delete
+    suspend fun delete(entity: SyncQueueEntity)
+
+    /** Increment attempt count and record the latest error message for an item. */
+    @Query("UPDATE sync_queue SET attempts = attempts + 1, lastError = :error WHERE id = :id")
+    suspend fun recordAttemptFailure(id: Long, error: String?)
+
+    @Query("DELETE FROM sync_queue WHERE id = :id")
+    suspend fun deleteById(id: Long)
+
+    /** Observe the total number of items waiting to be synced (drives UI badge). */
+    @Query("SELECT COUNT(*) FROM sync_queue")
+    fun observeQueueSize(): Flow<Int>
+}

--- a/core/database/src/main/java/app/otakureader/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/di/DatabaseModule.kt
@@ -7,6 +7,7 @@ import app.otakureader.core.database.BuildConfig
 import app.otakureader.core.database.OtakuReaderDatabase
 import app.otakureader.core.database.dao.AchievementDao
 import app.otakureader.core.database.dao.DownloadQueueDao
+import app.otakureader.core.database.dao.SyncQueueDao
 import app.otakureader.core.database.dao.TrackEntryDao
 import app.otakureader.core.database.migrations.ALL_MIGRATIONS
 import dagger.Module
@@ -91,4 +92,7 @@ object DatabaseModule {
 
     @Provides
     fun provideAchievementDao(database: OtakuReaderDatabase): AchievementDao = database.achievementDao()
+
+    @Provides
+    fun provideSyncQueueDao(database: OtakuReaderDatabase): SyncQueueDao = database.syncQueueDao()
 }

--- a/core/database/src/main/java/app/otakureader/core/database/entity/SyncQueueEntity.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/entity/SyncQueueEntity.kt
@@ -1,5 +1,6 @@
 package app.otakureader.core.database.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -18,7 +19,7 @@ data class SyncQueueEntity(
     val chapterId: Long,
     val mangaId: Long,
     val payload: String,
-    val attempts: Int = 0,
+    @ColumnInfo(defaultValue = "0") val attempts: Int = 0,
     val createdAt: Long,
     val lastError: String? = null,
 )

--- a/core/database/src/main/java/app/otakureader/core/database/entity/SyncQueueEntity.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/entity/SyncQueueEntity.kt
@@ -1,0 +1,23 @@
+package app.otakureader.core.database.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Room entity representing a queued reader-progress sync operation.
+ *
+ * Each row holds a serialized [payload] (JSON) for a single chapter-read event that
+ * has not yet been successfully pushed to the self-hosted sync server.  The
+ * [attempts] counter and [lastError] fields allow the drain loop to apply
+ * exponential-back-off and surface error details for debugging.
+ */
+@Entity(tableName = "sync_queue")
+data class SyncQueueEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val chapterId: Long,
+    val mangaId: Long,
+    val payload: String,
+    val attempts: Int = 0,
+    val createdAt: Long,
+    val lastError: String? = null,
+)

--- a/core/database/src/main/java/app/otakureader/core/database/entity/SyncQueueEntity.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/entity/SyncQueueEntity.kt
@@ -1,6 +1,7 @@
 package app.otakureader.core.database.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 /**
@@ -11,7 +12,7 @@ import androidx.room.PrimaryKey
  * [attempts] counter and [lastError] fields allow the drain loop to apply
  * exponential-back-off and surface error details for debugging.
  */
-@Entity(tableName = "sync_queue")
+@Entity(tableName = "sync_queue", indices = [Index("createdAt")])
 data class SyncQueueEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val chapterId: Long,

--- a/core/database/src/main/java/app/otakureader/core/database/migrations/DatabaseMigrations.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/migrations/DatabaseMigrations.kt
@@ -329,6 +329,22 @@ internal val MIGRATION_29_30 = object : Migration(29, 30) {
     }
 }
 
+/** Reader progress sync outbox queue (#958). */
+internal val MIGRATION_30_31 = object : Migration(30, 31) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("""CREATE TABLE IF NOT EXISTS sync_queue (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            chapterId INTEGER NOT NULL,
+            mangaId INTEGER NOT NULL,
+            payload TEXT NOT NULL,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            createdAt INTEGER NOT NULL,
+            lastError TEXT
+        )""")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_sync_queue_createdAt ON sync_queue(createdAt)")
+    }
+}
+
 /** All migrations in order, for use in [Room.databaseBuilder] and migration tests. */
 internal val ALL_MIGRATIONS = arrayOf(
     MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6,
@@ -337,5 +353,5 @@ internal val ALL_MIGRATIONS = arrayOf(
     MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
     MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
     MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
-    MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30
+    MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30, MIGRATION_30_31
 )

--- a/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
+++ b/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
@@ -20,8 +20,11 @@ import app.otakureader.core.database.migrations.MIGRATION_22_23
 import app.otakureader.core.database.migrations.MIGRATION_23_24
 import app.otakureader.core.database.migrations.MIGRATION_24_25
 import app.otakureader.core.database.migrations.MIGRATION_25_26
+import app.otakureader.core.database.migrations.MIGRATION_26_27
+import app.otakureader.core.database.migrations.MIGRATION_27_28
 import app.otakureader.core.database.migrations.MIGRATION_28_29
 import app.otakureader.core.database.migrations.MIGRATION_29_30
+import app.otakureader.core.database.migrations.MIGRATION_30_31
 import app.otakureader.core.database.migrations.MIGRATION_9_10
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -47,7 +50,7 @@ class DatabaseMigrationTest {
     fun allMigrations_formsContiguousChain() {
         val sorted = ALL_MIGRATIONS.sortedBy { it.startVersion }
         assertEquals("Migration chain must start at version 2", 2, sorted.first().startVersion)
-        assertEquals("Migration chain must end at version 30", 30, sorted.last().endVersion)
+        assertEquals("Migration chain must end at version 31", 31, sorted.last().endVersion)
 
         for (i in 0 until sorted.size - 1) {
             val current = sorted[i]
@@ -74,7 +77,7 @@ class DatabaseMigrationTest {
 
     @Test
     fun allMigrations_count() {
-        assertEquals("Expected 28 migrations (v2→v30)", 28, ALL_MIGRATIONS.size)
+        assertEquals("Expected 29 migrations (v2→v31)", 29, ALL_MIGRATIONS.size)
     }
 
     // ── Migration 9 → 10 ────────────────────────────────────────────────────
@@ -548,6 +551,41 @@ class DatabaseMigrationTest {
         assertFalse("mangaThemeOverride must NOT exist at v29", "mangaThemeOverride" in db.columnNames("manga"))
         MIGRATION_29_30.migrate(db)
         assertTrue("manga.mangaThemeOverride must exist after 29→30", "mangaThemeOverride" in db.columnNames("manga"))
+        db.close()
+    }
+
+    // ── Migration 30 → 31 ───────────────────────────────────────────────────
+    // Adds: sync_queue table for reader progress sync
+
+    @Test
+    fun migration30To31_createsSyncQueue() {
+        val db = helper.createDatabase(TEST_DB, 30)
+        assertFalse("sync_queue must NOT exist at v30", "sync_queue" in db.tableNames())
+        MIGRATION_30_31.migrate(db)
+        assertTrue("sync_queue must exist after 30→31", "sync_queue" in db.tableNames())
+        val cols = db.columnNames("sync_queue")
+        assertTrue("id must exist", "id" in cols)
+        assertTrue("chapterId must exist", "chapterId" in cols)
+        assertTrue("mangaId must exist", "mangaId" in cols)
+        assertTrue("payload must exist", "payload" in cols)
+        assertTrue("attempts must exist", "attempts" in cols)
+        assertTrue("createdAt must exist", "createdAt" in cols)
+        assertTrue("lastError must exist", "lastError" in cols)
+        db.close()
+    }
+
+    @Test
+    fun migration30To31_syncQueueAcceptsInsert() {
+        val db = helper.createDatabase(TEST_DB, 30)
+        MIGRATION_30_31.migrate(db)
+        db.execSQL(
+            "INSERT INTO sync_queue (chapterId, mangaId, payload, attempts, createdAt, lastError) " +
+                "VALUES (1, 2, '{\"chapter\":1}', 0, 1234567890, NULL)",
+        )
+        val cursor = db.query("SELECT COUNT(*) FROM sync_queue")
+        assertTrue(cursor.moveToFirst())
+        assertEquals("sync_queue must have one row after insert", 1, cursor.getInt(0))
+        cursor.close()
         db.close()
     }
 

--- a/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
+++ b/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
@@ -152,6 +152,9 @@ sealed interface Route {
     @Serializable
     data object LocalSourceBrowser : Route
 
+    @Serializable
+    data object SettingsSync : Route
+
     // ─── Downloads ───
 
     @Serializable

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/SyncSettingsStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/SyncSettingsStore.kt
@@ -45,14 +45,15 @@ class SyncSettingsStore @Inject constructor(private val dataStore: DataStore<Pre
      * so concurrent callers cannot each write a different UUID.
      */
     suspend fun ensureDeviceId(): String {
-        val newId = UUID.randomUUID().toString()
-        var resultId = newId
+        var resultId = ""
         dataStore.edit { prefs ->
             val existing = prefs[Keys.DEVICE_ID]
             if (!existing.isNullOrBlank()) {
                 resultId = existing
             } else {
+                val newId = UUID.randomUUID().toString()
                 prefs[Keys.DEVICE_ID] = newId
+                resultId = newId
             }
         }
         return resultId

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/SyncSettingsStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/SyncSettingsStore.kt
@@ -41,14 +41,21 @@ class SyncSettingsStore @Inject constructor(private val dataStore: DataStore<Pre
 
     /**
      * Returns the persisted device ID, generating and persisting a new UUID if one does
-     * not yet exist. Safe to call from any coroutine context.
+     * not yet exist. Atomic: generates and writes in a single [DataStore.edit] transaction
+     * so concurrent callers cannot each write a different UUID.
      */
     suspend fun ensureDeviceId(): String {
-        val existing = dataStore.data.map { it[Keys.DEVICE_ID] }.first()
-        if (!existing.isNullOrBlank()) return existing
         val newId = UUID.randomUUID().toString()
-        dataStore.edit { it[Keys.DEVICE_ID] = newId }
-        return newId
+        var resultId = newId
+        dataStore.edit { prefs ->
+            val existing = prefs[Keys.DEVICE_ID]
+            if (!existing.isNullOrBlank()) {
+                resultId = existing
+            } else {
+                prefs[Keys.DEVICE_ID] = newId
+            }
+        }
+        return resultId
     }
 
     /** True when a non-blank server URL is configured. */

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/SyncSettingsStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/SyncSettingsStore.kt
@@ -1,0 +1,62 @@
+package app.otakureader.core.preferences
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * DataStore-backed preference store for reader progress sync settings.
+ *
+ * Injected as a [Singleton] so that all callers observe the same DataStore
+ * instance provided by [PreferencesModule].
+ *
+ * Keys:
+ * - [serverUrl]    – base URL of the self-hosted sync server (blank = disabled)
+ * - [bearerToken]  – JWT / opaque bearer token for server auth
+ * - [deviceId]     – stable random UUID that identifies this installation
+ */
+@Singleton
+class SyncSettingsStore @Inject constructor(private val dataStore: DataStore<Preferences>) {
+
+    /** Base URL of the sync server, e.g. `https://sync.example.com`. Blank means disabled. */
+    val serverUrl: Flow<String> = dataStore.data.map { it[Keys.SERVER_URL] ?: "" }
+    suspend fun setServerUrl(value: String) = dataStore.edit { it[Keys.SERVER_URL] = value }
+
+    /** Bearer token for authenticating with the sync server. */
+    val bearerToken: Flow<String> = dataStore.data.map { it[Keys.BEARER_TOKEN] ?: "" }
+    suspend fun setBearerToken(value: String) = dataStore.edit { it[Keys.BEARER_TOKEN] = value }
+
+    /**
+     * Stable device identifier. Returns the persisted UUID, or a blank string if not yet
+     * written. Use [ensureDeviceId] to guarantee a value is generated and persisted.
+     */
+    val deviceId: Flow<String> = dataStore.data.map { it[Keys.DEVICE_ID] ?: "" }
+
+    /**
+     * Returns the persisted device ID, generating and persisting a new UUID if one does
+     * not yet exist. Safe to call from any coroutine context.
+     */
+    suspend fun ensureDeviceId(): String {
+        val existing = dataStore.data.map { it[Keys.DEVICE_ID] }.first()
+        if (!existing.isNullOrBlank()) return existing
+        val newId = UUID.randomUUID().toString()
+        dataStore.edit { it[Keys.DEVICE_ID] = newId }
+        return newId
+    }
+
+    /** True when a non-blank server URL is configured. */
+    val syncEnabled: Flow<Boolean> = dataStore.data.map { it[Keys.SERVER_URL]?.isNotBlank() ?: false }
+
+    private object Keys {
+        val SERVER_URL = stringPreferencesKey("sync_server_url")
+        val BEARER_TOKEN = stringPreferencesKey("sync_bearer_token")
+        val DEVICE_ID = stringPreferencesKey("sync_device_id")
+    }
+}

--- a/data/src/main/java/app/otakureader/data/di/RepositoryModule.kt
+++ b/data/src/main/java/app/otakureader/data/di/RepositoryModule.kt
@@ -14,6 +14,7 @@ import app.otakureader.domain.repository.ReadingListRepository
 import app.otakureader.domain.repository.RecommendationRepository
 import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.repository.StatisticsRepository
+import app.otakureader.domain.repository.SyncRepository
 import app.otakureader.data.opds.OpdsRepositoryImpl
 import app.otakureader.data.repository.AchievementRepositoryImpl
 import app.otakureader.data.repository.CategoryRepositoryImpl
@@ -44,12 +45,15 @@ import app.otakureader.data.repository.SourceRepositoryImpl
 import app.otakureader.data.repository.StatisticsRepositoryImpl
 import app.otakureader.data.repository.DynamicCategoryRepositoryImpl
 import app.otakureader.data.repository.RecommendationRepositoryImpl
+import app.otakureader.data.sync.SyncRepositoryImpl
 import app.otakureader.data.worker.ExtensionUpdateSchedulerImpl
+import app.otakureader.data.worker.SyncSchedulerImpl
 import app.otakureader.data.worker.TrackerSyncSchedulerImpl
 import app.otakureader.domain.scheduler.CoverRefreshScheduler
 import app.otakureader.domain.scheduler.ExtensionUpdateScheduler
 import app.otakureader.domain.scheduler.LibraryUpdateScheduler
 import app.otakureader.domain.scheduler.ReminderScheduler
+import app.otakureader.domain.scheduler.SyncScheduler
 import app.otakureader.domain.scheduler.TrackerSyncScheduler
 import app.otakureader.domain.tracking.TrackManager
 import app.otakureader.domain.updater.AppUpdateChecker
@@ -148,6 +152,12 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun bindRecommendationRepository(impl: RecommendationRepositoryImpl): RecommendationRepository
+
+    @Binds
+    abstract fun bindSyncRepository(impl: SyncRepositoryImpl): SyncRepository
+
+    @Binds
+    abstract fun bindSyncScheduler(impl: SyncSchedulerImpl): SyncScheduler
 
     companion object {
         @Provides

--- a/data/src/main/java/app/otakureader/data/repository/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/ChapterRepositoryImpl.kt
@@ -131,8 +131,9 @@ class ChapterRepositoryImpl @Inject constructor(
                     chapterNumber = chapterEntity.chapterNumber,
                 )
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            if (e is CancellationException) throw e
             // Intentionally swallowed: sync is best-effort and must not break reading.
         }
     }

--- a/data/src/main/java/app/otakureader/data/repository/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/ChapterRepositoryImpl.kt
@@ -3,6 +3,7 @@ package app.otakureader.data.repository
 import androidx.work.WorkManager
 import app.otakureader.core.database.dao.ChapterDao
 import app.otakureader.core.database.dao.ReadingHistoryDao
+import app.otakureader.domain.repository.SyncRepository
 import app.otakureader.core.database.entity.ChapterEntity
 import app.otakureader.core.database.entity.ChapterWithHistoryEntity
 import app.otakureader.core.database.entity.ChapterWithMangaEntity
@@ -31,6 +32,7 @@ class ChapterRepositoryImpl @Inject constructor(
     private val chapterDao: ChapterDao,
     private val readingHistoryDao: ReadingHistoryDao,
     private val workManager: WorkManager,
+    private val syncRepository: SyncRepository,
 ) : ChapterRepository {
     
     override fun getChaptersByMangaId(mangaId: Long): Flow<List<Chapter>> {
@@ -118,6 +120,19 @@ class ChapterRepositoryImpl @Inject constructor(
     override suspend fun recordHistory(chapterId: Long, readAt: Long, readDurationMs: Long) {
         readingHistoryDao.upsert(chapterId, readAt, readDurationMs)
         AchievementCheckWorker.enqueue(workManager)
+        // Enqueue a sync event — best-effort, never throws so reading is never blocked.
+        try {
+            val chapterEntity = chapterDao.getChapterById(chapterId)
+            if (chapterEntity != null) {
+                syncRepository.enqueueChapterRead(
+                    chapterId = chapterId,
+                    mangaId = chapterEntity.mangaId,
+                    chapterNumber = chapterEntity.chapterNumber,
+                )
+            }
+        } catch (_: Exception) {
+            // Intentionally swallowed: sync is best-effort and must not break reading.
+        }
     }
 
     override suspend fun removeFromHistory(chapterId: Long) {

--- a/data/src/main/java/app/otakureader/data/repository/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/ChapterRepositoryImpl.kt
@@ -131,9 +131,8 @@ class ChapterRepositoryImpl @Inject constructor(
                     chapterNumber = chapterEntity.chapterNumber,
                 )
             }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             // Intentionally swallowed: sync is best-effort and must not break reading.
         }
     }

--- a/data/src/main/java/app/otakureader/data/repository/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/ChapterRepositoryImpl.kt
@@ -18,6 +18,7 @@ import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.model.MangaUpdate
 import app.otakureader.domain.repository.ChapterRepository
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -130,6 +131,8 @@ class ChapterRepositoryImpl @Inject constructor(
                     chapterNumber = chapterEntity.chapterNumber,
                 )
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (_: Exception) {
             // Intentionally swallowed: sync is best-effort and must not break reading.
         }

--- a/data/src/main/java/app/otakureader/data/sync/SyncApi.kt
+++ b/data/src/main/java/app/otakureader/data/sync/SyncApi.kt
@@ -1,0 +1,55 @@
+package app.otakureader.data.sync
+
+import kotlinx.serialization.Serializable
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+/**
+ * Retrofit interface for the self-hosted Otaku Reader sync server.
+ *
+ * The base URL is determined at runtime from [SyncSettingsStore.serverUrl] so
+ * a fresh Retrofit instance is built per-call inside [SyncRepositoryImpl].
+ */
+interface SyncApi {
+
+    /** Push one chapter-read progress event to the server. */
+    @POST("progress/push")
+    suspend fun pushProgress(@Body body: PushProgressRequest): PushProgressResponse
+
+    /**
+     * Fetch progress events that happened on other devices after [since].
+     *
+     * @param deviceId  The calling device's stable identifier.  The server uses
+     *                  this to exclude events that originated here.
+     * @param since     Epoch-millis lower bound (exclusive).
+     */
+    @GET("progress/pull")
+    suspend fun pullProgress(
+        @Query("deviceId") deviceId: String,
+        @Query("since") since: Long,
+    ): List<RemoteProgressEntry>
+}
+
+// ─── Request / Response models ────────────────────────────────────────────────
+
+@Serializable
+data class PushProgressRequest(
+    val chapterId: Long,
+    val mangaId: Long,
+    val chapterNumber: Float,
+    val deviceId: String,
+    val readAt: Long,
+)
+
+@Serializable
+data class PushProgressResponse(val accepted: Boolean)
+
+@Serializable
+data class RemoteProgressEntry(
+    val chapterId: Long,
+    val mangaId: Long,
+    val chapterNumber: Float,
+    val readAt: Long,
+)

--- a/data/src/main/java/app/otakureader/data/sync/SyncRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/sync/SyncRepositoryImpl.kt
@@ -1,0 +1,135 @@
+package app.otakureader.data.sync
+
+import android.util.Log
+import app.otakureader.core.database.dao.ChapterDao
+import app.otakureader.core.database.dao.SyncQueueDao
+import app.otakureader.core.database.entity.SyncQueueEntity
+import app.otakureader.core.preferences.SyncSettingsStore
+import app.otakureader.domain.repository.SyncRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Data-layer implementation of [SyncRepository].
+ *
+ * **Why we inject [ChapterDao] instead of [ChapterRepository]:**
+ * [ChapterRepositoryImpl] depends on [SyncRepository] (to enqueue read events),
+ * so injecting the full [ChapterRepository] interface here would create a
+ * circular Hilt dependency.  Accessing the DAO directly is safe because
+ * [SyncRepositoryImpl] only needs a simple `UPDATE chapters SET read = 1`
+ * operation for pulled progress — no domain mapping is required.
+ *
+ * **Why we build Retrofit lazily per-call:** the sync server's base URL comes
+ * from DataStore and can change at any time via Settings.  Injecting the
+ * shared [Retrofit] singleton (which has a fixed `https://api.otakureader.app/`
+ * base URL) would silently send progress events to the wrong host.  Instead,
+ * we inject [OkHttpClient] (the shared, configured client) and [Json] (the
+ * shared serialisation config) and construct a lightweight `Retrofit` instance
+ * on every drain/pull call using the current URL from DataStore.
+ *
+ * This is intentional — Retrofit instances are cheap to create and the sync
+ * operations already have network I/O overhead that dwarfs object allocation.
+ */
+@Singleton
+class SyncRepositoryImpl @Inject constructor(
+    private val syncQueueDao: SyncQueueDao,
+    private val syncSettingsStore: SyncSettingsStore,
+    private val chapterDao: ChapterDao,
+    private val okHttpClient: OkHttpClient,
+    private val json: Json,
+) : SyncRepository {
+
+    // ─── Public API ───────────────────────────────────────────────────────────
+
+    override suspend fun enqueueChapterRead(chapterId: Long, mangaId: Long, chapterNumber: Float) {
+        val deviceId = syncSettingsStore.ensureDeviceId()
+        val payload = json.encodeToString(
+            PushProgressRequest(
+                chapterId = chapterId,
+                mangaId = mangaId,
+                chapterNumber = chapterNumber,
+                deviceId = deviceId,
+                readAt = System.currentTimeMillis(),
+            )
+        )
+        syncQueueDao.insert(
+            SyncQueueEntity(
+                chapterId = chapterId,
+                mangaId = mangaId,
+                payload = payload,
+                createdAt = System.currentTimeMillis(),
+            )
+        )
+    }
+
+    override suspend fun drainQueue() {
+        val serverUrl = syncSettingsStore.serverUrl.first()
+        if (serverUrl.isBlank()) return
+        val api = buildApi(serverUrl)
+        val pending = syncQueueDao.getPending()
+        for (item in pending) {
+            try {
+                val request = json.decodeFromString<PushProgressRequest>(item.payload)
+                api.pushProgress(request)
+                syncQueueDao.deleteById(item.id)
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to push sync item ${item.id}", e)
+                syncQueueDao.recordAttemptFailure(item.id, e.message)
+            }
+        }
+    }
+
+    override suspend fun pullAndApply(deviceId: String, since: Long) {
+        val serverUrl = syncSettingsStore.serverUrl.first()
+        if (serverUrl.isBlank()) return
+        try {
+            val api = buildApi(serverUrl)
+            val entries = api.pullProgress(deviceId, since)
+            for (entry in entries) {
+                // Mark the chapter as read via the DAO directly to avoid a circular
+                // dependency with ChapterRepositoryImpl (which depends on SyncRepository).
+                // lastPageRead = 0: we sync "read/not-read" state, not exact page position.
+                chapterDao.updateChapterProgress(
+                    chapterId = entry.chapterId,
+                    read = true,
+                    lastPageRead = 0,
+                )
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Pull failed", e)
+        }
+    }
+
+    override fun observeQueueSize(): Flow<Int> = syncQueueDao.observeQueueSize()
+
+    // ─── Private helpers ──────────────────────────────────────────────────────
+
+    /**
+     * Builds a minimal Retrofit instance pointed at [serverUrl].
+     *
+     * We reuse the shared [OkHttpClient] (timeouts, logging, Brotli) and [Json]
+     * (lenient, ignores unknown keys) from the network module.
+     */
+    private fun buildApi(serverUrl: String): SyncApi {
+        // Ensure the URL ends with "/" so that Retrofit resolves relative paths correctly.
+        val normalised = if (serverUrl.endsWith("/")) serverUrl else "$serverUrl/"
+        return Retrofit.Builder()
+            .baseUrl(normalised)
+            .client(okHttpClient)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(SyncApi::class.java)
+    }
+
+    companion object {
+        private const val TAG = "SyncRepository"
+    }
+}

--- a/data/src/main/java/app/otakureader/data/sync/SyncRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/sync/SyncRepositoryImpl.kt
@@ -73,13 +73,20 @@ class SyncRepositoryImpl @Inject constructor(
     override suspend fun drainQueue() {
         val serverUrl = syncSettingsStore.serverUrl.first()
         if (serverUrl.isBlank()) return
-        val api = buildApi(serverUrl)
+        val token = syncSettingsStore.bearerToken.first()
+        val api = buildApi(serverUrl, token)
         val pending = syncQueueDao.getPending()
         for (item in pending) {
             try {
                 val request = json.decodeFromString<PushProgressRequest>(item.payload)
-                api.pushProgress(request)
-                syncQueueDao.deleteById(item.id)
+                val response = api.pushProgress(request)
+                if (response.accepted) {
+                    syncQueueDao.deleteById(item.id)
+                } else {
+                    syncQueueDao.recordAttemptFailure(item.id, "Server rejected item")
+                }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to push sync item ${item.id}", e)
                 syncQueueDao.recordAttemptFailure(item.id, e.message)
@@ -113,17 +120,27 @@ class SyncRepositoryImpl @Inject constructor(
     // ─── Private helpers ──────────────────────────────────────────────────────
 
     /**
-     * Builds a minimal Retrofit instance pointed at [serverUrl].
-     *
-     * We reuse the shared [OkHttpClient] (timeouts, logging, Brotli) and [Json]
-     * (lenient, ignores unknown keys) from the network module.
+     * Builds a minimal Retrofit instance pointed at [serverUrl], optionally adding
+     * a Bearer token authorization header when [token] is non-blank.
      */
-    private fun buildApi(serverUrl: String): SyncApi {
-        // Ensure the URL ends with "/" so that Retrofit resolves relative paths correctly.
+    private fun buildApi(serverUrl: String, token: String = ""): SyncApi {
         val normalised = if (serverUrl.endsWith("/")) serverUrl else "$serverUrl/"
+        val client = if (token.isNotBlank()) {
+            okHttpClient.newBuilder()
+                .addInterceptor { chain ->
+                    chain.proceed(
+                        chain.request().newBuilder()
+                            .header("Authorization", "Bearer $token")
+                            .build()
+                    )
+                }
+                .build()
+        } else {
+            okHttpClient
+        }
         return Retrofit.Builder()
             .baseUrl(normalised)
-            .client(okHttpClient)
+            .client(client)
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
             .create(SyncApi::class.java)

--- a/data/src/main/java/app/otakureader/data/sync/SyncRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/sync/SyncRepositoryImpl.kt
@@ -75,7 +75,7 @@ class SyncRepositoryImpl @Inject constructor(
         if (serverUrl.isBlank()) return
         val token = syncSettingsStore.bearerToken.first()
         val api = buildApi(serverUrl, token)
-        val pending = syncQueueDao.getPending()
+        val pending = syncQueueDao.getPending().first()
         for (item in pending) {
             try {
                 val request = json.decodeFromString<PushProgressRequest>(item.payload)
@@ -111,6 +111,8 @@ class SyncRepositoryImpl @Inject constructor(
                     lastPageRead = 0,
                 )
             }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.w(TAG, "Pull failed", e)
         }
@@ -126,7 +128,8 @@ class SyncRepositoryImpl @Inject constructor(
      */
     private fun buildApi(serverUrl: String, token: String = ""): SyncApi {
         val normalised = if (serverUrl.endsWith("/")) serverUrl else "$serverUrl/"
-        val client = if (token.isNotBlank()) {
+        val isHttps = normalised.startsWith("https://", ignoreCase = true)
+        val client = if (token.isNotBlank() && isHttps) {
             okHttpClient.newBuilder()
                 .addInterceptor { chain ->
                     chain.proceed(

--- a/data/src/main/java/app/otakureader/data/sync/SyncRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/sync/SyncRepositoryImpl.kt
@@ -97,8 +97,9 @@ class SyncRepositoryImpl @Inject constructor(
     override suspend fun pullAndApply(deviceId: String, since: Long) {
         val serverUrl = syncSettingsStore.serverUrl.first()
         if (serverUrl.isBlank()) return
+        val token = syncSettingsStore.bearerToken.first()
         try {
-            val api = buildApi(serverUrl)
+            val api = buildApi(serverUrl, token)
             val entries = api.pullProgress(deviceId, since)
             for (entry in entries) {
                 // Mark the chapter as read via the DAO directly to avoid a circular

--- a/data/src/main/java/app/otakureader/data/worker/SyncSchedulerImpl.kt
+++ b/data/src/main/java/app/otakureader/data/worker/SyncSchedulerImpl.kt
@@ -1,0 +1,28 @@
+package app.otakureader.data.worker
+
+import android.content.Context
+import androidx.work.WorkManager
+import app.otakureader.domain.scheduler.SyncScheduler
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Data-layer implementation of [SyncScheduler].
+ *
+ * Delegates to [SyncWorker]'s companion-object helpers, keeping WorkManager out
+ * of the feature and domain layers.
+ */
+@Singleton
+class SyncSchedulerImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : SyncScheduler {
+
+    override fun schedulePeriodicSync() {
+        SyncWorker.schedulePeriodicSync(WorkManager.getInstance(context))
+    }
+
+    override fun enqueueSingleSync() {
+        SyncWorker.enqueueSingleSync(WorkManager.getInstance(context))
+    }
+}

--- a/data/src/main/java/app/otakureader/data/worker/SyncWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/SyncWorker.kt
@@ -1,0 +1,107 @@
+package app.otakureader.data.worker
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import app.otakureader.core.preferences.SyncSettingsStore
+import app.otakureader.domain.repository.SyncRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.first
+import java.util.concurrent.TimeUnit
+
+/**
+ * Background worker that drains the local sync queue and pulls remote progress.
+ *
+ * The worker runs on a 15-minute periodic schedule when a sync server URL is
+ * configured (see [schedulePeriodicSync]).  A one-shot run can be triggered
+ * immediately after a chapter is read via [enqueueSingleSync].
+ *
+ * If the worker fails it retries up to [MAX_RETRIES] times before giving up
+ * and returning [Result.failure].  WorkManager handles back-off automatically.
+ */
+@HiltWorker
+class SyncWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val syncRepository: SyncRepository,
+    private val syncSettingsStore: SyncSettingsStore,
+) : CoroutineWorker(context, workerParams) {
+
+    override suspend fun doWork(): Result {
+        val serverUrl = syncSettingsStore.serverUrl.first()
+        // Nothing to do if no server has been configured.
+        if (serverUrl.isBlank()) return Result.success()
+
+        return try {
+            syncRepository.drainQueue()
+            val deviceId = syncSettingsStore.ensureDeviceId()
+            syncRepository.pullAndApply(
+                deviceId = deviceId,
+                since = System.currentTimeMillis() - PULL_WINDOW_MS,
+            )
+            Result.success()
+        } catch (e: Exception) {
+            if (runAttemptCount < MAX_RETRIES) Result.retry() else Result.failure()
+        }
+    }
+
+    companion object {
+        const val WORK_NAME_PERIODIC = "sync_periodic"
+        const val WORK_NAME_ONE_SHOT = "sync_one_shot"
+
+        private const val MAX_RETRIES = 3
+
+        /** Pull events from the last 7 days on each sync cycle. */
+        private const val PULL_WINDOW_MS = 7L * 24 * 60 * 60 * 1_000L
+
+        /**
+         * Enqueues a periodic sync job that runs every 15 minutes while the
+         * device has network connectivity.
+         *
+         * Uses [ExistingPeriodicWorkPolicy.KEEP] so that rescheduling (e.g. on
+         * settings save) does not reset the existing timer unless the URL changed.
+         */
+        fun schedulePeriodicSync(workManager: WorkManager) {
+            val request = PeriodicWorkRequestBuilder<SyncWorker>(15, TimeUnit.MINUTES)
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .build()
+            workManager.enqueueUniquePeriodicWork(
+                WORK_NAME_PERIODIC,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request,
+            )
+        }
+
+        /**
+         * Enqueues an immediate one-shot sync.  Replaces any pending one-shot so
+         * rapid consecutive chapter reads collapse into a single network trip.
+         */
+        fun enqueueSingleSync(workManager: WorkManager) {
+            val request = OneTimeWorkRequestBuilder<SyncWorker>()
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .build()
+            workManager.enqueueUniqueWork(
+                WORK_NAME_ONE_SHOT,
+                ExistingWorkPolicy.REPLACE,
+                request,
+            )
+        }
+    }
+}

--- a/data/src/main/java/app/otakureader/data/worker/SyncWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/SyncWorker.kt
@@ -49,6 +49,8 @@ class SyncWorker @AssistedInject constructor(
                 since = System.currentTimeMillis() - PULL_WINDOW_MS,
             )
             Result.success()
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (e: Exception) {
             if (runAttemptCount < MAX_RETRIES) Result.retry() else Result.failure()
         }
@@ -59,6 +61,7 @@ class SyncWorker @AssistedInject constructor(
         const val WORK_NAME_ONE_SHOT = "sync_one_shot"
 
         private const val MAX_RETRIES = 3
+        private const val SYNC_INTERVAL_MINUTES = 15L
 
         /** Pull events from the last 7 days on each sync cycle. */
         private const val PULL_WINDOW_MS = 7L * 24 * 60 * 60 * 1_000L
@@ -71,7 +74,7 @@ class SyncWorker @AssistedInject constructor(
          * settings save) does not reset the existing timer unless the URL changed.
          */
         fun schedulePeriodicSync(workManager: WorkManager) {
-            val request = PeriodicWorkRequestBuilder<SyncWorker>(15, TimeUnit.MINUTES)
+            val request = PeriodicWorkRequestBuilder<SyncWorker>(SYNC_INTERVAL_MINUTES, TimeUnit.MINUTES)
                 .setConstraints(
                     Constraints.Builder()
                         .setRequiredNetworkType(NetworkType.CONNECTED)

--- a/data/src/test/java/app/otakureader/data/repository/ChapterRepositoryImplTest.kt
+++ b/data/src/test/java/app/otakureader/data/repository/ChapterRepositoryImplTest.kt
@@ -5,6 +5,7 @@ import app.otakureader.core.database.dao.ChapterDao
 import app.otakureader.core.database.entity.ChapterEntity
 import app.otakureader.core.database.entity.ChapterWithHistoryEntity
 import app.otakureader.domain.model.Chapter
+import app.otakureader.domain.repository.SyncRepository
 import app.cash.turbine.test
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -22,6 +23,7 @@ import org.junit.Test
 class ChapterRepositoryImplTest {
 
     private lateinit var chapterDao: ChapterDao
+    private lateinit var syncRepository: SyncRepository
     private lateinit var repository: ChapterRepositoryImpl
     private val workManager: WorkManager = mockk(relaxed = true)
 
@@ -51,7 +53,8 @@ class ChapterRepositoryImplTest {
     fun setUp() {
         chapterDao = mockk()
         readingHistoryDao = mockk()
-        repository = ChapterRepositoryImpl(chapterDao, readingHistoryDao, workManager)
+        syncRepository = mockk(relaxed = true)
+        repository = ChapterRepositoryImpl(chapterDao, readingHistoryDao, workManager, syncRepository)
     }
 
     // ---- getChaptersByMangaId ----

--- a/domain/src/main/java/app/otakureader/domain/repository/SyncRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/SyncRepository.kt
@@ -1,0 +1,41 @@
+package app.otakureader.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Repository interface for reader-progress sync with a self-hosted sync server.
+ *
+ * Implementations must be safe to call from any coroutine context and should
+ * never throw for network errors — failed items remain in the queue for the
+ * next drain cycle.
+ */
+interface SyncRepository {
+
+    /**
+     * Serialise a chapter-read event and add it to the local sync queue.
+     *
+     * This is a local-only operation and always succeeds; actual network
+     * transmission happens in [drainQueue].
+     */
+    suspend fun enqueueChapterRead(chapterId: Long, mangaId: Long, chapterNumber: Float)
+
+    /**
+     * Attempt to push all queued items to the server, removing each item on
+     * success and incrementing its attempt counter on failure.
+     */
+    suspend fun drainQueue()
+
+    /**
+     * Pull progress events from the server that occurred after [since] (epoch
+     * millis) and apply them to the local database.
+     *
+     * @param deviceId  Stable identifier for this installation (used as the
+     *                  "source" filter so the server can exclude events that
+     *                  originated on this device).
+     * @param since     Only fetch events newer than this epoch-millis timestamp.
+     */
+    suspend fun pullAndApply(deviceId: String, since: Long)
+
+    /** Observe the number of items currently waiting in the local sync queue. */
+    fun observeQueueSize(): Flow<Int>
+}

--- a/domain/src/main/java/app/otakureader/domain/scheduler/SyncScheduler.kt
+++ b/domain/src/main/java/app/otakureader/domain/scheduler/SyncScheduler.kt
@@ -1,0 +1,16 @@
+package app.otakureader.domain.scheduler
+
+/**
+ * Scheduler interface for reader-progress sync work.
+ *
+ * Implementations are expected to delegate to [WorkManager] and live in the
+ * data layer.  The interface lives in the domain layer so that feature modules
+ * can trigger sync without importing WorkManager or any data-layer class.
+ */
+interface SyncScheduler {
+    /** Start (or keep) the periodic 15-minute sync job. */
+    fun schedulePeriodicSync()
+
+    /** Enqueue an immediate one-shot sync (replaces any pending one-shot). */
+    fun enqueueSingleSync()
+}

--- a/domain/src/test/java/app/otakureader/domain/model/DomainModelsTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/model/DomainModelsTest.kt
@@ -165,4 +165,35 @@ class DomainModelsTest {
         assertEquals(4, TrackerType.MANGA_UPDATES)
         assertEquals(5, TrackerType.SHIKIMORI)
     }
+
+    // ── ContinueReadingItem ───────────────────────────────────────────────────
+
+    @Test
+    fun `ContinueReadingItem fields are correctly stored`() {
+        val item = ContinueReadingItem(
+            mangaId = 1L,
+            chapterId = 10L,
+            mangaTitle = "Naruto",
+            thumbnailUrl = "https://example.com/cover.jpg",
+            chapterName = "Chapter 1",
+            chapterNumber = 1.0f,
+            lastPageRead = 5,
+            readAt = 1000L
+        )
+        assertEquals(1L, item.mangaId)
+        assertEquals(10L, item.chapterId)
+        assertEquals("Naruto", item.mangaTitle)
+        assertEquals(5, item.lastPageRead)
+        assertEquals(1000L, item.readAt)
+    }
+
+    @Test
+    fun `ContinueReadingItem nullable thumbnailUrl is allowed`() {
+        val item = ContinueReadingItem(
+            mangaId = 2L, chapterId = 20L, mangaTitle = "Bleach",
+            thumbnailUrl = null, chapterName = "Ch 2", chapterNumber = 2.0f,
+            lastPageRead = 0, readAt = 2000L
+        )
+        assertNull(item.thumbnailUrl)
+    }
 }

--- a/domain/src/test/java/app/otakureader/domain/model/PrefetchStrategyTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/model/PrefetchStrategyTest.kt
@@ -1,0 +1,380 @@
+package app.otakureader.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PrefetchStrategyTest {
+
+    private val defaultBehavior = ReadingBehavior.DEFAULT
+    private val predictable = ReadingBehavior(
+        forwardNavigationRatio = 0.95f,
+        sequentialNavigationRatio = 0.9f,
+        sampleSize = 100,
+        completionRate = 0.9f
+    )
+    private val backwardProne = ReadingBehavior(
+        forwardNavigationRatio = 0.7f,
+        sequentialNavigationRatio = 0.9f,
+        sampleSize = 100,
+        completionRate = 0.9f
+    )
+    private val fastReader = ReadingBehavior(
+        forwardNavigationRatio = 0.95f,
+        averagePageDurationMs = 1500L,
+        sequentialNavigationRatio = 0.95f,
+        sampleSize = 100,
+        completionRate = 0.9f
+    )
+    private val slowReader = ReadingBehavior(
+        forwardNavigationRatio = 0.92f,
+        averagePageDurationMs = 10000L,
+        sequentialNavigationRatio = 0.85f,
+        sampleSize = 100,
+        completionRate = 0.9f
+    )
+    private val normalReader = ReadingBehavior(
+        forwardNavigationRatio = 0.92f,
+        averagePageDurationMs = 5000L,
+        sequentialNavigationRatio = 0.9f,
+        sampleSize = 100,
+        completionRate = 0.9f
+    )
+    private val lowCompletion = ReadingBehavior(
+        forwardNavigationRatio = 0.9f,
+        sequentialNavigationRatio = 0.9f,
+        sampleSize = 100,
+        completionRate = 0.3f
+    )
+
+    // ── Conservative ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `Conservative pagesBefore always returns zero`() {
+        assertEquals(0, PrefetchStrategy.Conservative.pagesBefore(5, 20, defaultBehavior))
+        assertEquals(0, PrefetchStrategy.Conservative.pagesBefore(0, 10, predictable))
+        assertEquals(0, PrefetchStrategy.Conservative.pagesBefore(9, 10, defaultBehavior))
+    }
+
+    @Test
+    fun `Conservative pagesAfter returns 2 when not near end`() {
+        assertEquals(2, PrefetchStrategy.Conservative.pagesAfter(0, 10, defaultBehavior))
+        assertEquals(2, PrefetchStrategy.Conservative.pagesAfter(5, 10, defaultBehavior))
+        assertEquals(2, PrefetchStrategy.Conservative.pagesAfter(7, 10, defaultBehavior))
+    }
+
+    @Test
+    fun `Conservative pagesAfter returns 1 at last two pages`() {
+        assertEquals(1, PrefetchStrategy.Conservative.pagesAfter(8, 10, defaultBehavior))
+        assertEquals(1, PrefetchStrategy.Conservative.pagesAfter(9, 10, defaultBehavior))
+    }
+
+    @Test
+    fun `Conservative never prefetches adjacent chapters`() {
+        assertFalse(PrefetchStrategy.Conservative.shouldPrefetchNextChapter(9, 10, defaultBehavior))
+        assertFalse(PrefetchStrategy.Conservative.shouldPrefetchNextChapter(0, 10, defaultBehavior))
+        assertFalse(PrefetchStrategy.Conservative.shouldPrefetchPreviousChapter(0, defaultBehavior))
+        assertFalse(PrefetchStrategy.Conservative.shouldPrefetchPreviousChapter(1, defaultBehavior))
+    }
+
+    // ── Balanced ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Balanced pagesBefore always returns 1`() {
+        assertEquals(1, PrefetchStrategy.Balanced.pagesBefore(0, 20, defaultBehavior))
+        assertEquals(1, PrefetchStrategy.Balanced.pagesBefore(10, 20, predictable))
+        assertEquals(1, PrefetchStrategy.Balanced.pagesBefore(19, 20, backwardProne))
+    }
+
+    @Test
+    fun `Balanced pagesAfter always returns 3`() {
+        assertEquals(3, PrefetchStrategy.Balanced.pagesAfter(0, 20, defaultBehavior))
+        assertEquals(3, PrefetchStrategy.Balanced.pagesAfter(10, 20, fastReader))
+        assertEquals(3, PrefetchStrategy.Balanced.pagesAfter(19, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Balanced shouldPrefetchNextChapter true on last 3 pages`() {
+        assertTrue(PrefetchStrategy.Balanced.shouldPrefetchNextChapter(17, 20, defaultBehavior))
+        assertTrue(PrefetchStrategy.Balanced.shouldPrefetchNextChapter(18, 20, defaultBehavior))
+        assertTrue(PrefetchStrategy.Balanced.shouldPrefetchNextChapter(19, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Balanced shouldPrefetchNextChapter false before last 3 pages`() {
+        assertFalse(PrefetchStrategy.Balanced.shouldPrefetchNextChapter(16, 20, defaultBehavior))
+        assertFalse(PrefetchStrategy.Balanced.shouldPrefetchNextChapter(0, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Balanced never prefetches previous chapter`() {
+        assertFalse(PrefetchStrategy.Balanced.shouldPrefetchPreviousChapter(0, defaultBehavior))
+        assertFalse(PrefetchStrategy.Balanced.shouldPrefetchPreviousChapter(0, backwardProne))
+    }
+
+    // ── Aggressive ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Aggressive pagesBefore returns 3 for backward-prone readers`() {
+        assertEquals(3, PrefetchStrategy.Aggressive.pagesBefore(5, 20, backwardProne))
+    }
+
+    @Test
+    fun `Aggressive pagesBefore returns 2 for mostly-forward readers`() {
+        assertEquals(2, PrefetchStrategy.Aggressive.pagesBefore(5, 20, predictable))
+    }
+
+    @Test
+    fun `Aggressive pagesAfter returns 10 near chapter end`() {
+        assertEquals(10, PrefetchStrategy.Aggressive.pagesAfter(15, 20, defaultBehavior))
+        assertEquals(10, PrefetchStrategy.Aggressive.pagesAfter(16, 20, defaultBehavior))
+        assertEquals(10, PrefetchStrategy.Aggressive.pagesAfter(19, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Aggressive pagesAfter returns 7 elsewhere`() {
+        assertEquals(7, PrefetchStrategy.Aggressive.pagesAfter(0, 20, defaultBehavior))
+        assertEquals(7, PrefetchStrategy.Aggressive.pagesAfter(10, 20, defaultBehavior))
+        assertEquals(7, PrefetchStrategy.Aggressive.pagesAfter(14, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Aggressive shouldPrefetchNextChapter true on last 5 pages`() {
+        assertTrue(PrefetchStrategy.Aggressive.shouldPrefetchNextChapter(15, 20, defaultBehavior))
+        assertTrue(PrefetchStrategy.Aggressive.shouldPrefetchNextChapter(19, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Aggressive shouldPrefetchNextChapter false before last 5 pages`() {
+        assertFalse(PrefetchStrategy.Aggressive.shouldPrefetchNextChapter(14, 20, defaultBehavior))
+        assertFalse(PrefetchStrategy.Aggressive.shouldPrefetchNextChapter(0, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Aggressive shouldPrefetchPreviousChapter when at start and backward prone`() {
+        assertTrue(PrefetchStrategy.Aggressive.shouldPrefetchPreviousChapter(0, backwardProne))
+        assertTrue(PrefetchStrategy.Aggressive.shouldPrefetchPreviousChapter(2, backwardProne))
+    }
+
+    @Test
+    fun `Aggressive shouldPrefetchPreviousChapter false for forward readers`() {
+        assertFalse(PrefetchStrategy.Aggressive.shouldPrefetchPreviousChapter(0, predictable))
+    }
+
+    @Test
+    fun `Aggressive shouldPrefetchPreviousChapter false past page 2`() {
+        assertFalse(PrefetchStrategy.Aggressive.shouldPrefetchPreviousChapter(3, backwardProne))
+    }
+
+    // ── Adaptive ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Adaptive pagesBefore returns 1 for unpredictable readers`() {
+        assertEquals(1, PrefetchStrategy.Adaptive.pagesBefore(5, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Adaptive pagesBefore returns 2 for backward-prone predictable readers`() {
+        assertEquals(2, PrefetchStrategy.Adaptive.pagesBefore(5, 20, backwardProne))
+    }
+
+    @Test
+    fun `Adaptive pagesBefore returns 1 for forward predictable readers`() {
+        assertEquals(1, PrefetchStrategy.Adaptive.pagesBefore(5, 20, predictable))
+    }
+
+    @Test
+    fun `Adaptive pagesAfter returns 3 for unpredictable readers`() {
+        assertEquals(3, PrefetchStrategy.Adaptive.pagesAfter(5, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Adaptive pagesAfter returns 6 for fast reader not near end`() {
+        assertEquals(6, PrefetchStrategy.Adaptive.pagesAfter(5, 20, fastReader))
+    }
+
+    @Test
+    fun `Adaptive pagesAfter returns 8 for fast reader near end`() {
+        assertEquals(8, PrefetchStrategy.Adaptive.pagesAfter(17, 20, fastReader))
+    }
+
+    @Test
+    fun `Adaptive pagesAfter returns 2 for slow reader not near end`() {
+        assertEquals(2, PrefetchStrategy.Adaptive.pagesAfter(5, 20, slowReader))
+    }
+
+    @Test
+    fun `Adaptive pagesAfter returns 4 for slow reader near end`() {
+        assertEquals(4, PrefetchStrategy.Adaptive.pagesAfter(17, 20, slowReader))
+    }
+
+    @Test
+    fun `Adaptive pagesAfter returns 3 for normal speed not near end`() {
+        assertEquals(3, PrefetchStrategy.Adaptive.pagesAfter(5, 20, normalReader))
+    }
+
+    @Test
+    fun `Adaptive pagesAfter returns 5 for normal speed near end`() {
+        assertEquals(5, PrefetchStrategy.Adaptive.pagesAfter(17, 20, normalReader))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchNextChapter false when unlikely to complete`() {
+        assertFalse(PrefetchStrategy.Adaptive.shouldPrefetchNextChapter(17, 20, lowCompletion))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchNextChapter for unpredictable reader near end`() {
+        val unpredictableCompleter = ReadingBehavior(completionRate = 0.9f, sampleSize = 0)
+        assertTrue(PrefetchStrategy.Adaptive.shouldPrefetchNextChapter(17, 20, unpredictableCompleter))
+        assertFalse(PrefetchStrategy.Adaptive.shouldPrefetchNextChapter(16, 20, unpredictableCompleter))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchNextChapter fast reader triggers at last 5 pages`() {
+        assertTrue(PrefetchStrategy.Adaptive.shouldPrefetchNextChapter(15, 20, fastReader))
+        assertFalse(PrefetchStrategy.Adaptive.shouldPrefetchNextChapter(14, 20, fastReader))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchNextChapter normal speed triggers at last 3 pages`() {
+        assertTrue(PrefetchStrategy.Adaptive.shouldPrefetchNextChapter(17, 20, normalReader))
+        assertFalse(PrefetchStrategy.Adaptive.shouldPrefetchNextChapter(16, 20, normalReader))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchPreviousChapter when at start backward prone and predictable`() {
+        assertTrue(PrefetchStrategy.Adaptive.shouldPrefetchPreviousChapter(0, backwardProne))
+        assertTrue(PrefetchStrategy.Adaptive.shouldPrefetchPreviousChapter(2, backwardProne))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchPreviousChapter false for unpredictable reader`() {
+        assertFalse(PrefetchStrategy.Adaptive.shouldPrefetchPreviousChapter(0, defaultBehavior))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchPreviousChapter false past page 2`() {
+        assertFalse(PrefetchStrategy.Adaptive.shouldPrefetchPreviousChapter(3, backwardProne))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchPreviousChapter false for forward predictable reader`() {
+        assertFalse(PrefetchStrategy.Adaptive.shouldPrefetchPreviousChapter(0, predictable))
+    }
+
+    // ── Companion: fromOrdinal / toOrdinal ────────────────────────────────────
+
+    @Test
+    fun `fromOrdinal maps to correct strategy`() {
+        assertEquals(PrefetchStrategy.Conservative, PrefetchStrategy.fromOrdinal(0))
+        assertEquals(PrefetchStrategy.Balanced, PrefetchStrategy.fromOrdinal(1))
+        assertEquals(PrefetchStrategy.Aggressive, PrefetchStrategy.fromOrdinal(2))
+        assertEquals(PrefetchStrategy.Adaptive, PrefetchStrategy.fromOrdinal(3))
+    }
+
+    @Test
+    fun `fromOrdinal out of bounds defaults to Balanced`() {
+        assertEquals(PrefetchStrategy.Balanced, PrefetchStrategy.fromOrdinal(-1))
+        assertEquals(PrefetchStrategy.Balanced, PrefetchStrategy.fromOrdinal(99))
+    }
+
+    @Test
+    fun `toOrdinal maps each strategy to correct index`() {
+        assertEquals(0, PrefetchStrategy.toOrdinal(PrefetchStrategy.Conservative))
+        assertEquals(1, PrefetchStrategy.toOrdinal(PrefetchStrategy.Balanced))
+        assertEquals(2, PrefetchStrategy.toOrdinal(PrefetchStrategy.Aggressive))
+        assertEquals(3, PrefetchStrategy.toOrdinal(PrefetchStrategy.Adaptive))
+    }
+
+    @Test
+    fun `fromOrdinal and toOrdinal are inverses`() {
+        listOf(
+            PrefetchStrategy.Conservative,
+            PrefetchStrategy.Balanced,
+            PrefetchStrategy.Aggressive,
+            PrefetchStrategy.Adaptive
+        ).forEach { strategy ->
+            assertEquals(strategy, PrefetchStrategy.fromOrdinal(PrefetchStrategy.toOrdinal(strategy)))
+        }
+    }
+
+    // ── ReadingBehavior computed properties ────────────────────────────────────
+
+    @Test
+    fun `ReadingBehavior DEFAULT is unpredictable due to zero sample size`() {
+        assertTrue(ReadingBehavior.DEFAULT.isUnpredictable)
+    }
+
+    @Test
+    fun `ReadingBehavior isPrimaryForwardReader when high ratios`() {
+        assertTrue(predictable.isPrimaryForwardReader)
+        assertFalse(backwardProne.isPrimaryForwardReader)
+    }
+
+    @Test
+    fun `ReadingBehavior likelyToCompleteChapter when completion rate meets threshold`() {
+        assertTrue(predictable.likelyToCompleteChapter)
+        assertFalse(lowCompletion.likelyToCompleteChapter)
+    }
+
+    @Test
+    fun `ReadingBehavior isUnpredictable when sequential ratio too low`() {
+        val chaotic = ReadingBehavior(sequentialNavigationRatio = 0.5f, sampleSize = 100)
+        assertTrue(chaotic.isUnpredictable)
+    }
+
+    @Test
+    fun `ReadingBehavior isUnpredictable false when sufficient sample and sequential ratio`() {
+        assertFalse(predictable.isUnpredictable)
+        assertFalse(normalReader.isUnpredictable)
+    }
+
+    // ── PageNavigationEvent properties ────────────────────────────────────────
+
+    @Test
+    fun `PageNavigationEvent isForward true when toPage greater than fromPage`() {
+        val event = PageNavigationEvent(
+            mangaId = 1L, chapterId = 2L, fromPage = 3, toPage = 4,
+            pageDurationMs = 2000L, readerMode = 0
+        )
+        assertTrue(event.isForward)
+    }
+
+    @Test
+    fun `PageNavigationEvent isForward false when going backward`() {
+        val event = PageNavigationEvent(
+            mangaId = 1L, chapterId = 2L, fromPage = 5, toPage = 3,
+            pageDurationMs = 1000L, readerMode = 0
+        )
+        assertFalse(event.isForward)
+    }
+
+    @Test
+    fun `PageNavigationEvent isSequential true for adjacent page in single mode`() {
+        val event = PageNavigationEvent(
+            mangaId = 1L, chapterId = 2L, fromPage = 3, toPage = 4,
+            pageDurationMs = 3000L, readerMode = 0
+        )
+        assertTrue(event.isSequential)
+    }
+
+    @Test
+    fun `PageNavigationEvent isSequential true for 2-page jump in dual mode`() {
+        val event = PageNavigationEvent(
+            mangaId = 1L, chapterId = 2L, fromPage = 2, toPage = 4,
+            pageDurationMs = 3000L, readerMode = 1
+        )
+        assertTrue(event.isSequential)
+    }
+
+    @Test
+    fun `PageNavigationEvent isSequential false for non-adjacent jump`() {
+        val event = PageNavigationEvent(
+            mangaId = 1L, chapterId = 2L, fromPage = 1, toPage = 10,
+            pageDurationMs = 500L, readerMode = 0
+        )
+        assertFalse(event.isSequential)
+    }
+}

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsScreen.kt
@@ -71,6 +71,7 @@ fun SettingsScreen(
     onNavigateToNotifications: () -> Unit = {},
     onNavigateToWidgetConfiguration: () -> Unit = {},
     onNavigateToLocalSourceBrowser: () -> Unit = {},
+    onNavigateToSync: () -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
@@ -154,6 +155,10 @@ fun SettingsScreen(
             SettingsCategoryRow(
                 title = stringResource(R.string.settings_local_source),
                 onClick = onNavigateToLocalSourceBrowser,
+            )
+            SettingsCategoryRow(
+                title = stringResource(R.string.settings_sync),
+                onClick = onNavigateToSync,
             )
 
             // ── Local source ──────────────────────────────────────────

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/navigation/SettingsNavigation.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/navigation/SettingsNavigation.kt
@@ -15,6 +15,7 @@ import app.otakureader.feature.settings.settingsNotificationsScreen
 import app.otakureader.feature.settings.settingsReaderScreen
 import app.otakureader.feature.settings.settingsSecurityScreen
 import app.otakureader.feature.settings.settingsTrackingScreen
+import app.otakureader.feature.settings.sync.syncSettingsScreen
 import app.otakureader.feature.settings.widgetConfigurationScreen
 
 /**
@@ -39,6 +40,7 @@ fun NavGraphBuilder.settingsScreen(
     onNavigateToWidgetConfiguration: () -> Unit = {},
     onNavigateToLocalSourceBrowser: () -> Unit = {},
     onNavigateToCloudBackup: () -> Unit = {},
+    onNavigateToSync: () -> Unit = {},
 ) {
     composable<Route.Settings> {
         SettingsScreen(
@@ -56,6 +58,7 @@ fun NavGraphBuilder.settingsScreen(
             onNavigateToNotifications = onNavigateToNotifications,
             onNavigateToWidgetConfiguration = onNavigateToWidgetConfiguration,
             onNavigateToLocalSourceBrowser = onNavigateToLocalSourceBrowser,
+            onNavigateToSync = onNavigateToSync,
         )
     }
 
@@ -75,4 +78,5 @@ fun NavGraphBuilder.settingsScreen(
     settingsDiscordScreen(onNavigateBack = onNavigateBack)
     widgetConfigurationScreen(onNavigateBack = onNavigateBack)
     localSourceBrowserScreen(onNavigateBack = onNavigateBack)
+    syncSettingsScreen(onNavigateBack = onNavigateBack)
 }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsMvi.kt
@@ -1,0 +1,30 @@
+package app.otakureader.feature.settings.sync
+
+/**
+ * MVI state for the Reader Sync settings screen.
+ *
+ * All fields are immutable; use [copy] in the ViewModel reducer to produce
+ * updated state.
+ */
+data class SyncSettingsState(
+    val serverUrl: String = "",
+    val bearerToken: String = "",
+    val deviceId: String = "",
+    val queueSize: Int = 0,
+    val isSyncing: Boolean = false,
+    val lastSyncResult: String? = null,
+)
+
+/** User actions dispatched to [SyncSettingsViewModel]. */
+sealed interface SyncSettingsEvent {
+    data class SetServerUrl(val url: String) : SyncSettingsEvent
+    data class SetBearerToken(val token: String) : SyncSettingsEvent
+    data object SaveSettings : SyncSettingsEvent
+    data object SyncNow : SyncSettingsEvent
+    data object TestConnection : SyncSettingsEvent
+}
+
+/** One-shot side-effects emitted by [SyncSettingsViewModel]. */
+sealed interface SyncSettingsEffect {
+    data class ShowSnackbar(val message: String) : SyncSettingsEffect
+}

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsScreen.kt
@@ -189,7 +189,7 @@ fun SyncSettingsScreen(
             item(key = "sync_device_id") {
                 ListItem(
                     headlineContent = { Text(stringResource(R.string.settings_sync_device_id)) },
-                    supportingContent = { Text(state.deviceId.ifBlank { "—" }) },
+                    supportingContent = { Text(state.deviceId.ifBlank { stringResource(R.string.settings_sync_device_id_none) }) },
                 )
             }
         }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsScreen.kt
@@ -1,0 +1,205 @@
+package app.otakureader.feature.settings.sync
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import app.otakureader.core.navigation.Route
+import app.otakureader.feature.settings.R
+import app.otakureader.feature.settings.SectionHeader
+
+/**
+ * Sync settings screen — lets the user configure a self-hosted Otaku Reader sync
+ * server and manually trigger a sync cycle.
+ *
+ * **Navigation entry point:** [syncSettingsScreen] extension on [NavGraphBuilder].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SyncSettingsScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: SyncSettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Collect one-shot effects and show snackbars.
+    LaunchedEffect(Unit) {
+        viewModel.effect.collect { effect ->
+            when (effect) {
+                is SyncSettingsEffect.ShowSnackbar -> snackbarHostState.showSnackbar(effect.message)
+            }
+        }
+    }
+
+    // Local draft fields so the user can edit without immediately persisting.
+    var serverUrlDraft by remember(state.serverUrl) { mutableStateOf(state.serverUrl) }
+    var bearerTokenDraft by remember(state.bearerToken) { mutableStateOf(state.bearerToken) }
+
+    Scaffold(
+        modifier = modifier,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.settings_sync)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.settings_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues)) {
+
+            // ── Description ──────────────────────────────────────────────
+            item(key = "sync_description") {
+                ListItem(
+                    headlineContent = { Text(stringResource(R.string.settings_sync_description)) },
+                )
+            }
+
+            item(key = "sync_divider_0") { HorizontalDivider() }
+
+            // ── Server configuration ─────────────────────────────────────
+            item(key = "sync_server_header") {
+                SectionHeader(title = stringResource(R.string.settings_sync))
+            }
+
+            item(key = "sync_server_url") {
+                ListItem(
+                    headlineContent = {
+                        OutlinedTextField(
+                            value = serverUrlDraft,
+                            onValueChange = {
+                                serverUrlDraft = it
+                                viewModel.onEvent(SyncSettingsEvent.SetServerUrl(it))
+                            },
+                            label = { Text(stringResource(R.string.settings_sync_server_url)) },
+                            singleLine = true,
+                        )
+                    },
+                )
+            }
+
+            item(key = "sync_bearer_token") {
+                ListItem(
+                    headlineContent = {
+                        OutlinedTextField(
+                            value = bearerTokenDraft,
+                            onValueChange = {
+                                bearerTokenDraft = it
+                                viewModel.onEvent(SyncSettingsEvent.SetBearerToken(it))
+                            },
+                            label = { Text(stringResource(R.string.settings_sync_bearer_token)) },
+                            singleLine = true,
+                            visualTransformation = PasswordVisualTransformation(),
+                        )
+                    },
+                )
+            }
+
+            // ── Save / test buttons ───────────────────────────────────────
+            item(key = "sync_buttons") {
+                ListItem(
+                    headlineContent = {
+                        Column {
+                            Button(onClick = { viewModel.onEvent(SyncSettingsEvent.SaveSettings) }) {
+                                Text(stringResource(R.string.settings_sync_save))
+                            }
+                            OutlinedButton(
+                                onClick = { viewModel.onEvent(SyncSettingsEvent.TestConnection) },
+                            ) {
+                                Text(stringResource(R.string.settings_sync_test_connection))
+                            }
+                        }
+                    },
+                )
+            }
+
+            item(key = "sync_divider_1") { HorizontalDivider() }
+
+            // ── Sync now ─────────────────────────────────────────────────
+            item(key = "sync_now") {
+                ListItem(
+                    headlineContent = { Text(stringResource(R.string.settings_sync_now)) },
+                    supportingContent = {
+                        if (state.isSyncing) CircularProgressIndicator()
+                        else state.lastSyncResult?.let { Text(it) }
+                    },
+                    trailingContent = {
+                        OutlinedButton(
+                            onClick = { viewModel.onEvent(SyncSettingsEvent.SyncNow) },
+                            enabled = !state.isSyncing,
+                        ) {
+                            Text(stringResource(R.string.settings_sync_now))
+                        }
+                    },
+                )
+            }
+
+            item(key = "sync_divider_2") { HorizontalDivider() }
+
+            // ── Status chips ─────────────────────────────────────────────
+            item(key = "sync_queue_size") {
+                ListItem(
+                    headlineContent = { Text(stringResource(R.string.settings_sync_queue_size)) },
+                    trailingContent = {
+                        AssistChip(
+                            onClick = {},
+                            label = { Text("${state.queueSize}") },
+                        )
+                    },
+                )
+            }
+
+            item(key = "sync_device_id") {
+                ListItem(
+                    headlineContent = { Text(stringResource(R.string.settings_sync_device_id)) },
+                    supportingContent = { Text(state.deviceId.ifBlank { "—" }) },
+                )
+            }
+        }
+    }
+}
+
+// ─── NavGraph extension ───────────────────────────────────────────────────────
+
+fun NavGraphBuilder.syncSettingsScreen(onNavigateBack: () -> Unit) {
+    composable<Route.SettingsSync> {
+        SyncSettingsScreen(onNavigateBack = onNavigateBack)
+    }
+}

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsViewModel.kt
@@ -83,13 +83,16 @@ class SyncSettingsViewModel @Inject constructor(
             }
 
             SyncSettingsEvent.SyncNow -> viewModelScope.launch {
-                if (_uiState.value.serverUrl.isBlank()) {
+                val currentState = _uiState.value
+                if (currentState.serverUrl.isBlank()) {
                     _effect.send(SyncSettingsEffect.ShowSnackbar("No sync server configured"))
                     return@launch
                 }
-                _uiState.update { it.copy(isSyncing = true) }
+                // Save latest drafts before enqueuing so the worker uses current settings.
+                syncSettingsStore.setServerUrl(currentState.serverUrl)
+                syncSettingsStore.setBearerToken(currentState.bearerToken)
                 syncScheduler.enqueueSingleSync()
-                _uiState.update { it.copy(isSyncing = false, lastSyncResult = "Sync enqueued") }
+                _uiState.update { it.copy(lastSyncResult = "Sync enqueued") }
             }
 
             SyncSettingsEvent.TestConnection -> viewModelScope.launch {

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsViewModel.kt
@@ -10,7 +10,8 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -42,26 +43,20 @@ class SyncSettingsViewModel @Inject constructor(
     val effect = _effect.receiveAsFlow()
 
     init {
-        // Observe all persistent values and keep the UI state in sync.
-        viewModelScope.launch {
-            combine(
-                syncSettingsStore.serverUrl,
-                syncSettingsStore.bearerToken,
-                syncSettingsStore.deviceId,
-                syncRepository.observeQueueSize(),
-            ) { serverUrl, bearerToken, deviceId, queueSize ->
-                SyncSettingsState(
-                    serverUrl = serverUrl,
-                    bearerToken = bearerToken,
-                    deviceId = deviceId,
-                    queueSize = queueSize,
-                    isSyncing = _uiState.value.isSyncing,
-                    lastSyncResult = _uiState.value.lastSyncResult,
-                )
-            }.collect { newState ->
-                _uiState.value = newState
-            }
-        }
+        // Observe each persistent value independently so that transient UI flags
+        // (isSyncing, lastSyncResult) are never overwritten by a preference emission.
+        syncSettingsStore.serverUrl
+            .onEach { v -> _uiState.update { it.copy(serverUrl = v) } }
+            .launchIn(viewModelScope)
+        syncSettingsStore.bearerToken
+            .onEach { v -> _uiState.update { it.copy(bearerToken = v) } }
+            .launchIn(viewModelScope)
+        syncSettingsStore.deviceId
+            .onEach { v -> _uiState.update { it.copy(deviceId = v) } }
+            .launchIn(viewModelScope)
+        syncRepository.observeQueueSize()
+            .onEach { v -> _uiState.update { it.copy(queueSize = v) } }
+            .launchIn(viewModelScope)
 
         // Ensure a stable device ID is generated on first launch.
         viewModelScope.launch { syncSettingsStore.ensureDeviceId() }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsViewModel.kt
@@ -1,11 +1,14 @@
 package app.otakureader.feature.settings.sync
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.otakureader.core.preferences.SyncSettingsStore
 import app.otakureader.domain.repository.SyncRepository
 import app.otakureader.domain.scheduler.SyncScheduler
+import app.otakureader.feature.settings.R
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -31,6 +34,7 @@ import javax.inject.Inject
  */
 @HiltViewModel
 class SyncSettingsViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val syncSettingsStore: SyncSettingsStore,
     private val syncRepository: SyncRepository,
     private val syncScheduler: SyncScheduler,
@@ -73,11 +77,12 @@ class SyncSettingsViewModel @Inject constructor(
             }
 
             SyncSettingsEvent.SaveSettings -> viewModelScope.launch {
-                syncSettingsStore.setServerUrl(_uiState.value.serverUrl)
-                syncSettingsStore.setBearerToken(_uiState.value.bearerToken)
-                _effect.send(SyncSettingsEffect.ShowSnackbar("Sync settings saved"))
+                val state = _uiState.value
+                syncSettingsStore.setServerUrl(state.serverUrl)
+                syncSettingsStore.setBearerToken(state.bearerToken)
+                _effect.send(SyncSettingsEffect.ShowSnackbar(context.getString(R.string.settings_sync_settings_saved)))
                 // Reschedule the periodic worker with the (possibly new) server URL.
-                if (_uiState.value.serverUrl.isNotBlank()) {
+                if (state.serverUrl.isNotBlank()) {
                     syncScheduler.schedulePeriodicSync()
                 }
             }
@@ -85,25 +90,25 @@ class SyncSettingsViewModel @Inject constructor(
             SyncSettingsEvent.SyncNow -> viewModelScope.launch {
                 val currentState = _uiState.value
                 if (currentState.serverUrl.isBlank()) {
-                    _effect.send(SyncSettingsEffect.ShowSnackbar("No sync server configured"))
+                    _effect.send(SyncSettingsEffect.ShowSnackbar(context.getString(R.string.settings_sync_no_server_configured)))
                     return@launch
                 }
                 // Save latest drafts before enqueuing so the worker uses current settings.
                 syncSettingsStore.setServerUrl(currentState.serverUrl)
                 syncSettingsStore.setBearerToken(currentState.bearerToken)
                 syncScheduler.enqueueSingleSync()
-                _uiState.update { it.copy(lastSyncResult = "Sync enqueued") }
+                _uiState.update { it.copy(lastSyncResult = context.getString(R.string.settings_sync_enqueued)) }
             }
 
             SyncSettingsEvent.TestConnection -> viewModelScope.launch {
                 val url = _uiState.value.serverUrl
                 if (url.isBlank()) {
-                    _effect.send(SyncSettingsEffect.ShowSnackbar("Enter a server URL first"))
+                    _effect.send(SyncSettingsEffect.ShowSnackbar(context.getString(R.string.settings_sync_enter_url_first)))
                     return@launch
                 }
                 // A real connection test would make a HEAD request; for now we
                 // simply report the URL that would be used so the user can verify it.
-                _effect.send(SyncSettingsEffect.ShowSnackbar("Will connect to: $url"))
+                _effect.send(SyncSettingsEffect.ShowSnackbar(context.getString(R.string.settings_sync_will_connect_to, url)))
             }
         }
     }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsViewModel.kt
@@ -1,0 +1,112 @@
+package app.otakureader.feature.settings.sync
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.otakureader.core.preferences.SyncSettingsStore
+import app.otakureader.domain.repository.SyncRepository
+import app.otakureader.domain.scheduler.SyncScheduler
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * ViewModel for the Reader Sync settings screen.
+ *
+ * Follows the project's MVI pattern:
+ * - Exposes immutable [SyncSettingsState] via [uiState].
+ * - Accepts [SyncSettingsEvent] intents via [onEvent].
+ * - Emits one-shot [SyncSettingsEffect] side-effects via [effect].
+ *
+ * Uses the domain-layer [SyncScheduler] interface so this ViewModel has no
+ * dependency on WorkManager or any data-layer class directly.  This is
+ * consistent with how [TrackerSyncScheduler] is used from the Tracking settings.
+ */
+@HiltViewModel
+class SyncSettingsViewModel @Inject constructor(
+    private val syncSettingsStore: SyncSettingsStore,
+    private val syncRepository: SyncRepository,
+    private val syncScheduler: SyncScheduler,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SyncSettingsState())
+    val uiState: StateFlow<SyncSettingsState> = _uiState.asStateFlow()
+
+    private val _effect = Channel<SyncSettingsEffect>(Channel.BUFFERED)
+    val effect = _effect.receiveAsFlow()
+
+    init {
+        // Observe all persistent values and keep the UI state in sync.
+        viewModelScope.launch {
+            combine(
+                syncSettingsStore.serverUrl,
+                syncSettingsStore.bearerToken,
+                syncSettingsStore.deviceId,
+                syncRepository.observeQueueSize(),
+            ) { serverUrl, bearerToken, deviceId, queueSize ->
+                SyncSettingsState(
+                    serverUrl = serverUrl,
+                    bearerToken = bearerToken,
+                    deviceId = deviceId,
+                    queueSize = queueSize,
+                    isSyncing = _uiState.value.isSyncing,
+                    lastSyncResult = _uiState.value.lastSyncResult,
+                )
+            }.collect { newState ->
+                _uiState.value = newState
+            }
+        }
+
+        // Ensure a stable device ID is generated on first launch.
+        viewModelScope.launch { syncSettingsStore.ensureDeviceId() }
+    }
+
+    fun onEvent(event: SyncSettingsEvent) {
+        when (event) {
+            is SyncSettingsEvent.SetServerUrl -> {
+                _uiState.update { it.copy(serverUrl = event.url) }
+            }
+
+            is SyncSettingsEvent.SetBearerToken -> {
+                _uiState.update { it.copy(bearerToken = event.token) }
+            }
+
+            SyncSettingsEvent.SaveSettings -> viewModelScope.launch {
+                syncSettingsStore.setServerUrl(_uiState.value.serverUrl)
+                syncSettingsStore.setBearerToken(_uiState.value.bearerToken)
+                _effect.send(SyncSettingsEffect.ShowSnackbar("Sync settings saved"))
+                // Reschedule the periodic worker with the (possibly new) server URL.
+                if (_uiState.value.serverUrl.isNotBlank()) {
+                    syncScheduler.schedulePeriodicSync()
+                }
+            }
+
+            SyncSettingsEvent.SyncNow -> viewModelScope.launch {
+                if (_uiState.value.serverUrl.isBlank()) {
+                    _effect.send(SyncSettingsEffect.ShowSnackbar("No sync server configured"))
+                    return@launch
+                }
+                _uiState.update { it.copy(isSyncing = true) }
+                syncScheduler.enqueueSingleSync()
+                _uiState.update { it.copy(isSyncing = false, lastSyncResult = "Sync enqueued") }
+            }
+
+            SyncSettingsEvent.TestConnection -> viewModelScope.launch {
+                val url = _uiState.value.serverUrl
+                if (url.isBlank()) {
+                    _effect.send(SyncSettingsEffect.ShowSnackbar("Enter a server URL first"))
+                    return@launch
+                }
+                // A real connection test would make a HEAD request; for now we
+                // simply report the URL that would be used so the user can verify it.
+                _effect.send(SyncSettingsEffect.ShowSnackbar("Will connect to: $url"))
+            }
+        }
+    }
+}

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -47,14 +48,17 @@ class SyncSettingsViewModel @Inject constructor(
     val effect = _effect.receiveAsFlow()
 
     init {
-        // Observe each persistent value independently so that transient UI flags
-        // (isSyncing, lastSyncResult) are never overwritten by a preference emission.
-        syncSettingsStore.serverUrl
-            .onEach { v -> _uiState.update { it.copy(serverUrl = v) } }
-            .launchIn(viewModelScope)
-        syncSettingsStore.bearerToken
-            .onEach { v -> _uiState.update { it.copy(bearerToken = v) } }
-            .launchIn(viewModelScope)
+        // serverUrl and bearerToken are editable draft fields.  Reading them
+        // reactively would overwrite in-progress user edits whenever DataStore
+        // re-emits (e.g. after SaveSettings persists the value).  Use a
+        // one-shot read instead so the UI draft is only seeded once on start.
+        viewModelScope.launch {
+            val url = syncSettingsStore.serverUrl.first()
+            val token = syncSettingsStore.bearerToken.first()
+            _uiState.update { it.copy(serverUrl = url, bearerToken = token) }
+        }
+
+        // deviceId and queueSize are read-only display values — observe reactively.
         syncSettingsStore.deviceId
             .onEach { v -> _uiState.update { it.copy(deviceId = v) } }
             .launchIn(viewModelScope)

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -479,4 +479,15 @@
     <string name="settings_about">About</string>
     <string name="settings_about_title">About Otaku Reader</string>
     <string name="settings_about_description">App info, FAQ, licenses</string>
+
+    <!-- Reader Sync (#958) -->
+    <string name="settings_sync">Reader Sync</string>
+    <string name="settings_sync_description">Sync your reading progress across devices using a self-hosted server. Leave blank to disable.</string>
+    <string name="settings_sync_server_url">Server URL</string>
+    <string name="settings_sync_bearer_token">Bearer Token</string>
+    <string name="settings_sync_save">Save</string>
+    <string name="settings_sync_now">Sync Now</string>
+    <string name="settings_sync_device_id">Device ID</string>
+    <string name="settings_sync_queue_size">Pending items</string>
+    <string name="settings_sync_test_connection">Test Connection</string>
 </resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -491,4 +491,9 @@
     <string name="settings_sync_queue_size">Pending items</string>
     <string name="settings_sync_test_connection">Test Connection</string>
     <string name="settings_sync_device_id_none">—</string>
+    <string name="settings_sync_settings_saved">Sync settings saved</string>
+    <string name="settings_sync_no_server_configured">No sync server configured</string>
+    <string name="settings_sync_enqueued">Sync enqueued</string>
+    <string name="settings_sync_enter_url_first">Enter a server URL first</string>
+    <string name="settings_sync_will_connect_to">Will connect to: %1$s</string>
 </resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -490,4 +490,5 @@
     <string name="settings_sync_device_id">Device ID</string>
     <string name="settings_sync_queue_size">Pending items</string>
     <string name="settings_sync_test_connection">Test Connection</string>
+    <string name="settings_sync_device_id_none">—</string>
 </resources>


### PR DESCRIPTION
## **User description**
## Summary

- Adds opt-in reader progress sync to a self-hosted server (configurable URL + bearer token)
- Every chapter read is enqueued locally and drained in the background — a broken server never blocks reading
- Remote progress is pulled and applied on each sync cycle so reading marks propagate across devices

## Changes

### New infrastructure
| File | Purpose |
|------|---------|
| `SyncQueueEntity` + `SyncQueueDao` | Room local outbox; tracks attempts + last error for retry |
| `MIGRATION_28_29` | Creates `sync_queue` table |
| `SyncSettingsStore` | DataStore: serverUrl, bearerToken, deviceId (UUID, generated once) |
| `SyncRepository` (domain interface) | `enqueueChapterRead`, `drainQueue`, `pullAndApply`, `observeQueueSize` |
| `SyncRepositoryImpl` | Builds Retrofit lazily per call from live DataStore URL; injects `ChapterDao` directly to break circular dep with `ChapterRepository` |
| `SyncScheduler` (domain interface) + `SyncSchedulerImpl` | Wraps WorkManager behind a domain interface so feature layer stays data-free |
| `SyncWorker` (HiltWorker) | Periodic 15-min + one-shot; skips when no URL configured; retries ≤3× |

### Settings screen
`Settings → Reader Sync` — server URL field, bearer token field (masked), Save, Sync Now, Test Connection, device ID display (read-only), pending queue size chip.

### Hook into reading
`ChapterRepositoryImpl.recordHistory()` calls `syncRepository.enqueueChapterRead()` after the DB upsert (best-effort, exception swallowed).

## Smoke test
1. Settings → Reader Sync → enter server URL + token → **Save**
2. Read a chapter → chip shows "1 item pending sync"
3. **Sync Now** → chip drops to 0; server receives the push
4. On second device, pull progress applies the read mark

## Architecture notes
- `SyncRepositoryImpl` injects `ChapterDao` (not `ChapterRepository`) to avoid a circular Hilt dependency — `ChapterRepositoryImpl` → `SyncRepository` → `ChapterRepository` would create a cycle
- Retrofit instance is built fresh per `drainQueue()`/`pullAndApply()` call because the base URL is runtime-configurable from DataStore
- Feature layer has zero data-layer imports; WorkManager access is gated behind `SyncScheduler` domain interface

## Deferred
- Per-manga conflict resolution UI
- Pull-on-launch flow (currently pull-on-worker-cycle only)
- Multi-device leaderboard / history view

Closes #958

_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reader progress sync with configurable server URL and bearer token
  * New Sync settings screen (server config, device ID, queue size, last sync status)
  * Manual "Sync Now" and "Test Connection" actions in settings
  * Automatic background sync (every 15 minutes) and one-shot enqueue
  * Local offline sync queue with retry and failure tracking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add reader progress sync with a new settings screen**

### What Changed
- Added a Reader Sync settings page where users can enter a self-hosted server URL and bearer token, save them, and trigger sync manually
- Reading progress is now saved locally first and synced in the background, so a sync server problem does not stop chapter reading
- The app now shows a stable device ID and a pending-items count so users can see whether sync is queued
- Added background sync handling that pushes read progress and pulls updates from other devices, keeping progress aligned across devices
- Added migration coverage and tests for the new sync queue and updated repository behavior

### Impact
`✅ Cross-device reading progress`
`✅ Fewer reading interruptions from sync failures`
`✅ Clearer sync status in settings` 
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
