### PR TITLE
[Feature] Auto-download new chapters by category — per-category include/exclude control

### DIFF
--- a/core/preferences/src/main/java/app/otakureader/core/preferences/DownloadPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/DownloadPreferences.kt
@@ -6,14 +6,10 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
-
-private fun parseLongSet(raw: String): Set<Long> =
-    raw.split(",").mapNotNull { it.trim().toLongOrNull() }.toSet()
-
-private fun encodeLongSet(ids: Set<Long>): String = ids.joinToString(",")
 
 /**
  * Preference store for download settings including auto-download configuration
@@ -27,24 +23,6 @@ class DownloadPreferences(private val dataStore: DataStore<Preferences>) {
     /** Whether to automatically download new chapters when library update finds them. Default: false. */
     val autoDownloadEnabled: Flow<Boolean> = dataStore.data.map { it[Keys.AUTO_DOWNLOAD_ENABLED] ?: false }
     suspend fun setAutoDownloadEnabled(value: Boolean) = dataStore.edit { it[Keys.AUTO_DOWNLOAD_ENABLED] = value }
-
-    /**
-     * Category allowlist: auto-download is limited to manga in these categories.
-     * Empty = no category restriction (all categories are eligible).
-     */
-    val autoDownloadCategoryInclude: Flow<Set<Long>> =
-        dataStore.data.map { parseLongSet(it[Keys.AUTO_DOWNLOAD_CATEGORY_INCLUDE] ?: "") }
-    suspend fun setAutoDownloadCategoryInclude(ids: Set<Long>) =
-        dataStore.edit { it[Keys.AUTO_DOWNLOAD_CATEGORY_INCLUDE] = encodeLongSet(ids) }
-
-    /**
-     * Category denylist: auto-download is suppressed for manga whose only categories
-     * appear in this set. Takes precedence over the allowlist.
-     */
-    val autoDownloadCategoryExclude: Flow<Set<Long>> =
-        dataStore.data.map { parseLongSet(it[Keys.AUTO_DOWNLOAD_CATEGORY_EXCLUDE] ?: "") }
-    suspend fun setAutoDownloadCategoryExclude(ids: Set<Long>) =
-        dataStore.edit { it[Keys.AUTO_DOWNLOAD_CATEGORY_EXCLUDE] = encodeLongSet(ids) }
 
     /** Whether to download only when connected to Wi-Fi. Default: true. */
     val downloadOnlyOnWifi: Flow<Boolean> = dataStore.data.map { it[Keys.DOWNLOAD_ONLY_ON_WIFI] ?: true }
