### PR TITLE
feat: backup contents checklist and restore preflight

### DIFF
--- a/feature/settings/src/main/java/app/otakureader/feature/settings/BackupSettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/BackupSettingsMvi.kt
@@ -22,4 +22,13 @@ data class BackupSettingsState(
     val tachiyomiImportTotal: Int = 0,
     val backupEncryptionEnabled: Boolean = false,
     val backupEncryptionPasswordSet: Boolean = false,
+    // Pre-backup checklist dialog
+    val showBackupChecklist: Boolean = false,
+    val backupChecklistMangaCount: Int = 0,
+    val backupChecklistCategoryCount: Int = 0,
+    val backupChecklistTrackingCount: Int = 0,
+    // Pre-restore preflight dialog
+    val showRestoreConfirm: Boolean = false,
+    val pendingRestoreUri: String? = null,
+    val pendingRestoreFileName: String = "",
 )

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsBackupScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsBackupScreen.kt
@@ -88,7 +88,8 @@ fun SettingsBackupScreen(
     val restoreFileLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument(),
     ) { uri: Uri? ->
-        uri?.let { viewModel.restoreBackup(it) }
+        // Route through the pre-restore preflight dialog before restoring.
+        uri?.let { viewModel.onEvent(SettingsEvent.ShowRestoreConfirm(it)) }
     }
 
     val tachiyomiImportLauncher = rememberLauncherForActivityResult(
@@ -176,6 +177,31 @@ fun SettingsBackupScreen(
         }
     }
 
+    // Pre-backup checklist dialog — shown before the file-save picker opens.
+    if (state.showBackupChecklist) {
+        BackupChecklistDialog(
+            mangaCount = state.backupChecklistMangaCount,
+            categoryCount = state.backupChecklistCategoryCount,
+            trackingCount = state.backupChecklistTrackingCount,
+            onConfirm = { viewModel.onEvent(SettingsEvent.ConfirmCreateBackup) },
+            onDismiss = { viewModel.onEvent(SettingsEvent.DismissBackupChecklist) },
+        )
+    }
+
+    // Pre-restore preflight dialog — shown after the restore file is picked.
+    if (state.showRestoreConfirm) {
+        RestorePreflightDialog(
+            fileName = state.pendingRestoreFileName,
+            onConfirm = {
+                val uri = state.pendingRestoreUri
+                if (uri != null) {
+                    viewModel.onEvent(SettingsEvent.ConfirmRestore(Uri.parse(uri)))
+                }
+            },
+            onDismiss = { viewModel.onEvent(SettingsEvent.DismissRestoreConfirm) },
+        )
+    }
+
     state.tachiyomiImportPreview?.let { preview ->
         TachiyomiImportConfirmDialog(
             preview = preview,
@@ -228,6 +254,79 @@ fun SettingsBackupScreen(
             )
         }
     }
+}
+
+/**
+ * Pre-backup checklist dialog.
+ * Shows the user what will be included in the backup (manga count, categories, tracking
+ * entries, history, and settings) before the file-save picker opens.
+ */
+@Composable
+private fun BackupChecklistDialog(
+    mangaCount: Int,
+    categoryCount: Int,
+    trackingCount: Int,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.backup_checklist_title)) },
+        text = {
+            Column {
+                Text(stringResource(R.string.backup_checklist_summary, mangaCount, categoryCount, trackingCount))
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(stringResource(R.string.backup_checklist_history_included))
+                Text(stringResource(R.string.backup_checklist_settings_included))
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.backup_checklist_create))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.settings_import_cancel))
+            }
+        },
+    )
+}
+
+/**
+ * Pre-restore preflight dialog.
+ * Shown after the user selects a backup file but before the restore begins, so they can
+ * confirm they understand the operation will replace their current library.
+ */
+@Composable
+private fun RestorePreflightDialog(
+    fileName: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.restore_preflight_title)) },
+        text = {
+            Column {
+                if (fileName.isNotBlank()) {
+                    Text(stringResource(R.string.restore_preflight_filename, fileName))
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+                Text(stringResource(R.string.restore_preflight_message))
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.restore_preflight_proceed))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.settings_import_cancel))
+            }
+        },
+    )
 }
 
 @Composable
