### PR TITLE
feat: page bookmark management screen (#935)

### DIFF
--- a/domain/src/test/java/app/otakureader/domain/model/PrefetchStrategyTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/model/PrefetchStrategyTest.kt
@@ -1,0 +1,380 @@
+package app.otakureader.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PrefetchStrategyTest {
+
+    private val defaultBehavior = ReadingBehavior.DEFAULT
+    private val predictable = ReadingBehavior(
+        forwardNavigationRatio = 0.95f,
+        sequentialNavigationRatio = 0.9f,
+        sampleSize = 100,
+        completionRate = 0.9f
+    )
+    private val backwardProne = ReadingBehavior(
+        forwardNavigationRatio = 0.7f,
+        sequentialNavigationRatio = 0.9f,
+        sampleSize = 100,
+        completionRate = 0.9f
+    )
+    private val fastReader = ReadingBehavior(
+        forwardNavigationRatio = 0.95f,
+        averagePageDurationMs = 1500L,
+        sequentialNavigationRatio = 0.95f,
+        sampleSize = 100,
+        completionRate = 0.9f
+    )
+    private val slowReader = ReadingBehavior(
+        forwardNavigationRatio = 0.92f,
+        averagePageDurationMs = 10000L,
+        sequentialNavigationRatio = 0.85f,
+        sampleSize = 100,
+        completionRate = 0.9f
+    )
+    private val normalReader = ReadingBehavior(
+        forwardNavigationRatio = 0.92f,
+        averagePageDurationMs = 5000L,
+        sequentialNavigationRatio = 0.9f,
+        sampleSize = 100,
+        completionRate = 0.9f
+    )
+    private val lowCompletion = ReadingBehavior(
+        forwardNavigationRatio = 0.9f,
+        sequentialNavigationRatio = 0.9f,
+        sampleSize = 100,
+        completionRate = 0.3f
+    )
+
+    // ── Conservative ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `Conservative pagesBefore always returns zero`() {
+        assertEquals(0, PrefetchStrategy.Conservative.pagesBefore(5, 20, defaultBehavior))
+        assertEquals(0, PrefetchStrategy.Conservative.pagesBefore(0, 10, predictable))
+        assertEquals(0, PrefetchStrategy.Conservative.pagesBefore(9, 10, defaultBehavior))
+    }
+
+    @Test
+    fun `Conservative pagesAfter returns 2 when not near end`() {
+        assertEquals(2, PrefetchStrategy.Conservative.pagesAfter(0, 10, defaultBehavior))
+        assertEquals(2, PrefetchStrategy.Conservative.pagesAfter(5, 10, defaultBehavior))
+        assertEquals(2, PrefetchStrategy.Conservative.pagesAfter(7, 10, defaultBehavior))
+    }
+
+    @Test
+    fun `Conservative pagesAfter returns 1 at last two pages`() {
+        assertEquals(1, PrefetchStrategy.Conservative.pagesAfter(8, 10, defaultBehavior))
+        assertEquals(1, PrefetchStrategy.Conservative.pagesAfter(9, 10, defaultBehavior))
+    }
+
+    @Test
+    fun `Conservative never prefetches adjacent chapters`() {
+        assertFalse(PrefetchStrategy.Conservative.shouldPrefetchNextChapter(9, 10, defaultBehavior))
+        assertFalse(PrefetchStrategy.Conservative.shouldPrefetchNextChapter(0, 10, defaultBehavior))
+        assertFalse(PrefetchStrategy.Conservative.shouldPrefetchPreviousChapter(0, defaultBehavior))
+        assertFalse(PrefetchStrategy.Conservative.shouldPrefetchPreviousChapter(1, defaultBehavior))
+    }
+
+    // ── Balanced ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Balanced pagesBefore always returns 1`() {
+        assertEquals(1, PrefetchStrategy.Balanced.pagesBefore(0, 20, defaultBehavior))
+        assertEquals(1, PrefetchStrategy.Balanced.pagesBefore(10, 20, predictable))
+        assertEquals(1, PrefetchStrategy.Balanced.pagesBefore(19, 20, backwardProne))
+    }
+
+    @Test
+    fun `Balanced pagesAfter always returns 3`() {
+        assertEquals(3, PrefetchStrategy.Balanced.pagesAfter(0, 20, defaultBehavior))
+        assertEquals(3, PrefetchStrategy.Balanced.pagesAfter(10, 20, fastReader))
+        assertEquals(3, PrefetchStrategy.Balanced.pagesAfter(19, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Balanced shouldPrefetchNextChapter true on last 3 pages`() {
+        assertTrue(PrefetchStrategy.Balanced.shouldPrefetchNextChapter(17, 20, defaultBehavior))
+        assertTrue(PrefetchStrategy.Balanced.shouldPrefetchNextChapter(18, 20, defaultBehavior))
+        assertTrue(PrefetchStrategy.Balanced.shouldPrefetchNextChapter(19, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Balanced shouldPrefetchNextChapter false before last 3 pages`() {
+        assertFalse(PrefetchStrategy.Balanced.shouldPrefetchNextChapter(16, 20, defaultBehavior))
+        assertFalse(PrefetchStrategy.Balanced.shouldPrefetchNextChapter(0, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Balanced never prefetches previous chapter`() {
+        assertFalse(PrefetchStrategy.Balanced.shouldPrefetchPreviousChapter(0, defaultBehavior))
+        assertFalse(PrefetchStrategy.Balanced.shouldPrefetchPreviousChapter(0, backwardProne))
+    }
+
+    // ── Aggressive ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Aggressive pagesBefore returns 3 for backward-prone readers`() {
+        assertEquals(3, PrefetchStrategy.Aggressive.pagesBefore(5, 20, backwardProne))
+    }
+
+    @Test
+    fun `Aggressive pagesBefore returns 2 for mostly-forward readers`() {
+        assertEquals(2, PrefetchStrategy.Aggressive.pagesBefore(5, 20, predictable))
+    }
+
+    @Test
+    fun `Aggressive pagesAfter returns 10 near chapter end`() {
+        assertEquals(10, PrefetchStrategy.Aggressive.pagesAfter(15, 20, defaultBehavior))
+        assertEquals(10, PrefetchStrategy.Aggressive.pagesAfter(16, 20, defaultBehavior))
+        assertEquals(10, PrefetchStrategy.Aggressive.pagesAfter(19, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Aggressive pagesAfter returns 7 elsewhere`() {
+        assertEquals(7, PrefetchStrategy.Aggressive.pagesAfter(0, 20, defaultBehavior))
+        assertEquals(7, PrefetchStrategy.Aggressive.pagesAfter(10, 20, defaultBehavior))
+        assertEquals(7, PrefetchStrategy.Aggressive.pagesAfter(14, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Aggressive shouldPrefetchNextChapter true on last 5 pages`() {
+        assertTrue(PrefetchStrategy.Aggressive.shouldPrefetchNextChapter(15, 20, defaultBehavior))
+        assertTrue(PrefetchStrategy.Aggressive.shouldPrefetchNextChapter(19, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Aggressive shouldPrefetchNextChapter false before last 5 pages`() {
+        assertFalse(PrefetchStrategy.Aggressive.shouldPrefetchNextChapter(14, 20, defaultBehavior))
+        assertFalse(PrefetchStrategy.Aggressive.shouldPrefetchNextChapter(0, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Aggressive shouldPrefetchPreviousChapter when at start and backward prone`() {
+        assertTrue(PrefetchStrategy.Aggressive.shouldPrefetchPreviousChapter(0, backwardProne))
+        assertTrue(PrefetchStrategy.Aggressive.shouldPrefetchPreviousChapter(2, backwardProne))
+    }
+
+    @Test
+    fun `Aggressive shouldPrefetchPreviousChapter false for forward readers`() {
+        assertFalse(PrefetchStrategy.Aggressive.shouldPrefetchPreviousChapter(0, predictable))
+    }
+
+    @Test
+    fun `Aggressive shouldPrefetchPreviousChapter false past page 2`() {
+        assertFalse(PrefetchStrategy.Aggressive.shouldPrefetchPreviousChapter(3, backwardProne))
+    }
+
+    // ── Adaptive ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Adaptive pagesBefore returns 1 for unpredictable readers`() {
+        assertEquals(1, PrefetchStrategy.Adaptive.pagesBefore(5, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Adaptive pagesBefore returns 2 for backward-prone predictable readers`() {
+        assertEquals(2, PrefetchStrategy.Adaptive.pagesBefore(5, 20, backwardProne))
+    }
+
+    @Test
+    fun `Adaptive pagesBefore returns 1 for forward predictable readers`() {
+        assertEquals(1, PrefetchStrategy.Adaptive.pagesBefore(5, 20, predictable))
+    }
+
+    @Test
+    fun `Adaptive pagesAfter returns 3 for unpredictable readers`() {
+        assertEquals(3, PrefetchStrategy.Adaptive.pagesAfter(5, 20, defaultBehavior))
+    }
+
+    @Test
+    fun `Adaptive pagesAfter returns 6 for fast reader not near end`() {
+        assertEquals(6, PrefetchStrategy.Adaptive.pagesAfter(5, 20, fastReader))
+    }
+
+    @Test
+    fun `Adaptive pagesAfter returns 8 for fast reader near end`() {
+        assertEquals(8, PrefetchStrategy.Adaptive.pagesAfter(17, 20, fastReader))
+    }
+
+    @Test
+    fun `Adaptive pagesAfter returns 2 for slow reader not near end`() {
+        assertEquals(2, PrefetchStrategy.Adaptive.pagesAfter(5, 20, slowReader))
+    }
+
+    @Test
+    fun `Adaptive pagesAfter returns 4 for slow reader near end`() {
+        assertEquals(4, PrefetchStrategy.Adaptive.pagesAfter(17, 20, slowReader))
+    }
+
+    @Test
+    fun `Adaptive pagesAfter returns 3 for normal speed not near end`() {
+        assertEquals(3, PrefetchStrategy.Adaptive.pagesAfter(5, 20, normalReader))
+    }
+
+    @Test
+    fun `Adaptive pagesAfter returns 5 for normal speed near end`() {
+        assertEquals(5, PrefetchStrategy.Adaptive.pagesAfter(17, 20, normalReader))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchNextChapter false when unlikely to complete`() {
+        assertFalse(PrefetchStrategy.Adaptive.shouldPrefetchNextChapter(17, 20, lowCompletion))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchNextChapter for unpredictable reader near end`() {
+        val unpredictableCompleter = ReadingBehavior(completionRate = 0.9f, sampleSize = 0)
+        assertTrue(PrefetchStrategy.Adaptive.shouldPrefetchNextChapter(17, 20, unpredictableCompleter))
+        assertFalse(PrefetchStrategy.Adaptive.shouldPrefetchNextChapter(16, 20, unpredictableCompleter))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchNextChapter fast reader triggers at last 5 pages`() {
+        assertTrue(PrefetchStrategy.Adaptive.shouldPrefetchNextChapter(15, 20, fastReader))
+        assertFalse(PrefetchStrategy.Adaptive.shouldPrefetchNextChapter(14, 20, fastReader))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchNextChapter normal speed triggers at last 3 pages`() {
+        assertTrue(PrefetchStrategy.Adaptive.shouldPrefetchNextChapter(17, 20, normalReader))
+        assertFalse(PrefetchStrategy.Adaptive.shouldPrefetchNextChapter(16, 20, normalReader))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchPreviousChapter when at start backward prone and predictable`() {
+        assertTrue(PrefetchStrategy.Adaptive.shouldPrefetchPreviousChapter(0, backwardProne))
+        assertTrue(PrefetchStrategy.Adaptive.shouldPrefetchPreviousChapter(2, backwardProne))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchPreviousChapter false for unpredictable reader`() {
+        assertFalse(PrefetchStrategy.Adaptive.shouldPrefetchPreviousChapter(0, defaultBehavior))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchPreviousChapter false past page 2`() {
+        assertFalse(PrefetchStrategy.Adaptive.shouldPrefetchPreviousChapter(3, backwardProne))
+    }
+
+    @Test
+    fun `Adaptive shouldPrefetchPreviousChapter false for forward predictable reader`() {
+        assertFalse(PrefetchStrategy.Adaptive.shouldPrefetchPreviousChapter(0, predictable))
+    }
+
+    // ── Companion: fromOrdinal / toOrdinal ────────────────────────────────────
+
+    @Test
+    fun `fromOrdinal maps to correct strategy`() {
+        assertEquals(PrefetchStrategy.Conservative, PrefetchStrategy.fromOrdinal(0))
+        assertEquals(PrefetchStrategy.Balanced, PrefetchStrategy.fromOrdinal(1))
+        assertEquals(PrefetchStrategy.Aggressive, PrefetchStrategy.fromOrdinal(2))
+        assertEquals(PrefetchStrategy.Adaptive, PrefetchStrategy.fromOrdinal(3))
+    }
+
+    @Test
+    fun `fromOrdinal out of bounds defaults to Balanced`() {
+        assertEquals(PrefetchStrategy.Balanced, PrefetchStrategy.fromOrdinal(-1))
+        assertEquals(PrefetchStrategy.Balanced, PrefetchStrategy.fromOrdinal(99))
+    }
+
+    @Test
+    fun `toOrdinal maps each strategy to correct index`() {
+        assertEquals(0, PrefetchStrategy.toOrdinal(PrefetchStrategy.Conservative))
+        assertEquals(1, PrefetchStrategy.toOrdinal(PrefetchStrategy.Balanced))
+        assertEquals(2, PrefetchStrategy.toOrdinal(PrefetchStrategy.Aggressive))
+        assertEquals(3, PrefetchStrategy.toOrdinal(PrefetchStrategy.Adaptive))
+    }
+
+    @Test
+    fun `fromOrdinal and toOrdinal are inverses`() {
+        listOf(
+            PrefetchStrategy.Conservative,
+            PrefetchStrategy.Balanced,
+            PrefetchStrategy.Aggressive,
+            PrefetchStrategy.Adaptive
+        ).forEach { strategy ->
+            assertEquals(strategy, PrefetchStrategy.fromOrdinal(PrefetchStrategy.toOrdinal(strategy)))
+        }
+    }
+
+    // ── ReadingBehavior computed properties ────────────────────────────────────
+
+    @Test
+    fun `ReadingBehavior DEFAULT is unpredictable due to zero sample size`() {
+        assertTrue(ReadingBehavior.DEFAULT.isUnpredictable)
+    }
+
+    @Test
+    fun `ReadingBehavior isPrimaryForwardReader when high ratios`() {
+        assertTrue(predictable.isPrimaryForwardReader)
+        assertFalse(backwardProne.isPrimaryForwardReader)
+    }
+
+    @Test
+    fun `ReadingBehavior likelyToCompleteChapter when completion rate meets threshold`() {
+        assertTrue(predictable.likelyToCompleteChapter)
+        assertFalse(lowCompletion.likelyToCompleteChapter)
+    }
+
+    @Test
+    fun `ReadingBehavior isUnpredictable when sequential ratio too low`() {
+        val chaotic = ReadingBehavior(sequentialNavigationRatio = 0.5f, sampleSize = 100)
+        assertTrue(chaotic.isUnpredictable)
+    }
+
+    @Test
+    fun `ReadingBehavior isUnpredictable false when sufficient sample and sequential ratio`() {
+        assertFalse(predictable.isUnpredictable)
+        assertFalse(normalReader.isUnpredictable)
+    }
+
+    // ── PageNavigationEvent properties ────────────────────────────────────────
+
+    @Test
+    fun `PageNavigationEvent isForward true when toPage greater than fromPage`() {
+        val event = PageNavigationEvent(
+            mangaId = 1L, chapterId = 2L, fromPage = 3, toPage = 4,
+            pageDurationMs = 2000L, readerMode = 0
+        )
+        assertTrue(event.isForward)
+    }
+
+    @Test
+    fun `PageNavigationEvent isForward false when going backward`() {
+        val event = PageNavigationEvent(
+            mangaId = 1L, chapterId = 2L, fromPage = 5, toPage = 3,
+            pageDurationMs = 1000L, readerMode = 0
+        )
+        assertFalse(event.isForward)
+    }
+
+    @Test
+    fun `PageNavigationEvent isSequential true for adjacent page in single mode`() {
+        val event = PageNavigationEvent(
+            mangaId = 1L, chapterId = 2L, fromPage = 3, toPage = 4,
+            pageDurationMs = 3000L, readerMode = 0
+        )
+        assertTrue(event.isSequential)
+    }
+
+    @Test
+    fun `PageNavigationEvent isSequential true for 2-page jump in dual mode`() {
+        val event = PageNavigationEvent(
+            mangaId = 1L, chapterId = 2L, fromPage = 2, toPage = 4,
+            pageDurationMs = 3000L, readerMode = 1
+        )
+        assertTrue(event.isSequential)
+    }
+
+    @Test
+    fun `PageNavigationEvent isSequential false for non-adjacent jump`() {
+        val event = PageNavigationEvent(
+            mangaId = 1L, chapterId = 2L, fromPage = 1, toPage = 10,
+            pageDurationMs = 500L, readerMode = 0
+        )
+        assertFalse(event.isSequential)
+    }
+}

--- a/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksMvi.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksMvi.kt
@@ -1,0 +1,102 @@
+package app.otakureader.feature.more.bookmarks
+
+import app.otakureader.core.common.mvi.UiEffect
+import app.otakureader.core.common.mvi.UiEvent
+import app.otakureader.core.common.mvi.UiState
+
+// ─── Domain display model ─────────────────────────────────────────────────────
+
+/** A single page bookmark enriched with display data for the Bookmarks screen. */
+data class BookmarkItem(
+    val id: Long,
+    val mangaId: Long,
+    val chapterId: Long,
+    val pageIndex: Int,
+    val note: String?,
+    val mangaTitle: String,
+    val chapterName: String,
+    /** Cover URL from the parent manga — used for the thumbnail in the list row. */
+    val mangaCoverUrl: String?,
+)
+
+/** Per-manga group shown in the list: header + expandable chapter sub-groups. */
+data class BookmarkGroup(
+    val mangaTitle: String,
+    val mangaId: Long,
+    val mangaCoverUrl: String?,
+    val isExpanded: Boolean = true,
+    val chapters: List<ChapterGroup>,
+)
+
+/** Sub-group of bookmarks belonging to a single chapter within a manga group. */
+data class ChapterGroup(
+    val chapterId: Long,
+    val chapterName: String,
+    val bookmarks: List<BookmarkItem>,
+)
+
+// ─── State ────────────────────────────────────────────────────────────────────
+
+data class BookmarksState(
+    val isLoading: Boolean = true,
+    val bookmarks: List<BookmarkItem> = emptyList(),
+    val searchQuery: String = "",
+    /** Set of mangaIds whose groups are currently collapsed. Default: all expanded. */
+    val collapsedManga: Set<Long> = emptySet(),
+    val error: String? = null,
+) : UiState {
+
+    /** Flat list filtered by [searchQuery]. */
+    val filteredBookmarks: List<BookmarkItem>
+        get() = if (searchQuery.isBlank()) bookmarks
+        else bookmarks.filter { bm ->
+            bm.mangaTitle.contains(searchQuery, ignoreCase = true) ||
+                bm.chapterName.contains(searchQuery, ignoreCase = true) ||
+                bm.note?.contains(searchQuery, ignoreCase = true) == true
+        }
+
+    /** Grouped structure consumed by the list UI. */
+    val grouped: List<BookmarkGroup>
+        get() = filteredBookmarks
+            .groupBy { it.mangaId }
+            .map { (mangaId, items) ->
+                val first = items.first()
+                val chapters = items
+                    .groupBy { it.chapterId }
+                    .map { (chapterId, chItems) ->
+                        ChapterGroup(
+                            chapterId = chapterId,
+                            chapterName = chItems.first().chapterName,
+                            bookmarks = chItems.sortedBy { it.pageIndex },
+                        )
+                    }
+                    .sortedBy { it.chapterName }
+                BookmarkGroup(
+                    mangaTitle = first.mangaTitle,
+                    mangaId = mangaId,
+                    mangaCoverUrl = first.mangaCoverUrl,
+                    isExpanded = mangaId !in collapsedManga,
+                    chapters = chapters,
+                )
+            }
+            .sortedBy { it.mangaTitle }
+
+    val isEmpty: Boolean get() = !isLoading && filteredBookmarks.isEmpty()
+    val hasBookmarks: Boolean get() = !isLoading && bookmarks.isNotEmpty()
+}
+
+// ─── Intent ───────────────────────────────────────────────────────────────────
+
+sealed interface BookmarksIntent : UiEvent {
+    data class SearchQueryChanged(val query: String) : BookmarksIntent
+    data class ToggleMangaExpanded(val mangaId: Long) : BookmarksIntent
+    data class DeleteBookmark(val item: BookmarkItem) : BookmarksIntent
+    data class OpenBookmark(val mangaId: Long, val chapterId: Long) : BookmarksIntent
+}
+
+// ─── Effect ───────────────────────────────────────────────────────────────────
+
+sealed interface BookmarksEffect : UiEffect {
+    data class NavigateToReader(val mangaId: Long, val chapterId: Long) : BookmarksEffect
+    data class ShowSnackbar(val message: String) : BookmarksEffect
+}

--- a/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksMvi.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksMvi.kt
@@ -46,43 +46,41 @@ data class BookmarksState(
     val error: String? = null,
 ) : UiState {
 
-    /** Flat list filtered by [searchQuery]. */
-    val filteredBookmarks: List<BookmarkItem>
-        get() = if (searchQuery.isBlank()) bookmarks
-        else bookmarks.filter { bm ->
-            bm.mangaTitle.contains(searchQuery, ignoreCase = true) ||
-                bm.chapterName.contains(searchQuery, ignoreCase = true) ||
-                bm.note?.contains(searchQuery, ignoreCase = true) == true
+    /** Flat list filtered by [searchQuery]. Computed once at construction time. */
+    val filteredBookmarks: List<BookmarkItem> = if (searchQuery.isBlank()) bookmarks
+    else bookmarks.filter { bm ->
+        bm.mangaTitle.contains(searchQuery, ignoreCase = true) ||
+            bm.chapterName.contains(searchQuery, ignoreCase = true) ||
+            bm.note?.contains(searchQuery, ignoreCase = true) == true
+    }
+
+    /** Grouped structure consumed by the list UI. Computed once at construction time. */
+    val grouped: List<BookmarkGroup> = filteredBookmarks
+        .groupBy { it.mangaId }
+        .map { (mangaId, items) ->
+            val first = items.first()
+            val chapters = items
+                .groupBy { it.chapterId }
+                .map { (chapterId, chItems) ->
+                    ChapterGroup(
+                        chapterId = chapterId,
+                        chapterName = chItems.first().chapterName,
+                        bookmarks = chItems.sortedBy { it.pageIndex },
+                    )
+                }
+                .sortedBy { it.chapterName }
+            BookmarkGroup(
+                mangaTitle = first.mangaTitle,
+                mangaId = mangaId,
+                mangaCoverUrl = first.mangaCoverUrl,
+                isExpanded = mangaId !in collapsedManga,
+                chapters = chapters,
+            )
         }
+        .sortedBy { it.mangaTitle }
 
-    /** Grouped structure consumed by the list UI. */
-    val grouped: List<BookmarkGroup>
-        get() = filteredBookmarks
-            .groupBy { it.mangaId }
-            .map { (mangaId, items) ->
-                val first = items.first()
-                val chapters = items
-                    .groupBy { it.chapterId }
-                    .map { (chapterId, chItems) ->
-                        ChapterGroup(
-                            chapterId = chapterId,
-                            chapterName = chItems.first().chapterName,
-                            bookmarks = chItems.sortedBy { it.pageIndex },
-                        )
-                    }
-                    .sortedBy { it.chapterName }
-                BookmarkGroup(
-                    mangaTitle = first.mangaTitle,
-                    mangaId = mangaId,
-                    mangaCoverUrl = first.mangaCoverUrl,
-                    isExpanded = mangaId !in collapsedManga,
-                    chapters = chapters,
-                )
-            }
-            .sortedBy { it.mangaTitle }
-
-    val isEmpty: Boolean get() = !isLoading && filteredBookmarks.isEmpty()
-    val hasBookmarks: Boolean get() = !isLoading && bookmarks.isNotEmpty()
+    val isEmpty: Boolean = !isLoading && filteredBookmarks.isEmpty()
+    val hasBookmarks: Boolean = !isLoading && bookmarks.isNotEmpty()
 }
 
 // ─── Intent ───────────────────────────────────────────────────────────────────

--- a/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksScreen.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksScreen.kt
@@ -1,29 +1,51 @@
 package app.otakureader.feature.more.bookmarks
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -31,10 +53,15 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import app.otakureader.core.navigation.Route
 import app.otakureader.feature.more.R
+import coil3.compose.AsyncImage
+import kotlinx.coroutines.flow.collectLatest
 
 /**
- * Centralized list of every page bookmark in the library, grouped by manga. Tapping a bookmark
- * opens that chapter in the reader; each row can be deleted.
+ * Centralized list of every page bookmark in the library.
+ *
+ * Bookmarks are grouped by manga then by chapter. Each manga group can be expanded or
+ * collapsed by tapping the header. A search bar filters the list by manga title, chapter
+ * name, or note. Individual rows can be deleted with the delete button or by swiping left.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -45,6 +72,18 @@ fun BookmarksScreen(
     viewModel: BookmarksViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(Unit) {
+        viewModel.effect.collectLatest { effect ->
+            when (effect) {
+                is BookmarksEffect.NavigateToReader ->
+                    onOpenBookmark(effect.mangaId, effect.chapterId)
+                is BookmarksEffect.ShowSnackbar ->
+                    snackbarHostState.showSnackbar(effect.message)
+            }
+        }
+    }
 
     Scaffold(
         modifier = modifier,
@@ -61,78 +100,311 @@ fun BookmarksScreen(
                 },
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { padding ->
-        when {
-            state.isLoading -> Box(
-                modifier = Modifier.fillMaxSize().padding(padding),
-                contentAlignment = Alignment.Center,
-            ) { CircularProgressIndicator() }
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            // Search bar — filters by manga title, chapter name, or note text.
+            OutlinedTextField(
+                value = state.searchQuery,
+                onValueChange = { viewModel.onIntent(BookmarksIntent.SearchQueryChanged(it)) },
+                placeholder = { Text(stringResource(R.string.bookmarks_search_placeholder)) },
+                singleLine = true,
+                leadingIcon = {
+                    Icon(Icons.Default.Bookmark, contentDescription = null)
+                },
+                trailingIcon = {
+                    if (state.searchQuery.isNotEmpty()) {
+                        IconButton(
+                            onClick = {
+                                viewModel.onIntent(BookmarksIntent.SearchQueryChanged(""))
+                            },
+                        ) {
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = stringResource(R.string.bookmarks_clear_search),
+                            )
+                        }
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+            )
 
-            state.isEmpty -> Box(
-                modifier = Modifier.fillMaxSize().padding(padding),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = stringResource(R.string.bookmarks_empty),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+            when {
+                state.isLoading -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) { CircularProgressIndicator() }
+
+                state.isEmpty -> EmptyBookmarksState(
+                    hasQuery = state.searchQuery.isNotEmpty(),
                 )
-            }
 
-            else -> LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
-                state.grouped.forEach { (mangaTitle, mangaBookmarks) ->
-                    item(key = "header_$mangaTitle") {
-                        Text(
-                            text = mangaTitle,
-                            style = MaterialTheme.typography.titleSmall,
-                            color = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                        )
-                    }
-                    items(mangaBookmarks, key = { it.id }) { bookmark ->
-                        BookmarkRow(
-                            bookmark = bookmark,
-                            onOpen = { onOpenBookmark(bookmark.mangaId, bookmark.chapterId) },
-                            onDelete = { viewModel.deleteBookmark(bookmark) },
-                        )
-                    }
-                }
+                else -> BookmarkGroupedList(
+                    groups = state.grouped,
+                    onToggleExpand = { mangaId ->
+                        viewModel.onIntent(BookmarksIntent.ToggleMangaExpanded(mangaId))
+                    },
+                    onOpenBookmark = { mangaId, chapterId ->
+                        viewModel.onIntent(BookmarksIntent.OpenBookmark(mangaId, chapterId))
+                    },
+                    onDeleteBookmark = { item ->
+                        viewModel.onIntent(BookmarksIntent.DeleteBookmark(item))
+                    },
+                )
             }
         }
     }
 }
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun EmptyBookmarksState(
+    hasQuery: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = if (hasQuery) {
+                stringResource(R.string.bookmarks_no_results)
+            } else {
+                stringResource(R.string.bookmarks_empty)
+            },
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+// ─── Grouped list ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun BookmarkGroupedList(
+    groups: List<BookmarkGroup>,
+    onToggleExpand: (mangaId: Long) -> Unit,
+    onOpenBookmark: (mangaId: Long, chapterId: Long) -> Unit,
+    onDeleteBookmark: (BookmarkItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier = modifier.fillMaxSize()) {
+        groups.forEach { group ->
+            // Manga header row — tap to expand/collapse the group.
+            item(key = "header_${group.mangaId}") {
+                MangaGroupHeader(
+                    group = group,
+                    onToggleExpand = { onToggleExpand(group.mangaId) },
+                )
+            }
+
+            // Only show chapter / bookmark rows when the group is expanded.
+            if (group.isExpanded) {
+                group.chapters.forEach { chapterGroup ->
+                    item(key = "chapter_${chapterGroup.chapterId}") {
+                        ChapterSubHeader(chapterName = chapterGroup.chapterName)
+                    }
+
+                    items(
+                        items = chapterGroup.bookmarks,
+                        key = { bm -> "bookmark_${bm.id}" },
+                    ) { bookmark ->
+                        SwipeToDismissBookmarkRow(
+                            bookmark = bookmark,
+                            onOpen = { onOpenBookmark(bookmark.mangaId, bookmark.chapterId) },
+                            onDelete = { onDeleteBookmark(bookmark) },
+                        )
+                        HorizontalDivider(modifier = Modifier.padding(start = 72.dp))
+                    }
+                }
+            }
+
+            item(key = "divider_${group.mangaId}") {
+                HorizontalDivider(thickness = 2.dp)
+            }
+        }
+    }
+}
+
+// ─── Manga group header ───────────────────────────────────────────────────────
+
+@Composable
+private fun MangaGroupHeader(
+    group: BookmarkGroup,
+    onToggleExpand: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggleExpand)
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        // Manga cover thumbnail (40×56 dp, portrait aspect ratio).
+        Surface(
+            shape = MaterialTheme.shapes.small,
+            modifier = Modifier.size(width = 40.dp, height = 56.dp),
+        ) {
+            AsyncImage(
+                model = group.mangaCoverUrl,
+                contentDescription = group.mangaTitle,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .aspectRatio(5f / 7f)
+                    .clip(MaterialTheme.shapes.small),
+            )
+        }
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = group.mangaTitle.ifBlank {
+                    stringResource(R.string.bookmarks_unknown_manga)
+                },
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.primary,
+                maxLines = 2,
+            )
+            val count = group.chapters.sumOf { it.bookmarks.size }
+            Text(
+                text = stringResource(R.string.bookmarks_count, count),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        Icon(
+            imageVector = if (group.isExpanded) {
+                Icons.Default.KeyboardArrowUp
+            } else {
+                Icons.Default.KeyboardArrowDown
+            },
+            contentDescription = if (group.isExpanded) {
+                stringResource(R.string.bookmarks_collapse)
+            } else {
+                stringResource(R.string.bookmarks_expand)
+            },
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+// ─── Chapter sub-header ───────────────────────────────────────────────────────
+
+@Composable
+private fun ChapterSubHeader(
+    chapterName: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = chapterName.ifBlank { stringResource(R.string.bookmarks_chapter_fallback) },
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 72.dp, end = 16.dp, top = 6.dp, bottom = 2.dp),
+    )
+}
+
+// ─── Swipe-to-dismiss bookmark row ───────────────────────────────────────────
+
+/**
+ * Wraps [BookmarkRow] in a [SwipeToDismissBox] so the user can swipe left to delete.
+ *
+ * [SwipeToDismissBox] is the Material3 replacement for the old M2 SwipeToDismiss composable.
+ * Swiping toward [SwipeToDismissBoxValue.EndToStart] (right-to-left) reveals a red delete
+ * icon in the background. Once the drag exceeds the positional threshold the delete is
+ * confirmed via [confirmValueChange] and [onDelete] is called.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SwipeToDismissBookmarkRow(
+    bookmark: BookmarkItem,
+    onOpen: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { value ->
+            if (value == SwipeToDismissBoxValue.EndToStart) {
+                onDelete()
+                true
+            } else {
+                false
+            }
+        },
+        // Require 40 % drag distance before confirming — reduces accidental swipes.
+        positionalThreshold = { totalDistance -> totalDistance * 0.4f },
+    )
+
+    SwipeToDismissBox(
+        state = dismissState,
+        modifier = modifier,
+        enableDismissFromStartToEnd = false,
+        enableDismissFromEndToStart = true,
+        backgroundContent = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp),
+                contentAlignment = Alignment.CenterEnd,
+            ) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = stringResource(R.string.bookmarks_delete),
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+    ) {
+        BookmarkRow(
+            bookmark = bookmark,
+            onOpen = onOpen,
+            onDelete = onDelete,
+        )
+    }
+}
+
+// ─── Bookmark row ─────────────────────────────────────────────────────────────
 
 @Composable
 private fun BookmarkRow(
     bookmark: BookmarkItem,
     onOpen: () -> Unit,
     onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     ListItem(
-        modifier = Modifier.clickable(onClick = onOpen),
+        modifier = modifier.clickable(onClick = onOpen),
         headlineContent = {
-            Text(
-                text = bookmark.chapterName.ifBlank {
-                    stringResource(R.string.bookmarks_chapter_fallback)
-                },
-            )
+            Text(stringResource(R.string.bookmarks_page, bookmark.pageIndex + 1))
         },
-        supportingContent = {
-            Column {
-                Text(stringResource(R.string.bookmarks_page, bookmark.pageIndex + 1))
-                bookmark.note?.takeIf { it.isNotBlank() }?.let { Text(it) }
-            }
-        },
+        supportingContent = bookmark.note
+            ?.takeIf { it.isNotBlank() }
+            ?.let { note -> { Text(note, maxLines = 2) } },
         trailingContent = {
             IconButton(onClick = onDelete) {
                 Icon(
                     Icons.Default.Delete,
                     contentDescription = stringResource(R.string.bookmarks_delete),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         },
     )
 }
+
+// ─── Navigation extension ─────────────────────────────────────────────────────
 
 fun NavGraphBuilder.bookmarksScreen(
     onNavigateBack: () -> Unit,

--- a/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksScreen.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksScreen.kt
@@ -338,7 +338,10 @@ private fun SwipeToDismissBookmarkRow(
         confirmValueChange = { value ->
             if (value == SwipeToDismissBoxValue.EndToStart) {
                 onDelete()
-                true
+                // Return false: the row stays until Room emits a new list without it.
+                // This avoids the UI/data race where the row disappears before the DB
+                // delete completes — if deletion fails the row never disappears at all.
+                false
             } else {
                 false
             }

--- a/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksScreen.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksScreen.kt
@@ -389,9 +389,11 @@ private fun BookmarkRow(
         headlineContent = {
             Text(stringResource(R.string.bookmarks_page, bookmark.pageIndex + 1))
         },
-        supportingContent = bookmark.note
-            ?.takeIf { it.isNotBlank() }
-            ?.let { note -> { Text(note, maxLines = 2) } },
+        supportingContent = if (!bookmark.note.isNullOrBlank()) {
+            { Text(bookmark.note, maxLines = 2) }
+        } else {
+            null
+        },
         trailingContent = {
             IconButton(onClick = onDelete) {
                 Icon(

--- a/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksViewModel.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksViewModel.kt
@@ -8,7 +8,10 @@ import app.otakureader.domain.repository.PageBookmarkRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -61,6 +64,14 @@ class BookmarksViewModel @Inject constructor(
                 .getMangaByIds(bookmarks.map { it.mangaId }.distinct())
                 .associate { manga -> manga.id to manga }
 
+            // Fetch all chapters in parallel to avoid N+1 sequential DB queries.
+            val chapterMap = coroutineScope {
+                bookmarks.map { it.chapterId }.distinct()
+                    .map { id -> async { id to chapterRepository.getChapterById(id) } }
+                    .awaitAll()
+                    .toMap()
+            }
+
             bookmarks.map { bm ->
                 val manga = mangaMap[bm.mangaId]
                 BookmarkItem(
@@ -70,7 +81,7 @@ class BookmarksViewModel @Inject constructor(
                     pageIndex = bm.pageIndex,
                     note = bm.note,
                     mangaTitle = manga?.title.orEmpty(),
-                    chapterName = chapterRepository.getChapterById(bm.chapterId)?.name.orEmpty(),
+                    chapterName = chapterMap[bm.chapterId]?.name.orEmpty(),
                     mangaCoverUrl = manga?.thumbnailUrl,
                 )
             }

--- a/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksViewModel.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksViewModel.kt
@@ -112,7 +112,7 @@ class BookmarksViewModel @Inject constructor(
         .catch { emit(BookmarksState(isLoading = false)) }
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
+            started = SharingStarted.Eagerly,
             initialValue = BookmarksState(),
         )
 

--- a/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksViewModel.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksViewModel.kt
@@ -6,35 +6,36 @@ import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.PageBookmarkRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-/** A single page bookmark enriched with the manga title and chapter name for display. */
-data class BookmarkItem(
-    val id: Long,
-    val mangaId: Long,
-    val chapterId: Long,
-    val pageIndex: Int,
-    val note: String?,
-    val mangaTitle: String,
-    val chapterName: String,
-)
-
-data class BookmarksState(
-    val isLoading: Boolean = true,
-    val bookmarks: List<BookmarkItem> = emptyList(),
-) {
-    /** Grouped by manga (preserving newest-first order of first appearance). */
-    val grouped: Map<String, List<BookmarkItem>> get() = bookmarks.groupBy { it.mangaTitle }
-    val isEmpty: Boolean get() = !isLoading && bookmarks.isEmpty()
-}
-
+/**
+ * ViewModel for the Bookmarks screen.
+ *
+ * Exposes a [StateFlow<BookmarksState>] built reactively from the repository flow.
+ * All user actions arrive through [onIntent] and are reduced synchronously (search/expand)
+ * or launched as suspend operations (delete/navigate).
+ *
+ * Why [combine] + [mapLatest]?
+ * - [pageBookmarkRepository.getAllBookmarks()] is a Room Flow that re-emits whenever the DB
+ *   changes (e.g. the user just deleted a bookmark from inside the reader).
+ * - [searchQuery] is a local StateFlow updated by the search bar.
+ * - Combining them means the list automatically re-filters whenever either changes, with no
+ *   manual "reload" calls needed.
+ */
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class BookmarksViewModel @Inject constructor(
@@ -43,29 +44,96 @@ class BookmarksViewModel @Inject constructor(
     private val chapterRepository: ChapterRepository,
 ) : ViewModel() {
 
-    val state: StateFlow<BookmarksState> = pageBookmarkRepository.getAllBookmarks()
+    // One-shot navigation / snackbar events delivered to the screen.
+    private val _effect = Channel<BookmarksEffect>(Channel.BUFFERED)
+    val effect: Flow<BookmarksEffect> = _effect.receiveAsFlow()
+
+    // Local UI state not derived from the DB (collapse flags).
+    private val _collapsedManga = MutableStateFlow<Set<Long>>(emptySet())
+
+    /** Enriched item list derived reactively from the repository. */
+    private val enrichedBookmarks = pageBookmarkRepository.getAllBookmarks()
         .mapLatest { bookmarks ->
-            val titles = mangaRepository.getMangaByIds(bookmarks.map { it.mangaId }.distinct())
-                .associate { it.id to it.title }
-            val items = bookmarks.map { bm ->
+            if (bookmarks.isEmpty()) return@mapLatest emptyList()
+
+            // Fetch all parent manga in a single batch call, then build a lookup map.
+            val mangaMap = mangaRepository
+                .getMangaByIds(bookmarks.map { it.mangaId }.distinct())
+                .associate { manga -> manga.id to manga }
+
+            bookmarks.map { bm ->
+                val manga = mangaMap[bm.mangaId]
                 BookmarkItem(
                     id = bm.id,
                     mangaId = bm.mangaId,
                     chapterId = bm.chapterId,
                     pageIndex = bm.pageIndex,
                     note = bm.note,
-                    mangaTitle = titles[bm.mangaId].orEmpty(),
+                    mangaTitle = manga?.title.orEmpty(),
                     chapterName = chapterRepository.getChapterById(bm.chapterId)?.name.orEmpty(),
+                    mangaCoverUrl = manga?.thumbnailUrl,
                 )
             }
-            BookmarksState(isLoading = false, bookmarks = items)
         }
-        .catch { emit(BookmarksState(isLoading = false)) }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), BookmarksState())
+        .catch { emit(emptyList()) }
 
-    fun deleteBookmark(item: BookmarkItem) {
+    /** The mutable search query from the search bar. */
+    private val _searchQuery = MutableStateFlow("")
+
+    /**
+     * UI state combining:
+     * 1. The enriched bookmark list from Room.
+     * 2. The current search query.
+     * 3. Which manga groups are collapsed.
+     */
+    val state: StateFlow<BookmarksState> = combine(
+        enrichedBookmarks,
+        _searchQuery,
+        _collapsedManga,
+    ) { items, query, collapsed ->
+        BookmarksState(
+            isLoading = false,
+            bookmarks = items,
+            searchQuery = query,
+            collapsedManga = collapsed,
+        )
+    }
+        .catch { emit(BookmarksState(isLoading = false)) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = BookmarksState(),
+        )
+
+    /** Single entry-point for all user actions. */
+    fun onIntent(intent: BookmarksIntent) {
+        when (intent) {
+            is BookmarksIntent.SearchQueryChanged -> _searchQuery.value = intent.query
+
+            is BookmarksIntent.ToggleMangaExpanded -> _collapsedManga.update { current ->
+                if (intent.mangaId in current) current - intent.mangaId
+                else current + intent.mangaId
+            }
+
+            is BookmarksIntent.DeleteBookmark -> deleteBookmark(intent.item)
+
+            is BookmarksIntent.OpenBookmark -> viewModelScope.launch {
+                _effect.send(
+                    BookmarksEffect.NavigateToReader(intent.mangaId, intent.chapterId)
+                )
+            }
+        }
+    }
+
+    private fun deleteBookmark(item: BookmarkItem) {
         viewModelScope.launch {
-            pageBookmarkRepository.removeBookmark(item.chapterId, item.pageIndex)
+            try {
+                pageBookmarkRepository.removeBookmark(item.chapterId, item.pageIndex)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                _effect.send(BookmarksEffect.ShowSnackbar("Failed to delete bookmark"))
+            }
         }
     }
 }

--- a/feature/more/src/main/res/values/strings.xml
+++ b/feature/more/src/main/res/values/strings.xml
@@ -86,4 +86,5 @@
     <string name="bookmarks_unknown_manga">Unknown manga</string>
     <string name="bookmarks_expand">Expand manga bookmarks</string>
     <string name="bookmarks_collapse">Collapse manga bookmarks</string>
+    <string name="bookmarks_delete_failed">Failed to delete bookmark</string>
 </resources>

--- a/feature/more/src/main/res/values/strings.xml
+++ b/feature/more/src/main/res/values/strings.xml
@@ -76,7 +76,14 @@
     <string name="bookmarks_title">Bookmarks</string>
     <string name="bookmarks_back">Back</string>
     <string name="bookmarks_empty">No bookmarks yet. Bookmark a page while reading to see it here.</string>
+    <string name="bookmarks_no_results">No bookmarks match your search.</string>
     <string name="bookmarks_page">Page %1$d</string>
     <string name="bookmarks_chapter_fallback">Chapter</string>
     <string name="bookmarks_delete">Delete bookmark</string>
+    <string name="bookmarks_search_placeholder">Search by manga, chapter, or note…</string>
+    <string name="bookmarks_clear_search">Clear search</string>
+    <string name="bookmarks_count">%1$d bookmark(s)</string>
+    <string name="bookmarks_unknown_manga">Unknown manga</string>
+    <string name="bookmarks_expand">Expand manga bookmarks</string>
+    <string name="bookmarks_collapse">Collapse manga bookmarks</string>
 </resources>

--- a/feature/more/src/test/java/app/otakureader/feature/more/bookmarks/BookmarksViewModelTest.kt
+++ b/feature/more/src/test/java/app/otakureader/feature/more/bookmarks/BookmarksViewModelTest.kt
@@ -1,0 +1,228 @@
+package app.otakureader.feature.more.bookmarks
+
+import app.otakureader.domain.model.Manga
+import app.otakureader.domain.model.PageBookmark
+import app.otakureader.domain.repository.ChapterRepository
+import app.otakureader.domain.repository.MangaRepository
+import app.otakureader.domain.repository.PageBookmarkRepository
+import app.otakureader.domain.model.Chapter
+import app.cash.turbine.test
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [BookmarksViewModel].
+ *
+ * All suspend/Flow interactions are tested with [runTest] and Turbine's [test] extension.
+ * External dependencies are mocked with MockK — no Room DB is needed here.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class BookmarksViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val pageBookmarkRepository: PageBookmarkRepository = mockk(relaxed = true)
+    private val mangaRepository: MangaRepository = mockk(relaxed = true)
+    private val chapterRepository: ChapterRepository = mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private fun bookmark(
+        id: Long = 1L,
+        mangaId: Long = 10L,
+        chapterId: Long = 100L,
+        pageIndex: Int = 0,
+        note: String? = null,
+    ) = PageBookmark(
+        id = id,
+        mangaId = mangaId,
+        chapterId = chapterId,
+        pageIndex = pageIndex,
+        note = note,
+    )
+
+    private fun manga(id: Long = 10L, title: String = "Test Manga") =
+        Manga(id = id, sourceId = 1L, url = "/m/$id", title = title, thumbnailUrl = "https://cover/$id.jpg")
+
+    private fun chapter(id: Long = 100L, mangaId: Long = 10L, name: String = "Chapter 1") =
+        Chapter(id = id, mangaId = mangaId, url = "/ch/$id", name = name)
+
+    private fun createViewModel() = BookmarksViewModel(
+        pageBookmarkRepository = pageBookmarkRepository,
+        mangaRepository = mangaRepository,
+        chapterRepository = chapterRepository,
+    )
+
+    // ── tests ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `initial state is loading`() {
+        every { pageBookmarkRepository.getAllBookmarks() } returns flowOf(emptyList())
+        val vm = createViewModel()
+        assertTrue(vm.state.value.isLoading)
+    }
+
+    @Test
+    fun `empty bookmark list transitions to not-loading isEmpty state`() = runTest {
+        every { pageBookmarkRepository.getAllBookmarks() } returns flowOf(emptyList())
+        coEvery { mangaRepository.getMangaByIds(any()) } returns emptyList()
+
+        val vm = createViewModel()
+        vm.state.test {
+            awaitItem() // initial loading
+            val ready = awaitItem()
+            assertFalse(ready.isLoading)
+            assertTrue(ready.isEmpty)
+        }
+    }
+
+    @Test
+    fun `bookmarks are enriched with manga title and chapter name`() = runTest {
+        val bm = bookmark()
+        every { pageBookmarkRepository.getAllBookmarks() } returns flowOf(listOf(bm))
+        coEvery { mangaRepository.getMangaByIds(listOf(10L)) } returns listOf(manga())
+        coEvery { chapterRepository.getChapterById(100L) } returns chapter()
+
+        val vm = createViewModel()
+        vm.state.test {
+            awaitItem() // initial
+            val state = awaitItem()
+            assertFalse(state.isLoading)
+            assertEquals(1, state.bookmarks.size)
+            assertEquals("Test Manga", state.bookmarks[0].mangaTitle)
+            assertEquals("Chapter 1", state.bookmarks[0].chapterName)
+            assertEquals("https://cover/10.jpg", state.bookmarks[0].mangaCoverUrl)
+        }
+    }
+
+    @Test
+    fun `search query filters by manga title`() = runTest {
+        val bm1 = bookmark(id = 1L, mangaId = 10L, chapterId = 100L)
+        val bm2 = bookmark(id = 2L, mangaId = 20L, chapterId = 200L)
+        every { pageBookmarkRepository.getAllBookmarks() } returns flowOf(listOf(bm1, bm2))
+        coEvery { mangaRepository.getMangaByIds(any()) } returns listOf(
+            manga(id = 10L, title = "Dragon Ball"),
+            manga(id = 20L, title = "One Piece"),
+        )
+        coEvery { chapterRepository.getChapterById(100L) } returns chapter(id = 100L, mangaId = 10L)
+        coEvery { chapterRepository.getChapterById(200L) } returns chapter(id = 200L, mangaId = 20L)
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.onIntent(BookmarksIntent.SearchQueryChanged("Dragon"))
+        advanceUntilIdle()
+
+        val state = vm.state.value
+        assertEquals(1, state.filteredBookmarks.size)
+        assertEquals("Dragon Ball", state.filteredBookmarks[0].mangaTitle)
+    }
+
+    @Test
+    fun `toggle manga expanded adds to and removes from collapsedManga`() = runTest {
+        every { pageBookmarkRepository.getAllBookmarks() } returns flowOf(emptyList())
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // Initially expanded (not in collapsed set).
+        assertFalse(10L in vm.state.value.collapsedManga)
+
+        // Collapse.
+        vm.onIntent(BookmarksIntent.ToggleMangaExpanded(10L))
+        advanceUntilIdle()
+        assertTrue(10L in vm.state.value.collapsedManga)
+
+        // Re-expand.
+        vm.onIntent(BookmarksIntent.ToggleMangaExpanded(10L))
+        advanceUntilIdle()
+        assertFalse(10L in vm.state.value.collapsedManga)
+    }
+
+    @Test
+    fun `delete bookmark intent calls repository removeBookmark`() = runTest {
+        val bm = bookmark(chapterId = 100L, pageIndex = 3)
+        every { pageBookmarkRepository.getAllBookmarks() } returns flowOf(listOf(bm))
+        coEvery { mangaRepository.getMangaByIds(any()) } returns listOf(manga())
+        coEvery { chapterRepository.getChapterById(any()) } returns chapter()
+        coEvery { pageBookmarkRepository.removeBookmark(any(), any()) } returns Unit
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        val item = vm.state.value.bookmarks.first()
+        vm.onIntent(BookmarksIntent.DeleteBookmark(item))
+        advanceUntilIdle()
+
+        coVerify { pageBookmarkRepository.removeBookmark(100L, 3) }
+    }
+
+    @Test
+    fun `open bookmark intent emits NavigateToReader effect`() = runTest {
+        every { pageBookmarkRepository.getAllBookmarks() } returns flowOf(emptyList())
+
+        val vm = createViewModel()
+
+        vm.effect.test {
+            vm.onIntent(BookmarksIntent.OpenBookmark(mangaId = 10L, chapterId = 100L))
+            val effect = awaitItem()
+            assertTrue(effect is BookmarksEffect.NavigateToReader)
+            effect as BookmarksEffect.NavigateToReader
+            assertEquals(10L, effect.mangaId)
+            assertEquals(100L, effect.chapterId)
+        }
+    }
+
+    @Test
+    fun `grouped property produces correct BookmarkGroup structure`() = runTest {
+        val bm1 = bookmark(id = 1L, mangaId = 10L, chapterId = 100L, pageIndex = 0)
+        val bm2 = bookmark(id = 2L, mangaId = 10L, chapterId = 100L, pageIndex = 2)
+        val bm3 = bookmark(id = 3L, mangaId = 10L, chapterId = 200L, pageIndex = 1)
+        every { pageBookmarkRepository.getAllBookmarks() } returns flowOf(listOf(bm1, bm2, bm3))
+        coEvery { mangaRepository.getMangaByIds(listOf(10L)) } returns listOf(manga())
+        coEvery { chapterRepository.getChapterById(100L) } returns chapter(id = 100L, name = "Ch 1")
+        coEvery { chapterRepository.getChapterById(200L) } returns chapter(id = 200L, name = "Ch 2")
+
+        val vm = createViewModel()
+        vm.state.test {
+            awaitItem()
+            val state = awaitItem()
+            val groups = state.grouped
+            assertEquals(1, groups.size)
+            assertEquals("Test Manga", groups[0].mangaTitle)
+            assertEquals(2, groups[0].chapters.size)
+            val ch1 = groups[0].chapters.first { it.chapterId == 100L }
+            assertEquals(2, ch1.bookmarks.size)
+            // Pages within a chapter are sorted by pageIndex.
+            assertEquals(0, ch1.bookmarks[0].pageIndex)
+            assertEquals(2, ch1.bookmarks[1].pageIndex)
+        }
+    }
+}


### PR DESCRIPTION
## **User description**
$(cat <<'EOF'
## Summary

- Adds `BookmarksMvi.kt` with full MVI sealed types (`BookmarksState`, `BookmarksIntent`, `BookmarksEffect`) and `BookmarkItem` / `BookmarkGroup` / `ChapterGroup` display models — separating display concerns from the ViewModel
- Rewrites `BookmarksViewModel` to proper MVI pattern: `MutableStateFlow` + `Channel` for effects, `combine()` to reactively merge the DB flow with the search query and collapsed-group set, `mangaCoverUrl` fetched in a single batch `getMangaByIds()` call
- Rewrites `BookmarksScreen` with: search/filter bar, expandable manga groups with cover thumbnails, chapter sub-headers, swipe-to-delete via Material3 `SwipeToDismissBox`, and a differentiated empty state for "no results vs no bookmarks"
- Adds 6 new string resources (search placeholder, clear search, bookmark count, expand/collapse a11y labels, unknown-manga fallback, no-results message)
- Adds `BookmarksViewModelTest` (8 tests) covering loading state, enrichment, search filtering, expand/collapse toggle, delete dispatch, navigation effect, and grouped structure

## Acceptance criteria coverage

- [x] Bookmark list screen accessible from More screen
- [x] Grouped by manga → chapter with expandable/collapsible manga sections
- [x] Manga cover thumbnail shown in every group header
- [x] Tap row → jumps to bookmarked chapter in reader
- [x] Swipe-to-delete (Material3 `SwipeToDismissBox`) + delete button per row
- [x] Empty state when no bookmarks (and separate "no results" state when searching)
- [x] Search/filter by manga title, chapter name, or note text

## Test plan

- [ ] Build passes (`./gradlew :feature:more:assembleDebug`)
- [ ] Unit tests pass (`./gradlew :feature:more:test`)
- [ ] Navigate More → Bookmarks, verify empty state message
- [ ] Bookmark a page in the reader, return to More → Bookmarks, verify it appears under the correct manga/chapter group
- [ ] Tap the bookmark row — verify the reader opens at the correct chapter
- [ ] Type a search query — verify the list filters in real time; clear the search, verify full list returns
- [ ] Tap a manga group header — verify it collapses (rows hidden), tap again to expand
- [ ] Swipe a row left past 40% — verify the bookmark is deleted and the row disappears
- [ ] Tap the delete icon on a row — verify the bookmark is deleted

Closes #935

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
Add a searchable, grouped bookmark management screen with expand/collapse and swipe delete

### What Changed
- Bookmarks are now shown as manga groups with chapter sub-sections, cover thumbnails, and a bookmark count for each manga
- Users can search bookmarks by manga title, chapter name, or note, and clear the search with one tap
- Manga groups can be expanded or collapsed, and bookmark rows can be opened or deleted from the list
- Deleting a bookmark now shows a clear error message if the delete fails
- Empty states now distinguish between “no bookmarks yet” and “no search results”

### Impact
`✅ Faster bookmark lookup`
`✅ Fewer accidental bookmark deletions`
`✅ Clearer empty states when searching`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
