### PR TITLE
feat: drag-and-drop nav tab reorder with hide/show toggles

### DIFF
--- a/app/src/main/java/app/otakureader/OtakuReaderBottomBar.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderBottomBar.kt
@@ -53,7 +53,8 @@ fun OtakuReaderBottomBar(
 
     if (!isTopLevelDestination) return
 
-    val tabOrder by navOrderPreferences.tabOrder.collectAsStateWithLifecycle(emptyList())
+    val tabOrderEntries by navOrderPreferences.tabOrder.collectAsStateWithLifecycle(emptyList())
+    val tabOrder = tabOrderEntries.filter { it.isVisible }.map { it.tab }
     if (tabOrder.isEmpty()) return
 
     NavigationBar(modifier = modifier) {

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/NavOrderPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/NavOrderPreferences.kt
@@ -14,21 +14,47 @@ private val DEFAULT_ORDER = listOf(
     NavTab.LIBRARY, NavTab.UPDATES, NavTab.BROWSE, NavTab.HISTORY, NavTab.MORE
 )
 
-/** Persists the user-defined bottom-nav tab order. */
+/**
+ * Lightweight projection of a tab's persisted state: its position in the list and whether
+ * the user has toggled it on or off. Kept in core so the ViewModel can convert to and from
+ * the UI-layer [NavTabEntry] without the preferences module depending on the feature layer.
+ */
+data class NavTabPreferenceEntry(val tab: NavTab, val isVisible: Boolean)
+
+/** Persists the user-defined bottom-nav tab order and per-tab visibility. */
 class NavOrderPreferences(private val dataStore: DataStore<Preferences>) {
 
-    /** Emits the current tab order. Falls back to the default on any parse error. */
-    val tabOrder: Flow<List<NavTab>> = dataStore.data.map { prefs ->
+    /**
+     * Emits the current ordered list of tabs with their visibility flags.
+     *
+     * Storage format (TAB_ORDER key): "LIBRARY:true,UPDATES:false,BROWSE:true,…"
+     * Falls back gracefully to the default order (all visible) on any parse error or if the
+     * stored list is incomplete (e.g. after a new tab is added in a future release).
+     */
+    val tabOrder: Flow<List<NavTabPreferenceEntry>> = dataStore.data.map { prefs ->
         prefs[Keys.TAB_ORDER]?.let { raw ->
             runCatching {
-                raw.split(",").map { NavTab.valueOf(it.trim()) }
-                    .takeIf { it.size == NavTab.entries.size && it.toSet().size == NavTab.entries.size }
+                val parsed = raw.split(",").map { token ->
+                    val parts = token.trim().split(":")
+                    NavTabPreferenceEntry(
+                        tab = NavTab.valueOf(parts[0]),
+                        isVisible = parts.getOrNull(1)?.toBooleanStrictOrNull() ?: true,
+                    )
+                }
+                // Only accept if every tab is represented exactly once.
+                parsed.takeIf {
+                    it.size == NavTab.entries.size &&
+                        it.map { e -> e.tab }.toSet().size == NavTab.entries.size
+                }
             }.getOrNull()
-        } ?: DEFAULT_ORDER
+        } ?: DEFAULT_ORDER.map { NavTabPreferenceEntry(it, isVisible = true) }
     }
 
-    suspend fun setTabOrder(order: List<NavTab>) {
-        dataStore.edit { it[Keys.TAB_ORDER] = order.joinToString(",") { tab -> tab.name } }
+    /** Persists the full ordered list including visibility flags. */
+    suspend fun setTabOrder(order: List<NavTabPreferenceEntry>) {
+        dataStore.edit { prefs ->
+            prefs[Keys.TAB_ORDER] = order.joinToString(",") { "${it.tab.name}:${it.isVisible}" }
+        }
     }
 
     private object Keys {

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/NavOrderPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/NavOrderPreferences.kt
@@ -34,18 +34,29 @@ class NavOrderPreferences(private val dataStore: DataStore<Preferences>) {
     val tabOrder: Flow<List<NavTabPreferenceEntry>> = dataStore.data.map { prefs ->
         prefs[Keys.TAB_ORDER]?.let { raw ->
             runCatching {
-                val parsed = raw.split(",").map { token ->
+                // Parse stored tokens, silently dropping any unknown tab names so that a
+                // downgrade (or a stored value from a future release with more tabs) never
+                // crashes or produces an empty list.
+                val parsed = raw.split(",").mapNotNull { token ->
                     val parts = token.trim().split(":")
+                    val tab = runCatching { NavTab.valueOf(parts[0]) }.getOrNull() ?: return@mapNotNull null
                     NavTabPreferenceEntry(
-                        tab = NavTab.valueOf(parts[0]),
+                        tab = tab,
                         isVisible = parts.getOrNull(1)?.toBooleanStrictOrNull() ?: true,
                     )
                 }
-                // Only accept if every tab is represented exactly once.
-                parsed.takeIf {
-                    it.size == NavTab.entries.size &&
-                        it.map { e -> e.tab }.toSet().size == NavTab.entries.size
-                }
+                // De-duplicate: keep only the first occurrence of each tab (guards against
+                // corrupted prefs that somehow repeated a tab name).
+                val seen = mutableSetOf<NavTab>()
+                val deduped = parsed.filter { seen.add(it.tab) }
+                // Append any tabs that are present in the current build but absent from the
+                // stored value (e.g. a new tab added in a later release). New tabs are visible
+                // by default and placed at the end of the list.
+                val knownTabs = deduped.map { it.tab }.toSet()
+                val appended = deduped + NavTab.entries
+                    .filter { it !in knownTabs }
+                    .map { NavTabPreferenceEntry(it, isVisible = true) }
+                appended.takeIf { it.isNotEmpty() }
             }.getOrNull()
         } ?: DEFAULT_ORDER.map { NavTabPreferenceEntry(it, isVisible = true) }
     }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/navorder/NavOrderMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/navorder/NavOrderMvi.kt
@@ -2,12 +2,22 @@ package app.otakureader.feature.settings.navorder
 
 import app.otakureader.core.preferences.NavTab
 
+/**
+ * Pairs a tab with its current visibility. Using a wrapper avoids modifying the NavTab enum,
+ * which lives in core and must remain stable for extension compatibility.
+ */
+data class NavTabEntry(val tab: NavTab, val isVisible: Boolean = true)
+
 data class NavOrderState(
-    val tabs: List<NavTab> = emptyList(),
+    val tabs: List<NavTabEntry> = emptyList(),
 )
 
 sealed interface NavOrderEvent {
     data class MoveUp(val index: Int) : NavOrderEvent
     data class MoveDown(val index: Int) : NavOrderEvent
+    /** Swap the entry at [from] with the entry at [to] (drag-and-drop reorder). */
+    data class MoveTab(val from: Int, val to: Int) : NavOrderEvent
+    /** Flip the visibility flag for the entry at [index]. */
+    data class ToggleTabVisibility(val index: Int) : NavOrderEvent
     data class Reset(val unit: Unit = Unit) : NavOrderEvent
 }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/navorder/NavOrderViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/navorder/NavOrderViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.otakureader.core.preferences.NavTab
 import app.otakureader.core.preferences.NavOrderPreferences
+import app.otakureader.core.preferences.NavTabPreferenceEntry
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -21,9 +22,10 @@ class NavOrderViewModel @Inject constructor(
     val state: StateFlow<NavOrderState> = _state.asStateFlow()
 
     init {
+        // Collect the persisted order + visibility and map it to UI state.
         viewModelScope.launch {
             prefs.tabOrder.collect { order ->
-                _state.update { it.copy(tabs = order) }
+                _state.update { it.copy(tabs = order.map { e -> NavTabEntry(e.tab, e.isVisible) }) }
             }
         }
     }
@@ -32,6 +34,8 @@ class NavOrderViewModel @Inject constructor(
         when (event) {
             is NavOrderEvent.MoveUp -> move(event.index, -1)
             is NavOrderEvent.MoveDown -> move(event.index, +1)
+            is NavOrderEvent.MoveTab -> moveTab(event.from, event.to)
+            is NavOrderEvent.ToggleTabVisibility -> toggleVisibility(event.index)
             is NavOrderEvent.Reset -> reset()
         }
     }
@@ -44,12 +48,37 @@ class NavOrderViewModel @Inject constructor(
         persist(current)
     }
 
-    private fun reset() {
-        persist(NavTab.entries)
+    /**
+     * Swaps [from] and [to] in the list. Called by the drag-and-drop gesture handler once
+     * the dragged item crosses the midpoint of a neighbour.
+     */
+    private fun moveTab(from: Int, to: Int) {
+        val current = _state.value.tabs.toMutableList()
+        if (from < 0 || from >= current.size || to < 0 || to >= current.size) return
+        val tmp = current[from]; current[from] = current[to]; current[to] = tmp
+        persist(current)
     }
 
-    private fun persist(order: List<NavTab>) {
+    /**
+     * Flips the [NavTabEntry.isVisible] flag for the entry at [index]. The tab remains in the
+     * list so the user can always re-enable it — hiding only removes it from the bottom nav.
+     */
+    private fun toggleVisibility(index: Int) {
+        val current = _state.value.tabs.toMutableList()
+        if (index < 0 || index >= current.size) return
+        current[index] = current[index].copy(isVisible = !current[index].isVisible)
+        persist(current)
+    }
+
+    private fun reset() {
+        // Restore default order with all tabs visible.
+        persist(NavTab.entries.map { NavTabEntry(it, isVisible = true) })
+    }
+
+    private fun persist(order: List<NavTabEntry>) {
         _state.update { it.copy(tabs = order) }
-        viewModelScope.launch { prefs.setTabOrder(order) }
+        viewModelScope.launch {
+            prefs.setTabOrder(order.map { NavTabPreferenceEntry(it.tab, it.isVisible) })
+        }
     }
 }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/navorder/NavOrderViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/navorder/NavOrderViewModel.kt
@@ -49,13 +49,18 @@ class NavOrderViewModel @Inject constructor(
     }
 
     /**
-     * Swaps [from] and [to] in the list. Called by the drag-and-drop gesture handler once
-     * the dragged item crosses the midpoint of a neighbour.
+     * Moves the item at [from] to position [to], shifting everything in between. Called by the
+     * drag-and-drop gesture handler once the dragged item crosses the midpoint of a neighbour.
+     *
+     * Unlike a simple swap, removeAt/add correctly handles non-adjacent moves and produces the
+     * intuitive result: the dragged item ends up exactly at the target position and all
+     * intervening items shift by one slot.
      */
     private fun moveTab(from: Int, to: Int) {
         val current = _state.value.tabs.toMutableList()
         if (from < 0 || from >= current.size || to < 0 || to >= current.size) return
-        val tmp = current[from]; current[from] = current[to]; current[to] = tmp
+        val item = current.removeAt(from)
+        current.add(to, item)
         persist(current)
     }
 

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/navorder/SettingsNavOrderScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/navorder/SettingsNavOrderScreen.kt
@@ -35,9 +35,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
@@ -184,6 +186,18 @@ fun SettingsNavOrderScreen(
                 .dragContainer(dragDropState),
         ) {
             itemsIndexed(state.tabs, key = { _, entry -> entry.tab.name }) { index, entry ->
+                val isDragging = index == dragDropState.draggingItemIndex
+                val itemModifier = if (isDragging) {
+                    // Lift the dragging item above its siblings and translate it by the
+                    // accumulated drag offset so it follows the user's finger.
+                    Modifier
+                        .zIndex(1f)
+                        .graphicsLayer { translationY = dragDropState.draggingItemOffset }
+                } else {
+                    // Non-dragging items animate smoothly into their new positions as the
+                    // list reorders around the dragged item.
+                    Modifier.animateItem()
+                }
                 NavTabRow(
                     entry = entry,
                     index = index,
@@ -193,6 +207,7 @@ fun SettingsNavOrderScreen(
                     onToggleVisibility = {
                         viewModel.onEvent(NavOrderEvent.ToggleTabVisibility(index))
                     },
+                    modifier = itemModifier,
                 )
             }
         }
@@ -211,12 +226,13 @@ private fun NavTabRow(
     onMoveUp: () -> Unit,
     onMoveDown: () -> Unit,
     onToggleVisibility: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Card(
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant,
         ),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/navorder/SettingsNavOrderScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/navorder/SettingsNavOrderScreen.kt
@@ -1,15 +1,20 @@
 package app.otakureader.feature.settings.navorder
 
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListItemInfo
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -18,12 +23,19 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -34,11 +46,99 @@ import app.otakureader.core.navigation.Route
 import app.otakureader.core.preferences.NavTab
 import app.otakureader.feature.settings.R
 
+// ---------------------------------------------------------------------------
+// Navigation registration
+// ---------------------------------------------------------------------------
+
 fun NavGraphBuilder.settingsNavOrderScreen(onNavigateBack: () -> Unit) {
     composable<Route.SettingsNavOrder> {
         SettingsNavOrderScreen(onNavigateBack = onNavigateBack)
     }
 }
+
+// ---------------------------------------------------------------------------
+// Drag-and-drop helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Holds mutable drag state for a [LazyColumn].
+ *
+ * [onMove] is called each time the dragging item crosses the midpoint of an adjacent item, so
+ * the list re-orders incrementally while the user is still dragging — the same behaviour as
+ * most drag-reorder implementations in Compose.
+ */
+class DragDropState(
+    val lazyListState: LazyListState,
+    private val onMove: (Int, Int) -> Unit,
+) {
+    var draggingItemIndex by mutableStateOf<Int?>(null)
+    var draggingItemOffset by mutableFloatStateOf(0f)
+
+    val draggingItemLayoutInfo: LazyListItemInfo?
+        get() = lazyListState.layoutInfo.visibleItemsInfo
+            .firstOrNull { it.index == draggingItemIndex }
+
+    /** Called when a long-press gesture starts at [offset] inside the list. */
+    fun onDragStart(offset: Offset) {
+        lazyListState.layoutInfo.visibleItemsInfo.firstOrNull { item ->
+            offset.y.toInt() in item.offset..(item.offset + item.size)
+        }?.also {
+            draggingItemIndex = it.index
+            draggingItemOffset = 0f
+        }
+    }
+
+    /**
+     * Called for every drag delta. Accumulates [offset.y] and checks whether the dragged item
+     * has crossed the midpoint of a neighbour — if so, triggers [onMove].
+     */
+    fun onDrag(offset: Offset) {
+        draggingItemOffset += offset.y
+        val current = draggingItemIndex ?: return
+        val info = draggingItemLayoutInfo ?: return
+        val startOffset = draggingItemOffset + info.offset
+        val endOffset = startOffset + info.size
+        val mid = (startOffset + endOffset) / 2f
+        lazyListState.layoutInfo.visibleItemsInfo
+            .firstOrNull { it.offset <= mid && mid <= it.offset + it.size && it.index != current }
+            ?.also { target ->
+                onMove(current, target.index)
+                draggingItemIndex = target.index
+                // After swapping, reset the offset accumulator so the visual position stays
+                // anchored to the pointer rather than jumping.
+                draggingItemOffset = 0f
+            }
+    }
+
+    fun onDragInterrupted() {
+        draggingItemIndex = null
+        draggingItemOffset = 0f
+    }
+}
+
+@Composable
+fun rememberDragDropState(listState: LazyListState, onMove: (Int, Int) -> Unit): DragDropState =
+    remember { DragDropState(listState, onMove) }
+
+/**
+ * Attaches [detectDragGesturesAfterLongPress] to the composable, forwarding events to [state].
+ * Long-press is used instead of immediate drag so that short taps (e.g. the Switch) still work.
+ */
+fun Modifier.dragContainer(state: DragDropState): Modifier = pointerInput(state) {
+    detectDragGesturesAfterLongPress(
+        onDragStart = { offset -> state.onDragStart(offset) },
+        onDrag = { change, dragAmount ->
+            state.onDrag(dragAmount)
+            change.consume()
+        },
+        onDragEnd = { state.onDragInterrupted() },
+        onDragCancel = { state.onDragInterrupted() },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -47,6 +147,10 @@ fun SettingsNavOrderScreen(
     viewModel: NavOrderViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val listState = rememberLazyListState()
+    val dragDropState = rememberDragDropState(listState) { from, to ->
+        viewModel.onEvent(NavOrderEvent.MoveTab(from, to))
+    }
 
     Scaffold(
         topBar = {
@@ -62,37 +166,51 @@ fun SettingsNavOrderScreen(
                 },
                 actions = {
                     IconButton(onClick = { viewModel.onEvent(NavOrderEvent.Reset()) }) {
-                        Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.nav_order_reset))
+                        Icon(
+                            Icons.Default.Refresh,
+                            contentDescription = stringResource(R.string.nav_order_reset),
+                        )
                     }
                 },
             )
         },
     ) { padding ->
         LazyColumn(
+            state = listState,
             contentPadding = padding,
             verticalArrangement = Arrangement.spacedBy(4.dp),
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .dragContainer(dragDropState),
         ) {
-            itemsIndexed(state.tabs) { index, tab ->
+            itemsIndexed(state.tabs, key = { _, entry -> entry.tab.name }) { index, entry ->
                 NavTabRow(
-                    tab = tab,
+                    entry = entry,
                     index = index,
                     total = state.tabs.size,
                     onMoveUp = { viewModel.onEvent(NavOrderEvent.MoveUp(index)) },
                     onMoveDown = { viewModel.onEvent(NavOrderEvent.MoveDown(index)) },
+                    onToggleVisibility = {
+                        viewModel.onEvent(NavOrderEvent.ToggleTabVisibility(index))
+                    },
                 )
             }
         }
     }
 }
 
+// ---------------------------------------------------------------------------
+// Row composable
+// ---------------------------------------------------------------------------
+
 @Composable
 private fun NavTabRow(
-    tab: NavTab,
+    entry: NavTabEntry,
     index: Int,
     total: Int,
     onMoveUp: () -> Unit,
     onMoveDown: () -> Unit,
+    onToggleVisibility: () -> Unit,
 ) {
     Card(
         colors = CardDefaults.cardColors(
@@ -104,22 +222,49 @@ private fun NavTabRow(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 4.dp),
+                .padding(horizontal = 8.dp, vertical = 4.dp),
         ) {
+            // Drag handle — the long-press gesture is captured by the LazyColumn modifier,
+            // so this icon is purely decorative / visual affordance.
+            Icon(
+                imageVector = Icons.Default.DragHandle,
+                contentDescription = stringResource(R.string.nav_order_drag_hint),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(end = 8.dp),
+            )
+
             Text(
-                text = tab.displayName(),
+                text = entry.tab.displayName(),
                 style = MaterialTheme.typography.bodyLarge,
                 modifier = Modifier.weight(1f),
             )
+
+            // Up / Down buttons kept for accessibility (non-drag reordering).
             IconButton(onClick = onMoveUp, enabled = index > 0) {
-                Icon(Icons.Default.ArrowUpward, contentDescription = stringResource(R.string.nav_order_move_up))
+                Icon(
+                    Icons.Default.ArrowUpward,
+                    contentDescription = stringResource(R.string.nav_order_move_up),
+                )
             }
             IconButton(onClick = onMoveDown, enabled = index < total - 1) {
-                Icon(Icons.Default.ArrowDownward, contentDescription = stringResource(R.string.nav_order_move_down))
+                Icon(
+                    Icons.Default.ArrowDownward,
+                    contentDescription = stringResource(R.string.nav_order_move_down),
+                )
             }
+
+            // Visibility toggle — Switch on the right edge.
+            Switch(
+                checked = entry.isVisible,
+                onCheckedChange = { onToggleVisibility() },
+            )
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Display name helpers
+// ---------------------------------------------------------------------------
 
 @Composable
 private fun NavTab.displayName(): String = when (this) {

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -571,6 +571,7 @@
     <string name="nav_order_reset">Reset to default</string>
     <string name="nav_order_move_up">Move up</string>
     <string name="nav_order_move_down">Move down</string>
+    <string name="nav_order_drag_hint">Hold to drag and reorder</string>
     <string name="nav_tab_library">Library</string>
     <string name="nav_tab_updates">Updates</string>
     <string name="nav_tab_browse">Browse</string>


### PR DESCRIPTION
## **User description**
$(cat <<'EOF'
## Summary

- Adds long-press drag-and-drop reordering to the nav order settings screen using `detectDragGesturesAfterLongPress` and a `DragDropState` helper class
- Adds a `Switch` on each row so users can hide individual tabs from the bottom nav without removing them from the list
- Introduces `NavTabEntry` (UI layer) and `NavTabPreferenceEntry` (core/preferences layer) wrappers to carry both tab identity and visibility without modifying the `NavTab` enum
- Persists tab order + visibility in DataStore as `"TAB:true/false"` CSV, with graceful fallback to default order on parse errors

## Test plan

- [ ] Open Settings → Tab Order; verify all five tabs appear with a drag handle, up/down arrows, and a Switch
- [ ] Long-press a row and drag it to a new position; confirm the list reorders live and persists after app restart
- [ ] Use the up/down arrows to reorder; confirm they still work
- [ ] Toggle a tab's Switch off; confirm the bottom nav no longer shows that tab after navigating away and back
- [ ] Tap the reset button; confirm all tabs return to default order and are all visible
- [ ] Kill and reopen the app; confirm both order and visibility survived

Closes #1038.

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Let users reorder and hide bottom navigation tabs from the Tab Order screen**

### What Changed
- Tabs can now be reordered by long-pressing and dragging them in the Tab Order list
- Each tab now has a visibility switch, so users can hide a tab without removing it from the list
- The reset action restores the default tab order with every tab visible
- Tab order and visibility are saved together and restored after reopening the app

### Impact
`✅ Faster tab customization`
`✅ Fewer accidental tab removals`
`✅ Persistent bottom navigation changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