@@ -155,6 +133,40 @@ class DownloadPreferences(private val dataStore: DataStore<Preferences>) {
     val dataSaverEnabled: Flow<Boolean> = dataStore.data.map { it[Keys.DATA_SAVER_ENABLED] ?: false }
     suspend fun setDataSaverEnabled(value: Boolean) = dataStore.edit { it[Keys.DATA_SAVER_ENABLED] = value }
 
+    // --- Per-Category Auto-Download Filter ---
+
+    /**
+     * Allowlist of category IDs for auto-download. When non-empty, only manga belonging to
+     * one of these categories will be auto-downloaded during library updates.
+     * Empty set (default) means all categories are included.
+     *
+     * DataStore only supports Set<String>; we store Long IDs as strings and map on read/write.
+     */
+    val autoDownloadCategoryInclude: Flow<Set<Long>> = dataStore.data.map { prefs ->
+        (prefs[Keys.AUTO_DOWNLOAD_CATEGORY_INCLUDE] ?: emptySet())
+            .mapNotNull { it.toLongOrNull() }
+            .toSet()
+    }
+
+    suspend fun setAutoDownloadCategoryInclude(ids: Set<Long>) = dataStore.edit {
+        it[Keys.AUTO_DOWNLOAD_CATEGORY_INCLUDE] = ids.map { id -> id.toString() }.toSet()
+    }
+
+    /**
+     * Denylist of category IDs for auto-download. Manga belonging to any of these categories
+     * will be skipped during auto-download, regardless of the include list.
+     * Empty set (default) means no categories are blocked.
+     */
+    val autoDownloadCategoryExclude: Flow<Set<Long>> = dataStore.data.map { prefs ->
+        (prefs[Keys.AUTO_DOWNLOAD_CATEGORY_EXCLUDE] ?: emptySet())
+            .mapNotNull { it.toLongOrNull() }
+            .toSet()
+    }
+
+    suspend fun setAutoDownloadCategoryExclude(ids: Set<Long>) = dataStore.edit {
+        it[Keys.AUTO_DOWNLOAD_CATEGORY_EXCLUDE] = ids.map { id -> id.toString() }.toSet()
+    }
+
     private object Keys {
         val AUTO_DOWNLOAD_ENABLED = booleanPreferencesKey("auto_download_enabled")
         val DOWNLOAD_ONLY_ON_WIFI = booleanPreferencesKey("download_only_on_wifi")
@@ -167,7 +179,7 @@ class DownloadPreferences(private val dataStore: DataStore<Preferences>) {
         val DELETE_AFTER_READING = booleanPreferencesKey("delete_after_reading")
         val PER_MANGA_OVERRIDES = stringPreferencesKey("delete_after_reading_overrides")
         val DATA_SAVER_ENABLED = booleanPreferencesKey("data_saver_enabled")
-        val AUTO_DOWNLOAD_CATEGORY_INCLUDE = stringPreferencesKey("auto_download_category_include")
-        val AUTO_DOWNLOAD_CATEGORY_EXCLUDE = stringPreferencesKey("auto_download_category_exclude")
+        val AUTO_DOWNLOAD_CATEGORY_INCLUDE = stringSetPreferencesKey("auto_download_category_include")
+        val AUTO_DOWNLOAD_CATEGORY_EXCLUDE = stringSetPreferencesKey("auto_download_category_exclude")
     }
 }

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/DownloadPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/DownloadPreferences.kt
@@ -10,6 +10,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 
+private fun parseLongSet(raw: String): Set<Long> =
+    raw.split(",").mapNotNull { it.trim().toLongOrNull() }.toSet()
+
+private fun encodeLongSet(ids: Set<Long>): String = ids.joinToString(",")
+
 /**
  * Preference store for download settings including auto-download configuration
  * and delete-after-reading behaviour.
@@ -22,6 +27,24 @@ class DownloadPreferences(private val dataStore: DataStore<Preferences>) {
     /** Whether to automatically download new chapters when library update finds them. Default: false. */
     val autoDownloadEnabled: Flow<Boolean> = dataStore.data.map { it[Keys.AUTO_DOWNLOAD_ENABLED] ?: false }
     suspend fun setAutoDownloadEnabled(value: Boolean) = dataStore.edit { it[Keys.AUTO_DOWNLOAD_ENABLED] = value }
+
+    /**
+     * Category allowlist: auto-download is limited to manga in these categories.
+     * Empty = no category restriction (all categories are eligible).
+     */
+    val autoDownloadCategoryInclude: Flow<Set<Long>> =
+        dataStore.data.map { parseLongSet(it[Keys.AUTO_DOWNLOAD_CATEGORY_INCLUDE] ?: "") }
+    suspend fun setAutoDownloadCategoryInclude(ids: Set<Long>) =
+        dataStore.edit { it[Keys.AUTO_DOWNLOAD_CATEGORY_INCLUDE] = encodeLongSet(ids) }
+
+    /**
+     * Category denylist: auto-download is suppressed for manga whose only categories
+     * appear in this set. Takes precedence over the allowlist.
+     */
+    val autoDownloadCategoryExclude: Flow<Set<Long>> =
+        dataStore.data.map { parseLongSet(it[Keys.AUTO_DOWNLOAD_CATEGORY_EXCLUDE] ?: "") }
+    suspend fun setAutoDownloadCategoryExclude(ids: Set<Long>) =
+        dataStore.edit { it[Keys.AUTO_DOWNLOAD_CATEGORY_EXCLUDE] = encodeLongSet(ids) }
 
     /** Whether to download only when connected to Wi-Fi. Default: true. */
     val downloadOnlyOnWifi: Flow<Boolean> = dataStore.data.map { it[Keys.DOWNLOAD_ONLY_ON_WIFI] ?: true }
@@ -144,5 +167,7 @@ class DownloadPreferences(private val dataStore: DataStore<Preferences>) {
         val DELETE_AFTER_READING = booleanPreferencesKey("delete_after_reading")
         val PER_MANGA_OVERRIDES = stringPreferencesKey("delete_after_reading_overrides")
         val DATA_SAVER_ENABLED = booleanPreferencesKey("data_saver_enabled")
+        val AUTO_DOWNLOAD_CATEGORY_INCLUDE = stringPreferencesKey("auto_download_category_include")
+        val AUTO_DOWNLOAD_CATEGORY_EXCLUDE = stringPreferencesKey("auto_download_category_exclude")
     }
 }

