### PR TITLE
feat: allow local source hidden folder scanning

### DIFF
--- a/core/preferences/src/main/java/app/otakureader/core/preferences/LocalSourcePreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/LocalSourcePreferences.kt
@@ -30,20 +30,20 @@ open class LocalSourcePreferences(private val dataStore: DataStore<Preferences>)
     }
 
     /**
-     * Whether the local source scanner should include dot-prefixed (hidden) directories.
-     * Defaults to `false` so that directories like `.thumbnails` or `.nomedia` are skipped
-     * unless the user explicitly opts in.
+     * When true, the local source scanner includes dot-prefixed (hidden) directories and
+     * files within [localSourceDirectory]. Defaults to false so hidden system folders are
+     * not inadvertently surfaced as manga entries.
      */
     open val allowLocalSourceHiddenFolders: Flow<Boolean> =
-        dataStore.data.map { it[Keys.ALLOW_LOCAL_SOURCE_HIDDEN_FOLDERS] ?: false }
+        dataStore.data.map { it[Keys.ALLOW_HIDDEN_FOLDERS] ?: false }
 
-    open suspend fun setAllowLocalSourceHiddenFolders(enabled: Boolean) {
-        dataStore.edit { it[Keys.ALLOW_LOCAL_SOURCE_HIDDEN_FOLDERS] = enabled }
+    open suspend fun setAllowLocalSourceHiddenFolders(allowed: Boolean) {
+        dataStore.edit { it[Keys.ALLOW_HIDDEN_FOLDERS] = allowed }
     }
 
     private object Keys {
         val LOCAL_SOURCE_DIRECTORY = stringPreferencesKey("local_source_directory")
-        val ALLOW_LOCAL_SOURCE_HIDDEN_FOLDERS = booleanPreferencesKey("allow_local_source_hidden_folders")
+        val ALLOW_HIDDEN_FOLDERS = booleanPreferencesKey("local_source_allow_hidden_folders")
     }
 
     companion object {
@@ -60,10 +60,12 @@ open class LocalSourcePreferences(private val dataStore: DataStore<Preferences>)
          * [localSourceDirectory].  Intended for tests and standalone utilities that
          * do not have a proper DataStore instance available.
          */
-        fun ofDirectory(directory: String): LocalSourcePreferences =
+        fun ofDirectory(directory: String, allowHidden: Boolean = false): LocalSourcePreferences =
             object : LocalSourcePreferences(NoOpDataStore) {
                 override val localSourceDirectory: Flow<String> = flowOf(directory)
                 override suspend fun setLocalSourceDirectory(path: String) = Unit
+                override val allowLocalSourceHiddenFolders: Flow<Boolean> = flowOf(allowHidden)
+                override suspend fun setAllowLocalSourceHiddenFolders(allowed: Boolean) = Unit
             }
 
         /** No-op DataStore used by [ofDirectory] — its data is never actually read. */
@@ -75,3 +77,4 @@ open class LocalSourcePreferences(private val dataStore: DataStore<Preferences>)
         }
     }
 }
+

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/LocalSourcePreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/LocalSourcePreferences.kt
@@ -3,6 +3,7 @@ package app.otakureader.core.preferences
 import android.os.Environment
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -28,8 +29,21 @@ open class LocalSourcePreferences(private val dataStore: DataStore<Preferences>)
         dataStore.edit { it[Keys.LOCAL_SOURCE_DIRECTORY] = path }
     }
 
