### PR TITLE
feat: library update run history and diagnostics

### DIFF
--- a/core/database/src/main/java/app/otakureader/core/database/OtakuReaderDatabase.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/OtakuReaderDatabase.kt
@@ -21,6 +21,7 @@ import app.otakureader.core.database.dao.RecommendationDao
 import app.otakureader.core.database.dao.SyncQueueDao
 import app.otakureader.core.database.dao.TrackEntryDao
 import app.otakureader.core.database.dao.TrackerSyncDao
+import app.otakureader.core.database.dao.UpdateRunSummaryDao
 import app.otakureader.core.database.entity.AchievementEntity
 import app.otakureader.core.database.entity.CategoryEntity
 import app.otakureader.core.database.entity.ChapterEntity
@@ -44,6 +45,7 @@ import app.otakureader.core.database.entity.SyncConfigurationEntity
 import app.otakureader.core.database.entity.SyncQueueEntity
 import app.otakureader.core.database.entity.TrackEntryEntity
 import app.otakureader.core.database.entity.TrackerSyncStateEntity
+import app.otakureader.core.database.entity.UpdateRunSummaryEntity
 
 @Database(
     entities = [
@@ -82,8 +84,10 @@ import app.otakureader.core.database.entity.TrackerSyncStateEntity
         SyncQueueEntity::class,
         // FTS index for library search (#997/Phase5)
         MangaFtsEntity::class,
+        // Library update run history diagnostics (#1041)
+        UpdateRunSummaryEntity::class,
     ],
-    version = 34,
+    version = 35,
     exportSchema = true
 )
 @TypeConverters(DatabaseConverters::class)
@@ -108,6 +112,7 @@ abstract class OtakuReaderDatabase : RoomDatabase() {
     abstract fun achievementDao(): AchievementDao
     abstract fun dataUsageDao(): DataUsageDao
     abstract fun syncQueueDao(): SyncQueueDao
+    abstract fun updateRunSummaryDao(): UpdateRunSummaryDao
 
     companion object {
         const val DATABASE_NAME = "otakureader.db"

--- a/core/database/src/main/java/app/otakureader/core/database/dao/UpdateRunSummaryDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/UpdateRunSummaryDao.kt
@@ -1,0 +1,19 @@
+package app.otakureader.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import app.otakureader.core.database.entity.UpdateRunSummaryEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface UpdateRunSummaryDao {
+    @Query("SELECT * FROM update_run_summary ORDER BY timestamp DESC LIMIT 20")
+    fun getRecentRuns(): Flow<List<UpdateRunSummaryEntity>>
+
+    @Insert
+    suspend fun insert(summary: UpdateRunSummaryEntity): Long
+
+    @Query("DELETE FROM update_run_summary WHERE timestamp < :cutoff")
+    suspend fun deleteOlderThan(cutoff: Long)
+}

--- a/core/database/src/main/java/app/otakureader/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/di/DatabaseModule.kt
@@ -10,6 +10,7 @@ import app.otakureader.core.database.dao.DataUsageDao
 import app.otakureader.core.database.dao.DownloadQueueDao
 import app.otakureader.core.database.dao.SyncQueueDao
 import app.otakureader.core.database.dao.TrackEntryDao
+import app.otakureader.core.database.dao.UpdateRunSummaryDao
 import app.otakureader.core.database.migrations.ALL_MIGRATIONS
 import dagger.Module
 import dagger.Provides
@@ -99,4 +100,7 @@ object DatabaseModule {
 
     @Provides
     fun provideSyncQueueDao(database: OtakuReaderDatabase): SyncQueueDao = database.syncQueueDao()
+
+    @Provides
+    fun provideUpdateRunSummaryDao(database: OtakuReaderDatabase): UpdateRunSummaryDao = database.updateRunSummaryDao()
 }

--- a/core/database/src/main/java/app/otakureader/core/database/entity/UpdateRunSummaryEntity.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/entity/UpdateRunSummaryEntity.kt
@@ -1,0 +1,15 @@
+package app.otakureader.core.database.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "update_run_summary")
+data class UpdateRunSummaryEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val timestamp: Long,
+    val checkedCount: Int,
+    val newChaptersCount: Int,
+    val skippedCount: Int,
+    val failedCount: Int,
+    val durationMs: Long,
+)

