### PR TITLE
feat(library): implement issue #989 — cover overlays, category tabs, …

### DIFF
--- a/core/ui/src/main/java/app/otakureader/core/ui/components/MangaCard.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/components/MangaCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -31,6 +32,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
@@ -52,6 +54,9 @@ import app.otakureader.core.ui.modifiers.bottomGradientScrim
  * @param isSelected Whether the card is in selected state (shows checkmark overlay)
  * @param readProgress 0f–1f fraction of chapters read; null hides the progress bar
  * @param onLongClick Optional long-click callback (enables multi-select)
+ * @param continueReading When true, shows a centered play button overlay on the cover
+ * @param isNew When true, shows a "NEW" badge in the top-left corner
+ * @param sourceIcon Optional composable for a small source favicon watermark (bottom-right corner)
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -66,6 +71,9 @@ fun MangaCard(
     isSelected: Boolean = false,
     readProgress: Float? = null,
     onLongClick: (() -> Unit)? = null,
+    continueReading: Boolean = false,
+    isNew: Boolean = false,
+    sourceIcon: @Composable (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
 
@@ -153,6 +161,60 @@ fun MangaCard(
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .padding(4.dp)
+                ) {
+                    it()
+                }
+            }
+
+            // NEW badge — distinct from unread count, shown in top-left when fresh
+            if (isNew) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(4.dp)
+                        .padding(start = if (statusBadge != null) 32.dp else 0.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.manga_card_new_badge),
+                        style = MaterialTheme.typography.labelSmall.copy(
+                            fontWeight = FontWeight.Bold
+                        ),
+                        color = Color.White,
+                        modifier = Modifier
+                            .background(
+                                color = MaterialTheme.colorScheme.tertiary,
+                                shape = RoundedCornerShape(4.dp)
+                            )
+                            .padding(horizontal = 4.dp, vertical = 2.dp)
+                    )
+                }
+            }
+
+            // Continue reading — centered play button overlay
+            if (continueReading) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(2f / 3f)
+                        .background(Color.Black.copy(alpha = 0.35f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.PlayArrow,
+                        contentDescription = stringResource(R.string.manga_card_continue_reading),
+                        tint = Color.White,
+                        modifier = Modifier.size(40.dp)
+                    )
+                }
+            }
+
+            // Source favicon watermark — bottom-right corner
+            sourceIcon?.let {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(4.dp)
+                        .padding(bottom = if (readProgress != null) 10.dp else 4.dp)
                 ) {
                     it()
                 }

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="core_ui_error_title">Something went wrong</string>
     <string name="manga_cover_content_description">Cover image for %1$s</string>
     <string name="manga_card_selected">Selected</string>
