### PR TITLE
feat: widget configuration studio

### DIFF
--- a/core/preferences/build.gradle.kts
+++ b/core/preferences/build.gradle.kts
@@ -10,6 +10,7 @@ android {
 
 dependencies {
     implementation(projects.core.common)
+    implementation(projects.domain)
     api(libs.datastore.preferences)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/WidgetPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/WidgetPreferences.kt
@@ -1,0 +1,67 @@
+package app.otakureader.core.preferences
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import app.otakureader.domain.model.WidgetSettings
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * DataStore-backed preferences for per-widget configuration.
+ *
+ * Settings are stored as a single JSON-encoded list keyed on [Keys.WIDGET_SETTINGS]. Using a
+ * single list instead of per-widget keys makes it trivial to add new widget types in the future
+ * without introducing new preference keys.
+ *
+ * The JSON codec is lenient so that adding new fields to [WidgetSettings] in a future release
+ * does not crash users who still have the old JSON written to disk.
+ */
+class WidgetPreferences(private val dataStore: DataStore<Preferences>) {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    /**
+     * The current widget settings list.
+     *
+     * Emits [WidgetSettings.defaults] when nothing has been saved yet (first launch or after
+     * a data-clear). Never emits an empty list — every [WidgetType] always has an entry.
+     */
+    val widgetSettings: Flow<List<WidgetSettings>> = dataStore.data.map { prefs ->
+        val raw = prefs[Keys.WIDGET_SETTINGS]
+        if (raw.isNullOrBlank()) {
+            WidgetSettings.defaults()
+        } else {
+            runCatching { json.decodeFromString<List<WidgetSettings>>(raw) }
+                .getOrDefault(WidgetSettings.defaults())
+        }
+    }
+
+    /**
+     * Persists a new settings list.
+     *
+     * Callers are responsible for supplying a complete list (one entry per [WidgetType]). The
+     * easiest way to update a single widget is:
+     * ```kotlin
+     * val current = widgetSettings.first().toMutableList()
+     * val index = current.indexOfFirst { it.widgetType == type }
+     * if (index >= 0) current[index] = updated
+     * setWidgetSettings(current)
+     * ```
+     */
+    suspend fun setWidgetSettings(settings: List<WidgetSettings>) {
+        dataStore.edit { prefs ->
+            prefs[Keys.WIDGET_SETTINGS] = json.encodeToString(settings)
+        }
+    }
+
+    private object Keys {
+        val WIDGET_SETTINGS = stringPreferencesKey("widget_settings")
+    }
+}

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/di/PreferencesModule.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/di/PreferencesModule.kt
@@ -21,6 +21,7 @@ import app.otakureader.core.preferences.NotificationPreferences
 import app.otakureader.core.preferences.ReaderPreferences
 import app.otakureader.core.preferences.ReadingGoalPreferences
 import app.otakureader.core.preferences.SearchHistoryPreferences
+import app.otakureader.core.preferences.WidgetPreferences
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -146,6 +147,11 @@ object PreferencesModule {
     fun provideTrackerTokenStore(
         @ApplicationContext context: Context
     ): TrackerTokenStore = TrackerTokenStore(context)
+
+    @Provides
+    @Singleton
+    fun provideWidgetPreferences(dataStore: DataStore<Preferences>): WidgetPreferences =
+        WidgetPreferences(dataStore)
 
     @Provides
     @Singleton

--- a/domain/src/main/java/app/otakureader/domain/model/WidgetSettings.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/WidgetSettings.kt
@@ -1,0 +1,60 @@
+package app.otakureader.domain.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Persisted configuration for a single home-screen widget instance.
+ *
+ * One [WidgetSettings] object is stored per [WidgetType]. The list is serialized to JSON and
+ * held in [app.otakureader.core.preferences.WidgetPreferences].
+ *
+ * @param widgetType     Which widget these settings belong to.
+ * @param categoryFilter Library category ID to filter by, or null for all categories.
+ * @param countLimit     How many items the widget should show (1–10).
+ * @param tapAction      What happens when the user taps a widget row.
+ * @param showThumbnails Whether to show manga cover thumbnails in the widget.
+ */
+@Serializable
+data class WidgetSettings(
+    val widgetType: WidgetType,
+    val categoryFilter: Long? = null,
+    val countLimit: Int = 5,
+    val tapAction: WidgetTapAction = WidgetTapAction.OPEN_MANGA,
+    val showThumbnails: Boolean = true,
+) {
+    companion object {
+        /** Returns a list of defaults, one per widget type. */
+        fun defaults(): List<WidgetSettings> = WidgetType.entries.map { WidgetSettings(widgetType = it) }
+    }
+}
+
+/**
+ * The widget types shipped with Otaku Reader.
+ *
+ * Each value maps to a Glance widget class:
+ * - [CONTINUE_READING] → ContinueReadingWidget
+ * - [NEW_UPDATES]      → RecentUpdatesWidget
+ * - [LIBRARY]          → HomeWidget
+ * - [NOW_READING]      → NowReadingWidget
+ */
+@Serializable
+enum class WidgetType {
+    CONTINUE_READING,
+    NEW_UPDATES,
+    LIBRARY,
+    NOW_READING,
+}
+
+/**
+ * Action taken when a user taps a row inside a widget.
+ *
+ * - [OPEN_MANGA]  → Opens the manga detail / chapter-list screen.
+ * - [OPEN_READER] → Jumps straight into the reader at the next unread chapter.
+ * - [OPEN_APP]    → Opens the app at its default home screen (library).
+ */
+@Serializable
+enum class WidgetTapAction {
+    OPEN_MANGA,
+    OPEN_READER,
+    OPEN_APP,
+}

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/WidgetConfigurationMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/WidgetConfigurationMvi.kt
@@ -1,0 +1,48 @@
+package app.otakureader.feature.settings
+
+import app.otakureader.core.common.mvi.UiEffect
+import app.otakureader.core.common.mvi.UiEvent
+import app.otakureader.core.common.mvi.UiState
+import app.otakureader.domain.model.Category
+import app.otakureader.domain.model.WidgetSettings
+import app.otakureader.domain.model.WidgetTapAction
+import app.otakureader.domain.model.WidgetType
+
+/**
+ * MVI contracts for [WidgetConfigurationScreen].
+ *
+ * State is an immutable snapshot; all mutations go through [WidgetConfigIntent] → reducer.
+ */
+data class WidgetConfigState(
+    /** One settings object per [WidgetType]. Ordered by [WidgetType.ordinal]. */
+    val widgetSettingsList: List<WidgetSettings> = WidgetSettings.defaults(),
+    /** Library categories available for the category-filter dropdown. */
+    val categories: List<Category> = emptyList(),
+    /** True while the initial settings are being loaded from DataStore. */
+    val isLoading: Boolean = true,
+) : UiState
+
+sealed interface WidgetConfigIntent : UiEvent {
+    /**
+     * Updates the [countLimit] for the given [widgetType].
+     * The slider emits a Float (1f–10f); the ViewModel rounds it to an Int.
+     */
+    data class SetCountLimit(val widgetType: WidgetType, val limit: Int) : WidgetConfigIntent
+
+    /** Changes the tap action for one widget. */
+    data class SetTapAction(val widgetType: WidgetType, val action: WidgetTapAction) : WidgetConfigIntent
+
+    /**
+     * Sets (or clears) the category filter for one widget.
+     * Passing null means "All categories".
+     */
+    data class SetCategoryFilter(val widgetType: WidgetType, val categoryId: Long?) : WidgetConfigIntent
+
+    /** Toggles the thumbnail visibility for one widget. */
+    data class SetShowThumbnails(val widgetType: WidgetType, val show: Boolean) : WidgetConfigIntent
+}
+
+sealed interface WidgetConfigEffect : UiEffect {
+    /** Shown after settings are saved to DataStore. */
+    data object SettingsSaved : WidgetConfigEffect
+}

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/WidgetConfigurationScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/WidgetConfigurationScreen.kt
@@ -1,41 +1,104 @@
 package app.otakureader.feature.settings
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Book
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import app.otakureader.core.navigation.Route
+import app.otakureader.domain.model.Category
+import app.otakureader.domain.model.WidgetSettings
+import app.otakureader.domain.model.WidgetTapAction
+import app.otakureader.domain.model.WidgetType
+import app.otakureader.feature.settings.viewmodel.WidgetConfigViewModel
 
 /**
- * Widget configuration and discovery screen.
+ * Widget Configuration Studio — lets the user configure each home-screen widget individually.
  *
- * The app already ships Glance widgets for continue reading, recent updates, and now reading.
- * This screen makes those widgets discoverable from Settings and documents what each one shows.
+ * Each widget type gets its own [WidgetConfigCard] with:
+ *  - A count-limit [Slider] (1–10 items).
+ *  - A tap-action dropdown.
+ *  - A category-filter dropdown (populated from the live category list).
+ *  - A thumbnail toggle.
+ *  - A static live-preview showing what the widget will approximately look like.
+ *
+ * All changes are persisted immediately via [WidgetConfigViewModel] → [WidgetPreferences].
+ * The screen is stateless — all state comes from the ViewModel.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WidgetConfigurationScreen(
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: WidgetConfigViewModel = hiltViewModel(),
 ) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Collect one-shot effects (currently just the save confirmation snackbar).
+    LaunchedEffect(Unit) {
+        viewModel.effect.collect { effect ->
+            when (effect) {
+                WidgetConfigEffect.SettingsSaved -> { /* silent save — no snackbar noise on every slider tick */ }
+            }
+        }
+    }
+
     Scaffold(
         modifier = modifier,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.settings_widgets)) },
