### PR TITLE
feat: saved source searches in Browse

### DIFF
--- a/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
@@ -157,6 +157,19 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
         prefs[Keys.SAVED_SEARCHES] = current.joinToString("\n")
     }
 
+    // --- Saved Source Searches (#1051) ---
+    // Stored as a raw JSON array string; deserialization to SavedSourceSearch is done by the
+    // ViewModel (feature layer) to avoid a domain dependency from this core module.
+
+    /** Raw JSON string of the saved source searches list. */
+    val savedSourceSearchesJson: Flow<String> = dataStore.data.map { prefs ->
+        prefs[Keys.SAVED_SOURCE_SEARCHES_JSON] ?: "[]"
+    }
+
+    suspend fun setSavedSourceSearchesJson(json: String) = dataStore.edit { prefs ->
+        prefs[Keys.SAVED_SOURCE_SEARCHES_JSON] = json
+    }
+
     // --- Browse Search History ---
 
     val browseSearchHistory: Flow<List<String>> = dataStore.data.map { prefs ->
@@ -413,6 +426,7 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
         val DARK_MODE_END_MINUTE = intPreferencesKey("dark_mode_end_minute")
         val PINNED_SOURCE_IDS = stringPreferencesKey("pinned_source_ids")
         val SOURCE_CATEGORY_MAP = stringPreferencesKey("source_category_map")
+        val SAVED_SOURCE_SEARCHES_JSON = stringPreferencesKey("saved_source_searches_json")
     }
 
     companion object {

--- a/domain/src/main/java/app/otakureader/domain/model/SavedSourceSearch.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/SavedSourceSearch.kt
@@ -1,0 +1,20 @@
+package app.otakureader.domain.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A named search query the user has bookmarked for a specific source.
+ *
+ * Stored as a JSON-serialized list in [app.otakureader.core.preferences.GeneralPreferences] so no
+ * database migration is needed. The [id] is a random UUID string that serves as a stable key for
+ * Compose list diffing and deletion.
+ */
+@Serializable
+data class SavedSourceSearch(
+    val id: String = java.util.UUID.randomUUID().toString(),
+    val name: String,
+    val query: String,
+    val sourceId: Long,
+    val sourceName: String,
+    val createdAt: Long = System.currentTimeMillis(),
+)

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseMvi.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseMvi.kt
@@ -4,6 +4,7 @@ import app.otakureader.core.common.mvi.UiEffect
 import app.otakureader.core.common.mvi.UiEvent
 import app.otakureader.core.common.mvi.UiState
 import app.otakureader.domain.model.FeedSavedSearch
+import app.otakureader.domain.model.SavedSourceSearch
 import app.otakureader.domain.model.SourceHealthEntry
 import app.otakureader.sourceapi.FilterList
 import app.otakureader.sourceapi.SourceManga
@@ -51,6 +52,12 @@ data class BrowseState(
     val sourceHealth: Map<Long, SourceHealthEntry> = emptyMap(),
     /** Source ID whose diagnostic sheet is currently open; null means sheet is hidden. */
     val selectedDiagnosticSourceId: Long? = null,
+    /** Named source search queries bookmarked by the user (#1051). */
+    val namedSavedSearches: List<SavedSourceSearch> = emptyList(),
+    /** Whether the "Save search" dialog is visible. */
+    val showSaveSearchDialog: Boolean = false,
+    /** Current text in the "Save search" name field. */
+    val saveSearchName: String = "",
 ) : UiState
 
 sealed interface BrowseEvent : UiEvent {
@@ -101,6 +108,20 @@ sealed interface BrowseEvent : UiEvent {
     data object ConfirmSetCategory : BrowseEvent
     /** User dismissed the category dialog without saving. */
     data object DismissSetCategoryDialog : BrowseEvent
+
+    // --- Named saved source searches (#1051) ---
+    /** Opens the "Save search" dialog for the current query + source. */
+    data object ShowSaveSearchDialog : BrowseEvent
+    /** Dismisses the "Save search" dialog without saving. */
+    data object HideSaveSearchDialog : BrowseEvent
+    /** Updates the name field in the "Save search" dialog. */
+    data class UpdateSaveSearchName(val name: String) : BrowseEvent
+    /** Saves the current search query under the given name. */
+    data object ConfirmSaveSearch : BrowseEvent
+    /** Re-applies a previously saved named search (sets query + runs search). */
+    data class ApplyNamedSavedSearch(val search: SavedSourceSearch) : BrowseEvent
+    /** Removes a saved named search by its UUID id. */
+    data class DeleteNamedSavedSearch(val id: String) : BrowseEvent
 }
 
 sealed interface BrowseEffect : UiEffect {

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -208,6 +208,33 @@ fun BrowseScreen(
             },
         )
     }
+
+    // Save search dialog (#1051)
+    if (state.showSaveSearchDialog) {
+        AlertDialog(
+            onDismissRequest = { viewModel.onEvent(BrowseEvent.HideSaveSearchDialog) },
+            title = { Text(stringResource(R.string.browse_save_search)) },
+            text = {
+                OutlinedTextField(
+                    value = state.saveSearchName,
+                    onValueChange = { viewModel.onEvent(BrowseEvent.UpdateSaveSearchName(it)) },
+                    placeholder = { Text(stringResource(R.string.browse_save_search_hint)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { viewModel.onEvent(BrowseEvent.ConfirmSaveSearch) }) {
+                    Text(stringResource(R.string.browse_save_search_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.onEvent(BrowseEvent.HideSaveSearchDialog) }) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+            },
+        )
+    }
 }
 
 @Composable
@@ -238,10 +265,10 @@ private fun BrowseContent(
                 singleLine = true
             )
 
-            // Save-search button (shown when there is a non-empty query)
+            // Bookmark icon: opens the "Save search" name dialog when query is non-empty
             if (state.searchQuery.isNotBlank()) {
                 Spacer(modifier = Modifier.width(4.dp))
-                IconButton(onClick = { onEvent(BrowseEvent.SaveCurrentSearch) }) {
+                IconButton(onClick = { onEvent(BrowseEvent.ShowSaveSearchDialog) }) {
                     Icon(
                         Icons.Default.BookmarkBorder,
                         contentDescription = stringResource(R.string.browse_save_search),
@@ -334,7 +361,7 @@ private fun BrowseContent(
             }
         }
 
-        // Saved search chips
+        // Saved search chips (DB-backed FeedSavedSearch)
         if (state.savedSearches.isNotEmpty()) {
             LazyRow(
                 modifier = Modifier
@@ -357,6 +384,49 @@ private fun BrowseContent(
                         trailingIcon = {
                             IconButton(
                                 onClick = { onEvent(BrowseEvent.DeleteSavedSearch(search.id)) },
+                                modifier = Modifier.size(18.dp),
+                            ) {
+                                Icon(
+                                    Icons.Default.Close,
+                                    contentDescription = stringResource(R.string.browse_delete_saved_search),
+                                    modifier = Modifier.size(14.dp),
+                                )
+                            }
+                        },
+                    )
+                }
+            }
+        }
+
+        // Named saved source searches (#1051) — preferences-backed, long-press to delete
+        if (state.namedSavedSearches.isNotEmpty()) {
+            Text(
+                text = stringResource(R.string.browse_saved_searches),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 16.dp, top = 4.dp, bottom = 2.dp),
+            )
+            LazyRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(state.namedSavedSearches, key = { it.id }) { search ->
+                    FilterChip(
+                        selected = state.searchQuery == search.query,
+                        onClick = { onEvent(BrowseEvent.ApplyNamedSavedSearch(search)) },
+                        label = { Text(search.name, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                        leadingIcon = {
+                            Icon(
+                                Icons.Default.Bookmark,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        trailingIcon = {
+                            IconButton(
+                                onClick = { onEvent(BrowseEvent.DeleteNamedSavedSearch(search.id)) },
                                 modifier = Modifier.size(18.dp),
                             ) {
                                 Icon(

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
@@ -213,10 +213,7 @@ class BrowseViewModel @Inject constructor(
                 it.copy(saveSearchName = event.name)
             }
             is BrowseEvent.ConfirmSaveSearch -> confirmSaveNamedSearch()
-            is BrowseEvent.ApplyNamedSavedSearch -> {
-                _state.update { it.copy(searchQuery = event.search.query) }
-                performSearch()
-            }
+            is BrowseEvent.ApplyNamedSavedSearch -> applyNamedSavedSearch(event.search)
             is BrowseEvent.DeleteNamedSavedSearch -> deleteNamedSavedSearch(event.id)
         }
     }
@@ -500,18 +497,22 @@ class BrowseViewModel @Inject constructor(
     // --- Named Saved Source Searches (#1051) ---
 
     /**
-     * Decodes the raw JSON from preferences into a list of [SavedSourceSearch] objects and keeps
-     * [BrowseState.namedSavedSearches] up-to-date.
+     * Decodes the raw JSON from preferences into a list of [SavedSourceSearch] objects, filters by
+     * the currently selected source, and keeps [BrowseState.namedSavedSearches] up-to-date.
      *
-     * We decode here (in the feature/ViewModel layer) rather than in [GeneralPreferences] so that
-     * `core:preferences` does not take a dependency on `domain` models.
+     * Combining with [currentSourceId] ensures chips only show for the active source — searches
+     * saved for other sources are hidden rather than mixed in.
      */
     private fun observeNamedSavedSearches() {
-        generalPreferences.savedSourceSearchesJson
-            .map { json ->
+        combine(
+            generalPreferences.savedSourceSearchesJson.map { json ->
                 runCatching { Json.decodeFromString<List<SavedSourceSearch>>(json) }.getOrDefault(emptyList())
-            }
-            .onEach { list -> _state.update { it.copy(namedSavedSearches = list) } }
+            },
+            _state.map { it.currentSourceId }.distinctUntilChanged()
+        ) { list, sourceId ->
+            if (sourceId != null) list.filter { it.sourceName == sourceId } else emptyList()
+        }
+            .onEach { filtered -> _state.update { it.copy(namedSavedSearches = filtered) } }
             .launchIn(viewModelScope)
     }
 
@@ -545,6 +546,28 @@ class BrowseViewModel @Inject constructor(
             }
         }
         _state.update { it.copy(showSaveSearchDialog = false, saveSearchName = "") }
+    }
+
+    private fun applyNamedSavedSearch(search: SavedSourceSearch) {
+        val savedSourceId = search.sourceName
+        val currentSourceId = _state.value.currentSourceId
+        if (savedSourceId.isNotEmpty() && savedSourceId != currentSourceId) {
+            _state.update {
+                it.copy(
+                    currentSourceId = savedSourceId,
+                    searchQuery = search.query,
+                    availableFilters = FilterList(),
+                    activeFilters = FilterList(),
+                    hasSearchResults = false,
+                    searchResults = emptyList()
+                )
+            }
+            loadPopularManga(savedSourceId)
+            loadSourceFilters(savedSourceId)
+        } else {
+            _state.update { it.copy(searchQuery = search.query) }
+        }
+        performSearch()
     }
 
     private fun deleteNamedSavedSearch(id: String) {

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
@@ -12,6 +12,7 @@ import app.otakureader.domain.usecase.source.GetLatestUpdatesUseCase
 import app.otakureader.domain.usecase.source.GetPopularMangaUseCase
 import app.otakureader.domain.usecase.source.GetSourceFiltersUseCase
 import app.otakureader.domain.usecase.source.GetSourcesUseCase
+import app.otakureader.domain.model.SavedSourceSearch
 import app.otakureader.domain.usecase.SearchLibraryMangaUseCase
 import app.otakureader.domain.usecase.source.SearchMangaUseCase
 import app.otakureader.sourceapi.FilterList
@@ -32,6 +33,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
 @HiltViewModel
@@ -91,6 +93,7 @@ class BrowseViewModel @Inject constructor(
         }.launchIn(viewModelScope)
         observeSearchHistory()
         observeSourcePinning()
+        observeNamedSavedSearches()
     }
 
     @Suppress("LongMethod", "CyclomaticComplexMethod")
@@ -198,6 +201,23 @@ class BrowseViewModel @Inject constructor(
             is BrowseEvent.DismissSetCategoryDialog -> _state.update {
                 it.copy(showSetCategoryDialog = false, categoryDialogSourceId = null, categoryDialogText = "")
             }
+
+            // Named saved source searches (#1051)
+            is BrowseEvent.ShowSaveSearchDialog -> _state.update {
+                it.copy(showSaveSearchDialog = true, saveSearchName = "")
+            }
+            is BrowseEvent.HideSaveSearchDialog -> _state.update {
+                it.copy(showSaveSearchDialog = false, saveSearchName = "")
+            }
+            is BrowseEvent.UpdateSaveSearchName -> _state.update {
+                it.copy(saveSearchName = event.name)
+            }
+            is BrowseEvent.ConfirmSaveSearch -> confirmSaveNamedSearch()
+            is BrowseEvent.ApplyNamedSavedSearch -> {
+                _state.update { it.copy(searchQuery = event.search.query) }
+                performSearch()
+            }
+            is BrowseEvent.DeleteNamedSavedSearch -> deleteNamedSavedSearch(event.id)
         }
     }
 
@@ -476,6 +496,71 @@ class BrowseViewModel @Inject constructor(
             .onEach { map -> _state.update { it.copy(sourceCategoryMap = map) } }
             .launchIn(viewModelScope)
     }
+
+    // --- Named Saved Source Searches (#1051) ---
+
+    /**
+     * Decodes the raw JSON from preferences into a list of [SavedSourceSearch] objects and keeps
+     * [BrowseState.namedSavedSearches] up-to-date.
+     *
+     * We decode here (in the feature/ViewModel layer) rather than in [GeneralPreferences] so that
+     * `core:preferences` does not take a dependency on `domain` models.
+     */
+    private fun observeNamedSavedSearches() {
+        generalPreferences.savedSourceSearchesJson
+            .map { json ->
+                runCatching { Json.decodeFromString<List<SavedSourceSearch>>(json) }.getOrDefault(emptyList())
+            }
+            .onEach { list -> _state.update { it.copy(namedSavedSearches = list) } }
+            .launchIn(viewModelScope)
+    }
+
+    private fun confirmSaveNamedSearch() {
+        val state = _state.value
+        val name = state.saveSearchName.trim()
+        if (name.isBlank()) {
+            viewModelScope.launch { _effect.send(BrowseEffect.ShowSnackbar("Enter a name for the search")) }
+            return
+        }
+        val query = state.searchQuery.trim()
+        if (query.isBlank()) {
+            viewModelScope.launch { _effect.send(BrowseEffect.ShowSnackbar("Enter a search query first")) }
+            return
+        }
+        val sourceId = state.currentSourceId
+        val newSearch = SavedSourceSearch(
+            name = name,
+            query = query,
+            sourceId = sourceId?.toLongOrNull() ?: 0L,
+            sourceName = sourceId ?: "",
+        )
+        val updated = state.namedSavedSearches + newSearch
+        viewModelScope.launch {
+            runCatching {
+                generalPreferences.setSavedSourceSearchesJson(Json.encodeToString(updated))
+            }.onSuccess {
+                _effect.send(BrowseEffect.ShowSnackbar("Search \"$name\" saved"))
+            }.onFailure {
+                _effect.send(BrowseEffect.ShowSnackbar("Failed to save search"))
+            }
+        }
+        _state.update { it.copy(showSaveSearchDialog = false, saveSearchName = "") }
+    }
+
+    private fun deleteNamedSavedSearch(id: String) {
+        val updated = _state.value.namedSavedSearches.filterNot { it.id == id }
+        viewModelScope.launch {
+            try {
+                generalPreferences.setSavedSourceSearchesJson(Json.encodeToString(updated))
+                _effect.send(BrowseEffect.ShowSnackbar("Saved search removed"))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                _effect.send(BrowseEffect.ShowSnackbar("Failed to remove saved search"))
+            }
+        }
+    }
+
 
     private var librarySearchJob: kotlinx.coroutines.Job? = null
 

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -10,6 +10,9 @@
     <string name="browse_title">Browse</string>
     <string name="browse_search">Search</string>
     <string name="browse_save_search">Save search</string>
+    <string name="browse_saved_searches">Saved searches</string>
+    <string name="browse_save_search_hint">Search name</string>
+    <string name="browse_save_search_confirm">Save</string>
     <string name="browse_delete_saved_search">Delete saved search</string>
     <string name="browse_install_extension">Install Extension</string>
     <string name="browse_search_placeholder">Search manga&#8230;</string>

--- a/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
+++ b/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
@@ -85,6 +85,8 @@ class BrowseViewModelTest {
         every { feedRepository.getSavedSearches() } returns flowOf(emptyList())
         every { generalPreferences.pinnedSourceIds } returns flowOf(emptySet())
         every { generalPreferences.sourceCategoryMap } returns flowOf(emptyMap())
+        every { generalPreferences.savedSourceSearchesJson } returns flowOf("[]")
+        coEvery { generalPreferences.setSavedSourceSearchesJson(any()) } just Awaits
 
         // observeLibraryFavorites() is called in ViewModel.init and subscribes to this flow.
         every { mangaRepository.getLibraryManga() } returns flowOf(emptyList())


### PR DESCRIPTION
## **User description**
## Summary
- Adds `SavedSourceSearch` domain model (`@Serializable`, pure Kotlin, no Android deps)
- Bookmark icon in the search bar opens a dialog to name and save the current query; the list persists in DataStore as a JSON array (no Room migration required)
- A horizontal `LazyRow` of `FilterChip`s appears above the source list — tap applies the search, × deletes it
- JSON encode/decode happens in `BrowseViewModel` so `core:preferences` stays free of `domain` model dependencies

## Test plan
- [ ] Type a query → Bookmark icon appears → tap → dialog prompts for a name
- [ ] Confirm → chip appears in the saved searches row labelled with the given name
- [ ] Tap chip → query is restored and search runs automatically
- [ ] Tap × on chip → chip is removed; deletion survives app restart
- [ ] Saving with a blank name shows a snackbar error
- [ ] Saving with a blank query shows a snackbar error
- [ ] Multiple saved searches display in order of creation

Closes #1051.

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Save and reuse named source searches in Browse, with source-specific chips and correct source switching**

### What Changed
- The bookmark button now opens a dialog where users can name and save the current Browse search
- Saved named searches now appear as chips above the source list for the active source; tapping a chip restores the query and runs the search
- Users can remove a saved named search from the chip row, and the saved list persists after app restart
- Saving is blocked with a clear message when the name or query is empty
- Saved searches are now kept separate by source, and applying one switches to the right source before running the search

### Impact
`✅ Faster repeat searches`
`✅ Fewer retyped source queries`
`✅ Fewer wrong-source search results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