--- a/core/database/src/main/java/app/otakureader/core/database/migrations/DatabaseMigrations.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/migrations/DatabaseMigrations.kt
@@ -411,6 +411,23 @@ internal val MIGRATION_33_34 = object : Migration(33, 34) {
     }
 }
 
+/** v34 → v35: Library update run history diagnostics (#1041). */
+internal val MIGRATION_34_35 = object : Migration(34, 35) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("""
+            CREATE TABLE IF NOT EXISTS update_run_summary (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                timestamp INTEGER NOT NULL,
+                checkedCount INTEGER NOT NULL,
+                newChaptersCount INTEGER NOT NULL,
+                skippedCount INTEGER NOT NULL,
+                failedCount INTEGER NOT NULL,
+                durationMs INTEGER NOT NULL
+            )
+        """.trimIndent())
+    }
+}
+
 /** All migrations in order, for use in [Room.databaseBuilder] and migration tests. */
 internal val ALL_MIGRATIONS = arrayOf(
     MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6,
@@ -420,5 +437,5 @@ internal val ALL_MIGRATIONS = arrayOf(
     MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
     MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
     MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30, MIGRATION_30_31,
-    MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34
+    MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35
 )

--- a/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
+++ b/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
@@ -51,7 +51,7 @@ class DatabaseMigrationTest {
     fun allMigrations_formsContiguousChain() {
         val sorted = ALL_MIGRATIONS.sortedBy { it.startVersion }
         assertEquals("Migration chain must start at version 2", 2, sorted.first().startVersion)
-        assertEquals("Migration chain must end at version 34", 34, sorted.last().endVersion)
+        assertEquals("Migration chain must end at version 35", 35, sorted.last().endVersion)
 
         for (i in 0 until sorted.size - 1) {
             val current = sorted[i]
@@ -78,7 +78,7 @@ class DatabaseMigrationTest {
 
     @Test
     fun allMigrations_count() {
-        assertEquals("Expected 32 migrations (v2→v34)", 32, ALL_MIGRATIONS.size)
+        assertEquals("Expected 33 migrations (v2→v35)", 33, ALL_MIGRATIONS.size)
     }
 
     // ── Migration 9 → 10 ────────────────────────────────────────────────────

--- a/data/src/main/java/app/otakureader/data/di/RepositoryModule.kt
+++ b/data/src/main/java/app/otakureader/data/di/RepositoryModule.kt
@@ -47,6 +47,7 @@ import app.otakureader.data.repository.SourceRepositoryImpl
 import app.otakureader.data.repository.StatisticsRepositoryImpl
 import app.otakureader.data.repository.DynamicCategoryRepositoryImpl
 import app.otakureader.data.repository.RecommendationRepositoryImpl
+import app.otakureader.data.repository.UpdateRunSummaryRepositoryImpl
 import app.otakureader.data.sync.SyncRepositoryImpl
 import app.otakureader.data.worker.ExtensionUpdateSchedulerImpl
 import app.otakureader.data.worker.SyncSchedulerImpl
@@ -55,6 +56,7 @@ import app.otakureader.domain.scheduler.CoverRefreshScheduler
 import app.otakureader.domain.scheduler.ExtensionUpdateScheduler
 import app.otakureader.domain.scheduler.LibraryUpdateScheduler
 import app.otakureader.domain.scheduler.ReminderScheduler
+import app.otakureader.domain.repository.UpdateRunSummaryRepository
 import app.otakureader.domain.scheduler.SyncScheduler
 import app.otakureader.domain.scheduler.TrackerSyncScheduler
 import app.otakureader.domain.tracking.TrackManager
@@ -163,6 +165,9 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun bindSyncScheduler(impl: SyncSchedulerImpl): SyncScheduler
+
+    @Binds
+    abstract fun bindUpdateRunSummaryRepository(impl: UpdateRunSummaryRepositoryImpl): UpdateRunSummaryRepository
 
     companion object {
         @Provides

--- a/data/src/main/java/app/otakureader/data/repository/UpdateRunSummaryRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/UpdateRunSummaryRepositoryImpl.kt
@@ -1,0 +1,47 @@
+package app.otakureader.data.repository
+
+import app.otakureader.core.database.dao.UpdateRunSummaryDao
+import app.otakureader.core.database.entity.UpdateRunSummaryEntity
+import app.otakureader.domain.model.UpdateRunSummary
+import app.otakureader.domain.repository.UpdateRunSummaryRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UpdateRunSummaryRepositoryImpl @Inject constructor(
+    private val dao: UpdateRunSummaryDao,
+) : UpdateRunSummaryRepository {
+
+    override fun getRecentRuns(): Flow<List<UpdateRunSummary>> =
+        dao.getRecentRuns().map { entities -> entities.map { it.toDomain() } }
+
+    override suspend fun insert(summary: UpdateRunSummary) {
+        dao.insert(summary.toEntity())
+    }
+
+    override suspend fun deleteOlderThan(cutoffMs: Long) {
+        dao.deleteOlderThan(cutoffMs)
+    }
+
+    private fun UpdateRunSummaryEntity.toDomain() = UpdateRunSummary(
+        id = id,
+        timestamp = timestamp,
+        checkedCount = checkedCount,
+        newChaptersCount = newChaptersCount,
+        skippedCount = skippedCount,
+        failedCount = failedCount,
+        durationMs = durationMs,
+    )
+
+    private fun UpdateRunSummary.toEntity() = UpdateRunSummaryEntity(
+        id = id,
+        timestamp = timestamp,
+        checkedCount = checkedCount,
+        newChaptersCount = newChaptersCount,
+        skippedCount = skippedCount,
+        failedCount = failedCount,
+        durationMs = durationMs,
+    )
+}

--- a/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
@@ -12,6 +12,8 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkerParameters
+import app.otakureader.core.database.dao.UpdateRunSummaryDao
+import app.otakureader.core.database.entity.UpdateRunSummaryEntity
 import app.otakureader.core.preferences.DownloadPreferences
 import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.core.preferences.LibraryPreferences
@@ -47,11 +49,13 @@ class LibraryUpdateWorker @AssistedInject constructor(
     private val downloadManager: DownloadManager,
     private val chapterRepository: ChapterRepository,
     private val categoryRepository: CategoryRepository,
-    private val notificationPreferences: app.otakureader.core.preferences.NotificationPreferences
+    private val notificationPreferences: app.otakureader.core.preferences.NotificationPreferences,
+    private val updateRunSummaryDao: UpdateRunSummaryDao,
 ) : CoroutineWorker(context, workerParams) {
 
     @Suppress("LongMethod", "CyclomaticComplexMethod", "CognitiveComplexMethod")
     override suspend fun doWork(): Result {
+        val startTime = System.currentTimeMillis()
         return try {
             // Check if update should only run on Wi-Fi
             val updateOnlyOnWifi = libraryPreferences.updateOnlyOnWifi.first()
@@ -142,6 +146,7 @@ class LibraryUpdateWorker @AssistedInject constructor(
             val successfullyUpdatedCategoryIds = mutableSetOf<Long>()
             var failedUpdates = 0
             var processedCount = 0
+            var newChapterTotal = 0
             val totalCount = libraryManga.size
 
             // Show progress notification if enabled
@@ -163,6 +168,7 @@ class LibraryUpdateWorker @AssistedInject constructor(
                 val result = updateLibraryManga(manga)
 
                 result.onSuccess { newChapterCount ->
+                    newChapterTotal += newChapterCount
                     successfullyUpdatedCategoryIds.addAll(manga.categoryIds.filter { it in updatedCategoryIds })
                     if (newChapterCount > 0) {
                         // Only add to notification list if notifications enabled for this manga
@@ -229,6 +235,26 @@ class LibraryUpdateWorker @AssistedInject constructor(
                     // Notification failures should not fail the entire library update.
                     Log.w(TAG, "Failed to send library update notification", e)
                 }
+            }
+
+            // Persist a diagnostics summary for the Updates screen (#1041).
+            try {
+                updateRunSummaryDao.insert(
+                    app.otakureader.core.database.entity.UpdateRunSummaryEntity(
+                        timestamp = System.currentTimeMillis(),
+                        checkedCount = totalCount,
+                        newChaptersCount = newChapterTotal,
+                        skippedCount = skippedManga.size,
+                        failedCount = failedUpdates,
+                        durationMs = System.currentTimeMillis() - startTime,
+                    )
+                )
+                // Keep only 90 days of history to prevent unbounded growth.
+                updateRunSummaryDao.deleteOlderThan(
+                    System.currentTimeMillis() - java.util.concurrent.TimeUnit.DAYS.toMillis(90)
+                )
+            } catch (_: Exception) {
+                // Diagnostics failure must never fail the worker itself.
             }
 
             // Consider it a success if at least some manga were updated successfully

--- a/data/src/test/java/app/otakureader/data/worker/LibraryUpdateWorkerTest.kt
+++ b/data/src/test/java/app/otakureader/data/worker/LibraryUpdateWorkerTest.kt
@@ -9,6 +9,7 @@ import androidx.work.WorkerParameters
 import app.otakureader.core.preferences.DownloadPreferences
 import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.core.preferences.LibraryPreferences
+import app.otakureader.core.database.dao.UpdateRunSummaryDao
 import app.otakureader.core.preferences.NotificationPreferences
 import app.otakureader.data.download.DownloadManager
 import app.otakureader.domain.model.Chapter
@@ -55,6 +56,7 @@ class LibraryUpdateWorkerTest {
     private lateinit var chapterRepository: ChapterRepository
     private lateinit var categoryRepository: CategoryRepository
     private lateinit var notificationPreferences: NotificationPreferences
+    private lateinit var updateRunSummaryDao: UpdateRunSummaryDao
     private lateinit var worker: LibraryUpdateWorker
 
     private lateinit var connectivityManager: ConnectivityManager
@@ -121,6 +123,7 @@ class LibraryUpdateWorkerTest {
         chapterRepository = mockk()
         categoryRepository = mockk()
         notificationPreferences = mockk(relaxed = true)
+        updateRunSummaryDao = mockk(relaxed = true)
 
         connectivityManager = mockk()
         network = mockk()
@@ -158,7 +161,8 @@ class LibraryUpdateWorkerTest {
             downloadManager,
             chapterRepository,
             categoryRepository,
-            notificationPreferences
+            notificationPreferences,
+            updateRunSummaryDao,
         )
     }
 

--- a/domain/src/main/java/app/otakureader/domain/model/UpdateRunSummary.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/UpdateRunSummary.kt
@@ -1,0 +1,11 @@
+package app.otakureader.domain.model
+
+data class UpdateRunSummary(
+    val id: Long = 0,
+    val timestamp: Long,
+    val checkedCount: Int,
+    val newChaptersCount: Int,
+    val skippedCount: Int,
+    val failedCount: Int,
+    val durationMs: Long,
+)

--- a/domain/src/main/java/app/otakureader/domain/repository/UpdateRunSummaryRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/UpdateRunSummaryRepository.kt
@@ -1,0 +1,15 @@
+package app.otakureader.domain.repository
+
+import app.otakureader.domain.model.UpdateRunSummary
+import kotlinx.coroutines.flow.Flow
+
+interface UpdateRunSummaryRepository {
+    /** Emits the most recent 20 update run records, newest first. */
+    fun getRecentRuns(): Flow<List<UpdateRunSummary>>
+
+    /** Persists a completed run summary. */
+    suspend fun insert(summary: UpdateRunSummary)
+
+    /** Deletes records older than [cutoffMs] to keep the table small. */
+    suspend fun deleteOlderThan(cutoffMs: Long)
+}

--- a/domain/src/main/java/app/otakureader/domain/usecase/GetLastUpdateRunSummaryUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/GetLastUpdateRunSummaryUseCase.kt
@@ -1,0 +1,18 @@
+package app.otakureader.domain.usecase
+
+import app.otakureader.domain.model.UpdateRunSummary
+import app.otakureader.domain.repository.UpdateRunSummaryRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+/**
+ * Returns a [Flow] emitting the most recent [UpdateRunSummary], or null if no run has been
+ * recorded yet. The Updates screen uses this to display a diagnostics card after each check.
+ */
+class GetLastUpdateRunSummaryUseCase @Inject constructor(
+    private val repository: UpdateRunSummaryRepository,
+) {
+    operator fun invoke(): Flow<UpdateRunSummary?> =
+        repository.getRecentRuns().map { it.firstOrNull() }
+}

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesMvi.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesMvi.kt
@@ -4,6 +4,7 @@ import app.otakureader.core.common.mvi.UiEffect
 import app.otakureader.core.common.mvi.UiEvent
 import app.otakureader.core.common.mvi.UiState
 import app.otakureader.domain.model.MangaUpdate
+import app.otakureader.domain.model.UpdateRunSummary
 
 /**
  * Represents a failed update entry for the error screen.
@@ -40,7 +41,9 @@ data class UpdatesState(
     /** List of manga that will be checked in the next update. */
     val pendingUpdates: List<PendingUpdateManga> = emptyList(),
     /** Whether the To-Be-Updated screen is visible. */
-    val showPendingUpdates: Boolean = false
+    val showPendingUpdates: Boolean = false,
+    /** Diagnostics card: summary of the last completed library update run (#1041). */
+    val lastRunSummary: UpdateRunSummary? = null,
 ) : UiState
 
 sealed interface UpdatesEvent : UiEvent {

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -42,6 +44,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.AlertDialog
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -194,6 +197,7 @@ fun UpdatesScreen(
             else -> UpdatesList(
                 updates = state.updates,
                 selectedItems = state.selectedItems,
+                lastRunSummary = state.lastRunSummary,
                 onChapterClick = { update ->
                     viewModel.onEvent(
                         UpdatesEvent.OnChapterClick(
@@ -277,6 +281,7 @@ private fun bucketLabel(bucket: UpdateDateBucket): String = when (bucket) {
 private fun UpdatesList(
     updates: List<MangaUpdate>,
     selectedItems: Set<Long>,
+    lastRunSummary: app.otakureader.domain.model.UpdateRunSummary?,
     onChapterClick: (MangaUpdate) -> Unit,
     onChapterLongClick: (MangaUpdate) -> Unit,
     onDownloadClick: (MangaUpdate) -> Unit,
@@ -298,6 +303,16 @@ private fun UpdatesList(
     }
 
     LazyColumn(modifier = modifier.fillMaxSize()) {
+        if (lastRunSummary != null) {
+            item(key = "last_run_summary") {
+                LastRunSummaryCard(
+                    summary = lastRunSummary,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                )
+            }
+        }
         items(listItems, key = { item ->
             when (item) {
                 is UpdateListItem.Header -> "header_${item.bucket}"
@@ -598,6 +613,99 @@ private fun PendingUpdatesDialog(
             }
         }
     )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Last run summary diagnostics card (#1041)
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun LastRunSummaryCard(
+    summary: app.otakureader.domain.model.UpdateRunSummary,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+            Text(
+                text = stringResource(R.string.updates_last_run_title),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            androidx.compose.foundation.layout.Spacer(modifier = Modifier.height(6.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                LastRunStat(
+                    label = stringResource(R.string.updates_last_run_checked),
+                    value = summary.checkedCount.toString(),
+                )
+                LastRunStat(
+                    label = stringResource(R.string.updates_last_run_new),
+                    value = summary.newChaptersCount.toString(),
+                    highlight = summary.newChaptersCount > 0,
+                )
+                LastRunStat(
+                    label = stringResource(R.string.updates_last_run_skipped),
+                    value = summary.skippedCount.toString(),
+                )
+                LastRunStat(
+                    label = stringResource(R.string.updates_last_run_failed),
+                    value = summary.failedCount.toString(),
+                    highlight = summary.failedCount > 0,
+                    highlightError = true,
+                )
+            }
+            androidx.compose.foundation.layout.Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(
+                    R.string.updates_last_run_meta,
+                    formatFetchDate(summary.timestamp),
+                    formatDurationMs(summary.durationMs),
+                ),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LastRunStat(
+    label: String,
+    value: String,
+    highlight: Boolean = false,
+    highlightError: Boolean = false,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = when {
+                highlight && highlightError -> MaterialTheme.colorScheme.error
+                highlight -> MaterialTheme.colorScheme.primary
+                else -> MaterialTheme.colorScheme.onSurface
+            },
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun formatDurationMs(durationMs: Long): String {
+    val seconds = durationMs / 1_000
+    return if (seconds < 60) "${seconds}s" else "${seconds / 60}m ${seconds % 60}s"
 }
 
 @Composable

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
@@ -8,6 +8,7 @@ import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.model.DownloadBlockedException
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.scheduler.LibraryUpdateScheduler
+import app.otakureader.domain.usecase.GetLastUpdateRunSummaryUseCase
 import app.otakureader.domain.usecase.GetLibraryMangaUseCase
 import app.otakureader.domain.usecase.GetRecentUpdatesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -31,6 +32,7 @@ class UpdatesViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val getRecentUpdatesUseCase: GetRecentUpdatesUseCase,
     private val getLibraryMangaUseCase: GetLibraryMangaUseCase,
+    private val getLastUpdateRunSummaryUseCase: GetLastUpdateRunSummaryUseCase,
     private val generalPreferences: GeneralPreferences,
     private val downloadRepository: DownloadRepository,
     private val chapterRepository: ChapterRepository,
@@ -45,6 +47,7 @@ class UpdatesViewModel @Inject constructor(
 
     init {
         loadUpdates()
+        loadLastRunSummary()
         markUpdatesViewed()
     }
 
@@ -208,6 +211,16 @@ class UpdatesViewModel @Inject constructor(
             .catch { error ->
                 _state.update { it.copy(isLoading = false, error = error.message) }
             }
+            .launchIn(viewModelScope)
+    }
+
+    /** Observe the last library update run summary for the diagnostics card. */
+    private fun loadLastRunSummary() {
+        getLastUpdateRunSummaryUseCase()
+            .onEach { summary ->
+                _state.update { it.copy(lastRunSummary = summary) }
+            }
+            .catch { /* diagnostics failure should not affect the main updates list */ }
             .launchIn(viewModelScope)
     }
 

--- a/feature/updates/src/main/res/values/strings.xml
+++ b/feature/updates/src/main/res/values/strings.xml
@@ -73,6 +73,13 @@
     </plurals>
     <string name="updates_mark_as_read_failed">Failed to mark as read</string>
     <string name="updates_library_update_started">Library update started</string>
+    <!-- Last run summary diagnostics card (#1041) -->
+    <string name="updates_last_run_title">Last Update Run</string>
+    <string name="updates_last_run_checked">Checked</string>
+    <string name="updates_last_run_new">New</string>
+    <string name="updates_last_run_skipped">Skipped</string>
+    <string name="updates_last_run_failed">Failed</string>
+    <string name="updates_last_run_meta">%1$s · took %2$s</string>
     <!-- Date group headers -->
     <string name="updates_date_today">Today</string>
     <string name="updates_date_yesterday">Yesterday</string>

--- a/feature/updates/src/test/java/app/otakureader/feature/updates/UpdatesViewModelTest.kt
+++ b/feature/updates/src/test/java/app/otakureader/feature/updates/UpdatesViewModelTest.kt
@@ -10,6 +10,7 @@ import app.otakureader.domain.model.MangaUpdate
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.scheduler.LibraryUpdateScheduler
+import app.otakureader.domain.usecase.GetLastUpdateRunSummaryUseCase
 import app.otakureader.domain.usecase.GetLibraryMangaUseCase
 import app.otakureader.domain.usecase.GetRecentUpdatesUseCase
 import app.cash.turbine.test
@@ -41,6 +42,7 @@ class UpdatesViewModelTest {
 
     private lateinit var getRecentUpdatesUseCase: GetRecentUpdatesUseCase
     private lateinit var getLibraryMangaUseCase: GetLibraryMangaUseCase
+    private lateinit var getLastUpdateRunSummaryUseCase: GetLastUpdateRunSummaryUseCase
     private lateinit var generalPreferences: GeneralPreferences
     private lateinit var downloadRepository: DownloadRepository
     private lateinit var chapterRepository: ChapterRepository
@@ -62,6 +64,9 @@ class UpdatesViewModelTest {
         Dispatchers.setMain(testDispatcher)
         getRecentUpdatesUseCase = mockk()
         getLibraryMangaUseCase = mockk(relaxed = true)
+        getLastUpdateRunSummaryUseCase = mockk {
+            every { this@mockk.invoke() } returns flowOf(null)
+        }
         generalPreferences = mockk {
             coEvery { setLastUpdatesViewedAt(any()) } returns mockk<Preferences>(relaxed = true)
         }
@@ -81,6 +86,7 @@ class UpdatesViewModelTest {
             context,
             getRecentUpdatesUseCase,
             getLibraryMangaUseCase,
+            getLastUpdateRunSummaryUseCase,
             generalPreferences,
             downloadRepository,
             chapterRepository,


### PR DESCRIPTION
## **User description**
$(cat <<'EOF'
## Summary

- Adds `UpdateRunSummary` domain model, Room entity/DAO, and an explicit v34→v35 migration that creates the `update_run_summary` table
- `LibraryUpdateWorker` now records checked/new chapter/skipped/failed counts and wall-clock duration at the end of every run; records older than 90 days are pruned automatically
- `UpdatesViewModel` observes the last run summary via `GetLastUpdateRunSummaryUseCase` and exposes it in `UpdatesState`; the Updates screen renders a compact diagnostics card at the top of the list showing the four counters, the run date, and duration

## Test plan

- [ ] First launch after install: updates screen shows no card (no runs yet)
- [ ] Trigger a manual library update; after it completes the diagnostics card appears with correct counts
- [ ] Checked = number of manga evaluated; New = chapters found; Skipped = filtered by smart-skip rules; Failed = network/source errors
- [ ] Failed count renders in error colour; New count renders in primary colour when > 0
- [ ] Card persists across screen navigation (data comes from Room, survives process death)
- [ ] Confirm Room migration passes: install old APK, update to new, verify no crash and table exists

Closes #1041.

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS
EOF
)

_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Show the last library update run in the Updates screen**

### What Changed
- The Updates screen now shows a summary card for the most recent library update, including checked, new, skipped, and failed counts
- The card also shows when the run finished and how long it took
- Update results are saved after each run, and older summaries are removed after 90 days
- The summary card stays hidden until at least one update has completed

### Impact
`✅ Clearer library update results`
`✅ Easier spotting of failed updates`
`✅ Shorter check time when reviewing update history`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
