### PR TITLE
fix: WebView security hardening and MangaUpdates credential warning

### DIFF
--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewSession.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewSession.kt
@@ -27,6 +27,11 @@ class WebViewSession(
             useWideViewPort = true
             loadWithOverviewMode = true
             cacheMode = WebSettings.LOAD_DEFAULT
+            // Block local file/content access from web content (default true on API < 30)
+            allowFileAccess = false
+            allowContentAccess = false
+            // Flag malicious URLs via Google Safe Browsing
+            safeBrowsingEnabled = true
         }
         CookieManager.getInstance().apply {
             setAcceptCookie(true)

--- a/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingScreen.kt
+++ b/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingScreen.kt
@@ -120,8 +120,7 @@ fun TrackingScreen(
     if (loginDialogTrackerId != null) {
         val trackerName = state.trackers.find { it.id == loginDialogTrackerId }?.name ?: ""
         val securityNote = if (loginDialogTrackerId == TrackerType.MANGA_UPDATES) {
-            "MangaUpdates requires your password directly (OAuth not yet supported by their API). " +
-            "Your password is sent securely over HTTPS and is not stored — only the session token is saved."
+            stringResource(R.string.tracking_mangaupdates_security_note)
         } else null
         CredentialLoginDialog(
             trackerName = trackerName,
@@ -520,7 +519,7 @@ private fun CredentialLoginDialog(
                     Text(
                         text = securityNote,
                         style = MaterialTheme.typography.bodySmall,
-                        color = Color(0xFFB25900),
+                        color = MaterialTheme.colorScheme.tertiary,
                     )
                 }
             }

--- a/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingScreen.kt
+++ b/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.domain.model.SyncStatus
+import app.otakureader.domain.model.TrackerType
 import app.otakureader.domain.model.TrackEntry
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -118,8 +119,13 @@ fun TrackingScreen(
     val loginDialogTrackerId = state.loginDialogTrackerId
     if (loginDialogTrackerId != null) {
         val trackerName = state.trackers.find { it.id == loginDialogTrackerId }?.name ?: ""
+        val securityNote = if (loginDialogTrackerId == TrackerType.MANGA_UPDATES) {
+            "MangaUpdates requires your password directly (OAuth not yet supported by their API). " +
+            "Your password is sent securely over HTTPS and is not stored — only the session token is saved."
+        } else null
         CredentialLoginDialog(
             trackerName = trackerName,
+            securityNote = securityNote,
             onConfirm = { username, password ->
                 viewModel.onEvent(TrackingEvent.Login(loginDialogTrackerId, username, password))
             },
@@ -483,6 +489,7 @@ private fun LinkedMangaInfo(
 @Composable
 private fun CredentialLoginDialog(
     trackerName: String,
+    securityNote: String? = null,
     onConfirm: (username: String, password: String) -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -509,6 +516,13 @@ private fun CredentialLoginDialog(
                     visualTransformation = PasswordVisualTransformation(),
                     modifier = Modifier.fillMaxWidth()
                 )
+                if (securityNote != null) {
+                    Text(
+                        text = securityNote,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color(0xFFB25900),
+                    )
+                }
             }
         },
         confirmButton = {

--- a/feature/tracking/src/main/res/values/strings.xml
+++ b/feature/tracking/src/main/res/values/strings.xml
@@ -76,4 +76,5 @@
     <string name="tracking_push_success">Progress pushed to trackers</string>
     <string name="tracking_pull_success">Progress pulled from trackers</string>
     <string name="tracking_conflict_resolved">Conflict resolved</string>
+    <string name="tracking_mangaupdates_security_note">MangaUpdates requires your password directly (OAuth not yet supported by their API). Your password is sent securely over HTTPS and is not stored — only the session token is saved.</string>
 </resources>


### PR DESCRIPTION
## **User description**
## Summary

- **WebView hardening** (`core/webview/WebViewSession.kt`): disable `allowFileAccess` and `allowContentAccess` (prevent web content from reading device files, defaulted to `true` on API < 30), and enable `safeBrowsingEnabled` for malicious-URL detection via Google Safe Browsing. `MIXED_CONTENT_NEVER_ALLOW` is intentionally omitted — extension source login pages load images over HTTP and would break.
- **MangaUpdates credential warning** (`feature/tracking/TrackingScreen.kt`): add optional `securityNote` parameter to `CredentialLoginDialog`; when non-null, renders amber-colored warning text below the password field. Only MangaUpdates receives the note, explaining that OAuth is not yet supported by their API and that only the session token (not the password) is stored.

Addresses audit findings R5 and R6.

## Test plan

- [ ] Open a WebView source page — no file-scheme access visible in network logs
- [ ] Safe Browsing active (test with known test URL if available)
- [ ] Navigate to Settings → Tracking → tap "Log in" for MangaUpdates → amber warning appears below password field
- [ ] Log in to MAL / AniList — no warning shown (note is MangaUpdates-only)

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Block risky WebView access and warn MangaUpdates users about password login**

### What Changed
- Web pages opened in the app can no longer read local files or device content, and malicious links are checked with Google Safe Browsing
- MangaUpdates login now shows a clear warning that password sign-in is required, the password is not stored, and only the session token is saved
- Other tracker logins keep the same login dialog without the warning

### Impact
`✅ Safer in-app web browsing`
`✅ Lower risk of local file exposure`
`✅ Clearer MangaUpdates login expectations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