@@ -56,19 +119,21 @@ fun WidgetConfigurationScreen(
                 .verticalScroll(rememberScrollState()),
         ) {
             SectionHeader(title = stringResource(R.string.settings_widgets_available))
-            WidgetInfoItem(
-                title = stringResource(R.string.settings_widget_continue_reading),
-                description = stringResource(R.string.settings_widget_continue_reading_description),
-            )
-            WidgetInfoItem(
-                title = stringResource(R.string.settings_widget_recent_updates),
-                description = stringResource(R.string.settings_widget_recent_updates_description),
-            )
-            WidgetInfoItem(
-                title = stringResource(R.string.settings_widget_now_reading),
-                description = stringResource(R.string.settings_widget_now_reading_description),
-            )
-            HorizontalDivider()
+
+            if (!state.isLoading) {
+                state.widgetSettingsList.forEach { settings ->
+                    WidgetConfigCard(
+                        settings = settings,
+                        categories = state.categories,
+                        onIntent = viewModel::onIntent,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 6.dp),
+                    )
+                }
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
             ListItem(
                 headlineContent = { Text(stringResource(R.string.settings_widgets_how_to_add)) },
                 supportingContent = {
@@ -82,16 +147,378 @@ fun WidgetConfigurationScreen(
     }
 }
 
+// ─── Widget config card ───────────────────────────────────────────────────────
+
+/**
+ * A Material 3 card that groups all configurable options for a single widget type.
+ *
+ * The card is collapsed/expanded by tapping the header so the user isn't overwhelmed
+ * if they only care about one or two widgets.
+ */
 @Composable
-private fun WidgetInfoItem(title: String, description: String) {
+private fun WidgetConfigCard(
+    settings: WidgetSettings,
+    categories: List<Category>,
+    onIntent: (WidgetConfigIntent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = modifier,
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            // ── Card header (tap to expand/collapse) ─────────────────────────
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = settings.widgetType.displayName(),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        text = settings.widgetType.description(),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                IconButton(onClick = { expanded = !expanded }) {
+                    Icon(
+                        imageVector = if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                        contentDescription = if (expanded) "Collapse" else "Expand",
+                    )
+                }
+            }
+
+            // ── Expandable settings body ──────────────────────────────────────
+            AnimatedVisibility(
+                visible = expanded,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+            ) {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    HorizontalDivider()
+
+                    // Count-limit slider
+                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                        Text(
+                            text = stringResource(R.string.widget_config_count_limit, settings.countLimit),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        Slider(
+                            value = settings.countLimit.toFloat(),
+                            onValueChange = { raw ->
+                                onIntent(
+                                    WidgetConfigIntent.SetCountLimit(
+                                        widgetType = settings.widgetType,
+                                        limit = raw.toInt().coerceIn(1, 10),
+                                    )
+                                )
+                            },
+                            valueRange = 1f..10f,
+                            steps = 8, // steps between 1 and 10 exclusive = 8
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+
+                    HorizontalDivider()
+
+                    // Tap-action dropdown
+                    TapActionRow(
+                        current = settings.tapAction,
+                        onSelected = { action ->
+                            onIntent(WidgetConfigIntent.SetTapAction(settings.widgetType, action))
+                        },
+                    )
+
+                    HorizontalDivider()
+
+                    // Category-filter dropdown
+                    CategoryFilterRow(
+                        categories = categories,
+                        selected = settings.categoryFilter,
+                        onSelected = { categoryId ->
+                            onIntent(WidgetConfigIntent.SetCategoryFilter(settings.widgetType, categoryId))
+                        },
+                    )
+
+                    HorizontalDivider()
+
+                    // Thumbnail toggle
+                    ListItem(
+                        headlineContent = { Text(stringResource(R.string.widget_config_show_thumbnails)) },
+                        trailingContent = {
+                            Switch(
+                                checked = settings.showThumbnails,
+                                onCheckedChange = { show ->
+                                    onIntent(WidgetConfigIntent.SetShowThumbnails(settings.widgetType, show))
+                                },
+                            )
+                        },
+                    )
+
+                    HorizontalDivider()
+
+                    // Static widget preview
+                    WidgetPreview(
+                        settings = settings,
+                        modifier = Modifier.padding(16.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ─── Setting rows ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun TapActionRow(
+    current: WidgetTapAction,
+    onSelected: (WidgetTapAction) -> Unit,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+
     ListItem(
-        headlineContent = { Text(title) },
-        supportingContent = { Text(description) },
+        headlineContent = { Text(stringResource(R.string.widget_config_tap_action)) },
+        trailingContent = {
+            Box {
+                OutlinedButton(onClick = { menuOpen = true }) {
+                    Text(current.label())
+                }
+                DropdownMenu(
+                    expanded = menuOpen,
+                    onDismissRequest = { menuOpen = false },
+                ) {
+                    WidgetTapAction.entries.forEach { action ->
+                        DropdownMenuItem(
+                            text = { Text(action.label()) },
+                            onClick = {
+                                onSelected(action)
+                                menuOpen = false
+                            },
+                        )
+                    }
+                }
+            }
+        },
     )
 }
+
+@Composable
+private fun CategoryFilterRow(
+    categories: List<Category>,
+    selected: Long?,
+    onSelected: (Long?) -> Unit,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    val selectedName = categories.firstOrNull { it.id == selected }?.name
+        ?: stringResource(R.string.widget_config_all_categories)
+
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.widget_config_category_filter)) },
+        trailingContent = {
+            Box {
+                OutlinedButton(onClick = { menuOpen = true }) {
+                    Text(
+                        text = selectedName,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                DropdownMenu(
+                    expanded = menuOpen,
+                    onDismissRequest = { menuOpen = false },
+                ) {
+                    // "All categories" option
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.widget_config_all_categories)) },
+                        onClick = {
+                            onSelected(null)
+                            menuOpen = false
+                        },
+                    )
+                    categories.forEach { category ->
+                        DropdownMenuItem(
+                            text = { Text(category.name) },
+                            onClick = {
+                                onSelected(category.id)
+                                menuOpen = false
+                            },
+                        )
+                    }
+                }
+            }
+        },
+    )
+}
+
+// ─── Static widget preview ────────────────────────────────────────────────────
+
+/**
+ * A purely decorative Compose mockup of what the widget looks like with the current settings.
+ *
+ * This is NOT a real Glance preview — Glance widgets can't be rendered inside a Compose
+ * hierarchy. Instead we replicate the widget's visual language (surface background, title,
+ * item rows with optional thumbnail placeholder) using standard Compose components. It gives
+ * the user a quick visual sanity-check without any runtime overhead.
+ */
+@Composable
+private fun WidgetPreview(
+    settings: WidgetSettings,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.widget_config_preview_label),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                    shape = RoundedCornerShape(12.dp),
+                )
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+                    shape = RoundedCornerShape(12.dp),
+                )
+                .padding(12.dp),
+        ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = settings.widgetType.displayName(),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // Show `countLimit` placeholder rows (capped at 4 in the preview for brevity)
+                val previewRows = minOf(settings.countLimit, 4)
+                repeat(previewRows) { index ->
+                    PreviewRow(
+                        showThumbnail = settings.showThumbnails,
+                        alpha = 1f - (index * 0.15f).coerceIn(0f, 0.6f),
+                    )
+                    if (index < previewRows - 1) {
+                        Spacer(modifier = Modifier.height(6.dp))
+                    }
+                }
+
+                if (settings.countLimit > 4) {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = "… +${settings.countLimit - 4} more",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreviewRow(showThumbnail: Boolean, alpha: Float) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        if (showThumbnail) {
+            Box(
+                modifier = Modifier
+                    .size(width = 28.dp, height = 38.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.outline.copy(alpha = alpha * 0.25f),
+                        shape = RoundedCornerShape(4.dp),
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Book,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = alpha * 0.5f),
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+
+        Column(modifier = Modifier.weight(1f)) {
+            // Placeholder "title" bar
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.75f)
+                    .height(10.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = alpha * 0.35f),
+                        shape = RoundedCornerShape(4.dp),
+                    ),
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            // Placeholder "subtitle" bar
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.5f)
+                    .height(8.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = alpha * 0.2f),
+                        shape = RoundedCornerShape(4.dp),
+                    ),
+            )
+        }
+    }
+}
+
+// ─── NavGraph extension ───────────────────────────────────────────────────────
 
 fun NavGraphBuilder.widgetConfigurationScreen(onNavigateBack: () -> Unit) {
     composable<Route.WidgetConfiguration> {
         WidgetConfigurationScreen(onNavigateBack = onNavigateBack)
     }
+}
+
+// ─── Display-name helpers ─────────────────────────────────────────────────────
+
+/**
+ * Human-readable name for a [WidgetType].
+ * These map to existing string resources to avoid adding duplicate strings.
+ */
+@Composable
+private fun WidgetType.displayName(): String = when (this) {
+    WidgetType.CONTINUE_READING -> stringResource(R.string.settings_widget_continue_reading)
+    WidgetType.NEW_UPDATES -> stringResource(R.string.settings_widget_recent_updates)
+    WidgetType.LIBRARY -> stringResource(R.string.settings_widget_library)
+    WidgetType.NOW_READING -> stringResource(R.string.settings_widget_now_reading)
+}
+
+@Composable
+private fun WidgetType.description(): String = when (this) {
+    WidgetType.CONTINUE_READING -> stringResource(R.string.settings_widget_continue_reading_description)
+    WidgetType.NEW_UPDATES -> stringResource(R.string.settings_widget_recent_updates_description)
+    WidgetType.LIBRARY -> stringResource(R.string.settings_widget_library_description)
+    WidgetType.NOW_READING -> stringResource(R.string.settings_widget_now_reading_description)
+}
+
+@Composable
+private fun WidgetTapAction.label(): String = when (this) {
+    WidgetTapAction.OPEN_MANGA -> stringResource(R.string.widget_config_tap_open_manga)
+    WidgetTapAction.OPEN_READER -> stringResource(R.string.widget_config_tap_open_reader)
+    WidgetTapAction.OPEN_APP -> stringResource(R.string.widget_config_tap_open_app)
 }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/viewmodel/WidgetConfigViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/viewmodel/WidgetConfigViewModel.kt
