### PR TITLE
feat: extension capability manifest fields (hasReadme, hasChangelog, hasCloudflare)

### DIFF
--- a/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
@@ -419,7 +419,12 @@ private fun MinifiedExtensionDto.toDomain(baseUrl: String): Extension {
         isNsfw = nsfw == 1,
         installDate = null,
         signatureHash = null, // Signature not provided in minified format
-        isEnabled = true
+        isEnabled = true,
+        hasReadme = hasReadme,
+        hasChangelog = hasChangelog,
+        // hasCloudflare is a per-source flag in the minified format (0/1 int on each source).
+        // We aggregate it to the extension level: true if any source requires Cloudflare bypass.
+        hasCloudflare = sources.any { it.hasCloudflare == 1 }
     )
 }
 

--- a/core/extension/src/main/java/app/otakureader/core/extension/domain/model/Extension.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/domain/model/Extension.kt
@@ -61,7 +61,27 @@ data class Extension(
     val isEnabled: Boolean = true,
 
     /** URL of the repository this extension belongs to */
-    val repoUrl: String? = null
+    val repoUrl: String? = null,
+
+    /**
+     * Whether the extension has a README in its repository.
+     * Populated from the repo index JSON (Keiyoushi/Komikku minified format: "hasReadme").
+     */
+    val hasReadme: Boolean = false,
+
+    /**
+     * Whether the extension has a CHANGELOG in its repository.
+     * Populated from the repo index JSON (Keiyoushi/Komikku minified format: "hasChangelog").
+     */
+    val hasChangelog: Boolean = false,
+
+    /**
+     * Whether the extension requires Cloudflare bypass to function.
+     * Populated from the repo index JSON (Keiyoushi/Komikku minified format: "hasCloudflare"
+     * on the source level — aggregated to the extension level here as true if any source
+     * has hasCloudflare == 1).
+     */
+    val hasCloudflare: Boolean = false
 ) : Parcelable {
     
     val isInstalled: Boolean

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
@@ -43,6 +43,8 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SuggestionChipDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
@@ -392,6 +394,9 @@ private fun ExtensionItem(
                         MaterialTheme.colorScheme.onSurfaceVariant
                     }
                 )
+                // Capability badges: shown only when the flag is true so the row is invisible
+                // for most extensions and adds zero visual noise.
+                ExtensionCapabilityBadges(extension = extension)
             }
 
             // Action buttons based on status
@@ -444,6 +449,77 @@ private fun ExtensionItem(
                     }
                 }
             }
+        }
+    }
+}
+
+/**
+ * Displays glanceable capability badges for an extension.
+ *
+ * - Amber "CF" chip: extension requires Cloudflare bypass (any of its sources has hasCloudflare).
+ * - Blue "README" chip: extension has README documentation in its repository.
+ * - Green "CHANGELOG" chip: extension has a changelog in its repository.
+ *
+ * The Row is only shown when at least one badge is visible; otherwise it collapses to nothing,
+ * so extensions without any of these flags incur zero layout cost.
+ */
+@Composable
+private fun ExtensionCapabilityBadges(
+    extension: Extension,
+    modifier: Modifier = Modifier
+) {
+    val hasAny = extension.hasCloudflare || extension.hasReadme || extension.hasChangelog
+    if (!hasAny) return
+
+    Row(
+        modifier = modifier.padding(top = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (extension.hasCloudflare) {
+            SuggestionChip(
+                onClick = {},
+                label = {
+                    Text(
+                        text = stringResource(R.string.extension_has_cloudflare),
+                        style = MaterialTheme.typography.labelSmall
+                    )
+                },
+                colors = SuggestionChipDefaults.suggestionChipColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    labelColor = MaterialTheme.colorScheme.onErrorContainer
+                )
+            )
+        }
+        if (extension.hasReadme) {
+            SuggestionChip(
+                onClick = {},
+                label = {
+                    Text(
+                        text = stringResource(R.string.extension_has_readme),
+                        style = MaterialTheme.typography.labelSmall
+                    )
+                },
+                colors = SuggestionChipDefaults.suggestionChipColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    labelColor = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            )
+        }
+        if (extension.hasChangelog) {
+            SuggestionChip(
+                onClick = {},
+                label = {
+                    Text(
+                        text = stringResource(R.string.extension_has_changelog),
+                        style = MaterialTheme.typography.labelSmall
+                    )
+                },
+                colors = SuggestionChipDefaults.suggestionChipColors(
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    labelColor = MaterialTheme.colorScheme.onTertiaryContainer
+                )
+            )
         }
     }
 }

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -154,4 +154,12 @@
     <string name="browse_search_history">Recent searches</string>
     <string name="browse_search_history_remove">Remove from recent searches</string>
     <string name="filter_sheet_clear_all">Clear all</string>
