### PR TITLE
feat: bulk action confirmations and incognito description polish

### DIFF
--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -33,5 +33,5 @@
     <string name="offline_title">No connection</string>
     <string name="offline_message">Check your internet connection and try again</string>
     <string name="offline_action">Retry</string>
-    <string name="incognito_banner_text">Incognito — history paused</string>
+    <string name="incognito_banner_text">Incognito — history, stats, tracking &amp; backups paused</string>
 </resources>

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
@@ -39,6 +40,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
@@ -89,7 +91,8 @@ fun LibraryScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     var showMenu by remember { mutableStateOf(false) }
-    
+    var pendingBulkAction: LibraryEvent? by remember { mutableStateOf(null) }
+
     LaunchedEffect(viewModel.effect) {
         viewModel.effect.collectLatest { effect ->
             when (effect) {
@@ -128,7 +131,42 @@ fun LibraryScreen(
             }
         }
     }
-    
+
+    pendingBulkAction?.let { action ->
+        val actionLabel = when (action) {
+            is LibraryEvent.RemoveSelectedFromLibrary -> stringResource(R.string.library_remove_selected)
+            is LibraryEvent.MarkSelectedAsCompleted -> stringResource(R.string.library_mark_selected_completed)
+            is LibraryEvent.MarkSelectedAsDropped -> stringResource(R.string.library_mark_selected_dropped)
+            else -> ""
+        }
+        AlertDialog(
+            onDismissRequest = { pendingBulkAction = null },
+            title = { Text(stringResource(R.string.library_bulk_action_confirm_title)) },
+            text = {
+                Text(
+                    stringResource(
+                        R.string.library_bulk_action_confirm_message,
+                        state.selectedManga.size,
+                        actionLabel,
+                    )
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.onEvent(action)
+                    pendingBulkAction = null
+                }) {
+                    Text(stringResource(R.string.library_bulk_action_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingBulkAction = null }) {
+                    Text(stringResource(R.string.library_bulk_action_cancel))
+                }
+            },
+        )
+    }
+
     Scaffold(
         topBar = {
             when {
@@ -154,7 +192,7 @@ fun LibraryScreen(
                         IconButton(onClick = { viewModel.onEvent(LibraryEvent.DownloadSelected) }) {
                             Icon(Icons.Default.Download, contentDescription = stringResource(R.string.library_download_selected))
                         }
-                        IconButton(onClick = { viewModel.onEvent(LibraryEvent.RemoveSelectedFromLibrary) }) {
+                        IconButton(onClick = { pendingBulkAction = LibraryEvent.RemoveSelectedFromLibrary }) {
                             Icon(Icons.Default.DeleteForever, contentDescription = stringResource(R.string.library_remove_selected))
                         }
                         var selectionOverflowExpanded by remember { mutableStateOf(false) }
@@ -171,14 +209,14 @@ fun LibraryScreen(
                             DropdownMenuItem(
                                 text = { Text(stringResource(R.string.library_mark_selected_completed)) },
                                 onClick = {
-                                    viewModel.onEvent(LibraryEvent.MarkSelectedAsCompleted)
+                                    pendingBulkAction = LibraryEvent.MarkSelectedAsCompleted
                                     selectionOverflowExpanded = false
                                 },
                             )
                             DropdownMenuItem(
                                 text = { Text(stringResource(R.string.library_mark_selected_dropped)) },
                                 onClick = {
-                                    viewModel.onEvent(LibraryEvent.MarkSelectedAsDropped)
+                                    pendingBulkAction = LibraryEvent.MarkSelectedAsDropped
                                     selectionOverflowExpanded = false
                                 },
                             )

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -228,4 +228,10 @@
     <string name="merge_duplicates_primary_badge">Primary</string>
     <string name="merge_duplicates_chapters">%1$d ch.</string>
     <string name="merge_duplicates_unread">%1$d unread</string>
+
+    <!-- Bulk action confirmation dialog -->
+    <string name="library_bulk_action_confirm_title">Confirm action</string>
+    <string name="library_bulk_action_confirm_message">%2$s for %1$d manga?</string>
+    <string name="library_bulk_action_confirm">Confirm</string>
+    <string name="library_bulk_action_cancel">Cancel</string>
 </resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -82,7 +82,7 @@
     <string name="settings_keep_screen_on">Keep Screen On</string>
     <string name="settings_keep_screen_on_description">Prevent the screen from sleeping while reading</string>
     <string name="settings_incognito_mode">Incognito Mode</string>
-    <string name="settings_incognito_mode_description">Reading history and progress are not saved while enabled</string>
+    <string name="settings_incognito_mode_description">Reading history, statistics, tracker progress updates, and automatic backups are paused while incognito mode is active</string>
     <string name="settings_secure_screen">Secure Screen</string>
     <string name="settings_secure_screen_description">Prevent screenshots and screen recording while reading</string>
     <string name="settings_preload_before">Preload Pages Before: %1$d</string>


### PR DESCRIPTION
## **User description**
$(cat <<'EOF'
## Summary

- Add confirmation `AlertDialog` before three destructive library bulk actions: Remove from Library, Mark as Completed, Mark as Dropped
- Uses `pendingBulkAction: LibraryEvent? by remember { mutableStateOf(null) }` pattern — dialog shows count and action label, dispatches the event only on confirm
- Expand `settings_incognito_mode_description` to explicitly list history, statistics, tracker progress updates, and automatic backups
- Update `incognito_banner_text` in `core/ui` to reflect the same expanded scope

## Changed files

- `feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt` — AlertDialog + pendingBulkAction state
- `feature/library/src/main/res/values/strings.xml` — four new string resources (`library_bulk_action_confirm_title`, `library_bulk_action_confirm_message`, `library_bulk_action_confirm`, `library_bulk_action_cancel`)
- `feature/settings/src/main/res/values/strings.xml` — expanded incognito mode description
- `core/ui/src/main/res/values/strings.xml` — updated IncognitoBanner text

## Test plan

- [ ] Long-press manga in library to enter selection mode, tap Delete (trash icon) — confirmation dialog appears with correct count
- [ ] Tap overflow menu → Mark as Completed with items selected — confirmation dialog appears
- [ ] Tap overflow menu → Mark as Dropped with items selected — confirmation dialog appears
- [ ] Confirm in dialog — action executes, selection clears
- [ ] Dismiss dialog (back or Cancel) — no action taken, selection preserved
- [ ] Enable incognito mode in Settings — description shows history, statistics, tracker progress, and auto-backups
- [ ] IncognitoBanner visible while reading — text reads "Incognito — history, stats, tracking & backups paused"

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Confirm destructive bulk actions and clarify incognito mode coverage**

### What Changed
- Bulk remove, mark as completed, and mark as dropped now ask for confirmation before they run, showing the selected count and the action name.
- Canceling the dialog leaves the current selection in place; confirming applies the action.
- Incognito mode wording now says it pauses reading history, statistics, tracker progress updates, and automatic backups in both Settings and the reader banner.

### Impact
`✅ Fewer accidental library changes`
`✅ Clearer bulk-action warnings`
`✅ Clearer incognito mode expectations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