@@ -1,0 +1,106 @@
+package app.otakureader.feature.settings.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.otakureader.core.preferences.WidgetPreferences
+import app.otakureader.domain.model.WidgetSettings
+import app.otakureader.domain.usecase.GetCategoriesUseCase
+import app.otakureader.feature.settings.WidgetConfigEffect
+import app.otakureader.feature.settings.WidgetConfigIntent
+import app.otakureader.feature.settings.WidgetConfigState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * ViewModel for the Widget Configuration screen.
+ *
+ * Responsibilities:
+ * 1. Observe [WidgetPreferences.widgetSettings] and [GetCategoriesUseCase] reactively.
+ * 2. Translate [WidgetConfigIntent] actions into DataStore writes.
+ * 3. Emit [WidgetConfigEffect] one-shot events (e.g. a save-confirmation snackbar).
+ *
+ * Why a dedicated ViewModel instead of folding into the existing SettingsViewModel?
+ * The settings ViewModel is already large (handling dozens of concerns). Following the
+ * pattern established by [AppearanceViewModel] and [ReaderSettingsViewModel], each settings
+ * section that has non-trivial async data gets its own focused ViewModel. This also makes
+ * the widget config screen independently testable.
+ */
+@HiltViewModel
+class WidgetConfigViewModel @Inject constructor(
+    private val widgetPreferences: WidgetPreferences,
+    private val getCategoriesUseCase: GetCategoriesUseCase,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(WidgetConfigState())
+    val state: StateFlow<WidgetConfigState> = _state.asStateFlow()
+
+    private val _effect = Channel<WidgetConfigEffect>(Channel.BUFFERED)
+    val effect = _effect.receiveAsFlow()
+
+    init {
+        // Combine widget settings + categories into a single state snapshot.
+        // Using `combine` here means the UI automatically reacts if either changes —
+        // for example if the user creates a new category while this screen is open.
+        viewModelScope.launch {
+            combine(
+                widgetPreferences.widgetSettings,
+                getCategoriesUseCase(),
+            ) { settings, categories ->
+                _state.update {
+                    it.copy(
+                        widgetSettingsList = settings,
+                        categories = categories,
+                        isLoading = false,
+                    )
+                }
+            }.collect { }
+        }
+    }
+
+    fun onIntent(intent: WidgetConfigIntent) {
+        viewModelScope.launch {
+            when (intent) {
+                is WidgetConfigIntent.SetCountLimit -> updateWidget(intent.widgetType) {
+                    it.copy(countLimit = intent.limit.coerceIn(1, 10))
+                }
+                is WidgetConfigIntent.SetTapAction -> updateWidget(intent.widgetType) {
+                    it.copy(tapAction = intent.action)
+                }
+                is WidgetConfigIntent.SetCategoryFilter -> updateWidget(intent.widgetType) {
+                    it.copy(categoryFilter = intent.categoryId)
+                }
+                is WidgetConfigIntent.SetShowThumbnails -> updateWidget(intent.widgetType) {
+                    it.copy(showThumbnails = intent.show)
+                }
+            }
+        }
+    }
+
+    /**
+     * Applies [transform] to the [WidgetSettings] entry for [type], saves the resulting list,
+     * and emits a [WidgetConfigEffect.SettingsSaved] effect.
+     *
+     * This helper is the single place where writes happen, which makes it easy to add
+     * debouncing or validation later without touching each individual branch.
+     */
+    private suspend fun updateWidget(
+        type: app.otakureader.domain.model.WidgetType,
+        transform: (WidgetSettings) -> WidgetSettings,
+    ) {
+        val current = _state.value.widgetSettingsList.toMutableList()
+        val index = current.indexOfFirst { it.widgetType == type }
+        if (index < 0) return   // guard: should never happen with defaults() seeding
+
+        current[index] = transform(current[index])
+        widgetPreferences.setWidgetSettings(current)
+        _effect.send(WidgetConfigEffect.SettingsSaved)
+    }
+}

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -496,6 +496,21 @@
     <string name="settings_widget_now_reading_description">Shows your most recent active chapter as a compact home or lock-screen widget.</string>
     <string name="settings_widgets_how_to_add">How to add widgets</string>
     <string name="settings_widgets_how_to_add_description">Long-press your launcher home screen, choose Widgets, then select an Otaku Reader widget. Widget refresh cadence is controlled by Android and the widget provider metadata.</string>