+
+    <!-- Extension capability badges (#1046) -->
+    <string name="extension_has_cloudflare">CF</string>
+    <string name="extension_has_cloudflare_cd">Requires Cloudflare bypass</string>
+    <string name="extension_has_readme">README</string>
+    <string name="extension_has_readme_cd">Has README documentation</string>
+    <string name="extension_has_changelog">CHANGELOG</string>
+    <string name="extension_has_changelog_cd">Has changelog</string>
 </resources>


### PR DESCRIPTION
## **User description**
## Summary

- Adds `hasReadme`, `hasChangelog`, and `hasCloudflare` Boolean fields (all default `false`) to the `Extension` domain model, so every existing construction site continues to compile with zero changes.
- Populates `hasReadme` and `hasChangelog` from `MinifiedExtensionDto`, which already carries those camelCase fields from the Keiyoushi/Komikku `index.min.json` format (`@SerialName("hasReadme")` / `@SerialName("hasChangelog")`).
- Aggregates `hasCloudflare` from the per-source `MinifiedExtensionSourceDto.hasCloudflare` (int 0/1): the extension-level flag is `true` if any of its sources require Cloudflare bypass.
- The standard `index.json` path (`ExtensionDto`) does not carry these fields; all three fields default to `false` there, which is correct behavior.
- Adds a new `ExtensionCapabilityBadges` composable in `ExtensionsBottomSheet` using Material 3 `SuggestionChip`: amber "CF" for Cloudflare, blue "README", green "CHANGELOG". The `Row` short-circuits via an early `return` when none of the flags are set, so extensions without capabilities incur zero layout overhead.
- Adds 6 string resources for badge labels and accessibility content descriptions.

## Files changed

- `core/extension/src/main/java/app/otakureader/core/extension/domain/model/Extension.kt` — three new fields
- `core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt` — `MinifiedExtensionDto.toDomain()` now maps the three new fields
- `feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt` — `ExtensionCapabilityBadges` composable + `SuggestionChip`/`SuggestionChipDefaults` imports
- `feature/browse/src/main/res/values/strings.xml` — 6 new string resources

## Test plan

- [ ] Open Browse → Extensions sheet; confirm existing extensions display with no badge row (no visual regression)
- [ ] Create a mock `Extension` with `hasCloudflare = true` and verify the amber "CF" chip appears in the card
- [ ] Create a mock `Extension` with `hasReadme = true` and verify the blue "README" chip appears
- [ ] Create a mock `Extension` with `hasChangelog = true` and verify the green "CHANGELOG" chip appears
- [ ] Confirm all three chips appear together when all three flags are true
- [ ] Confirm `MinifiedExtensionDto` with `"hasReadme": true, "hasChangelog": true` and a source with `"hasCloudflare": 1` deserializes into an `Extension` with all three flags set
- [ ] Confirm `ExtensionDto` (standard index.json path) still maps to `Extension` with all three flags `false`

Closes #1046

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Show extension capability badges in the browse sheet**

### What Changed
- Extensions can now display simple badges for three visible capabilities: Cloudflare bypass, README, and CHANGELOG.
- Badge data is now carried with each extension, and Cloudflare is marked when any of its sources needs bypass support.
- Extensions without any of these capabilities show no badges, so the list stays clean.

### Impact
`✅ Clearer extension details`
`✅ Easier to spot Cloudflare-reliant sources`
`✅ Faster extension selection`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
