### PR TITLE
feat: source categories and pinning in Browse

### DIFF
--- a/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
@@ -284,6 +284,54 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
     suspend fun setDarkModeEndMinuteOfDay(value: Int) =
         dataStore.edit { it[Keys.DARK_MODE_END_MINUTE] = value.coerceIn(0, 1439) }
 
+    // --- Source Pinning & Categories ---
+
+    /**
+     * Set of source IDs that the user has pinned in Browse.
+     * Stored as a comma-separated string in DataStore.
+     */
+    val pinnedSourceIds: Flow<Set<Long>> = dataStore.data.map { prefs ->
+        val raw = prefs[Keys.PINNED_SOURCE_IDS] ?: return@map emptySet()
+        raw.split(",").filter { it.isNotBlank() }.mapNotNull { it.trim().toLongOrNull() }.toSet()
+    }
+
+    suspend fun setPinnedSourceIds(ids: Set<Long>) = dataStore.edit { prefs ->
+        if (ids.isEmpty()) prefs.remove(Keys.PINNED_SOURCE_IDS)
+        else prefs[Keys.PINNED_SOURCE_IDS] = ids.joinToString(",")
+    }
+
+    suspend fun togglePinnedSource(sourceId: Long) = dataStore.edit { prefs ->
+        val current = prefs[Keys.PINNED_SOURCE_IDS]
+            ?.split(",")?.filter { it.isNotBlank() }?.mapNotNull { it.trim().toLongOrNull() }?.toMutableSet()
+            ?: mutableSetOf()
+        if (sourceId in current) current.remove(sourceId) else current.add(sourceId)
+        if (current.isEmpty()) prefs.remove(Keys.PINNED_SOURCE_IDS)
+        else prefs[Keys.PINNED_SOURCE_IDS] = current.joinToString(",")
+    }
+
+    /**
+     * Map of source ID → user-defined category label.
+     * Stored as a JSON object (Map<String, String>) in DataStore.
+     */
+    val sourceCategoryMap: Flow<Map<Long, String>> = dataStore.data.map { prefs ->
+        val raw = prefs[Keys.SOURCE_CATEGORY_MAP] ?: return@map emptyMap()
+        runCatching {
+            Json.decodeFromString<Map<String, String>>(raw)
+                .entries.mapNotNull { (k, v) -> k.toLongOrNull()?.let { it to v } }
+                .toMap()
+        }.getOrDefault(emptyMap())
+    }
+
+    suspend fun setSourceCategory(sourceId: Long, category: String) = dataStore.edit { prefs ->
+        val raw = prefs[Keys.SOURCE_CATEGORY_MAP]
+        val current: MutableMap<String, String> = raw
+            ?.let { runCatching { Json.decodeFromString<Map<String, String>>(it) }.getOrDefault(emptyMap()) }
+            ?.toMutableMap() ?: mutableMapOf()
+        if (category.isBlank()) current.remove(sourceId.toString()) else current[sourceId.toString()] = category.trim()
+        if (current.isEmpty()) prefs.remove(Keys.SOURCE_CATEGORY_MAP)
+        else prefs[Keys.SOURCE_CATEGORY_MAP] = Json.encodeToString(current)
+    }
+
     // --- Image Cache ---
 
     /**
@@ -334,6 +382,8 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
         val DARK_MODE_SCHEDULE_ENABLED = booleanPreferencesKey("dark_mode_schedule_enabled")
         val DARK_MODE_START_MINUTE = intPreferencesKey("dark_mode_start_minute")
         val DARK_MODE_END_MINUTE = intPreferencesKey("dark_mode_end_minute")
+        val PINNED_SOURCE_IDS = stringPreferencesKey("pinned_source_ids")
+        val SOURCE_CATEGORY_MAP = stringPreferencesKey("source_category_map")
     }
 
     companion object {

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseMvi.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseMvi.kt
@@ -36,6 +36,16 @@ data class BrowseState(
     val searchScope: BrowseSearchScope = BrowseSearchScope.SOURCES,
     /** Recent search history (last 10 queries). */
     val searchHistory: List<String> = emptyList(),