+    <string name="settings_widget_library">Library</string>
+    <string name="settings_widget_library_description">Shows your most-recently-read manga with cover art and reading progress.</string>
+    <!-- Widget configuration studio strings -->
+    <string name="widget_config_count_limit">Items to show: %1$d</string>
+    <string name="widget_config_tap_action">Tap action</string>
+    <string name="widget_config_tap_open_manga">Open manga details</string>
+    <string name="widget_config_tap_open_reader">Open reader</string>
+    <string name="widget_config_tap_open_app">Open app</string>
+    <string name="widget_config_category_filter">Filter by category</string>
+    <string name="widget_config_all_categories">All categories</string>
+    <string name="widget_config_show_thumbnails">Show thumbnails</string>
+    <string name="widget_config_preview_label">Preview</string>
+    <string name="widget_config_preview_item_placeholder">Manga title</string>
+    <string name="widget_config_preview_subtitle_placeholder">Chapter info</string>
+    <string name="widget_config_settings_saved">Widget settings saved</string>
     <string name="settings_local_source_supported_formats">Supported local library formats</string>
     <string name="settings_local_source_archives">Archives</string>
     <string name="settings_local_source_archives_description">CBZ, ZIP, and EPUB files can be scanned directly from the configured local-source directory.</string>


### PR DESCRIPTION
## **User description**
## Summary