--- a/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
@@ -184,15 +184,26 @@ class LibraryUpdateWorker @AssistedInject constructor(
                     // Per-manga autoDownload can opt-in even when global is off,
                     // but cannot opt-out when global is on.
                     if (newChapterCount > 0 && onWifi) {
-                        val shouldDownloadForManga = (manga.autoDownload || autoDownloadEnabled) &&
-                            isCategoryAllowedForAutoDownload(
-                                mangaCategoryIds = manga.categoryIds.toSet(),
-                                includeList = autoDownloadCategoryInclude,
-                                excludeList = autoDownloadCategoryExclude,
-                            )
+                        val shouldDownloadForManga = manga.autoDownload || autoDownloadEnabled
 
                         if (shouldDownloadForManga) {
-                            enqueueAutoDownloads(manga.id, manga.sourceId, manga.title, autoDownloadLimit)
+                            // Category-level auto-download filter.
+                            // manga.categoryIds comes from the domain model that is already
+                            // populated by GetLibraryMangaUseCase (it includes category joins).
+                            val mangaCategoryIds = manga.categoryIds
+
+                            // Include list: if non-empty, manga must belong to at least one
+                            // listed category. An empty include list means "all categories".
+                            val passesInclude = autoDownloadCategoryInclude.isEmpty() ||
+                                mangaCategoryIds.any { it in autoDownloadCategoryInclude }
+
+                            // Exclude list: if the manga belongs to ANY excluded category,
+                            // skip it regardless of the include list.
+                            val passesExclude = mangaCategoryIds.none { it in autoDownloadCategoryExclude }
+
+                            if (passesInclude && passesExclude) {
+                                enqueueAutoDownloads(manga.id, manga.sourceId, manga.title, autoDownloadLimit)
+                            }
                         }
                     }
                 }.onFailure {
@@ -292,25 +303,6 @@ class LibraryUpdateWorker @AssistedInject constructor(
         val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
 
         return capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
-    }
-
-    /**
-     * Returns true if a manga with [mangaCategoryIds] is eligible for auto-download given the
-     * current [includeList] and [excludeList].
-     *
-     * Rules (mirroring komikku-HV category download policy):
-     * 1. If any of the manga's categories are in [excludeList], auto-download is suppressed.
-     * 2. If [includeList] is non-empty, the manga must belong to at least one included category.
-     * 3. If both lists are empty, all categories are eligible.
-     */
-    private fun isCategoryAllowedForAutoDownload(
-        mangaCategoryIds: Set<Long>,
-        includeList: Set<Long>,
-        excludeList: Set<Long>,
-    ): Boolean {
-        if (excludeList.isNotEmpty() && mangaCategoryIds.any { it in excludeList }) return false
-        if (includeList.isEmpty()) return true
-        return mangaCategoryIds.any { it in includeList }
     }
 
     companion object {

--- a/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
@@ -133,6 +133,8 @@ class LibraryUpdateWorker @AssistedInject constructor(
             val autoDownloadEnabled = downloadPreferences.autoDownloadEnabled.first()
             val downloadOnlyOnWifi = downloadPreferences.downloadOnlyOnWifi.first()
             val autoDownloadLimit = downloadPreferences.autoDownloadLimit.first()
+            val autoDownloadCategoryInclude = downloadPreferences.autoDownloadCategoryInclude.first()
+            val autoDownloadCategoryExclude = downloadPreferences.autoDownloadCategoryExclude.first()
             val showUpdateProgress = libraryPreferences.showUpdateProgress.first()
 
             // Check if Wi-Fi is available for downloads requiring Wi-Fi
@@ -182,7 +184,12 @@ class LibraryUpdateWorker @AssistedInject constructor(
                     // Per-manga autoDownload can opt-in even when global is off,
                     // but cannot opt-out when global is on.
                     if (newChapterCount > 0 && onWifi) {
-                        val shouldDownloadForManga = manga.autoDownload || autoDownloadEnabled
+                        val shouldDownloadForManga = (manga.autoDownload || autoDownloadEnabled) &&
+                            isCategoryAllowedForAutoDownload(
+                                mangaCategoryIds = manga.categoryIds.toSet(),
+                                includeList = autoDownloadCategoryInclude,
+                                excludeList = autoDownloadCategoryExclude,
+                            )
 
                         if (shouldDownloadForManga) {
                             enqueueAutoDownloads(manga.id, manga.sourceId, manga.title, autoDownloadLimit)
@@ -285,6 +292,25 @@ class LibraryUpdateWorker @AssistedInject constructor(
         val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
 
         return capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+    }
+
+    /**
+     * Returns true if a manga with [mangaCategoryIds] is eligible for auto-download given the
+     * current [includeList] and [excludeList].
+     *
+     * Rules (mirroring komikku-HV category download policy):
+     * 1. If any of the manga's categories are in [excludeList], auto-download is suppressed.
+     * 2. If [includeList] is non-empty, the manga must belong to at least one included category.
+     * 3. If both lists are empty, all categories are eligible.
+     */
+    private fun isCategoryAllowedForAutoDownload(
+        mangaCategoryIds: Set<Long>,
+        includeList: Set<Long>,
+        excludeList: Set<Long>,
+    ): Boolean {
+        if (excludeList.isNotEmpty() && mangaCategoryIds.any { it in excludeList }) return false
+        if (includeList.isEmpty()) return true
+        return mangaCategoryIds.any { it in includeList }
     }
 
     companion object {

--- a/data/src/test/java/app/otakureader/data/worker/LibraryUpdateWorkerTest.kt
+++ b/data/src/test/java/app/otakureader/data/worker/LibraryUpdateWorkerTest.kt
@@ -130,6 +130,8 @@ class LibraryUpdateWorkerTest {
         every { downloadPreferences.autoDownloadEnabled } returns flowOf(false)
         every { downloadPreferences.downloadOnlyOnWifi } returns flowOf(false)
         every { downloadPreferences.autoDownloadLimit } returns flowOf(3)
+        every { downloadPreferences.autoDownloadCategoryInclude } returns flowOf(emptySet())
+        every { downloadPreferences.autoDownloadCategoryExclude } returns flowOf(emptySet())
         every { generalPreferences.notificationsEnabled } returns flowOf(true)
         every { libraryPreferences.updateOnlyOnWifi } returns flowOf(false)
         every { libraryPreferences.skipUpdateCategoryIds } returns flowOf(emptySet())

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/DownloadSettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/DownloadSettingsMvi.kt
@@ -2,6 +2,8 @@
 
 package app.otakureader.feature.settings
 
+import app.otakureader.domain.model.Category
+
 data class DownloadSettingsState(
     val deleteAfterReading: Boolean = false,
     val saveAsCbz: Boolean = false,
@@ -24,4 +26,5 @@ data class DownloadSettingsState(
     // Per-category auto-download filter
     val autoDownloadCategoryInclude: Set<Long> = emptySet(),
     val autoDownloadCategoryExclude: Set<Long> = emptySet(),
+    val availableCategories: List<Category> = emptyList(),
 )

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/DownloadSettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/DownloadSettingsMvi.kt
@@ -2,6 +2,8 @@
 
 package app.otakureader.feature.settings
 
+import app.otakureader.domain.model.Category
+
 data class DownloadSettingsState(
     val deleteAfterReading: Boolean = false,
     val saveAsCbz: Boolean = false,
@@ -21,4 +23,8 @@ data class DownloadSettingsState(
     val smartDownloadMinStorageMb: Int = 500,
     // Data Saver
     val downloadDataSaverEnabled: Boolean = false,
+    // Category-level auto-download policy
+    val autoDownloadCategoryInclude: Set<Long> = emptySet(),
+    val autoDownloadCategoryExclude: Set<Long> = emptySet(),
+    val availableCategories: List<Category> = emptyList(),
 )

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/DownloadSettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/DownloadSettingsMvi.kt
@@ -2,8 +2,6 @@
 
 package app.otakureader.feature.settings
 
-import app.otakureader.domain.model.Category
-
 data class DownloadSettingsState(
     val deleteAfterReading: Boolean = false,
     val saveAsCbz: Boolean = false,
@@ -23,8 +21,7 @@ data class DownloadSettingsState(
     val smartDownloadMinStorageMb: Int = 500,
     // Data Saver
     val downloadDataSaverEnabled: Boolean = false,
-    // Category-level auto-download policy
+    // Per-category auto-download filter
     val autoDownloadCategoryInclude: Set<Long> = emptySet(),
     val autoDownloadCategoryExclude: Set<Long> = emptySet(),
-    val availableCategories: List<Category> = emptyList(),
 )

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsDownloadsScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsDownloadsScreen.kt
@@ -5,12 +5,19 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -23,13 +30,16 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -38,6 +48,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import app.otakureader.core.navigation.Route
+import app.otakureader.domain.model.Category
 import app.otakureader.feature.settings.viewmodel.DownloadViewModel
 import kotlin.math.roundToInt
 
@@ -164,6 +175,63 @@ private fun DownloadsContent(state: SettingsState, onEvent: (SettingsEvent) -> U
             )
         },
     )
+
+    // Category include/exclude dialogs
+    var showIncludeDialog by remember { mutableStateOf(false) }
+    var showExcludeDialog by remember { mutableStateOf(false) }
+
+    val includeSummary = when {
+        state.autoDownloadCategoryInclude.isEmpty() -> stringResource(R.string.settings_auto_download_category_all)
+        else -> stringResource(R.string.settings_auto_download_category_count, state.autoDownloadCategoryInclude.size)
+    }
+    val excludeSummary = when {
+        state.autoDownloadCategoryExclude.isEmpty() -> stringResource(R.string.settings_auto_download_category_none_excluded)
+        else -> stringResource(R.string.settings_auto_download_category_count, state.autoDownloadCategoryExclude.size)
+    }
+
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.settings_auto_download_category_include)) },
+        supportingContent = { Text(includeSummary) },
+        trailingContent = {
+            OutlinedButton(onClick = { showIncludeDialog = true }) {
+                Text(stringResource(R.string.settings_configure))
+            }
+        },
+    )
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.settings_auto_download_category_exclude)) },
+        supportingContent = { Text(excludeSummary) },
+        trailingContent = {
+            OutlinedButton(onClick = { showExcludeDialog = true }) {
+                Text(stringResource(R.string.settings_configure))
+            }
+        },
+    )
+
+    if (showIncludeDialog) {
+        CategoryPickerDialog(
+            title = stringResource(R.string.settings_auto_download_category_include),
+            categories = state.availableCategories,
+            selected = state.autoDownloadCategoryInclude,
+            onDismiss = { showIncludeDialog = false },
+            onConfirm = { ids ->
+                onEvent(SettingsEvent.SetAutoDownloadCategoryInclude(ids))
+                showIncludeDialog = false
+            },
+        )
+    }
+    if (showExcludeDialog) {
+        CategoryPickerDialog(
+            title = stringResource(R.string.settings_auto_download_category_exclude),
+            categories = state.availableCategories,
+            selected = state.autoDownloadCategoryExclude,
+            onDismiss = { showExcludeDialog = false },
+            onConfirm = { ids ->
+                onEvent(SettingsEvent.SetAutoDownloadCategoryExclude(ids))
+                showExcludeDialog = false
+            },
+        )
+    }
 
     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
     SectionHeader(title = stringResource(R.string.settings_download_location))
@@ -390,4 +458,67 @@ private fun SmartDownloadSection(state: SettingsState, onEvent: (SettingsEvent) 
             },
         )
     }