+    /** Source IDs pinned to the top of the source list in Browse. */
+    val pinnedSourceIds: Set<Long> = emptySet(),
+    /** User-defined category label per source ID. */
+    val sourceCategoryMap: Map<Long, String> = emptyMap(),
+    /** Controls visibility of the "Set category" dialog. */
+    val showSetCategoryDialog: Boolean = false,
+    /** Source ID being configured via the category dialog (stored as Long for preferences). */
+    val categoryDialogSourceId: Long? = null,
+    /** Current text in the "Set category" dialog input field. */
+    val categoryDialogText: String = "",
 ) : UiState
 
 sealed interface BrowseEvent : UiEvent {
@@ -74,6 +84,18 @@ sealed interface BrowseEvent : UiEvent {
     data object ClearSearchHistory : BrowseEvent
     /** Removes a single recent-search entry. */
     data class DeleteSearchHistoryItem(val query: String) : BrowseEvent
+
+    // --- Source pinning & categories ---
+    /** Toggles the pinned state for the source identified by its numeric ID string. */
+    data class TogglePinSource(val sourceId: Long) : BrowseEvent
+    /** Opens the "Set category" dialog pre-populated with the current label. */
+    data class OpenSetCategoryDialog(val sourceId: Long, val currentCategory: String) : BrowseEvent
+    /** User typed in the category dialog text field. */
+    data class UpdateCategoryDialogText(val text: String) : BrowseEvent
+    /** User confirmed the category dialog — persists the category. */
+    data object ConfirmSetCategory : BrowseEvent
+    /** User dismissed the category dialog without saving. */
+    data object DismissSetCategoryDialog : BrowseEvent
 }
 
 sealed interface BrowseEffect : UiEffect {

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -30,11 +30,15 @@ import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.ClearAll
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.LibraryAdd
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Storage
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FloatingActionButton
@@ -54,7 +58,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -172,6 +178,33 @@ fun BrowseScreen(
             onReset = { viewModel.onEvent(BrowseEvent.ResetFilters) },
             onApply = { viewModel.onEvent(BrowseEvent.ApplyFilters) },
             onDismiss = { viewModel.onEvent(BrowseEvent.ToggleFilterSheet) }
+        )
+    }
+
+    // Set category dialog
+    if (state.showSetCategoryDialog) {
+        AlertDialog(
+            onDismissRequest = { viewModel.onEvent(BrowseEvent.DismissSetCategoryDialog) },
+            title = { Text(stringResource(R.string.source_set_category)) },
+            text = {
+                OutlinedTextField(
+                    value = state.categoryDialogText,
+                    onValueChange = { viewModel.onEvent(BrowseEvent.UpdateCategoryDialogText(it)) },
+                    placeholder = { Text(stringResource(R.string.source_category_hint)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { viewModel.onEvent(BrowseEvent.ConfirmSetCategory) }) {
+                    Text(stringResource(android.R.string.ok))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.onEvent(BrowseEvent.DismissSetCategoryDialog) }) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+            },
         )
     }
 }
@@ -358,12 +391,18 @@ private fun BrowseContent(
                     sources = state.sources,
                     currentSourceId = state.currentSourceId,
                     popularManga = state.popularManga,
+                    pinnedSourceIds = state.pinnedSourceIds,
+                    sourceCategoryMap = state.sourceCategoryMap,
                     onSourceSelect = { onEvent(BrowseEvent.SelectSource(it)) },
                     onMangaClick = { onEvent(BrowseEvent.OnMangaClick(it)) },
                     onLoadMore = { onEvent(BrowseEvent.LoadNextPage) },
                     hasNextPage = state.hasNextPage,
                     isLoading = state.isLoading,
                     onMangaLongClick = { onEvent(BrowseEvent.LongClickManga(it)) },
+                    onTogglePin = { sourceId -> onEvent(BrowseEvent.TogglePinSource(sourceId)) },
+                    onOpenSetCategory = { sourceId, current ->
+                        onEvent(BrowseEvent.OpenSetCategoryDialog(sourceId, current))
+                    },
                 )
             }
         }
