### PR TITLE
feat: expand reader presets from 6 to 13 captured settings

### DIFF
--- a/core/preferences/src/main/java/app/otakureader/core/preferences/ReaderPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/ReaderPreferences.kt
@@ -191,7 +191,6 @@ class ReaderPreferences(private val dataStore: DataStore<Preferences>) {
             prefs[Keys.AUTO_ZOOM_WIDE_IMAGES] = preset.autoZoomWideImages
             prefs[Keys.ANIMATE_PAGE_TRANSITIONS] = preset.animatePageTransitions
             prefs[Keys.WEBTOON_SIDE_PADDING] = preset.webtoonSidePadding
-            prefs[Keys.TAP_ZONE_CONFIG] = preset.tapZoneConfig
             prefs[Keys.INVERT_TAP_ZONES] = preset.invertTapZones
             prefs[Keys.VOLUME_KEYS_ENABLED] = preset.volumeKeysEnabled
             prefs[Keys.VOLUME_KEYS_INVERTED] = preset.volumeKeysInverted
@@ -213,7 +212,6 @@ class ReaderPreferences(private val dataStore: DataStore<Preferences>) {
             autoZoomWideImages = prefs[Keys.AUTO_ZOOM_WIDE_IMAGES] ?: true,
             animatePageTransitions = prefs[Keys.ANIMATE_PAGE_TRANSITIONS] ?: true,
             webtoonSidePadding = prefs[Keys.WEBTOON_SIDE_PADDING] ?: 0,
-            tapZoneConfig = prefs[Keys.TAP_ZONE_CONFIG] ?: 0,
             invertTapZones = prefs[Keys.INVERT_TAP_ZONES] ?: false,
             volumeKeysEnabled = prefs[Keys.VOLUME_KEYS_ENABLED] ?: false,
             volumeKeysInverted = prefs[Keys.VOLUME_KEYS_INVERTED] ?: false,

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/ReaderPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/ReaderPreferences.kt
@@ -184,19 +184,21 @@ class ReaderPreferences(private val dataStore: DataStore<Preferences>) {
 
     /** Applies a preset by writing its values to the individual reader preference keys. */
     suspend fun applyPreset(preset: ReaderPreset) {
-        setReaderMode(preset.readerMode)
-        setBackgroundColor(preset.backgroundColor)
-        setReaderScale(preset.readerScale)
-        setAutoZoomWideImages(preset.autoZoomWideImages)
-        setAnimatePageTransitions(preset.animatePageTransitions)
-        setWebtoonSidePadding(preset.webtoonSidePadding)
-        setTapZoneConfig(preset.tapZoneConfig)
-        setInvertTapZones(preset.invertTapZones)
-        setVolumeKeysEnabled(preset.volumeKeysEnabled)
-        setVolumeKeysInverted(preset.volumeKeysInverted)
-        setShowPageNumber(preset.showPageNumber)
-        setSkipReadChapters(preset.skipReadChapters)
-        setSkipFilteredChapters(preset.skipFilteredChapters)
+        dataStore.edit { prefs ->
+            prefs[Keys.READER_MODE] = preset.readerMode
+            prefs[Keys.BACKGROUND_COLOR] = preset.backgroundColor
+            prefs[Keys.READER_SCALE] = preset.readerScale
+            prefs[Keys.AUTO_ZOOM_WIDE_IMAGES] = preset.autoZoomWideImages
+            prefs[Keys.ANIMATE_PAGE_TRANSITIONS] = preset.animatePageTransitions
+            prefs[Keys.WEBTOON_SIDE_PADDING] = preset.webtoonSidePadding
+            prefs[Keys.TAP_ZONE_CONFIG] = preset.tapZoneConfig
+            prefs[Keys.INVERT_TAP_ZONES] = preset.invertTapZones
+            prefs[Keys.VOLUME_KEYS_ENABLED] = preset.volumeKeysEnabled
+            prefs[Keys.VOLUME_KEYS_INVERTED] = preset.volumeKeysInverted
+            prefs[Keys.SHOW_PAGE_NUMBER] = preset.showPageNumber
+            prefs[Keys.SKIP_READ_CHAPTERS] = preset.skipReadChapters
+            prefs[Keys.SKIP_FILTERED_CHAPTERS] = preset.skipFilteredChapters
+        }
     }
 
     /** Captures the current reader settings as a new [ReaderPreset] with the given [name]. */

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/ReaderPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/ReaderPreferences.kt
@@ -190,6 +190,13 @@ class ReaderPreferences(private val dataStore: DataStore<Preferences>) {
         setAutoZoomWideImages(preset.autoZoomWideImages)
         setAnimatePageTransitions(preset.animatePageTransitions)
         setWebtoonSidePadding(preset.webtoonSidePadding)
+        setTapZoneConfig(preset.tapZoneConfig)
+        setInvertTapZones(preset.invertTapZones)
+        setVolumeKeysEnabled(preset.volumeKeysEnabled)
+        setVolumeKeysInverted(preset.volumeKeysInverted)
+        setShowPageNumber(preset.showPageNumber)
+        setSkipReadChapters(preset.skipReadChapters)
+        setSkipFilteredChapters(preset.skipFilteredChapters)
     }
 
     /** Captures the current reader settings as a new [ReaderPreset] with the given [name]. */
@@ -204,6 +211,13 @@ class ReaderPreferences(private val dataStore: DataStore<Preferences>) {
             autoZoomWideImages = prefs[Keys.AUTO_ZOOM_WIDE_IMAGES] ?: true,
             animatePageTransitions = prefs[Keys.ANIMATE_PAGE_TRANSITIONS] ?: true,
             webtoonSidePadding = prefs[Keys.WEBTOON_SIDE_PADDING] ?: 0,
+            tapZoneConfig = prefs[Keys.TAP_ZONE_CONFIG] ?: 0,
+            invertTapZones = prefs[Keys.INVERT_TAP_ZONES] ?: false,
+            volumeKeysEnabled = prefs[Keys.VOLUME_KEYS_ENABLED] ?: false,
+            volumeKeysInverted = prefs[Keys.VOLUME_KEYS_INVERTED] ?: false,
+            showPageNumber = prefs[Keys.SHOW_PAGE_NUMBER] ?: true,
+            skipReadChapters = prefs[Keys.SKIP_READ_CHAPTERS] ?: false,
+            skipFilteredChapters = prefs[Keys.SKIP_FILTERED_CHAPTERS] ?: true,
         )
     }
 

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/ReaderPreset.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/ReaderPreset.kt
@@ -16,4 +16,11 @@ data class ReaderPreset(
     val autoZoomWideImages: Boolean = true,
     val animatePageTransitions: Boolean = true,
     val webtoonSidePadding: Int = 0,
+    val tapZoneConfig: Int = 0,
+    val invertTapZones: Boolean = false,
+    val volumeKeysEnabled: Boolean = false,
+    val volumeKeysInverted: Boolean = false,
+    val showPageNumber: Boolean = true,
+    val skipReadChapters: Boolean = false,
+    val skipFilteredChapters: Boolean = true,
 )

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/ReaderPreset.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/ReaderPreset.kt
@@ -16,7 +16,6 @@ data class ReaderPreset(
     val autoZoomWideImages: Boolean = true,
     val animatePageTransitions: Boolean = true,
     val webtoonSidePadding: Int = 0,
-    val tapZoneConfig: Int = 0,
     val invertTapZones: Boolean = false,
     val volumeKeysEnabled: Boolean = false,
     val volumeKeysInverted: Boolean = false,


### PR DESCRIPTION
## **User description**
## Summary

- `ReaderPreset` gains 7 new `@Serializable` fields covering tap zones, volume keys, page number visibility, and chapter skip behavior — the settings users most commonly change between "light casual reading" and "focused session" profiles
- `applyPreset()` now writes all 13 fields to their individual DataStore keys
- `captureCurrentAsPreset()` now reads all 13 fields from DataStore
- All new fields carry defaults matching the existing preference defaults, so old preset JSON deserializes cleanly with no migration needed
- Intentionally excluded: e-ink settings (device-specific), keep-screen-on (system-level), preload counts (performance tuning) — these don't belong in a reading-context preset

Addresses audit finding: reader presets captured only 6 of 40+ reader settings.

## Test plan

- [ ] Create a new reader preset — tap zone layout, volume key settings, page number, skip settings are captured
- [ ] Apply the preset — those settings change immediately in the reader
- [ ] Old preset JSON (6-field format) deserializes without error (new fields get defaults)
- [ ] `./gradlew :feature:reader:test` — all existing tests pass (ReaderPreset default params absorb new fields)

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Reader presets now save and restore more reader preferences**

### What Changed
- Reader presets now include tap zone, volume key, page number, and chapter-skip settings
- Saving a preset captures these extra reader preferences from the current session
- Applying a preset now restores all of those settings in the reader
- Existing presets still load with the same defaults, so older saved presets continue to work

### Impact
`✅ More complete reader presets`
`✅ Fewer manual setting changes after switching presets`
`✅ Safe use of older saved presets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