+    <string name="manga_card_new_badge">NEW</string>
+    <string name="manga_card_continue_reading">Continue reading</string>
 
     <!-- Empty State Titles -->
     <string name="empty_library_title">Your library is empty</string>

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.lazy.staggeredgrid.items as staggeredItems
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
@@ -51,7 +52,6 @@ import app.otakureader.core.ui.theme.LocalOtakuColors
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.offset
 
 /** Returns true when a manga item belongs to the manhwa/webtoon content type. */
 internal fun isManhwa(manga: LibraryMangaItem): Boolean {
@@ -108,6 +108,13 @@ internal fun MangaGrid(
         }
 
         CategoryFilterChips(
+            categories = state.categories,
+            selectedCategory = state.selectedCategory,
+            onCategorySelected = { onEvent(LibraryEvent.OnCategorySelected(it)) },
+            modifier = Modifier.padding(vertical = 8.dp)
+        )
+
+        CategoryTabRow(
             categories = state.categories,
             selectedCategory = state.selectedCategory,
             onCategorySelected = { onEvent(LibraryEvent.OnCategorySelected(it)) },
@@ -193,6 +200,7 @@ internal fun MangaGrid(
                                 .toFloat() / manga.totalChapterCount
                         } else null
                         val downloadCount = state.downloadCountByManga[manga.id] ?: 0
+                        val continueReading = manga.lastRead != null && manga.unreadCount > 0
                         MangaCard(
                             title = manga.title,
                             coverUrl = manga.thumbnailUrl,
@@ -203,6 +211,8 @@ internal fun MangaGrid(
                             onLongClick = { onEvent(LibraryEvent.OnMangaLongClick(manga.id)) },
                             isSelected = manga.id in state.selectedManga,
                             readProgress = readProgress,
+                            continueReading = continueReading,
+                            isNew = manga.unreadCount > 0,
                             badge = when {
                                 state.showBadges && manga.unreadCount > 0 && state.showDownloadBadge && downloadCount > 0 -> {
                                     {
@@ -270,6 +280,7 @@ internal fun MangaGrid(
                         .toFloat() / manga.totalChapterCount
                 } else null
                 val downloadCount = state.downloadCountByManga[manga.id] ?: 0
+                val continueReading = manga.lastRead != null && manga.unreadCount > 0
                 val cardContent: @Composable () -> Unit = {
                     MangaCard(
                         title = manga.title,
@@ -281,6 +292,8 @@ internal fun MangaGrid(
                         onLongClick = { onEvent(LibraryEvent.OnMangaLongClick(manga.id)) },
                         isSelected = manga.id in state.selectedManga,
                         readProgress = readProgress,
+                        continueReading = continueReading,
+                        isNew = manga.unreadCount > 0,
                         badge = when {
                             state.showBadges && manga.unreadCount > 0 && state.showDownloadBadge && downloadCount > 0 -> {
                                 {
@@ -320,6 +333,48 @@ internal fun MangaGrid(
                     cardContent()
                 }
             }
+        }
+    }
+}
+
+@Composable
+internal fun CategoryTabRow(
+    categories: List<CategoryItem>,
+    selectedCategory: Long?,
+    onCategorySelected: (Long?) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val totalCount = categories.sumOf { it.count }
+    val categoryTabs = listOf(
+        CategoryItem(id = -1, name = stringResource(R.string.library_category_all), count = totalCount)
+    ) + categories
+
+    val selectedIndex = when (selectedCategory) {
+        null -> 0
+        else -> categoryTabs.indexOfFirst { it.id == selectedCategory }.coerceAtLeast(0)
+    }
+
+    ScrollableTabRow(
+        selectedTabIndex = selectedIndex,
+        containerColor = Color.Transparent,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        edgePadding = 16.dp,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        categoryTabs.forEachIndexed { index, category ->
+            Tab(
+                selected = selectedIndex == index,
+                onClick = {
+                    if (category.id == -1L) onCategorySelected(null)
+                    else onCategorySelected(category.id)
+                },
+                text = {
+                    Text(
+                        text = "${category.name} ${category.count}",
+                        style = MaterialTheme.typography.labelLarge
+                    )
+                }
+            )
         }
     }
 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -111,6 +111,13 @@ sealed class LibraryEvent {
     data class SetFilterMode(val mode: LibraryFilterMode) : LibraryEvent()
     data class SetFilterSource(val sourceId: Long?) : LibraryEvent()
     data class ToggleNsfw(val show: Boolean) : LibraryEvent()
+    // New overflow menu events
+    data object UpdateLibrary : LibraryEvent()
+    data object UpdateCategory : LibraryEvent()
+    data object OpenRandomEntry : LibraryEvent()
+    data object ReindexDownloads : LibraryEvent()
+    data object SyncEhFavorites : LibraryEvent()
+    data object SyncLibrary : LibraryEvent()
     // Bulk selection actions
     data object MarkSelectedAsRead : LibraryEvent()
     data object MarkSelectedAsUnread : LibraryEvent()

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -188,7 +188,7 @@ fun LibraryScreen(
                     }
                 )
                 else -> TopAppBar(
-                    title = { Text(stringResource(R.string.library_title)) },
+                    title = { Text(stringResource(R.string.library_title_with_count, state.mangaList.size)) },
                     actions = {
                         IconButton(onClick = { viewModel.onEvent(LibraryEvent.ToggleIncognito) }) {
                             Icon(
@@ -214,6 +214,31 @@ fun LibraryScreen(
                             Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.library_more))
                         }
                         DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.library_update_library)) },
+                                onClick = { showMenu = false; viewModel.onEvent(LibraryEvent.UpdateLibrary) }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.library_update_category)) },
+                                onClick = { showMenu = false; viewModel.onEvent(LibraryEvent.UpdateCategory) },
+                                enabled = state.selectedCategory != null
+                            )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.library_open_random)) },
+                                onClick = { showMenu = false; viewModel.onEvent(LibraryEvent.OpenRandomEntry) }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.library_reindex_downloads)) },
+                                onClick = { showMenu = false; viewModel.onEvent(LibraryEvent.ReindexDownloads) }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.library_sync_eh_favorites)) },
+                                onClick = { showMenu = false; viewModel.onEvent(LibraryEvent.SyncEhFavorites) }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.library_sync_library)) },
+                                onClick = { showMenu = false; viewModel.onEvent(LibraryEvent.SyncLibrary) }
+                            )
                             DropdownMenuItem(
                                 text = { Text(stringResource(R.string.library_downloads)) },
                                 onClick = { showMenu = false; onNavigateToDownloads() }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -115,6 +115,10 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.MarkSelectedAsUnread, is LibraryEvent.RemoveSelectedFromLibrary,
             is LibraryEvent.DownloadSelected, is LibraryEvent.MarkSelectedAsCompleted,
             is LibraryEvent.MarkSelectedAsDropped -> handleActionEvent(event)
+            // New overflow menu events — wired as no-ops/TODOs for now
+            is LibraryEvent.UpdateLibrary, is LibraryEvent.UpdateCategory,
+            is LibraryEvent.OpenRandomEntry, is LibraryEvent.ReindexDownloads,
+            is LibraryEvent.SyncEhFavorites, is LibraryEvent.SyncLibrary -> handleNewEvent(event)
         }
     }
 
@@ -171,6 +175,41 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.DownloadSelected -> downloadSelected()
             is LibraryEvent.MarkSelectedAsCompleted -> markSelectedAsCompleted()
             is LibraryEvent.MarkSelectedAsDropped -> markSelectedAsDropped()