@@ -347,7 +446,7 @@ private fun BackupContent(
             if (state.isBackupInProgress) {
                 CircularProgressIndicator()
             } else {
-                Button(onClick = { onEvent(SettingsEvent.OnCreateBackup) }) {
+                Button(onClick = { onEvent(SettingsEvent.ShowBackupChecklist) }) {
                     Text(stringResource(R.string.settings_backup_button))
                 }
             }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
@@ -161,6 +161,13 @@ data class SettingsState(
     val tachiyomiImportTotal get() = backup.tachiyomiImportTotal
     val backupEncryptionEnabled get() = backup.backupEncryptionEnabled
     val backupEncryptionPasswordSet get() = backup.backupEncryptionPasswordSet
+    val showBackupChecklist get() = backup.showBackupChecklist
+    val backupChecklistMangaCount get() = backup.backupChecklistMangaCount
+    val backupChecklistCategoryCount get() = backup.backupChecklistCategoryCount
+    val backupChecklistTrackingCount get() = backup.backupChecklistTrackingCount
+    val showRestoreConfirm get() = backup.showRestoreConfirm
+    val pendingRestoreUri get() = backup.pendingRestoreUri
+    val pendingRestoreFileName get() = backup.pendingRestoreFileName
 
     // --- Tracking ---
     val trackers get() = tracking.trackers
@@ -282,6 +289,18 @@ sealed interface SettingsEvent : UiEvent {
     data object OnCreateBackup : SettingsEvent
     data object OnRestoreBackup : SettingsEvent
     data object OnImportTachiyomiBackup : SettingsEvent
+    /** User tapped the Backup button — shows the checklist dialog before the file picker. */
+    data object ShowBackupChecklist : SettingsEvent
+    /** User confirmed the checklist dialog — opens the file-save picker. */
+    data object ConfirmCreateBackup : SettingsEvent
+    /** User cancelled the checklist dialog. */
+    data object DismissBackupChecklist : SettingsEvent
+    /** File picker returned a restore URI — show the preflight confirmation before restoring. */
+    data class ShowRestoreConfirm(val uri: Uri) : SettingsEvent
+    /** User confirmed the restore preflight dialog — proceed with the restore. */
+    data class ConfirmRestore(val uri: Uri) : SettingsEvent
+    /** User cancelled the restore preflight dialog. */
+    data object DismissRestoreConfirm : SettingsEvent
     data class CreateBackupWithUri(val uri: Uri) : SettingsEvent
     data class RestoreBackupFromUri(val uri: Uri) : SettingsEvent
     data class ImportTachiyomiBackupFromUri(val uri: Uri) : SettingsEvent

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/BackupSettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/BackupSettingsDelegate.kt
@@ -1,10 +1,14 @@
 package app.otakureader.feature.settings.delegate
 
 import android.content.Context
+import android.net.Uri
 import app.otakureader.core.preferences.BackupPreferences
 import app.otakureader.domain.backup.BackupRepository
 import app.otakureader.domain.backup.BackupScheduler
 import app.otakureader.domain.backup.TachiyomiBackupImporter
+import app.otakureader.domain.repository.CategoryRepository
+import app.otakureader.domain.repository.MangaRepository
+import app.otakureader.domain.repository.TrackerSyncRepository
 import app.otakureader.feature.settings.SettingsEffect
 import app.otakureader.feature.settings.SettingsEvent
 import app.otakureader.feature.settings.SettingsState
@@ -24,6 +28,9 @@ class BackupSettingsDelegate @Inject constructor(
     private val backupRepository: BackupRepository,
     private val backupScheduler: BackupScheduler,
     private val tachiyomiImporter: TachiyomiBackupImporter,
+    private val mangaRepository: MangaRepository,
+    private val categoryRepository: CategoryRepository,
+    private val trackerSyncRepository: TrackerSyncRepository,
 ) {
 
     private var updateState: ((SettingsState) -> SettingsState) -> Unit = {}
@@ -31,7 +38,7 @@ class BackupSettingsDelegate @Inject constructor(
     /** URI of the backup the user is previewing, awaiting import confirmation. */
     private var pendingImportUri: String? = null
 
-    private fun readBytes(uri: android.net.Uri): ByteArray =
+    private fun readBytes(uri: Uri): ByteArray =
         context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
             ?: error("Failed to read backup file")
 
@@ -75,6 +82,74 @@ class BackupSettingsDelegate @Inject constructor(
         event: SettingsEvent,
         sendEffect: suspend (SettingsEffect) -> Unit,
     ): Boolean = when (event) {
+        // ── Pre-backup checklist ──────────────────────────────────────────────────
+        // ShowBackupChecklist loads library counts and shows the checklist dialog.
+        // The actual file-save picker is opened in ConfirmCreateBackup so the user
+        // can review what will be included before committing to the file.
+        SettingsEvent.ShowBackupChecklist -> {
+            val mangaCount = mangaRepository.getLibraryManga().first().size
+            val categoryCount = categoryRepository.getCategories().first().size
+            // Count distinct tracker sync configurations (one per tracked manga/tracker pair).
+            val trackingCount = trackerSyncRepository.getSyncConfigurations().first().size
+            updateState {
+                it.copy(backup = it.backup.copy(
+                    showBackupChecklist = true,
+                    backupChecklistMangaCount = mangaCount,
+                    backupChecklistCategoryCount = categoryCount,
+                    backupChecklistTrackingCount = trackingCount,
+                ))
+            }
+            true
+        }
+        SettingsEvent.ConfirmCreateBackup -> {
+            // Dismiss checklist, then open the file-save picker.
+            updateState { it.copy(backup = it.backup.copy(showBackupChecklist = false)) }
+            sendEffect(SettingsEffect.ShowBackupPicker)
+            true
+        }
+        SettingsEvent.DismissBackupChecklist -> {
+            updateState { it.copy(backup = it.backup.copy(showBackupChecklist = false)) }
+            true
+        }
+
+        // ── Pre-restore confirmation ──────────────────────────────────────────────
+        // The file picker result routes through ShowRestoreConfirm; ConfirmRestore
+        // carries the URI directly so no state-stored side-effect is needed.
+        is SettingsEvent.ShowRestoreConfirm -> {
+            val fileName = event.uri.lastPathSegment ?: event.uri.toString()
+            updateState {
+                it.copy(backup = it.backup.copy(
+                    showRestoreConfirm = true,
+                    pendingRestoreUri = event.uri.toString(),
+                    pendingRestoreFileName = fileName,
+                ))
+            }
+            true
+        }
+        is SettingsEvent.ConfirmRestore -> {
+            // Clear the dialog state and restore using the URI carried in the event.
+            // No mutable field needed — the URI is delivered directly by the caller.
+            updateState {
+                it.copy(backup = it.backup.copy(
+                    showRestoreConfirm = false,
+                    pendingRestoreUri = null,
+                    pendingRestoreFileName = "",
+                ))
+            }
+            handleEvent(SettingsEvent.RestoreBackupFromUri(event.uri), sendEffect)
+            true
+        }
+        SettingsEvent.DismissRestoreConfirm -> {
+            updateState {
+                it.copy(backup = it.backup.copy(
+                    showRestoreConfirm = false,
+                    pendingRestoreUri = null,
+                    pendingRestoreFileName = "",
+                ))
+            }
+            true
+        }
+
         SettingsEvent.OnCreateBackup -> { sendEffect(SettingsEffect.ShowBackupPicker); true }
         SettingsEvent.OnRestoreBackup -> { sendEffect(SettingsEffect.ShowRestorePicker); true }
         SettingsEvent.OnImportTachiyomiBackup -> { sendEffect(SettingsEffect.ShowTachiyomiImportPicker); true }
@@ -123,7 +198,7 @@ class BackupSettingsDelegate @Inject constructor(
                     ))
                 }
                 try {
-                    val data = readBytes(android.net.Uri.parse(uriString))
+                    val data = readBytes(Uri.parse(uriString))
                     val result = tachiyomiImporter.importBackup(
                         data = data,
                         overwriteExisting = event.overwriteExisting,

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -138,6 +138,17 @@
     <string name="settings_restore_backup">Restore Backup</string>
     <string name="settings_restore_backup_description">Import library and settings from a backup file</string>
     <string name="settings_restore_button">Restore</string>
+    <!-- Pre-backup checklist dialog -->
+    <string name="backup_checklist_title">Backup contents</string>
+    <string name="backup_checklist_summary">%1$d manga · %2$d categories · %3$d tracking entries</string>
+    <string name="backup_checklist_history_included">History: included</string>
+    <string name="backup_checklist_settings_included">Settings: included</string>
+    <string name="backup_checklist_create">Create backup</string>
+    <!-- Pre-restore preflight dialog -->
+    <string name="restore_preflight_title">Restore backup?</string>
+    <string name="restore_preflight_filename">Restore from: %1$s</string>
+    <string name="restore_preflight_message">This will replace your current library with the selected backup. This cannot be undone.</string>
+    <string name="restore_preflight_proceed">Restore</string>
     <string name="settings_import_tachiyomi">Import from Tachiyomi/Mihon</string>
     <string name="settings_import_tachiyomi_description">Bring your library from another manga reader app</string>
     <string name="settings_import_button">Import</string>


### PR DESCRIPTION
## **User description**
## Summary

- Shows a **backup contents checklist** dialog before opening the file-save picker, displaying the live count of manga, categories, and tracking entries plus a note that history and settings are included.
- Shows a **pre-restore preflight dialog** after the user picks a restore file but before any data is replaced, warning that the operation cannot be undone.

Both dialogs are wired through clean MVI intent/state/effect cycles in `BackupSettingsDelegate`, with live counts sourced from `MangaRepository`, `CategoryRepository`, and `TrackerSyncRepository`.

## Changed files

- `BackupSettingsMvi.kt` — new state fields: `showBackupChecklist`, `showRestoreConfirm`, count fields, `pendingRestoreUri/FileName`
- `SettingsMvi.kt` — new events: `ShowBackupChecklist`, `ConfirmCreateBackup`, `DismissBackupChecklist`, `ShowRestoreConfirm`, `ConfirmRestore`, `DismissRestoreConfirm`; new convenience accessors in `SettingsState`
- `BackupSettingsDelegate.kt` — injects `MangaRepository`, `CategoryRepository`, `TrackerSyncRepository`; handles all new events
- `SettingsBackupScreen.kt` — `BackupChecklistDialog` and `RestorePreflightDialog` composables; Backup button routes through `ShowBackupChecklist`; restore file picker routes through `ShowRestoreConfirm`
- `strings.xml` — `backup_checklist_title`, `backup_checklist_create`, `backup_checklist_history_included`, `backup_checklist_settings_included`, `restore_preflight_title`, `restore_preflight_filename`, `restore_preflight_message`, `restore_preflight_proceed`

## Test plan

- [ ] Tap "Backup" button → checklist dialog appears with correct manga/category/tracking counts
- [ ] Tap "Cancel" in checklist → dialog dismisses, no file picker
- [ ] Tap "Create backup" in checklist → file picker opens, backup proceeds normally
- [ ] Tap "Restore" button → file picker opens
- [ ] Select a file → preflight dialog shows filename and warning message
- [ ] Tap "Cancel" in preflight → dialog dismisses, no restore
- [ ] Tap "Restore" in preflight → restore proceeds (encrypted backup still shows password dialog)

Closes #1042.

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Show backup contents before creating a backup and confirm restore before replacing data**

### What Changed
- Tapping **Backup** now opens a checklist first, showing how many manga, categories, and tracking entries will be included, along with notes that history and settings are included
- Tapping **Create backup** from that checklist opens the file save picker; cancelling the checklist closes it without starting a backup
- After selecting a restore file, a confirmation dialog now appears with the file name and a warning that restoring will replace the current library and cannot be undone
- The restore only starts after the user confirms; cancelling leaves the current library unchanged

### Impact
`✅ Fewer accidental backup actions`
`✅ Clearer restore warnings before data is replaced`
`✅ Easier checking of what gets saved in a backup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
