### PR TITLE
feat: tracking sync health section

### DIFF
--- a/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingMvi.kt
+++ b/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingMvi.kt
@@ -46,7 +46,16 @@ data class TrackerUiModel(
     val isLoggedIn: Boolean,
     val entry: TrackEntry? = null,
     /** Current sync status for this tracker, or null if no sync state exists. */
-    val syncStatus: SyncStatus? = null
+    val syncStatus: SyncStatus? = null,
+    /**
+     * Epoch-millisecond timestamp of the last successful sync for this tracker,
+     * or null if no sync has ever completed successfully.
+     */
+    val lastSyncAt: Long? = null,
+    /** Number of local changes that are queued and waiting to be pushed to the tracker. */
+    val pendingUpdates: Int = 0,
+    /** Number of sync operations that ended in an error state for this tracker. */
+    val failedUpdates: Int = 0,
 )
 
 sealed interface TrackingEvent : UiEvent {
@@ -77,6 +86,8 @@ sealed interface TrackingEvent : UiEvent {
     data class ResolveConflict(val trackerId: Int, val useLocal: Boolean) : TrackingEvent
     /** Dismisses the conflict dialog without resolving. */
     data object DismissConflict : TrackingEvent
+    /** Retries all failed sync operations for a specific tracker. */
+    data class RetryFailedUpdates(val trackerId: Int) : TrackingEvent
 }
 
 sealed interface TrackingEffect : UiEffect {

--- a/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingScreen.kt
+++ b/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingScreen.kt
@@ -219,6 +219,25 @@ fun TrackingScreen(
                             onPull = { viewModel.onEvent(TrackingEvent.PullFromTracker(tracker.id)) }
                         )
                     }
+
+                    // Only show the Sync Health section for trackers that are logged in.
+                    val loggedInTrackers = state.trackers.filter { it.isLoggedIn }
+                    if (loggedInTrackers.isNotEmpty()) {
+                        item(key = "sync_health_header") {
+                            Text(
+                                text = stringResource(R.string.tracking_health_section),
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
+                            )
+                        }
+                        items(loggedInTrackers, key = { "health_${it.id}" }) { tracker ->
+                            SyncHealthCard(
+                                tracker = tracker,
+                                onRetry = { viewModel.onEvent(TrackingEvent.RetryFailedUpdates(tracker.id)) }
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -696,5 +715,65 @@ private fun SearchResultItem(
                 overflow = TextOverflow.Ellipsis
             )
         }
+    }
+}
+
+/**
+ * Displays per-tracker sync health: last sync timestamp and any failed update count.
+ *
+ * This card is shown only for trackers the user is logged in to.  Tapping "Retry failed"
+ * dispatches [TrackingEvent.RetryFailedUpdates] — the actual retry logic is handled in
+ * [TrackingViewModel.retryFailedUpdates].
+ */
+@Composable
+private fun SyncHealthCard(
+    tracker: TrackerUiModel,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val lastSyncText = if (tracker.lastSyncAt != null) {
+        formatRelativeTime(tracker.lastSyncAt)
+    } else {
+        stringResource(R.string.tracking_never_synced)
+    }
+
+    Card(modifier = modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = tracker.name,
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.tracking_last_sync, lastSyncText),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (tracker.failedUpdates > 0) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.tracking_failed_updates, tracker.failedUpdates),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                TextButton(onClick = onRetry) {
+                    Text(stringResource(R.string.tracking_retry_failed))
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Converts an epoch-millisecond timestamp to a human-readable relative time string,
+ * e.g. "Just now", "5m ago", "2h ago", "3d ago".
+ */
+private fun formatRelativeTime(epochMs: Long): String {
+    val diff = System.currentTimeMillis() - epochMs
+    return when {
+        diff < 60_000L -> "Just now"
+        diff < 3_600_000L -> "${diff / 60_000L}m ago"
+        diff < 86_400_000L -> "${diff / 3_600_000L}h ago"
+        else -> "${diff / 86_400_000L}d ago"
     }
 }

--- a/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingViewModel.kt
+++ b/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingViewModel.kt
@@ -427,6 +427,7 @@ class TrackingViewModel @Inject constructor(
      * Full retry logic is a larger feature — for now this emits a snackbar to acknowledge the
      * request and surfaces the event path so the infrastructure is in place.
      */
+    @Suppress("UnusedParameter")
     private fun retryFailedUpdates(trackerId: Int) {
         viewModelScope.launch {
             _effect.trySend(

--- a/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingViewModel.kt
+++ b/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingViewModel.kt
@@ -78,6 +78,7 @@ class TrackingViewModel @Inject constructor(
             is TrackingEvent.PullFromTracker -> pullFromTracker(event.trackerId)
             is TrackingEvent.ResolveConflict -> resolveConflict(event.trackerId, event.useLocal)
             TrackingEvent.DismissConflict -> _state.update { it.copy(conflictState = null) }
+            is TrackingEvent.RetryFailedUpdates -> retryFailedUpdates(event.trackerId)
         }
     }
 
@@ -113,7 +114,16 @@ class TrackingViewModel @Inject constructor(
                 val syncMap = syncStateList.associateBy { it.trackerId }
                 _state.update { state ->
                     val updatedTrackers = state.trackers.map { model ->
-                        model.copy(syncStatus = syncMap[model.id]?.syncStatus)
+                        val syncState = syncMap[model.id]
+                        model.copy(
+                            syncStatus = syncState?.syncStatus,
+                            // Convert the Instant to epoch-ms for the UI; null means never synced.
+                            lastSyncAt = syncState?.lastSuccessfulSync?.toEpochMilli(),
+                            // A PENDING status means there is at least one change waiting to sync.
+                            pendingUpdates = if (syncState?.syncStatus == SyncStatus.PENDING) 1 else 0,
+                            // An ERROR status means the last sync attempt failed.
+                            failedUpdates = if (syncState?.syncStatus == SyncStatus.ERROR) 1 else 0,
+                        )
                     }
                     state.copy(trackers = updatedTrackers, syncStates = syncMap)
                 }
@@ -408,6 +418,22 @@ class TrackingViewModel @Inject constructor(
             _effect.trySend(TrackingEffect.ShowMessage(
                 context.getString(R.string.tracking_conflict_resolved)
             ))
+        }
+    }
+
+    /**
+     * Handles the [TrackingEvent.RetryFailedUpdates] event.
+     *
+     * Full retry logic is a larger feature — for now this emits a snackbar to acknowledge the
+     * request and surfaces the event path so the infrastructure is in place.
+     */
+    private fun retryFailedUpdates(trackerId: Int) {
+        viewModelScope.launch {
+            _effect.trySend(
+                TrackingEffect.ShowMessage(
+                    context.getString(R.string.tracking_retrying_failed_updates)
+                )
+            )
         }
     }
 

--- a/feature/tracking/src/main/res/values/strings.xml
+++ b/feature/tracking/src/main/res/values/strings.xml
@@ -77,4 +77,12 @@
     <string name="tracking_pull_success">Progress pulled from trackers</string>
     <string name="tracking_conflict_resolved">Conflict resolved</string>
     <string name="tracking_mangaupdates_security_note">MangaUpdates requires your password directly (OAuth not yet supported by their API). Your password is sent securely over HTTPS and is not stored — only the session token is saved.</string>
+
+    <!-- Sync Health section -->
+    <string name="tracking_health_section">Sync Health</string>
+    <string name="tracking_last_sync">Last sync: %1$s</string>
+    <string name="tracking_failed_updates">%1$d failed update(s)</string>
+    <string name="tracking_retry_failed">Retry failed</string>
+    <string name="tracking_never_synced">Never</string>
+    <string name="tracking_retrying_failed_updates">Retrying failed updates…</string>
 </resources>


### PR DESCRIPTION
## **User description**
Adds a Sync Health section to the Tracking screen. Closes #1043.

## Summary
- New `SyncHealthCard` composable shown for each logged-in tracker: displays last sync time (relative, e.g. "5m ago") and failed update count
- `TrackerUiModel` gains three new fields: `lastSyncAt` (epoch-ms), `pendingUpdates`, and `failedUpdates` — populated from existing `SyncStatus` in the ViewModel
- `TrackingEvent.RetryFailedUpdates` added and wired through the ViewModel; surfaces a snackbar acknowledgement (full retry logic is a follow-up)
- New string resources for the section header, last-sync label, failed-updates count, retry button, and "Never" fallback

## Test plan
- [ ] Open Tracking screen for a manga linked to at least one tracker
- [ ] Verify "Sync Health" section header appears below the tracker cards
- [ ] Confirm each logged-in tracker shows a `SyncHealthCard` with its name and "Last sync: Never" (or a relative time if previously synced)
- [ ] Force a sync error and confirm "N failed update(s)" appears in red with a "Retry failed" button
- [ ] Tap "Retry failed" — snackbar "Retrying failed updates…" appears
- [ ] Trackers not logged in do not appear in the Sync Health section

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Show sync health for logged-in trackers on the Tracking screen**

### What Changed
- Adds a new Sync Health section for trackers that are logged in
- Shows each tracker’s last successful sync time, or “Never” if it has never synced
- Shows the number of failed updates when sync errors are present, with a “Retry failed” action
- Tapping retry now shows a message that retrying has started

### Impact
`✅ Easier spotting of stale tracker syncs`
`✅ Clearer sync error status`
`✅ Faster retry requests for failed tracker updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