- Adds a full per-widget configuration surface to the Widget settings screen, closing #1044
- Each widget type (Continue Reading, New Updates, Library, Now Reading) gets an expandable `Card` with: count-limit `Slider` (1–10), tap-action dropdown (Open manga details / Open reader / Open app), category-filter dropdown, thumbnail toggle, and a static live-preview mockup
- Settings are persisted immediately to DataStore via the new `WidgetPreferences` class (JSON-serialized `List<WidgetSettings>`) and exposed as a reactive `Flow` so the UI recomposes automatically

## Changed files

| File | What changed |
|------|-------------|
| `domain/.../model/WidgetSettings.kt` | New `@Serializable` domain models: `WidgetSettings`, `WidgetType`, `WidgetTapAction` |
| `core/preferences/.../WidgetPreferences.kt` | New DataStore-backed preferences class; lenient JSON codec for forward-compat |
| `core/preferences/.../di/PreferencesModule.kt` | Registers `WidgetPreferences` as a `@Singleton` Hilt binding |
| `core/preferences/build.gradle.kts` | Adds `projects.domain` dependency (no circular dependency) |
| `feature/settings/.../WidgetConfigurationMvi.kt` | New MVI contracts: `WidgetConfigState`, `WidgetConfigIntent`, `WidgetConfigEffect` |
| `feature/settings/.../viewmodel/WidgetConfigViewModel.kt` | `@HiltViewModel` combining `WidgetPreferences` + `GetCategoriesUseCase` |
| `feature/settings/.../WidgetConfigurationScreen.kt` | Full replacement of stub screen with expandable widget cards, sliders, dropdowns, and static preview |
| `feature/settings/.../res/values/strings.xml` | New strings for all new UI labels |

## Test plan

- [ ] Open Settings → Widgets; verify four expandable cards appear (Continue Reading, New Updates, Library, Now Reading)
- [ ] Expand each card; verify slider, tap-action dropdown, category-filter dropdown, thumbnail switch, and preview all render
- [ ] Move the count-limit slider; verify the preview immediately reflects the new row count
- [ ] Toggle thumbnails off; verify thumbnail column disappears from the preview
- [ ] Select a category from the dropdown; verify the label updates in the button
- [ ] Kill and reopen the app; verify settings persisted correctly
- [ ] Create a new library category while the screen is open; verify it appears in the dropdown without navigating away
- [ ] Verify no Hilt binding errors at startup

Closes #1044

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Add per-widget configuration for home screen widgets**

### What Changed
- Each widget type now has its own settings card for item count, tap action, category filter, and thumbnail display
- A live preview shows how the widget will look with the current settings
- Widget choices are saved right away and restored the next time the settings screen opens
- The widget list now includes the Library widget, alongside Continue Reading, Recent Updates, and Now Reading

### Impact
`✅ Faster widget setup`
`✅ Fewer taps to customize each widget`
`✅ Clearer widget previews before adding to the home screen`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
