### PR TITLE
feat: WebView session bridge — injectable cookie bridge + challenge manager

### DIFF
--- a/core/webview/build.gradle.kts
+++ b/core/webview/build.gradle.kts
@@ -13,4 +13,7 @@ dependencies {
     implementation(projects.core.preferences)
     implementation(libs.lifecycle.runtime.compose)
     implementation(libs.compose.material.icons.extended)
+    // Cookie syncing between WebView's CookieManager and OkHttp's CookieJar
+    implementation(platform(libs.okhttp.bom))
+    implementation(libs.okhttp.core)
 }

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewChallengeManager.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewChallengeManager.kt
@@ -41,12 +41,14 @@ class WebViewChallengeManager @Inject constructor(
      */
     suspend fun requestChallenge(sourceId: Long, url: String): Boolean {
         val deferred = CompletableDeferred<Boolean>()
-        pendingCompletions[sourceId] = deferred
+        // Complete any existing deferred for this source so it doesn't hang indefinitely.
+        // Use remove(key, value) in finally so we only remove OUR deferred, not a subsequent one.
+        pendingCompletions.put(sourceId, deferred)?.complete(false)
         _pendingChallenge.emit(ChallengeRequest(sourceId, url))
         return try {
             deferred.await()
         } finally {
-            pendingCompletions.remove(sourceId)
+            pendingCompletions.remove(sourceId, deferred)
         }
     }
 

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewChallengeManager.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewChallengeManager.kt
@@ -1,0 +1,77 @@
+package app.otakureader.core.webview
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import okhttp3.CookieJar
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Mediates WebView challenge requests between extension sources and the app's navigation layer.
+ *
+ * Usage flow:
+ * 1. An extension source detects a Cloudflare/CAPTCHA barrier and calls [requestChallenge].
+ * 2. This class emits a [ChallengeRequest] on [pendingChallenge] and suspends.
+ * 3. The app's navigation layer observes [pendingChallenge] and navigates to the WebView screen.
+ * 4. When the user finishes and closes the WebView, the nav layer calls [completeChallenge].
+ * 5. [requestChallenge] resumes and returns `true` if cookies were obtained, `false` if cancelled.
+ */
+@Singleton
+class WebViewChallengeManager @Inject constructor(
+    private val cookieBridge: WebViewCookieBridge,
+) {
+
+    data class ChallengeRequest(val sourceId: Long, val url: String)
+
+    private val _pendingChallenge = MutableSharedFlow<ChallengeRequest>(extraBufferCapacity = 1)
+
+    /** Emits whenever a source requests a WebView challenge. Observe in the navigation host. */
+    val pendingChallenge: SharedFlow<ChallengeRequest> = _pendingChallenge.asSharedFlow()
+
+    private val pendingCompletions = ConcurrentHashMap<Long, CompletableDeferred<Boolean>>()
+
+    /**
+     * Requests a WebView challenge for [url] on behalf of source [sourceId].
+     * Suspends until [completeChallenge] is called with a matching [sourceId].
+     *
+     * @return `true` if the challenge completed with cookies, `false` if the user cancelled.
+     */
+    suspend fun requestChallenge(sourceId: Long, url: String): Boolean {
+        val deferred = CompletableDeferred<Boolean>()
+        pendingCompletions[sourceId] = deferred
+        _pendingChallenge.emit(ChallengeRequest(sourceId, url))
+        return try {
+            deferred.await()
+        } finally {
+            pendingCompletions.remove(sourceId)
+        }
+    }
+
+    /**
+     * Signals that the WebView challenge for source [sourceId] is done.
+     *
+     * If [cookieJar] is provided and [cookieString] is non-empty, the cookies are
+     * synced from Android's [android.webkit.CookieManager] into OkHttp so subsequent
+     * requests from the same source carry the freshly acquired session cookies.
+     *
+     * @param sourceId   The source that initiated the challenge.
+     * @param url        The URL that was opened in the WebView.
+     * @param cookieString Raw cookie string from [android.webkit.CookieManager]; null if none.
+     * @param cookieJar  Optional OkHttp jar to receive the synced cookies.
+     */
+    fun completeChallenge(
+        sourceId: Long,
+        url: String,
+        cookieString: String?,
+        cookieJar: CookieJar? = null,
+    ) {
+        if (cookieJar != null && !cookieString.isNullOrEmpty()) {
+            cookieBridge.syncCookiesToOkHttp(url, cookieJar)
+        }
+        val success = !cookieString.isNullOrEmpty()
+        pendingCompletions[sourceId]?.complete(success)
+    }
+}

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewChallengeManager.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewChallengeManager.kt
@@ -43,9 +43,11 @@ class WebViewChallengeManager @Inject constructor(
         val deferred = CompletableDeferred<Boolean>()
         // Complete any existing deferred for this source so it doesn't hang indefinitely.
         // Use remove(key, value) in finally so we only remove OUR deferred, not a subsequent one.
+        // The entire body (emit + await) is inside try/finally so cancellation during emit
+        // also cleans up the deferred from the map.
         pendingCompletions.put(sourceId, deferred)?.complete(false)
-        _pendingChallenge.emit(ChallengeRequest(sourceId, url))
         return try {
+            _pendingChallenge.emit(ChallengeRequest(sourceId, url))
             deferred.await()
         } finally {
             pendingCompletions.remove(sourceId, deferred)

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewCookieBridge.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewCookieBridge.kt
@@ -33,10 +33,23 @@ class WebViewCookieBridge @Inject constructor() {
     fun syncCookiesToOkHttp(url: String, cookieJar: CookieJar) {
         val httpUrl = url.toHttpUrlOrNull() ?: return
         val raw = CookieManager.getInstance().getCookie(url) ?: return
-        val cookies = raw.split(";")
-            .mapNotNull { part ->
-                Cookie.parse(httpUrl, part.trim())
-            }
+        // CookieManager returns "name=value; name2=value2" — no domain/path metadata.
+        // Cookie.parse() would default the path to the challenge URL's path and mark cookies
+        // as host-only, preventing them from being sent to other paths or subdomains.
+        // Use Cookie.Builder with domain(host) and path("/") so cookies apply site-wide.
+        val cookies = raw.split(";").mapNotNull { part ->
+            val kv = part.trim().split("=", limit = 2)
+            if (kv.size != 2) return@mapNotNull null
+            runCatching {
+                Cookie.Builder()
+                    .name(kv[0].trim())
+                    .value(kv[1].trim())
+                    .domain(httpUrl.host)
+                    .path("/")
+                    .apply { if (httpUrl.isHttps) secure() }
+                    .build()
+            }.getOrNull()
+        }
         if (cookies.isNotEmpty()) {
             cookieJar.saveFromResponse(httpUrl, cookies)
         }

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewCookieBridge.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewCookieBridge.kt
@@ -1,8 +1,44 @@
 package app.otakureader.core.webview
 
 import android.webkit.CookieManager
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import javax.inject.Inject
+import javax.inject.Singleton
 
-object WebViewCookieBridge {
+/**
+ * Bridges cookies between Android's [CookieManager] (used by WebView) and
+ * OkHttp's [CookieJar] (used by extension network requests).
+ *
+ * After a source completes a WebView challenge (e.g. Cloudflare), call
+ * [syncCookiesToOkHttp] so that subsequent OkHttp requests from the same
+ * source automatically include the freshly acquired cookies.
+ */
+@Singleton
+class WebViewCookieBridge @Inject constructor() {
+
+    /** Returns the raw cookie header string for [url] from Android's [CookieManager]. */
     fun cookiesForUrl(url: String): String =
         CookieManager.getInstance().getCookie(url) ?: ""
+
+    /**
+     * Copies all cookies that [CookieManager] holds for [url] into [cookieJar].
+     *
+     * Each cookie in the `Set-Cookie` / `Cookie` header format is parsed into an
+     * [okhttp3.Cookie] and saved to the jar via [CookieJar.saveFromResponse].
+     *
+     * No-op if the URL is invalid or if there are no cookies for it.
+     */
+    fun syncCookiesToOkHttp(url: String, cookieJar: CookieJar) {
+        val httpUrl = url.toHttpUrlOrNull() ?: return
+        val raw = CookieManager.getInstance().getCookie(url) ?: return
+        val cookies = raw.split(";")
+            .mapNotNull { part ->
+                Cookie.parse(httpUrl, part.trim())
+            }
+        if (cookies.isNotEmpty()) {
+            cookieJar.saveFromResponse(httpUrl, cookies)
+        }
+    }
 }

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewScreen.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewScreen.kt
@@ -81,6 +81,10 @@ fun WebViewScreen(
                             adBlockEnabled = adBlockEnabled,
                             onPageFinished = { /* no-op — callers get cookies via onClose */ },
                         ).configure(wv)
+                        // configure() already sets allowContentAccess = false; repeat here
+                        // so static analysis tools (CodeQL) can verify it without tracing
+                        // through the opaque configure() call.
+                        wv.settings.allowContentAccess = false
                         wv.loadUrl(url)
                     }
                 },

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewScreen.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewScreen.kt
@@ -63,7 +63,7 @@ fun WebViewScreen(
 
     Column(modifier = modifier.fillMaxSize()) {
         WebViewTopBar(
-            onBack = { onClose(webViewRef?.let { WebViewCookieBridge.cookiesForUrl(url) }) },
+            onBack = { onClose(webViewRef?.let { viewModel.cookiesForUrl(url) }) },
             onNavigateBack = { webViewRef?.goBack() },
             onNavigateForward = { webViewRef?.goForward() },
             onReload = { webViewRef?.reload() },

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewViewModel.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewViewModel.kt
@@ -10,16 +10,18 @@ import javax.inject.Inject
 @HiltViewModel
 class WebViewViewModel @Inject constructor(
     private val webViewPreferences: WebViewPreferences,
+    private val cookieBridge: WebViewCookieBridge,
 ) : ViewModel() {
 
-    /** Reactive stream of the ad-block enabled flag. Collect with [collectAsStateWithLifecycle]. */
     val adBlockEnabled = webViewPreferences.adBlockEnabled
 
-    /** Toggles the ad-block setting based on its current persisted value. */
     fun toggleAdBlock() {
         viewModelScope.launch {
             val current = webViewPreferences.adBlockEnabled.first()
             webViewPreferences.setAdBlockEnabled(!current)
         }
     }
+
+    /** Returns cookies held by the WebView's [android.webkit.CookieManager] for [url]. */
+    fun cookiesForUrl(url: String): String = cookieBridge.cookiesForUrl(url)
 }


### PR DESCRIPTION
## **User description**
## Summary

Closes #1052 — WebView session bridge: let sources request WebView challenge, share cookies with OkHttp.

- **`WebViewCookieBridge`**: converted from singleton `object` to `@Singleton class @Inject constructor()`. Added `syncCookiesToOkHttp(url, CookieJar)` that copies cookies from Android's `CookieManager` into OkHttp's `CookieJar` so subsequent extension HTTP requests carry freshly acquired session cookies.
- **`WebViewViewModel`**: injects `WebViewCookieBridge`; exposes `cookiesForUrl(url)` as the screen-facing API (removes direct static call on the bridge object).
- **`WebViewScreen`**: `onBack` lambda now uses `viewModel.cookiesForUrl(url)` instead of the old object reference.
- **`WebViewChallengeManager`** (new): `@Singleton` mediator that lets extension sources suspend-request a WebView challenge and be resumed when the user dismisses the WebView. Pattern: source calls `requestChallenge(sourceId, url)` → suspends; nav layer observes `pendingChallenge: SharedFlow<ChallengeRequest>`, navigates to `Route.WebView`; on close, nav layer calls `completeChallenge(sourceId, url, cookieString, cookieJar?)` which syncs cookies and resumes the coroutine.
- **`build.gradle.kts`**: added OkHttp BOM + core dependency required by `CookieJar`.

## Test plan

- [ ] Open a source that uses Cloudflare protection → `WebViewChallengeManager.requestChallenge()` emits to `pendingChallenge`, app navigates to WebView
- [ ] Complete the challenge in WebView and close → `completeChallenge()` called, cookies synced to OkHttp, source's suspended coroutine resumes with `true`
- [ ] Cancel the WebView without completing → `completeChallenge()` called with null cookies, resumes with `false`
- [ ] Non-Cloudflare WebView (general purpose) → cookie string flows through `onClose` callback as before
- [ ] Verify `./gradlew :core:webview:compileDebugKotlin` passes

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**WebView can hand session cookies back to the app after a challenge**

### What Changed
- WebView closing now reads cookies through the screen model, so the app can pass back the session cookies it just picked up.
- WebView cookies can now be copied into the app’s request storage after a completed challenge, letting follow-up requests reuse the same session.
- Added a challenge flow that pauses a source while a WebView check is shown, then resumes it with success or cancellation once the user closes the WebView.

### Impact
`✅ Fewer repeated Cloudflare checks`
`✅ Session cookies carried into follow-up requests`
`✅ Shorter recovery after WebView challenges`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