+    /**
+     * When true, the local source scanner includes dot-prefixed (hidden) directories and
+     * files within [localSourceDirectory]. Defaults to false so hidden system folders are
+     * not inadvertently surfaced as manga entries.
+     */
+    open val allowLocalSourceHiddenFolders: Flow<Boolean> =
+        dataStore.data.map { it[Keys.ALLOW_HIDDEN_FOLDERS] ?: false }
+
+    open suspend fun setAllowLocalSourceHiddenFolders(allowed: Boolean) {
+        dataStore.edit { it[Keys.ALLOW_HIDDEN_FOLDERS] = allowed }
+    }
+
     private object Keys {
         val LOCAL_SOURCE_DIRECTORY = stringPreferencesKey("local_source_directory")
+        val ALLOW_HIDDEN_FOLDERS = booleanPreferencesKey("local_source_allow_hidden_folders")
     }
 
     companion object {
@@ -46,10 +60,12 @@ open class LocalSourcePreferences(private val dataStore: DataStore<Preferences>)
          * [localSourceDirectory].  Intended for tests and standalone utilities that
          * do not have a proper DataStore instance available.
          */
-        fun ofDirectory(directory: String): LocalSourcePreferences =
+        fun ofDirectory(directory: String, allowHidden: Boolean = false): LocalSourcePreferences =
             object : LocalSourcePreferences(NoOpDataStore) {
                 override val localSourceDirectory: Flow<String> = flowOf(directory)
                 override suspend fun setLocalSourceDirectory(path: String) = Unit
+                override val allowLocalSourceHiddenFolders: Flow<Boolean> = flowOf(allowHidden)
+                override suspend fun setAllowLocalSourceHiddenFolders(allowed: Boolean) = Unit
             }
 
         /** No-op DataStore used by [ofDirectory] — its data is never actually read. */

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/LocalSourcePreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/LocalSourcePreferences.kt
@@ -30,20 +30,20 @@ open class LocalSourcePreferences(private val dataStore: DataStore<Preferences>)
     }
 
     /**
-     * When true, the local source scanner includes dot-prefixed (hidden) directories and
-     * files within [localSourceDirectory]. Defaults to false so hidden system folders are
-     * not inadvertently surfaced as manga entries.
+     * Whether the local source scanner should include dot-prefixed (hidden) directories.
+     * Defaults to `false` so that directories like `.thumbnails` or `.nomedia` are skipped
+     * unless the user explicitly opts in.
      */
     open val allowLocalSourceHiddenFolders: Flow<Boolean> =
-        dataStore.data.map { it[Keys.ALLOW_HIDDEN_FOLDERS] ?: false }
+        dataStore.data.map { it[Keys.ALLOW_LOCAL_SOURCE_HIDDEN_FOLDERS] ?: false }
 
-    open suspend fun setAllowLocalSourceHiddenFolders(allowed: Boolean) {
-        dataStore.edit { it[Keys.ALLOW_HIDDEN_FOLDERS] = allowed }
+    open suspend fun setAllowLocalSourceHiddenFolders(enabled: Boolean) {
+        dataStore.edit { it[Keys.ALLOW_LOCAL_SOURCE_HIDDEN_FOLDERS] = enabled }
     }
 
     private object Keys {
         val LOCAL_SOURCE_DIRECTORY = stringPreferencesKey("local_source_directory")
-        val ALLOW_HIDDEN_FOLDERS = booleanPreferencesKey("local_source_allow_hidden_folders")
+        val ALLOW_LOCAL_SOURCE_HIDDEN_FOLDERS = booleanPreferencesKey("allow_local_source_hidden_folders")
     }
 
     companion object {
@@ -60,12 +60,10 @@ open class LocalSourcePreferences(private val dataStore: DataStore<Preferences>)
          * [localSourceDirectory].  Intended for tests and standalone utilities that
          * do not have a proper DataStore instance available.
          */
-        fun ofDirectory(directory: String, allowHidden: Boolean = false): LocalSourcePreferences =
+        fun ofDirectory(directory: String): LocalSourcePreferences =
             object : LocalSourcePreferences(NoOpDataStore) {
                 override val localSourceDirectory: Flow<String> = flowOf(directory)
                 override suspend fun setLocalSourceDirectory(path: String) = Unit
-                override val allowLocalSourceHiddenFolders: Flow<Boolean> = flowOf(allowHidden)
-                override suspend fun setAllowLocalSourceHiddenFolders(allowed: Boolean) = Unit
             }
 
         /** No-op DataStore used by [ofDirectory] — its data is never actually read. */
@@ -77,4 +75,3 @@ open class LocalSourcePreferences(private val dataStore: DataStore<Preferences>)
         }
     }
 }