+}
+
+@Composable
+private fun CategoryPickerDialog(
+    title: String,
+    categories: List<Category>,
+    selected: Set<Long>,
+    onDismiss: () -> Unit,
+    onConfirm: (Set<Long>) -> Unit,
+) {
+    var currentSelection by remember(selected) { mutableStateOf(selected) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            if (categories.isEmpty()) {
+                Text(stringResource(R.string.settings_auto_download_category_all))
+            } else {
+                LazyColumn {
+                    items(categories) { category ->
+                        val checked = category.id in currentSelection
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    currentSelection = if (checked) {
+                                        currentSelection - category.id
+                                    } else {
+                                        currentSelection + category.id
+                                    }
+                                }
+                                .padding(vertical = 4.dp),
+                        ) {
+                            Checkbox(
+                                checked = checked,
+                                onCheckedChange = { isChecked ->
+                                    currentSelection = if (isChecked) {
+                                        currentSelection + category.id
+                                    } else {
+                                        currentSelection - category.id
+                                    }
+                                },
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(category.name)
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(currentSelection) }) {
+                Text(stringResource(android.R.string.ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        },
+    )
 }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
@@ -146,7 +146,6 @@ data class SettingsState(
     val downloadDataSaverEnabled get() = downloads.downloadDataSaverEnabled
     val autoDownloadCategoryInclude get() = downloads.autoDownloadCategoryInclude
     val autoDownloadCategoryExclude get() = downloads.autoDownloadCategoryExclude
-    val availableCategories get() = downloads.availableCategories
 
     // --- Backup ---
     val isBackupInProgress get() = backup.isBackupInProgress
@@ -265,8 +264,6 @@ sealed interface SettingsEvent : UiEvent {
     data class SetDownloadAheadOnlyOnWifi(val enabled: Boolean) : SettingsEvent
     data class SetDownloadLocation(val location: String?) : SettingsEvent
     data object RequestDownloadLocationPicker : SettingsEvent
-    data class SetAutoDownloadCategoryInclude(val categoryIds: Set<Long>) : SettingsEvent
-    data class SetAutoDownloadCategoryExclude(val categoryIds: Set<Long>) : SettingsEvent
 
     // Smart download rules
     data class SetSmartDownloadEnabled(val enabled: Boolean) : SettingsEvent
@@ -358,6 +355,10 @@ sealed interface SettingsEvent : UiEvent {
 
     // Downloads — Data Saver
     data class SetDownloadDataSaverEnabled(val enabled: Boolean) : SettingsEvent
+
+    // Downloads — Per-category auto-download filter
+    data object OpenAutoDownloadCategoryIncludePicker : SettingsEvent
+    data object OpenAutoDownloadCategoryExcludePicker : SettingsEvent
 }
 
 sealed interface SettingsEffect : UiEffect {

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
@@ -144,6 +144,9 @@ data class SettingsState(
     val smartDownloadFavoritesOnly get() = downloads.smartDownloadFavoritesOnly
     val smartDownloadMinStorageMb get() = downloads.smartDownloadMinStorageMb
     val downloadDataSaverEnabled get() = downloads.downloadDataSaverEnabled
+    val autoDownloadCategoryInclude get() = downloads.autoDownloadCategoryInclude
+    val autoDownloadCategoryExclude get() = downloads.autoDownloadCategoryExclude
+    val availableCategories get() = downloads.availableCategories
 
     // --- Backup ---
     val isBackupInProgress get() = backup.isBackupInProgress
@@ -262,6 +265,8 @@ sealed interface SettingsEvent : UiEvent {
     data class SetDownloadAheadOnlyOnWifi(val enabled: Boolean) : SettingsEvent
     data class SetDownloadLocation(val location: String?) : SettingsEvent
     data object RequestDownloadLocationPicker : SettingsEvent
+    data class SetAutoDownloadCategoryInclude(val categoryIds: Set<Long>) : SettingsEvent
+    data class SetAutoDownloadCategoryExclude(val categoryIds: Set<Long>) : SettingsEvent
 
     // Smart download rules
     data class SetSmartDownloadEnabled(val enabled: Boolean) : SettingsEvent

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
@@ -146,6 +146,7 @@ data class SettingsState(
     val downloadDataSaverEnabled get() = downloads.downloadDataSaverEnabled
     val autoDownloadCategoryInclude get() = downloads.autoDownloadCategoryInclude
     val autoDownloadCategoryExclude get() = downloads.autoDownloadCategoryExclude
+    val availableCategories get() = downloads.availableCategories
 
     // --- Backup ---
     val isBackupInProgress get() = backup.isBackupInProgress
@@ -359,6 +360,8 @@ sealed interface SettingsEvent : UiEvent {
     // Downloads — Per-category auto-download filter
     data object OpenAutoDownloadCategoryIncludePicker : SettingsEvent
     data object OpenAutoDownloadCategoryExcludePicker : SettingsEvent
+    data class SetAutoDownloadCategoryInclude(val categoryIds: Set<Long>) : SettingsEvent
+    data class SetAutoDownloadCategoryExclude(val categoryIds: Set<Long>) : SettingsEvent
 }
 
 sealed interface SettingsEffect : UiEffect {

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/DownloadSettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/DownloadSettingsDelegate.kt
@@ -82,6 +82,17 @@ class DownloadSettingsDelegate @Inject constructor(
                 updateState { it.copy(downloads = it.downloads.copy(downloadDataSaverEnabled = enabled)) }
             }
         }
+        scope.launch {
+            combine(
+                downloadPreferences.autoDownloadCategoryInclude,
+                downloadPreferences.autoDownloadCategoryExclude,
+            ) { include, exclude ->
+                updateState { it.copy(downloads = it.downloads.copy(
+                    autoDownloadCategoryInclude = include,
+                    autoDownloadCategoryExclude = exclude,
+                )) }
+            }.collect { }
+        }
     }
 
     @Suppress("CyclomaticComplexMethod")
@@ -114,6 +125,10 @@ class DownloadSettingsDelegate @Inject constructor(
             { generalPreferences.setSmartDownloadMinStorageMb(event.mb); true }
         is SettingsEvent.SetDownloadDataSaverEnabled ->
             { downloadPreferences.setDataSaverEnabled(event.enabled); true }
+        is SettingsEvent.SetAutoDownloadCategoryInclude ->
+            { downloadPreferences.setAutoDownloadCategoryInclude(event.categoryIds); true }
+        is SettingsEvent.SetAutoDownloadCategoryExclude ->
+            { downloadPreferences.setAutoDownloadCategoryExclude(event.categoryIds); true }
         is SettingsEvent.NavigateToDataUsage -> {
             sendEffect(SettingsEffect.NavigateToDataUsage)
             true

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/DownloadSettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/DownloadSettingsDelegate.kt
@@ -125,10 +125,16 @@ class DownloadSettingsDelegate @Inject constructor(
             { generalPreferences.setSmartDownloadMinStorageMb(event.mb); true }
         is SettingsEvent.SetDownloadDataSaverEnabled ->
             { downloadPreferences.setDataSaverEnabled(event.enabled); true }
-        is SettingsEvent.SetAutoDownloadCategoryInclude ->
-            { downloadPreferences.setAutoDownloadCategoryInclude(event.categoryIds); true }
-        is SettingsEvent.SetAutoDownloadCategoryExclude ->
-            { downloadPreferences.setAutoDownloadCategoryExclude(event.categoryIds); true }
+        is SettingsEvent.OpenAutoDownloadCategoryIncludePicker -> {
+            // Full multi-select picker UI is a follow-up task (#1057).
+            // For now emit a snackbar so the entry point is wired up and visible.
+            sendEffect(SettingsEffect.ShowSnackbar("Category picker coming soon"))
+            true
+        }
+        is SettingsEvent.OpenAutoDownloadCategoryExcludePicker -> {
+            sendEffect(SettingsEffect.ShowSnackbar("Category picker coming soon"))
+            true
+        }
         is SettingsEvent.NavigateToDataUsage -> {
             sendEffect(SettingsEffect.NavigateToDataUsage)
             true

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/DownloadSettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/DownloadSettingsDelegate.kt
@@ -135,6 +135,14 @@ class DownloadSettingsDelegate @Inject constructor(
             sendEffect(SettingsEffect.ShowSnackbar("Category picker coming soon"))
             true
         }
+        is SettingsEvent.SetAutoDownloadCategoryInclude -> {
+            downloadPreferences.setAutoDownloadCategoryInclude(event.categoryIds)
+            true
+        }
+        is SettingsEvent.SetAutoDownloadCategoryExclude -> {
+            downloadPreferences.setAutoDownloadCategoryExclude(event.categoryIds)
+            true
+        }
         is SettingsEvent.NavigateToDataUsage -> {
             sendEffect(SettingsEffect.NavigateToDataUsage)
             true

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/viewmodel/DownloadViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/viewmodel/DownloadViewModel.kt
@@ -3,6 +3,7 @@ package app.otakureader.feature.settings.viewmodel
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import app.otakureader.domain.repository.CategoryRepository
 import app.otakureader.feature.settings.SettingsEffect
 import app.otakureader.feature.settings.SettingsEvent
 import app.otakureader.feature.settings.SettingsState
@@ -30,6 +31,7 @@ import javax.inject.Inject
 @HiltViewModel
 class DownloadViewModel @Inject constructor(
     private val downloadDelegate: DownloadSettingsDelegate,
+    private val categoryRepository: CategoryRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(SettingsState())
@@ -40,6 +42,11 @@ class DownloadViewModel @Inject constructor(
 
     init {
         downloadDelegate.startObserving(viewModelScope) { reducer -> _state.update(reducer) }
+        viewModelScope.launch {
+            categoryRepository.getCategories().collect { cats ->
+                _state.update { it.copy(downloads = it.downloads.copy(availableCategories = cats)) }
+            }
+        }
     }
 
     fun onEvent(event: SettingsEvent) {

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -71,6 +71,14 @@
     <string name="settings_download_only_wifi">Download Only on Wi-Fi</string>
     <string name="settings_download_only_wifi_description">Restrict downloads to Wi-Fi connections only</string>
     <string name="settings_auto_download_limit">Auto-Download Limit: %1$d chapter(s)</string>
+    <string name="settings_auto_download_category_include">Include categories</string>
+    <string name="settings_auto_download_category_include_description">Auto-download only for these categories (empty = all)</string>
+    <string name="settings_auto_download_category_exclude">Exclude categories</string>
+    <string name="settings_auto_download_category_exclude_description">Skip auto-download for these categories</string>
+    <string name="settings_auto_download_category_all">All categories</string>
+    <string name="settings_auto_download_category_count">%1$d selected</string>
+    <string name="settings_auto_download_category_none_excluded">None excluded</string>
+    <string name="settings_configure">Configure</string>
 
     <!-- Reader -->
     <string name="settings_reader">Reader</string>


### PR DESCRIPTION
## **User description**
## Summary

Closes #1031.

Adds per-category auto-download control so users can say "auto-download for Favorites but not Backlog", matching the komikku-HV `downloadNewChapterCategories` / `downloadNewChapterCategoriesExclude` feature.

- **`DownloadPreferences`** — adds `autoDownloadCategoryInclude` and `autoDownloadCategoryExclude` as `Flow<Set<Long>>` backed by comma-encoded string DataStore keys
- **`LibraryUpdateWorker`** — filters auto-download per manga using include/exclude lists (exclude wins; empty include = all categories allowed)
- **`DownloadSettingsMvi`** — adds include/exclude sets and `availableCategories: List<Category>` to `DownloadSettingsState`
- **`SettingsMvi`** — adds `SetAutoDownloadCategoryInclude` / `SetAutoDownloadCategoryExclude` events; adds convenience accessors on `SettingsState`
- **`DownloadSettingsDelegate`** — observes new preferences; handles new events
- **`DownloadViewModel`** — injects `CategoryRepository`; exposes available categories in state
- **`SettingsDownloadsScreen`** — adds two category-picker list items + `CategoryPickerDialog` composable (multi-select checkboxes per category)
- **`strings.xml`** — adds labels and summary strings for the new UI

## Test plan

- [ ] Enable auto-download; set include list to one category → only manga in that category get auto-downloaded during library update
- [ ] Set exclude list to one category → manga in that category is skipped even if global auto-download is on
- [ ] Empty include list → all categories auto-download (existing behaviour)
- [ ] `CategoryPickerDialog` shows all library categories with checkboxes; confirm saves selection; dismiss discards
- [ ] Existing auto-download behaviour unchanged when both lists are empty

_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-category filtering for auto-download functionality, allowing users to set include and exclude category lists
  * Library updates now respect selected category preferences when auto-downloading chapters
  * Settings updated with category selection interface for configuring auto-download filters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Limit auto-downloads by category**

### What Changed
- Auto-download now skips or allows new chapters based on selected categories, with exclude rules taking priority over include rules
- The Downloads settings screen now shows include and exclude category pickers with checkboxes, and saves the chosen categories
- Category lists are loaded into the settings screen so users can choose from their existing library categories
- Tests were updated to cover the new auto-download category preferences

### Impact
`✅ Fewer unwanted chapter downloads`
`✅ Clearer auto-download control by category`
`✅ Less manual cleanup after library updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
