### PR TITLE
feat: cross-source duplicate detection with source name display

### DIFF
--- a/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesMvi.kt
@@ -7,6 +7,12 @@ data class MergeDuplicatesState(
     val duplicateGroups: List<DuplicateGroup> = emptyList(),
     val isMerging: Boolean = false,
     val error: String? = null,
+    /**
+     * Maps [Manga.sourceId] to a human-readable source name.
+     * Populated from the extension registry so duplicate group cards can show
+     * "MangaDex" instead of a raw source ID.
+     */
+    val sourceNames: Map<Long, String> = emptyMap(),
 )
 
 /** A set of library manga entries sharing the same normalised title. */
@@ -16,7 +22,10 @@ data class DuplicateGroup(
     /** The ID of the entry chosen to survive the merge (defaulting to the one with the most chapters). */
     val primaryId: Long = entries.maxByOrNull { it.unreadCount + it.totalChapters }?.id
         ?: entries.first().id,
-)
+) {
+    /** True when entries in this group come from more than one source. */
+    val isCrossSource: Boolean get() = entries.map { it.sourceId }.distinct().size > 1
+}
 
 sealed class MergeDuplicatesEvent {
     data object LoadDuplicates : MergeDuplicatesEvent()

--- a/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesScreen.kt
@@ -18,6 +18,9 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.MergeType
+import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -132,6 +135,7 @@ fun MergeDuplicatesScreen(
                 itemsIndexed(state.duplicateGroups, key = { _, g -> g.entries.first().id }) { index, group ->
                     DuplicateGroupCard(
                         group = group,
+                        sourceNames = state.sourceNames,
                         onSelectPrimary = { primaryId ->
                             viewModel.onEvent(MergeDuplicatesEvent.SelectPrimary(index, primaryId))
                         },
@@ -147,6 +151,7 @@ fun MergeDuplicatesScreen(
 @Composable
 private fun DuplicateGroupCard(
     group: DuplicateGroup,
+    sourceNames: Map<Long, String>,
     onSelectPrimary: (Long) -> Unit,
     onMerge: () -> Unit,
     enabled: Boolean,
@@ -154,17 +159,37 @@ private fun DuplicateGroupCard(
 ) {
     Card(modifier = modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(12.dp)) {
-            Text(
-                text = stringResource(R.string.merge_duplicates_group_header, group.entries.size),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.merge_duplicates_group_header, group.entries.size),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f),
+                )
+                if (group.isCrossSource) {
+                    AssistChip(
+                        onClick = {},
+                        label = { Text(stringResource(R.string.merge_duplicates_cross_source)) },
+                        leadingIcon = {
+                            Icon(
+                                Icons.Default.SwapHoriz,
+                                contentDescription = null,
+                                modifier = Modifier.size(AssistChipDefaults.IconSize),
+                            )
+                        },
+                    )
+                }
+            }
             Spacer(Modifier.height(8.dp))
 
             group.entries.forEach { manga ->
                 val isPrimary = manga.id == group.primaryId
                 MangaEntryRow(
                     manga = manga,
+                    sourceName = sourceNames[manga.sourceId],
                     isPrimary = isPrimary,
                     onSelect = { onSelectPrimary(manga.id) },
                     enabled = enabled,
@@ -189,6 +214,7 @@ private fun DuplicateGroupCard(
 @Composable
 private fun MangaEntryRow(
     manga: app.otakureader.domain.model.Manga,
+    sourceName: String?,
     isPrimary: Boolean,
     onSelect: () -> Unit,
     enabled: Boolean,
@@ -233,7 +259,7 @@ private fun MangaEntryRow(
                     maxLines = 2,
                 )
                 Text(
-                    text = "Source ID: ${manga.sourceId}",
+                    text = sourceName ?: stringResource(R.string.merge_duplicates_source_id, manga.sourceId),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesViewModel.kt
@@ -3,6 +3,7 @@ package app.otakureader.feature.library
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.otakureader.domain.repository.MangaRepository
+import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.usecase.MergeDuplicateMangaUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
@@ -20,6 +21,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MergeDuplicatesViewModel @Inject constructor(
     private val mangaRepository: MangaRepository,
+    private val sourceRepository: SourceRepository,
     private val mergeDuplicateManga: MergeDuplicateMangaUseCase,
 ) : ViewModel() {
 
@@ -31,6 +33,7 @@ class MergeDuplicatesViewModel @Inject constructor(
 
     init {
         observeDuplicates()
+        observeSourceNames()
     }
 
     fun onEvent(event: MergeDuplicatesEvent) {
@@ -55,6 +58,19 @@ class MergeDuplicatesViewModel @Inject constructor(
                     }
                     current.copy(isLoading = false, duplicateGroups = newGroups, error = null)
                 }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    private fun observeSourceNames() {
+        sourceRepository.getSources()
+            .onEach { sources ->
+                val names = sources.associate { source ->
+                    // MangaSource.id is the Long source ID serialized to String
+                    val id = source.id.toLongOrNull() ?: return@associate source.id.hashCode().toLong() to source.name
+                    id to source.name
+                }
+                _state.update { it.copy(sourceNames = names) }
             }
             .launchIn(viewModelScope)
     }

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -228,4 +228,6 @@
     <string name="merge_duplicates_primary_badge">Primary</string>
     <string name="merge_duplicates_chapters">%1$d ch.</string>
     <string name="merge_duplicates_unread">%1$d unread</string>
+    <string name="merge_duplicates_cross_source">Cross-source</string>
+    <string name="merge_duplicates_source_id">Source %1$d</string>
 </resources>


### PR DESCRIPTION
## **User description**
## Summary

- **Source name resolution**: `MergeDuplicatesViewModel` now injects `SourceRepository` and builds a `Map<Long, String>` mapping source IDs to human-readable names (e.g. "MangaDex"). Exposed as `sourceNames` on `MergeDuplicatesState`; survives recomposition since it's part of the state.
- **Cross-source badge**: Added `isCrossSource` computed property on `DuplicateGroup` (true when entries span > 1 source). The group card header shows an `AssistChip` with a `SwapHoriz` icon labelled "Cross-source" when this is true, giving users an immediate visual signal before merging.
- **Source name in entry rows**: `MangaEntryRow` now shows the resolved source name (e.g. "MangaDex") instead of the raw numeric `sourceId`. Falls back to "Source \<id\>" if the name hasn't resolved yet.

## Test plan

- [ ] Library → overflow → Merge duplicates: source names appear ("MangaDex", "MangaPlus") instead of raw IDs
- [ ] Groups from multiple sources show "Cross-source" chip; same-source groups do not
- [ ] Primary selection and merge still work correctly after these changes
- [ ] `./gradlew :feature:library:testDebugUnitTest` passes

Closes #997 (cross-source detection aspect)

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Show source names and flag duplicate groups that span multiple sources**

### What Changed
- Duplicate groups now show a “Cross-source” label when the same title includes entries from different sources
- Each manga entry shows its source name when available, instead of only a numeric source ID
- If a source name has not loaded yet, the screen falls back to a readable “Source <id>” label

### Impact
`✅ Easier cross-source merge review`
`✅ Clearer source identification in duplicate lists`
`✅ Fewer raw ID labels in the merge screen`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