-

--- a/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/local/LocalSource.kt
+++ b/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/local/LocalSource.kt
@@ -45,7 +45,7 @@ import kotlinx.coroutines.CancellationException
 class LocalSource(
     private val context: Context,
     private val directory: String,
-    private val allowHiddenFolders: Boolean = false,
+    private val allowHiddenFolders: Boolean = false
 ) : MangaSource {
 
     override val id: String = "local"
@@ -70,6 +70,7 @@ class LocalSource(
 
         return buildList {
             root.listFiles()?.forEach { entry ->
+                // Skip dot-prefixed (hidden) entries unless the user has opted in.
                 if (!allowHiddenFolders && entry.name.startsWith(".")) return@forEach
                 when {
                     // Sub-directory → manga with one or more chapters

--- a/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/local/LocalSource.kt
+++ b/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/local/LocalSource.kt
@@ -45,7 +45,7 @@ import kotlinx.coroutines.CancellationException
 class LocalSource(
     private val context: Context,
     private val directory: String,
-    private val allowHiddenFolders: Boolean = false
+    private val allowHiddenFolders: Boolean = false,
 ) : MangaSource {
 
     override val id: String = "local"
@@ -70,7 +70,6 @@ class LocalSource(
 
         return buildList {
             root.listFiles()?.forEach { entry ->
-                // Skip dot-prefixed (hidden) entries unless the user has opted in.
                 if (!allowHiddenFolders && entry.name.startsWith(".")) return@forEach
                 when {
                     // Sub-directory → manga with one or more chapters

--- a/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/local/LocalSource.kt
+++ b/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/local/LocalSource.kt
@@ -44,7 +44,8 @@ import kotlinx.coroutines.CancellationException
  */
 class LocalSource(
     private val context: Context,
-    private val directory: String
+    private val directory: String,
+    private val allowHiddenFolders: Boolean = false,
 ) : MangaSource {
 
     override val id: String = "local"
@@ -69,6 +70,7 @@ class LocalSource(
 
         return buildList {
             root.listFiles()?.forEach { entry ->
+                if (!allowHiddenFolders && entry.name.startsWith(".")) return@forEach
                 when {
                     // Sub-directory → manga with one or more chapters
                     entry.isDirectory -> add(LocalMangaEntry.Folder(entry))

--- a/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
@@ -81,13 +81,14 @@ class SourceRepositoryImpl @Inject constructor(
     )
 
     /**
-     * Returns a fresh [LocalSource] using the current scan directory from preferences.
-     * Reading from the Flow is deferred to suspend call-sites so no blocking occurs at init.
+     * Returns a fresh [LocalSource] using the current scan directory and hidden-folder
+     * preference from preferences. Reading from the Flows is deferred to suspend call-sites
+     * so no blocking occurs at init.
      */
     private suspend fun currentLocalSource(): LocalSource {
         val dir = localSourcePreferences.localSourceDirectory.first()
         val allowHidden = localSourcePreferences.allowLocalSourceHiddenFolders.first()
-        return LocalSource(context, dir, allowHiddenFolders = allowHidden)
+        return LocalSource(context, dir, allowHidden)
     }
 
     private val _sources = MutableStateFlow<List<MangaSource>>(emptyList())

--- a/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
@@ -86,7 +86,8 @@ class SourceRepositoryImpl @Inject constructor(
      */
     private suspend fun currentLocalSource(): LocalSource {
         val dir = localSourcePreferences.localSourceDirectory.first()
-        return LocalSource(context, dir)
+        val allowHidden = localSourcePreferences.allowLocalSourceHiddenFolders.first()
+        return LocalSource(context, dir, allowHiddenFolders = allowHidden)
     }
 
     private val _sources = MutableStateFlow<List<MangaSource>>(emptyList())

--- a/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
@@ -81,14 +81,13 @@ class SourceRepositoryImpl @Inject constructor(
     )
 
     /**
-     * Returns a fresh [LocalSource] using the current scan directory and hidden-folder
-     * preference from preferences. Reading from the Flows is deferred to suspend call-sites
-     * so no blocking occurs at init.
+     * Returns a fresh [LocalSource] using the current scan directory from preferences.
+     * Reading from the Flow is deferred to suspend call-sites so no blocking occurs at init.
      */
     private suspend fun currentLocalSource(): LocalSource {
         val dir = localSourcePreferences.localSourceDirectory.first()
         val allowHidden = localSourcePreferences.allowLocalSourceHiddenFolders.first()
-        return LocalSource(context, dir, allowHidden)
+        return LocalSource(context, dir, allowHiddenFolders = allowHidden)
     }
 
     private val _sources = MutableStateFlow<List<MangaSource>>(emptyList())

--- a/data/src/test/java/app/otakureader/data/repository/SourceRepositoryImplTest.kt
+++ b/data/src/test/java/app/otakureader/data/repository/SourceRepositoryImplTest.kt
@@ -486,7 +486,8 @@ class SourceRepositoryImplTest {
         // However currentLocalSource() constructs a real LocalSource with
         // File I/O.  For pure unit tests we would ideally refactor
         // currentLocalSource() to be injectable / replaceable in tests.
-        // Here we mock the preference flow to return a temp directory.
+        // Here we mock the preference flows to return safe defaults.
         every { localSourcePreferences.localSourceDirectory } returns kotlinx.coroutines.flow.flowOf("/tmp/local")
+        every { localSourcePreferences.allowLocalSourceHiddenFolders } returns kotlinx.coroutines.flow.flowOf(false)
     }
 }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/LocalSourceBrowserScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/LocalSourceBrowserScreen.kt
@@ -107,15 +107,16 @@ fun LocalSourceBrowserScreen(
                     },
                 )
             }
-            item(key = "hidden_folders_divider") { HorizontalDivider() }
-            item(key = "hidden_folders") {
+            item(key = "hidden_folders_toggle") {
                 ListItem(
-                    headlineContent = { Text(stringResource(R.string.settings_local_source_allow_hidden_folders)) },
-                    supportingContent = { Text(stringResource(R.string.settings_local_source_allow_hidden_folders_description)) },
+                    headlineContent = { Text(stringResource(R.string.settings_local_source_hidden_folders)) },
+                    supportingContent = { Text(stringResource(R.string.settings_local_source_hidden_folders_description)) },
                     trailingContent = {
                         Switch(
                             checked = state.allowLocalSourceHiddenFolders,
-                            onCheckedChange = { viewModel.onEvent(SettingsEvent.SetAllowLocalSourceHiddenFolders(it)) },
+                            onCheckedChange = {
+                                viewModel.onEvent(SettingsEvent.SetAllowLocalSourceHiddenFolders(it))
+                            },
                         )
                     },
                 )

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/LocalSourceBrowserScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/LocalSourceBrowserScreen.kt
@@ -107,16 +107,15 @@ fun LocalSourceBrowserScreen(
                     },
                 )
             }
-            item(key = "hidden_folders_toggle") {
+            item(key = "hidden_folders_divider") { HorizontalDivider() }
+            item(key = "hidden_folders") {
                 ListItem(
-                    headlineContent = { Text(stringResource(R.string.settings_local_source_hidden_folders)) },
-                    supportingContent = { Text(stringResource(R.string.settings_local_source_hidden_folders_description)) },
+                    headlineContent = { Text(stringResource(R.string.settings_local_source_allow_hidden_folders)) },
+                    supportingContent = { Text(stringResource(R.string.settings_local_source_allow_hidden_folders_description)) },
                     trailingContent = {
                         Switch(
                             checked = state.allowLocalSourceHiddenFolders,
-                            onCheckedChange = {
-                                viewModel.onEvent(SettingsEvent.SetAllowLocalSourceHiddenFolders(it))
-                            },
+                            onCheckedChange = { viewModel.onEvent(SettingsEvent.SetAllowLocalSourceHiddenFolders(it)) },
                         )
                     },
                 )

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/LocalSourceBrowserScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/LocalSourceBrowserScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -103,6 +104,19 @@ fun LocalSourceBrowserScreen(
                                 Text(stringResource(R.string.settings_save))
                             }
                         }
+                    },
+                )
+            }
+            item(key = "hidden_folders_divider") { HorizontalDivider() }
+            item(key = "hidden_folders") {
+                ListItem(
+                    headlineContent = { Text(stringResource(R.string.settings_local_source_allow_hidden_folders)) },
+                    supportingContent = { Text(stringResource(R.string.settings_local_source_allow_hidden_folders_description)) },
+                    trailingContent = {
+                        Switch(
+                            checked = state.allowLocalSourceHiddenFolders,
+                            onCheckedChange = { viewModel.onEvent(SettingsEvent.SetAllowLocalSourceHiddenFolders(it)) },
+                        )
                     },
                 )
             }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
@@ -274,7 +274,7 @@ sealed interface SettingsEvent : UiEvent {
 
     // Local Source
     data class SetLocalSourceDirectory(val path: String) : SettingsEvent
-    data class SetAllowLocalSourceHiddenFolders(val enabled: Boolean) : SettingsEvent
+    data class SetAllowLocalSourceHiddenFolders(val allowed: Boolean) : SettingsEvent
 
     // Notifications
     data class SetNotificationsEnabled(val enabled: Boolean) : SettingsEvent

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
@@ -274,7 +274,7 @@ sealed interface SettingsEvent : UiEvent {
 
     // Local Source
     data class SetLocalSourceDirectory(val path: String) : SettingsEvent
-    data class SetAllowLocalSourceHiddenFolders(val allowed: Boolean) : SettingsEvent
+    data class SetAllowLocalSourceHiddenFolders(val enabled: Boolean) : SettingsEvent
 
     // Notifications
     data class SetNotificationsEnabled(val enabled: Boolean) : SettingsEvent

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
@@ -27,6 +27,7 @@ data class SettingsState(
 
     // --- Local Source ---
     val localSourceDirectory: String = LocalSourcePreferences.defaultDirectory(),
+    val allowLocalSourceHiddenFolders: Boolean = false,
 
     // --- Notifications ---
     val notificationsEnabled: Boolean = true,
@@ -273,6 +274,7 @@ sealed interface SettingsEvent : UiEvent {
 
     // Local Source
     data class SetLocalSourceDirectory(val path: String) : SettingsEvent
+    data class SetAllowLocalSourceHiddenFolders(val allowed: Boolean) : SettingsEvent
 
     // Notifications
     data class SetNotificationsEnabled(val enabled: Boolean) : SettingsEvent

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
@@ -95,6 +95,8 @@ class SettingsViewModel @Inject constructor(
             // Local source
             is SettingsEvent.SetLocalSourceDirectory ->
                 localSourcePreferences.setLocalSourceDirectory(event.path)
+            is SettingsEvent.SetAllowLocalSourceHiddenFolders ->
+                localSourcePreferences.setAllowLocalSourceHiddenFolders(event.allowed)
 
             // Migration
             is SettingsEvent.SetMigrationSimilarityThreshold ->
@@ -154,6 +156,11 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             localSourcePreferences.localSourceDirectory.collect { dir ->
                 _state.update { it.copy(localSourceDirectory = dir) }
+            }
+        }
+        viewModelScope.launch {
+            localSourcePreferences.allowLocalSourceHiddenFolders.collect { allowed ->
+                _state.update { it.copy(allowLocalSourceHiddenFolders = allowed) }
             }
         }
     }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
@@ -91,50 +91,6 @@ class SettingsViewModel @Inject constructor(
     fun restoreBackup(uri: android.net.Uri) { onEvent(SettingsEvent.RestoreBackupFromUri(uri)) }
 
     private suspend fun handleRemainingEvent(event: SettingsEvent) {
-        when (event) {
-            // Local source
-            is SettingsEvent.SetLocalSourceDirectory ->
-                localSourcePreferences.setLocalSourceDirectory(event.path)
-            is SettingsEvent.SetAllowLocalSourceHiddenFolders ->
-                localSourcePreferences.setAllowLocalSourceHiddenFolders(event.allowed)
-
-            // Migration
-            is SettingsEvent.SetMigrationSimilarityThreshold ->
-                appPreferences.setMigrationSimilarityThreshold(event.threshold)
-            is SettingsEvent.SetMigrationAlwaysConfirm ->
-                appPreferences.setMigrationAlwaysConfirm(event.enabled)
-            is SettingsEvent.SetMigrationMinChapterCount ->
-                appPreferences.setMigrationMinChapterCount(event.count)
-            SettingsEvent.OnNavigateToMigration ->
-                _effect.send(SettingsEffect.NavigateToMigrationEntry)
-
-            // Reading goals
-            is SettingsEvent.SetDailyChapterGoal ->
-                readingGoalPreferences.setDailyChapterGoal(event.goal)
-            is SettingsEvent.SetWeeklyChapterGoal ->
-                readingGoalPreferences.setWeeklyChapterGoal(event.goal)
-            is SettingsEvent.SetReadingRemindersEnabled ->
-                handleSetReadingRemindersEnabled(event.enabled)
-            is SettingsEvent.SetReadingReminderHour ->
-                handleSetReadingReminderHour(event.hour)
-
-            // Data management
-            SettingsEvent.ClearImageCache -> clearImageCache()
-            SettingsEvent.RefreshLibraryCovers -> refreshLibraryCovers()
-            SettingsEvent.ClearHistory -> clearHistory()
-            is SettingsEvent.SetCoilDiskCacheSizeMb ->
-                generalPreferences.setCoilDiskCacheSizeMb(event.sizeMb)
-
-            // Security
-            is SettingsEvent.SetBiometricLockEnabled ->
-                generalPreferences.setBiometricLockEnabled(event.enabled)
-            is SettingsEvent.SetBiometricLockTimeout ->
-                generalPreferences.setBiometricLockTimeoutMinutes(event.minutes)
-
-            // Navigation
-            SettingsEvent.NavigateToAbout -> _effect.send(SettingsEffect.NavigateToAbout)
-
-            else -> Unit
         when {
             handleMigrationEvent(event) -> Unit
             handleReadingGoalEvent(event) -> Unit
@@ -143,6 +99,8 @@ class SettingsViewModel @Inject constructor(
             else -> when (event) {
                 is SettingsEvent.SetLocalSourceDirectory ->
                     localSourcePreferences.setLocalSourceDirectory(event.path)
+                is SettingsEvent.SetAllowLocalSourceHiddenFolders ->
+                    localSourcePreferences.setAllowLocalSourceHiddenFolders(event.allowed)
                 SettingsEvent.NavigateToAbout ->
                     _effect.send(SettingsEffect.NavigateToAbout)
                 else -> Unit

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
@@ -96,7 +96,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsEvent.SetLocalSourceDirectory ->
                 localSourcePreferences.setLocalSourceDirectory(event.path)
             is SettingsEvent.SetAllowLocalSourceHiddenFolders ->
-                localSourcePreferences.setAllowLocalSourceHiddenFolders(event.allowed)
+                localSourcePreferences.setAllowLocalSourceHiddenFolders(event.enabled)
 
             // Migration
             is SettingsEvent.SetMigrationSimilarityThreshold ->
@@ -154,14 +154,15 @@ class SettingsViewModel @Inject constructor(
 
     private fun observeLocalSourcePreferences() {
         viewModelScope.launch {
-            localSourcePreferences.localSourceDirectory.collect { dir ->
-                _state.update { it.copy(localSourceDirectory = dir) }
-            }
-        }
-        viewModelScope.launch {
-            localSourcePreferences.allowLocalSourceHiddenFolders.collect { allowed ->
-                _state.update { it.copy(allowLocalSourceHiddenFolders = allowed) }
-            }
+            combine(
+                localSourcePreferences.localSourceDirectory,
+                localSourcePreferences.allowLocalSourceHiddenFolders,
+            ) { dir, allowHidden ->
+                _state.update { it.copy(
+                    localSourceDirectory = dir,
+                    allowLocalSourceHiddenFolders = allowHidden,
+                ) }
+            }.collect { }
         }
     }
 

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
@@ -96,7 +96,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsEvent.SetLocalSourceDirectory ->
                 localSourcePreferences.setLocalSourceDirectory(event.path)
             is SettingsEvent.SetAllowLocalSourceHiddenFolders ->
-                localSourcePreferences.setAllowLocalSourceHiddenFolders(event.enabled)
+                localSourcePreferences.setAllowLocalSourceHiddenFolders(event.allowed)
 
             // Migration
             is SettingsEvent.SetMigrationSimilarityThreshold ->
@@ -154,15 +154,14 @@ class SettingsViewModel @Inject constructor(
 
     private fun observeLocalSourcePreferences() {
         viewModelScope.launch {
-            combine(
-                localSourcePreferences.localSourceDirectory,
-                localSourcePreferences.allowLocalSourceHiddenFolders,
-            ) { dir, allowHidden ->
-                _state.update { it.copy(
-                    localSourceDirectory = dir,
-                    allowLocalSourceHiddenFolders = allowHidden,
-                ) }
-            }.collect { }
+            localSourcePreferences.localSourceDirectory.collect { dir ->
+                _state.update { it.copy(localSourceDirectory = dir) }
+            }
+        }
+        viewModelScope.launch {
+            localSourcePreferences.allowLocalSourceHiddenFolders.collect { allowed ->
+                _state.update { it.copy(allowLocalSourceHiddenFolders = allowed) }
+            }
         }
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -503,6 +503,8 @@
     <string name="settings_local_source_folders_description">Plain folders containing readable image files are exposed as local manga.</string>
     <string name="settings_local_source_metadata">Metadata</string>
     <string name="settings_local_source_metadata_description">series.json and ComicInfo.xml metadata are recognized when present, and directory traversal is constrained to the configured base directory.</string>
+    <string name="settings_local_source_allow_hidden_folders">Allow hidden folders</string>
+    <string name="settings_local_source_allow_hidden_folders_description">Include dot-prefixed directories (e.g. .manga) when scanning the local source. Off by default to avoid surfacing system folders.</string>
 
     <!-- About section (settings hub) -->
     <string name="settings_about">About</string>


### PR DESCRIPTION
## **User description**
Adds `allowLocalSourceHiddenFolders` preference. When enabled, the local source scanner includes dot-prefixed (hidden) directories when scanning for manga. Default is `false` to preserve existing behavior.

Closes #1059

_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Let users include hidden folders in local library scans**

### What Changed
- Added a setting that lets local library scans include dot-prefixed hidden folders, such as `.manga`
- The option is off by default, so hidden system folders stay excluded unless the user turns it on
- The local source settings screen now shows a switch for this option

### Impact
`✅ Access to manga stored in hidden folders`
`✅ Fewer missing local libraries`
`✅ Less risk of showing system folders by default`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