+            else -> Unit
+        }
+    }
+
+    /** Temporary handler for new overflow menu events (#989). These are no-ops until the domain logic is implemented. */
+    private fun handleNewEvent(event: LibraryEvent) {
+        when (event) {
+            is LibraryEvent.UpdateLibrary -> {
+                // TODO: Trigger full library update (background refresh from all sources)
+                android.util.Log.d("LibraryViewModel", "UpdateLibrary requested — not yet implemented")
+            }
+            is LibraryEvent.UpdateCategory -> {
+                // TODO: Trigger update for the currently selected category only
+                android.util.Log.d("LibraryViewModel", "UpdateCategory requested — not yet implemented")
+            }
+            is LibraryEvent.OpenRandomEntry -> {
+                // TODO: Open a random manga from the current filtered list
+                val currentList = _state.value.mangaList
+                if (currentList.isNotEmpty()) {
+                    val random = currentList.random()
+                    viewModelScope.launch { _effect.send(LibraryEffect.NavigateToManga(random.id)) }
+                }
+            }
+            is LibraryEvent.ReindexDownloads -> {
+                // TODO: Rebuild the download index / verify downloaded files
+                android.util.Log.d("LibraryViewModel", "ReindexDownloads requested — not yet implemented")
+            }
+            is LibraryEvent.SyncEhFavorites -> {
+                // TODO: Sync E-Hentai favorites list
+                android.util.Log.d("LibraryViewModel", "SyncEhFavorites requested — not yet implemented")
+            }
+            is LibraryEvent.SyncLibrary -> {
+                // TODO: Sync library with remote account (e.g., AniList, MAL, Kitsu)
+                android.util.Log.d("LibraryViewModel", "SyncLibrary requested — not yet implemented")
+            }
             else -> Unit
         }
     }

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="library_manage_categories">Manage categories</string>
     <string name="library_selected_count">%1$d selected</string>
     <string name="library_title">Library</string>
+    <string name="library_title_with_count">Library %1$d</string>
     <string name="library_more">More</string>
     <string name="library_downloads">Downloads</string>
     <string name="library_settings">Settings</string>
@@ -148,6 +149,12 @@
     <string name="browse_scope_sources">Sources</string>
     <string name="browse_search_history">Recent searches</string>
     <string name="browse_search_history_empty">No recent searches</string>
+    <string name="library_update_library">Update library</string>
+    <string name="library_update_category">Update category</string>
+    <string name="library_open_random">Open random entry</string>
+    <string name="library_reindex_downloads">Reindex downloads</string>
+    <string name="library_sync_eh_favorites">Sync EH favorites</string>
+    <string name="library_sync_library">Sync library</string>
     <!-- Reading Lists (#945) -->
     <string name="reading_lists_title">Reading Lists</string>
     <string name="reading_lists_back">Back</string>


### PR DESCRIPTION
## **User description**
…overflow menu

- MangaCard: add continueReading (play overlay), isNew (NEW badge), sourceIcon watermark
- LibraryMangaGrid: pass overlay flags; add CategoryTabRow with counts (All + categories)
- LibraryScreen: header shows total count ("Library 448"); add 6 overflow menu actions
- LibraryMvi: add UpdateLibrary, UpdateCategory, OpenRandomEntry, ReindexDownloads, SyncEhFavorites, SyncLibrary events
- LibraryViewModel: wire new events as no-ops/TODOs (OpenRandomEntry partially implemented)
- strings: add all new UI text resources

## 📋 Description
Brief description of changes.

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation
- [ ] 🎨 UI/UX
- [ ] ♻️ Refactoring
- [ ] 🚀 Performance
- [ ] 🧪 Tests

## 🧪 Testing
How has this been tested?

## 📸 Screenshots
If UI changes, add screenshots.

## ✅ Checklist
- [ ] Code follows style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated
- [ ] No new warnings
- [ ] Tests pass

## 🔗 Related Issues
Fixes #(issue number)


___

## **CodeAnt-AI Description**
**Show library counts, card status overlays, and new library actions**

### What Changed
- The library header now shows the total number of items, so users can see their library size at a glance.
- Manga cards now show a clear “NEW” badge, a play-style “continue reading” overlay, and a source icon watermark when those states apply.
- Library browsing now includes category tabs with item counts, including an “All” tab for quickly returning to the full list.
- The overflow menu now includes actions for updating the library, updating the current category, opening a random entry, reindexing downloads, syncing EH favorites, and syncing the library.

### Impact
`✅ Faster library browsing`
`✅ Clearer unread and continue-reading status`
`✅ Quicker access to library maintenance actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "NEW" badge indicator to manga cards for recently added titles
  * Added continue reading overlay on manga cards for quick access
  * Added source icon watermark display on manga cards
  * Replaced category filters with scrollable tab navigation for improved browsing
  * Added library management actions: update library, update category, open random entry, reindex downloads, and sync options
  * Library title now displays total manga count

<!-- end of auto-generated comment: release notes by coderabbit.ai -->