@@ -421,15 +460,28 @@ private fun SourcesContent(
     sources: List<String>,
     currentSourceId: String?,
     popularManga: List<SourceManga>,
+    pinnedSourceIds: Set<Long>,
+    sourceCategoryMap: Map<Long, String>,
     onSourceSelect: (String) -> Unit,
     onMangaClick: (SourceManga) -> Unit,
     onLoadMore: () -> Unit,
     hasNextPage: Boolean,
     isLoading: Boolean,
     onMangaLongClick: ((SourceManga) -> Unit)? = null,
+    onTogglePin: (Long) -> Unit = {},
+    onOpenSetCategory: (Long, String) -> Unit = { _, _ -> },
 ) {
     // Determine if the currently selected source is manga or manhwa for the accent bar
     val isMangaSection = currentSourceId == null || !isManhwaSource(currentSourceId)
+
+    // Partition sources into pinned and unpinned, then group unpinned by category
+    val (pinnedIds, unpinnedIds) = sources.partition { sourceId ->
+        sourceId.toLongOrNull()?.let { it in pinnedSourceIds } == true
+    }
+    // Group unpinned sources by their user-defined category; sources without a category go under ""
+    val grouped: Map<String, List<String>> = unpinnedIds.groupBy { sourceId ->
+        sourceId.toLongOrNull()?.let { sourceCategoryMap[it] } ?: ""
+    }
 
     Column {
         // Section header with colored accent bar
@@ -453,17 +505,61 @@ private fun SourcesContent(
             )
         }
 
-        // Source filter chips
-        LazyRow(
-            contentPadding = PaddingValues(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            items(sources, key = { it }) { sourceId ->
-                FilterChip(
-                    selected = sourceId == currentSourceId,
-                    onClick = { onSourceSelect(sourceId) },
-                    label = { Text(sourceId.substringAfterLast(".").take(20)) }
+        // --- Pinned section ---
+        if (pinnedIds.isNotEmpty()) {
+            Text(
+                text = stringResource(R.string.source_pinned_section),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(start = 16.dp, top = 4.dp, bottom = 2.dp),
+            )
+            LazyRow(
+                contentPadding = PaddingValues(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(pinnedIds, key = { it }) { sourceId ->
+                    SourceChipWithMenu(
+                        sourceId = sourceId,
+                        isSelected = sourceId == currentSourceId,
+                        isPinned = true,
+                        onSelect = { onSourceSelect(sourceId) },
+                        onTogglePin = onTogglePin,
+                        onOpenSetCategory = onOpenSetCategory,
+                        categoryMap = sourceCategoryMap,
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+
+        // --- Grouped unpinned sources ---
+        // Show sources without a category first (empty key), then named categories alphabetically
+        val categoryOrder = grouped.keys.sortedWith(compareBy { if (it.isBlank()) "" else it })
+        for (category in categoryOrder) {
+            val categorySourceIds = grouped[category] ?: continue
+            if (category.isNotBlank()) {
+                Text(
+                    text = category,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(start = 16.dp, top = 6.dp, bottom = 2.dp),
                 )
+            }
+            LazyRow(
+                contentPadding = PaddingValues(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(categorySourceIds, key = { it }) { sourceId ->
+                    SourceChipWithMenu(
+                        sourceId = sourceId,
+                        isSelected = sourceId == currentSourceId,
+                        isPinned = false,
+                        onSelect = { onSourceSelect(sourceId) },
+                        onTogglePin = onTogglePin,
+                        onOpenSetCategory = onOpenSetCategory,
+                        categoryMap = sourceCategoryMap,
+                    )
+                }
             }
         }
 
@@ -498,6 +594,72 @@ private fun SourcesContent(
                 currentSourceId = currentSourceId,
                 onMangaLongClick = onMangaLongClick,
             )
+        }
+    }
+}
+
+/**
+ * A source [FilterChip] that shows a [DropdownMenu] on long-press with "Pin/Unpin" and
+ * "Set category" options.
+ *
+ * Why long-press + DropdownMenu?  We want the normal tap to still select the source, so we
+ * intercept the long-press via [combinedClickable] and surface the contextual actions in a
+ * lightweight menu without navigating away from the screen.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun SourceChipWithMenu(
+    sourceId: String,
+    isSelected: Boolean,
+    isPinned: Boolean,
+    onSelect: () -> Unit,
+    onTogglePin: (Long) -> Unit,
+    onOpenSetCategory: (Long, String) -> Unit,
+    categoryMap: Map<Long, String>,
+) {
+    var menuExpanded by remember { mutableStateOf(false) }
+    val sourceIdLong = sourceId.toLongOrNull()
+    val currentCategory = sourceIdLong?.let { categoryMap[it] } ?: ""
+
+    Box {
+        FilterChip(
+            selected = isSelected,
+            onClick = onSelect,
+            label = { Text(sourceId.substringAfterLast(".").take(20)) },
+            leadingIcon = if (isPinned) {
+                { Icon(Icons.Default.PushPin, contentDescription = null, modifier = Modifier.size(14.dp)) }
+            } else null,
+            modifier = Modifier.combinedClickable(
+                onClick = onSelect,
+                onLongClick = { menuExpanded = true },
+            ),
+        )
+        if (sourceIdLong != null) {
+            DropdownMenu(
+                expanded = menuExpanded,
+                onDismissRequest = { menuExpanded = false },
+            ) {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            if (isPinned) stringResource(R.string.source_unpin)
+                            else stringResource(R.string.source_pin)
+                        )
+                    },
+                    leadingIcon = { Icon(Icons.Default.PushPin, contentDescription = null) },
+                    onClick = {
+                        menuExpanded = false
+                        onTogglePin(sourceIdLong)
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.source_set_category)) },
+                    onClick = {
+                        menuExpanded = false
+                        onOpenSetCategory(sourceIdLong, currentCategory)
+                    },
+                )
+            }
         }
     }
 }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -75,6 +75,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.sourceapi.Filter
 import app.otakureader.sourceapi.isActive
 import app.otakureader.sourceapi.SourceManga
+import app.otakureader.sourceapi.toSourceId
 import coil3.compose.AsyncImage
 import androidx.compose.ui.tooling.preview.Preview
 import app.otakureader.core.ui.theme.OtakuReaderTheme
@@ -476,11 +477,11 @@ private fun SourcesContent(
 
     // Partition sources into pinned and unpinned, then group unpinned by category
     val (pinnedIds, unpinnedIds) = sources.partition { sourceId ->
-        sourceId.toLongOrNull()?.let { it in pinnedSourceIds } == true
+        sourceId.toSourceId() in pinnedSourceIds
     }
     // Group unpinned sources by their user-defined category; sources without a category go under ""
     val grouped: Map<String, List<String>> = unpinnedIds.groupBy { sourceId ->
-        sourceId.toLongOrNull()?.let { sourceCategoryMap[it] } ?: ""
+        sourceCategoryMap[sourceId.toSourceId()] ?: ""
     }
 
     Column {
@@ -618,13 +619,15 @@ private fun SourceChipWithMenu(
     categoryMap: Map<Long, String>,
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
-    val sourceIdLong = sourceId.toLongOrNull()
-    val currentCategory = sourceIdLong?.let { categoryMap[it] } ?: ""
+    val sourceIdLong = sourceId.toSourceId()
+    val currentCategory = categoryMap[sourceIdLong] ?: ""
 
     Box {
         FilterChip(
             selected = isSelected,
-            onClick = onSelect,
+            // Pass empty lambda so combinedClickable is the sole click handler.
+            // Without this, both FilterChip.onClick and combinedClickable.onClick fire on tap.
+            onClick = {},
             label = { Text(sourceId.substringAfterLast(".").take(20)) },
             leadingIcon = if (isPinned) {
                 { Icon(Icons.Default.PushPin, contentDescription = null, modifier = Modifier.size(14.dp)) }
@@ -634,32 +637,30 @@ private fun SourceChipWithMenu(
                 onLongClick = { menuExpanded = true },
             ),
         )
-        if (sourceIdLong != null) {
-            DropdownMenu(
-                expanded = menuExpanded,
-                onDismissRequest = { menuExpanded = false },
-            ) {
-                DropdownMenuItem(
-                    text = {
-                        Text(
-                            if (isPinned) stringResource(R.string.source_unpin)
-                            else stringResource(R.string.source_pin)
-                        )
-                    },
-                    leadingIcon = { Icon(Icons.Default.PushPin, contentDescription = null) },
-                    onClick = {
-                        menuExpanded = false
-                        onTogglePin(sourceIdLong)
-                    },
-                )
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.source_set_category)) },
-                    onClick = {
-                        menuExpanded = false
-                        onOpenSetCategory(sourceIdLong, currentCategory)
-                    },
-                )
-            }
+        DropdownMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false },
+        ) {
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        if (isPinned) stringResource(R.string.source_unpin)
+                        else stringResource(R.string.source_pin)
+                    )
+                },
+                leadingIcon = { Icon(Icons.Default.PushPin, contentDescription = null) },
+                onClick = {
+                    menuExpanded = false
+                    onTogglePin(sourceIdLong)
+                },
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.source_set_category)) },
+                onClick = {
+                    menuExpanded = false
+                    onOpenSetCategory(sourceIdLong, currentCategory)
+                },
+            )
         }
     }
 }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
@@ -90,6 +90,7 @@ class BrowseViewModel @Inject constructor(
             _state.update { it.copy(selectedManga = ids, isBulkSelectionMode = active) }
         }.launchIn(viewModelScope)
         observeSearchHistory()
+        observeSourcePinning()
     }
 
     @Suppress("LongMethod", "CyclomaticComplexMethod")
@@ -172,6 +173,31 @@ class BrowseViewModel @Inject constructor(
             is BrowseEvent.ClearSearchHistory -> viewModelScope.launch { generalPreferences.clearBrowseSearchHistory() }
             is BrowseEvent.DeleteSearchHistoryItem ->
                 viewModelScope.launch { generalPreferences.removeBrowseSearchHistory(event.query) }
+
+            // Source pinning & categories
+            is BrowseEvent.TogglePinSource ->
+                viewModelScope.launch { generalPreferences.togglePinnedSource(event.sourceId) }
+            is BrowseEvent.OpenSetCategoryDialog -> _state.update {
+                it.copy(
+                    showSetCategoryDialog = true,
+                    categoryDialogSourceId = event.sourceId,
+                    categoryDialogText = event.currentCategory,
+                )
+            }
+            is BrowseEvent.UpdateCategoryDialogText -> _state.update {
+                it.copy(categoryDialogText = event.text)
+            }
+            is BrowseEvent.ConfirmSetCategory -> {
+                val state = _state.value
+                val sid = state.categoryDialogSourceId ?: return
+                viewModelScope.launch {
+                    generalPreferences.setSourceCategory(sid, state.categoryDialogText)
+                }
+                _state.update { it.copy(showSetCategoryDialog = false, categoryDialogSourceId = null, categoryDialogText = "") }
+            }
+            is BrowseEvent.DismissSetCategoryDialog -> _state.update {
+                it.copy(showSetCategoryDialog = false, categoryDialogSourceId = null, categoryDialogText = "")
+            }
         }
     }
 
@@ -438,6 +464,16 @@ class BrowseViewModel @Inject constructor(
     private fun observeSearchHistory() {
         generalPreferences.browseSearchHistory
             .onEach { history -> _state.update { it.copy(searchHistory = history) } }
+            .launchIn(viewModelScope)
+    }
+
+    /** Keeps [BrowseState.pinnedSourceIds] and [BrowseState.sourceCategoryMap] in sync with preferences. */
+    private fun observeSourcePinning() {
+        generalPreferences.pinnedSourceIds
+            .onEach { ids -> _state.update { it.copy(pinnedSourceIds = ids) } }
+            .launchIn(viewModelScope)
+        generalPreferences.sourceCategoryMap
+            .onEach { map -> _state.update { it.copy(sourceCategoryMap = map) } }
             .launchIn(viewModelScope)
     }
 

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -149,6 +149,13 @@
     <string name="extension_cancel">Cancel</string>
     <string name="extension_repo_warning">Extension repositories contain executable code that runs inside Otaku Reader with full app privileges. Only add repositories you trust.</string>
     <string name="extension_repo_warning_learn_more">Learn More</string>
+    <!-- Source pinning and categories (#1050) -->
+    <string name="source_pinned_section">Pinned</string>
+    <string name="source_pin">Pin source</string>
+    <string name="source_unpin">Unpin source</string>
+    <string name="source_set_category">Set category</string>
+    <string name="source_category_hint">Category name</string>
+
     <string name="browse_scope_sources">Sources</string>
     <string name="browse_scope_library">Library</string>
     <string name="browse_search_history">Recent searches</string>

--- a/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
+++ b/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
@@ -83,6 +83,8 @@ class BrowseViewModelTest {
         coEvery { generalPreferences.getBrowseFilterState(any()) } returns null
         coEvery { generalPreferences.setBrowseFilterState(any(), any()) } just Awaits
         every { feedRepository.getSavedSearches() } returns flowOf(emptyList())
+        every { generalPreferences.pinnedSourceIds } returns flowOf(emptySet())
+        every { generalPreferences.sourceCategoryMap } returns flowOf(emptyMap())
 
         // observeLibraryFavorites() is called in ViewModel.init and subscribes to this flow.
         every { mangaRepository.getLibraryManga() } returns flowOf(emptyList())


### PR DESCRIPTION
## **User description**
## Summary
- Lets users pin sources to a dedicated "Pinned" section at the top of the Browse source list via long-press → "Pin/Unpin"
- Lets users assign custom category labels to sources via long-press → "Set category", grouping unpinned sources under labelled section headers
- Preferences stored in DataStore (`pinned_source_ids` as comma-separated string, `source_category_map` as JSON map) and observed as Flows in `BrowseViewModel`

## Test plan
- [ ] Long-press a source chip → dropdown shows "Pin source" and "Set category"
- [ ] Tap "Pin source" → source moves to "Pinned" section and chip shows pin icon; re-long-press shows "Unpin source"
- [ ] Tap "Set category" → dialog with text field; confirm → source appears under named section header
- [ ] Blank category clears the assignment and source returns to the uncategorised group
- [ ] Pinned state and categories survive app restart (DataStore persists)
- [ ] NSFW filter still works correctly on top of pinning

Closes #1050.

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Pin sources and group Browse entries by custom categories**

### What Changed
- Sources in Browse can now be pinned to a “Pinned” section at the top of the list
- Long-pressing a source chip now opens actions to pin or unpin it, or set a custom category
- Unpinned sources are grouped under category headings, with uncategorized sources kept together
- Pin and category choices are saved and restored when the app is reopened

### Impact
`✅ Faster access to favorite sources`
`✅ Less scrolling to reach often-used sources`
`✅ Clearer Browse source organization`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
