### PR TITLE
[Feature] Biometric lock — time-of-day and day-of-week scheduling windows

### DIFF
--- a/app/src/main/java/app/otakureader/MainActivity.kt
+++ b/app/src/main/java/app/otakureader/MainActivity.kt
@@ -162,6 +162,14 @@ class MainActivity : FragmentActivity() {
                 .collectAsStateWithLifecycle(initialValue = false)
             val biometricLockTimeoutMinutes by generalPreferences.biometricLockTimeoutMinutes
                 .collectAsStateWithLifecycle(initialValue = 0)
+            val biometricLockScheduleEnabled by generalPreferences.biometricLockScheduleEnabled
+                .collectAsStateWithLifecycle(initialValue = false)
+            val biometricLockStartHour by generalPreferences.biometricLockStartHour
+                .collectAsStateWithLifecycle(initialValue = 22)
+            val biometricLockEndHour by generalPreferences.biometricLockEndHour
+                .collectAsStateWithLifecycle(initialValue = 8)
+            val biometricLockActiveDays by generalPreferences.biometricLockActiveDays
+                .collectAsStateWithLifecycle(initialValue = emptySet())
             val darkModeScheduleEnabled by generalPreferences.darkModeScheduleEnabled
                 .collectAsStateWithLifecycle(initialValue = false)
             val darkModeStartMinute by generalPreferences.darkModeStartMinuteOfDay
@@ -218,6 +226,10 @@ class MainActivity : FragmentActivity() {
                     BiometricLockGate(
                         enabled = biometricLockEnabled,
                         timeoutMillis = biometricLockTimeoutMinutes * 60_000L,
+                        scheduleEnabled = biometricLockScheduleEnabled,
+                        startHour = biometricLockStartHour,
+                        endHour = biometricLockEndHour,
+                        activeDays = biometricLockActiveDays,
                     ) {
                         OtakuReaderApp(
                             generalPreferences = generalPreferences,

--- a/app/src/main/java/app/otakureader/security/BiometricLockGate.kt
+++ b/app/src/main/java/app/otakureader/security/BiometricLockGate.kt
@@ -5,6 +5,7 @@ import android.content.ContextWrapper
 import android.content.Intent
 import android.os.SystemClock
 import android.provider.Settings
+import java.util.Calendar
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
 import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
@@ -53,8 +54,13 @@ import app.otakureader.R
 fun BiometricLockGate(
     enabled: Boolean,
     timeoutMillis: Long,
+    scheduleEnabled: Boolean = false,
+    startHour: Int = 0,
+    endHour: Int = 0,
+    activeDays: Set<Int> = emptySet(),
     content: @Composable () -> Unit,
 ) {
+    val effectivelyEnabled = enabled && (!scheduleEnabled || isWithinLockSchedule(startHour, endHour, activeDays))
     val context = LocalContext.current
     // LocalContext may be a ContextWrapper (theme wrapper, Hilt/navigation wrapper); walk the
     // chain to find the hosting FragmentActivity rather than casting directly.
@@ -66,24 +72,24 @@ fun BiometricLockGate(
 
     // Lock once when the feature is first known to be on (cold start). Disabling resets the
     // one-shot guard so re-enabling within the same process locks again immediately.
-    LaunchedEffect(enabled) {
-        if (enabled && !initialized) {
+    LaunchedEffect(effectivelyEnabled) {
+        if (effectivelyEnabled && !initialized) {
             locked = true
             initialized = true
-        } else if (!enabled) {
+        } else if (!effectivelyEnabled) {
             locked = false
             initialized = false
         }
     }
 
     val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner, enabled, timeoutMillis) {
+    DisposableEffect(lifecycleOwner, effectivelyEnabled, timeoutMillis) {
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
                 // elapsedRealtime() is monotonic — unaffected by clock changes / NTP sync.
                 Lifecycle.Event.ON_STOP -> backgroundedAt = SystemClock.elapsedRealtime()
                 Lifecycle.Event.ON_START -> {
-                    if (enabled && backgroundedAt > 0L &&
+                    if (effectivelyEnabled && backgroundedAt > 0L &&
                         SystemClock.elapsedRealtime() - backgroundedAt >= timeoutMillis
                     ) {
                         locked = true
@@ -98,7 +104,7 @@ fun BiometricLockGate(
 
     content()
 
-    if (enabled && locked) {
+    if (effectivelyEnabled && locked) {
         val title = stringResource(R.string.biometric_lock_title)
         val subtitle = stringResource(R.string.biometric_lock_subtitle)
         val authAvailable = activity != null && canAuthenticate(activity)
@@ -169,6 +175,27 @@ private fun Context.findFragmentActivity(): FragmentActivity? {
         ctx = ctx.baseContext
     }
     return null
+}
+
+/**
+ * Returns true if the current wall-clock time falls within the lock enforcement window.
+ *
+ * [startHour] and [endHour] are 0-23. When [startHour] > [endHour] the window wraps midnight
+ * (e.g., start=22, end=8 enforces lock from 22:00 to 07:59).
+ * [activeDays] uses [Calendar] day constants (Calendar.MONDAY = 2 … Calendar.SUNDAY = 1).
+ * An empty [activeDays] set means all days are active.
+ */
+private fun isWithinLockSchedule(startHour: Int, endHour: Int, activeDays: Set<Int>): Boolean {
+    val now = Calendar.getInstance()
+    val dayOfWeek = now.get(Calendar.DAY_OF_WEEK)
+    val hour = now.get(Calendar.HOUR_OF_DAY)
+    val dayAllowed = activeDays.isEmpty() || dayOfWeek in activeDays
+    val hourAllowed = if (startHour <= endHour) {
+        hour in startHour until endHour
+    } else {
+        hour >= startHour || hour < endHour
+    }
+    return dayAllowed && hourAllowed
 }
 
 private const val ALLOWED_AUTHENTICATORS = BIOMETRIC_STRONG or DEVICE_CREDENTIAL

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
@@ -209,6 +209,26 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
     suspend fun setBiometricLockTimeoutMinutes(value: Int) =
         dataStore.edit { it[Keys.BIOMETRIC_LOCK_TIMEOUT_MINUTES] = value }
 
+    val biometricLockScheduleEnabled: Flow<Boolean> =
+        dataStore.data.map { it[Keys.BIOMETRIC_LOCK_SCHEDULE_ENABLED] ?: false }
+    suspend fun setBiometricLockScheduleEnabled(value: Boolean) =
+        dataStore.edit { it[Keys.BIOMETRIC_LOCK_SCHEDULE_ENABLED] = value }
+
+    val biometricLockStartHour: Flow<Int> =
+        dataStore.data.map { it[Keys.BIOMETRIC_LOCK_START_HOUR] ?: 22 }
+    suspend fun setBiometricLockStartHour(value: Int) =
+        dataStore.edit { it[Keys.BIOMETRIC_LOCK_START_HOUR] = value.coerceIn(0, 23) }
+
+    val biometricLockEndHour: Flow<Int> =
+        dataStore.data.map { it[Keys.BIOMETRIC_LOCK_END_HOUR] ?: 8 }
+    suspend fun setBiometricLockEndHour(value: Int) =
+        dataStore.edit { it[Keys.BIOMETRIC_LOCK_END_HOUR] = value.coerceIn(0, 23) }
+
+    val biometricLockActiveDays: Flow<Set<Int>> =
+        dataStore.data.map { parseDaySet(it[Keys.BIOMETRIC_LOCK_ACTIVE_DAYS] ?: "") }
+    suspend fun setBiometricLockActiveDays(days: Set<Int>) =
+        dataStore.edit { it[Keys.BIOMETRIC_LOCK_ACTIVE_DAYS] = encodeDaySet(days) }
+
     // --- App Update Checker ---
 
     /** Whether automatic app update checking is enabled. */
@@ -295,6 +315,11 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
     suspend fun setCoilDiskCacheSizeMb(value: Int) =
         dataStore.edit { it[Keys.COIL_DISK_CACHE_SIZE_MB] = value.coerceIn(MIN_COIL_DISK_CACHE_MB, MAX_COIL_DISK_CACHE_MB) }
 
+    private fun parseDaySet(raw: String): Set<Int> =
+        raw.split(",").mapNotNull { it.trim().toIntOrNull() }.toSet()
+
+    private fun encodeDaySet(days: Set<Int>): String = days.joinToString(",")
+
     private object Keys {
         val THEME_MODE = intPreferencesKey("theme_mode")
         val USE_DYNAMIC_COLOR = booleanPreferencesKey("use_dynamic_color")
@@ -331,6 +356,10 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
         val BROWSE_FILTER_STATES = stringPreferencesKey("browse_filter_states")
         val BIOMETRIC_LOCK_ENABLED = booleanPreferencesKey("biometric_lock_enabled")
         val BIOMETRIC_LOCK_TIMEOUT_MINUTES = intPreferencesKey("biometric_lock_timeout_minutes")
+        val BIOMETRIC_LOCK_SCHEDULE_ENABLED = booleanPreferencesKey("biometric_lock_schedule_enabled")
+        val BIOMETRIC_LOCK_START_HOUR = intPreferencesKey("biometric_lock_start_hour")
+        val BIOMETRIC_LOCK_END_HOUR = intPreferencesKey("biometric_lock_end_hour")
+        val BIOMETRIC_LOCK_ACTIVE_DAYS = stringPreferencesKey("biometric_lock_active_days")
         val DARK_MODE_SCHEDULE_ENABLED = booleanPreferencesKey("dark_mode_schedule_enabled")
         val DARK_MODE_START_MINUTE = intPreferencesKey("dark_mode_start_minute")
         val DARK_MODE_END_MINUTE = intPreferencesKey("dark_mode_end_minute")

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
@@ -43,6 +43,10 @@ data class SettingsState(
     // --- Security ---
     val biometricLockEnabled: Boolean = false,
     val biometricLockTimeoutMinutes: Int = 0,
+    val biometricLockScheduleEnabled: Boolean = false,
+    val biometricLockStartHour: Int = 22,
+    val biometricLockEndHour: Int = 8,
+    val biometricLockActiveDays: Set<Int> = emptySet(),
 
     // --- Discord ---
     val discordRpcEnabled: Boolean = false,
@@ -320,6 +324,10 @@ sealed interface SettingsEvent : UiEvent {
     // Security
     data class SetBiometricLockEnabled(val enabled: Boolean) : SettingsEvent
     data class SetBiometricLockTimeout(val minutes: Int) : SettingsEvent
+    data class SetBiometricLockScheduleEnabled(val enabled: Boolean) : SettingsEvent
+    data class SetBiometricLockStartHour(val hour: Int) : SettingsEvent
+    data class SetBiometricLockEndHour(val hour: Int) : SettingsEvent
+    data class SetBiometricLockActiveDays(val days: Set<Int>) : SettingsEvent
 
     // Discord
     data class SetDiscordRpcEnabled(val enabled: Boolean) : SettingsEvent

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsSecurityScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsSecurityScreen.kt
@@ -1,6 +1,9 @@
 package app.otakureader.feature.settings
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -11,16 +14,22 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -31,6 +40,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import app.otakureader.core.navigation.Route
+import java.util.Calendar
 
 /**
  * Security settings: optional biometric / device-credential app lock and its grace period.
@@ -109,6 +119,26 @@ fun SettingsSecurityScreen(
                         }
                     },
                 )
+
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                SectionHeader(title = stringResource(R.string.settings_lock_schedule))
+
+                ListItem(
+                    headlineContent = { Text(stringResource(R.string.settings_lock_schedule_enabled)) },
+                    supportingContent = { Text(stringResource(R.string.settings_lock_schedule_enabled_description)) },
+                    trailingContent = {
+                        Switch(
+                            checked = state.biometricLockScheduleEnabled,
+                            onCheckedChange = {
+                                viewModel.onEvent(SettingsEvent.SetBiometricLockScheduleEnabled(it))
+                            },
+                        )
+                    },
+                )
+
+                if (state.biometricLockScheduleEnabled) {
+                    BiometricScheduleSection(state = state, onEvent = viewModel::onEvent)
+                }
             }
         }
     }
@@ -118,4 +148,85 @@ fun NavGraphBuilder.settingsSecurityScreen(onNavigateBack: () -> Unit) {
     composable<Route.SettingsSecurity> {
         SettingsSecurityScreen(onNavigateBack = onNavigateBack)
     }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun BiometricScheduleSection(state: SettingsState, onEvent: (SettingsEvent) -> Unit) {
+    var startSlider by remember(state.biometricLockStartHour) {
+        mutableFloatStateOf(state.biometricLockStartHour.toFloat())
+    }
+    ListItem(
+        headlineContent = {
+            Text(stringResource(R.string.settings_lock_schedule_start, startSlider.toInt()))
+        },
+        supportingContent = {
+            Slider(
+                value = startSlider,
+                onValueChange = { startSlider = it },
+                onValueChangeFinished = {
+                    onEvent(SettingsEvent.SetBiometricLockStartHour(startSlider.toInt()))
+                },
+                valueRange = 0f..23f,
+                steps = 22,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+    )
+
+    var endSlider by remember(state.biometricLockEndHour) {
+        mutableFloatStateOf(state.biometricLockEndHour.toFloat())
+    }
+    ListItem(
+        headlineContent = {
+            Text(stringResource(R.string.settings_lock_schedule_end, endSlider.toInt()))
+        },
+        supportingContent = {
+            Slider(
+                value = endSlider,
+                onValueChange = { endSlider = it },
+                onValueChangeFinished = {
+                    onEvent(SettingsEvent.SetBiometricLockEndHour(endSlider.toInt()))
+                },
+                valueRange = 0f..23f,
+                steps = 22,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+    )
+
+    val days = listOf(
+        stringResource(R.string.day_sun) to Calendar.SUNDAY,
+        stringResource(R.string.day_mon) to Calendar.MONDAY,
+        stringResource(R.string.day_tue) to Calendar.TUESDAY,
+        stringResource(R.string.day_wed) to Calendar.WEDNESDAY,
+        stringResource(R.string.day_thu) to Calendar.THURSDAY,
+        stringResource(R.string.day_fri) to Calendar.FRIDAY,
+        stringResource(R.string.day_sat) to Calendar.SATURDAY,
+    )
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.settings_lock_schedule_days)) },
+        supportingContent = {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                days.forEach { (label, calDay) ->
+                    val selected = state.biometricLockActiveDays.isEmpty() ||
+                        calDay in state.biometricLockActiveDays
+                    FilterChip(
+                        selected = selected,
+                        onClick = {
+                            val current = state.biometricLockActiveDays.ifEmpty {
+                                days.map { it.second }.toSet()
+                            }
+                            val updated = if (calDay in current) current - calDay else current + calDay
+                            onEvent(SettingsEvent.SetBiometricLockActiveDays(updated))
+                        },
+                        label = { Text(label) },
+                    )
+                }
+            }
+        },
+    )
 }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
@@ -128,6 +128,14 @@ class SettingsViewModel @Inject constructor(
                 generalPreferences.setBiometricLockEnabled(event.enabled)
             is SettingsEvent.SetBiometricLockTimeout ->
                 generalPreferences.setBiometricLockTimeoutMinutes(event.minutes)
+            is SettingsEvent.SetBiometricLockScheduleEnabled ->
+                generalPreferences.setBiometricLockScheduleEnabled(event.enabled)
+            is SettingsEvent.SetBiometricLockStartHour ->
+                generalPreferences.setBiometricLockStartHour(event.hour)
+            is SettingsEvent.SetBiometricLockEndHour ->
+                generalPreferences.setBiometricLockEndHour(event.hour)
+            is SettingsEvent.SetBiometricLockActiveDays ->
+                generalPreferences.setBiometricLockActiveDays(event.days)
 
             // Navigation
             SettingsEvent.NavigateToAbout -> _effect.send(SettingsEffect.NavigateToAbout)
@@ -145,6 +153,21 @@ class SettingsViewModel @Inject constructor(
                 _state.update { it.copy(
                     biometricLockEnabled = enabled,
                     biometricLockTimeoutMinutes = timeout,
+                ) }
+            }.collect { }
+        }
+        viewModelScope.launch {
+            combine(
+                generalPreferences.biometricLockScheduleEnabled,
+                generalPreferences.biometricLockStartHour,
+                generalPreferences.biometricLockEndHour,
+                generalPreferences.biometricLockActiveDays,
+            ) { schedEnabled, startHour, endHour, activeDays ->
+                _state.update { it.copy(
+                    biometricLockScheduleEnabled = schedEnabled,
+                    biometricLockStartHour = startHour,
+                    biometricLockEndHour = endHour,
+                    biometricLockActiveDays = activeDays,
                 ) }
             }.collect { }
         }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
@@ -91,57 +91,68 @@ class SettingsViewModel @Inject constructor(
     fun restoreBackup(uri: android.net.Uri) { onEvent(SettingsEvent.RestoreBackupFromUri(uri)) }
 
     private suspend fun handleRemainingEvent(event: SettingsEvent) {
-        when (event) {
-            // Local source
-            is SettingsEvent.SetLocalSourceDirectory ->
-                localSourcePreferences.setLocalSourceDirectory(event.path)
-
-            // Migration
-            is SettingsEvent.SetMigrationSimilarityThreshold ->
-                appPreferences.setMigrationSimilarityThreshold(event.threshold)
-            is SettingsEvent.SetMigrationAlwaysConfirm ->
-                appPreferences.setMigrationAlwaysConfirm(event.enabled)
-            is SettingsEvent.SetMigrationMinChapterCount ->
-                appPreferences.setMigrationMinChapterCount(event.count)
-            SettingsEvent.OnNavigateToMigration ->
-                _effect.send(SettingsEffect.NavigateToMigrationEntry)
-
-            // Reading goals
-            is SettingsEvent.SetDailyChapterGoal ->
-                readingGoalPreferences.setDailyChapterGoal(event.goal)
-            is SettingsEvent.SetWeeklyChapterGoal ->
-                readingGoalPreferences.setWeeklyChapterGoal(event.goal)
-            is SettingsEvent.SetReadingRemindersEnabled ->
-                handleSetReadingRemindersEnabled(event.enabled)
-            is SettingsEvent.SetReadingReminderHour ->
-                handleSetReadingReminderHour(event.hour)
-
-            // Data management
-            SettingsEvent.ClearImageCache -> clearImageCache()
-            SettingsEvent.RefreshLibraryCovers -> refreshLibraryCovers()
-            SettingsEvent.ClearHistory -> clearHistory()
-            is SettingsEvent.SetCoilDiskCacheSizeMb ->
-                generalPreferences.setCoilDiskCacheSizeMb(event.sizeMb)
-
-            // Security
-            is SettingsEvent.SetBiometricLockEnabled ->
-                generalPreferences.setBiometricLockEnabled(event.enabled)
-            is SettingsEvent.SetBiometricLockTimeout ->
-                generalPreferences.setBiometricLockTimeoutMinutes(event.minutes)
-            is SettingsEvent.SetBiometricLockScheduleEnabled ->
-                generalPreferences.setBiometricLockScheduleEnabled(event.enabled)
-            is SettingsEvent.SetBiometricLockStartHour ->
-                generalPreferences.setBiometricLockStartHour(event.hour)
-            is SettingsEvent.SetBiometricLockEndHour ->
-                generalPreferences.setBiometricLockEndHour(event.hour)
-            is SettingsEvent.SetBiometricLockActiveDays ->
-                generalPreferences.setBiometricLockActiveDays(event.days)
-
-            // Navigation
-            SettingsEvent.NavigateToAbout -> _effect.send(SettingsEffect.NavigateToAbout)
-
-            else -> Unit
+        when {
+            handleMigrationEvent(event) -> Unit
+            handleReadingGoalEvent(event) -> Unit
+            handleDataManagementEvent(event) -> Unit
+            handleSecurityEvent(event) -> Unit
+            else -> when (event) {
+                is SettingsEvent.SetLocalSourceDirectory ->
+                    localSourcePreferences.setLocalSourceDirectory(event.path)
+                SettingsEvent.NavigateToAbout ->
+                    _effect.send(SettingsEffect.NavigateToAbout)
+                else -> Unit
+            }
         }
+    }
+
+    private suspend fun handleMigrationEvent(event: SettingsEvent): Boolean = when (event) {
+        is SettingsEvent.SetMigrationSimilarityThreshold ->
+            { appPreferences.setMigrationSimilarityThreshold(event.threshold); true }
+        is SettingsEvent.SetMigrationAlwaysConfirm ->
+            { appPreferences.setMigrationAlwaysConfirm(event.enabled); true }
+        is SettingsEvent.SetMigrationMinChapterCount ->
+            { appPreferences.setMigrationMinChapterCount(event.count); true }
+        SettingsEvent.OnNavigateToMigration ->
+            { _effect.send(SettingsEffect.NavigateToMigrationEntry); true }
+        else -> false
+    }
+
+    private suspend fun handleReadingGoalEvent(event: SettingsEvent): Boolean = when (event) {
+        is SettingsEvent.SetDailyChapterGoal ->
+            { readingGoalPreferences.setDailyChapterGoal(event.goal); true }
+        is SettingsEvent.SetWeeklyChapterGoal ->
+            { readingGoalPreferences.setWeeklyChapterGoal(event.goal); true }
+        is SettingsEvent.SetReadingRemindersEnabled ->
+            { handleSetReadingRemindersEnabled(event.enabled); true }
+        is SettingsEvent.SetReadingReminderHour ->
+            { handleSetReadingReminderHour(event.hour); true }
+        else -> false
+    }
+
+    private suspend fun handleDataManagementEvent(event: SettingsEvent): Boolean = when (event) {
+        SettingsEvent.ClearImageCache -> { clearImageCache(); true }
+        SettingsEvent.RefreshLibraryCovers -> { refreshLibraryCovers(); true }
+        SettingsEvent.ClearHistory -> { clearHistory(); true }
+        is SettingsEvent.SetCoilDiskCacheSizeMb ->
+            { generalPreferences.setCoilDiskCacheSizeMb(event.sizeMb); true }
+        else -> false
+    }
+
+    private suspend fun handleSecurityEvent(event: SettingsEvent): Boolean = when (event) {
+        is SettingsEvent.SetBiometricLockEnabled ->
+            { generalPreferences.setBiometricLockEnabled(event.enabled); true }
+        is SettingsEvent.SetBiometricLockTimeout ->
+            { generalPreferences.setBiometricLockTimeoutMinutes(event.minutes); true }
+        is SettingsEvent.SetBiometricLockScheduleEnabled ->
+            { generalPreferences.setBiometricLockScheduleEnabled(event.enabled); true }
+        is SettingsEvent.SetBiometricLockStartHour ->
+            { generalPreferences.setBiometricLockStartHour(event.hour); true }
+        is SettingsEvent.SetBiometricLockEndHour ->
+            { generalPreferences.setBiometricLockEndHour(event.hour); true }
+        is SettingsEvent.SetBiometricLockActiveDays ->
+            { generalPreferences.setBiometricLockActiveDays(event.days); true }
+        else -> false
     }
 
     private fun observeSecurityPreferences() {

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -278,6 +278,19 @@
     <string name="settings_lock_timeout_1min">After 1 minute</string>
     <string name="settings_lock_timeout_5min">After 5 minutes</string>
     <string name="settings_lock_timeout_15min">After 15 minutes</string>
+    <string name="settings_lock_schedule">Lock Schedule</string>
+    <string name="settings_lock_schedule_enabled">Enable lock schedule</string>
+    <string name="settings_lock_schedule_enabled_description">Enforce the lock only during specific hours and days</string>
+    <string name="settings_lock_schedule_start">Lock from %1$d:00</string>
+    <string name="settings_lock_schedule_end">Lock until %1$d:00</string>
+    <string name="settings_lock_schedule_days">Active days</string>
+    <string name="day_sun">Sun</string>
+    <string name="day_mon">Mon</string>
+    <string name="day_tue">Tue</string>
+    <string name="day_wed">Wed</string>
+    <string name="day_thu">Thu</string>
+    <string name="day_fri">Fri</string>
+    <string name="day_sat">Sat</string>
     <string name="settings_discord_rich_presence">Rich Presence</string>
     <string name="settings_discord_rich_presence_description">Show current reading activity as your Discord status</string>
 


### PR DESCRIPTION
## **User description**
## Summary

Closes #1032.

Adds komikku-HV-style biometric lock scheduling so users can restrict enforcement to specific hours and days — e.g., "enforce the lock only between 10 PM and 8 AM on weeknights" — without disabling the lock entirely.

- **`GeneralPreferences`** — adds `biometricLockScheduleEnabled`, `biometricLockStartHour` (default 22), `biometricLockEndHour` (default 8), `biometricLockActiveDays` (`Set<Int>`, stored as comma-separated `Calendar` day constants)
- **`BiometricLockGate`** — derives `effectivelyEnabled = enabled && (!scheduleEnabled || isWithinLockSchedule(...))`. `isWithinLockSchedule` handles midnight-wrapping ranges (e.g., start=22, end=8 → 22:00–07:59). Empty `activeDays` = all days.
- **`SettingsMvi`** — 4 new state fields + 4 new events (`SetBiometricLockScheduleEnabled`, `SetBiometricLockStartHour`, `SetBiometricLockEndHour`, `SetBiometricLockActiveDays`)
- **`SettingsViewModel`** — observes new preferences; handles new events
- **`MainActivity`** — collects schedule preferences; passes to `BiometricLockGate`
- **`SettingsSecurityScreen`** — adds "Lock Schedule" section (toggle, start/end hour sliders, day-of-week `FilterChip` row); visible only when biometric lock is enabled

## Test plan

- [ ] Enable biometric lock → schedule section appears
- [ ] Enable schedule → start/end sliders and day chips appear
- [ ] Set schedule to current hour/day → lock is active (gate shows overlay)
- [ ] Set schedule to exclude current hour/day → gate is disabled (app accessible without auth)
- [ ] Midnight-wrap: set start=22, end=6 → lock active at 23:00 and 05:00
- [ ] Day chips: deselect today → app accessible today; reselect → lock resumes
- [ ] Empty days (all deselected doesn't happen — all-day is the empty-set default)
- [ ] Disable biometric lock → schedule section hidden

_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Add a schedule for biometric app lock**

### What Changed
- Added a schedule option for the biometric lock so it can apply only during selected hours and days
- The lock can now be limited to a time window that crosses midnight, such as late night to early morning
- The security settings screen now includes a schedule section with start/end hour controls and day-of-week chips
- The app now keeps the lock active or inactive based on the current time and selected days

### Impact
`✅ Lock only during night hours`
`✅ Lock only on selected weekdays`
`✅ Fewer unnecessary unlock prompts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
