### PR TITLE
feat: reader preset expansion round 2 — e-ink, keep-screen-on, preload counts

### DIFF
--- a/core/preferences/src/main/java/app/otakureader/core/preferences/ReaderPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/ReaderPreferences.kt
@@ -197,6 +197,11 @@ class ReaderPreferences(private val dataStore: DataStore<Preferences>) {
             prefs[Keys.SHOW_PAGE_NUMBER] = preset.showPageNumber
             prefs[Keys.SKIP_READ_CHAPTERS] = preset.skipReadChapters
             prefs[Keys.SKIP_FILTERED_CHAPTERS] = preset.skipFilteredChapters
+            prefs[Keys.KEEP_SCREEN_ON] = preset.keepScreenOn
+            prefs[Keys.EINK_FLASH_ON_PAGE_CHANGE] = preset.einkFlashOnPageChange
+            prefs[Keys.EINK_BLACK_AND_WHITE] = preset.einkBlackAndWhite
+            prefs[Keys.PRELOAD_PAGES_BEFORE] = preset.preloadPagesBefore
+            prefs[Keys.PRELOAD_PAGES_AFTER] = preset.preloadPagesAfter
         }
     }
 
@@ -218,6 +223,11 @@ class ReaderPreferences(private val dataStore: DataStore<Preferences>) {
             showPageNumber = prefs[Keys.SHOW_PAGE_NUMBER] ?: true,
             skipReadChapters = prefs[Keys.SKIP_READ_CHAPTERS] ?: false,
             skipFilteredChapters = prefs[Keys.SKIP_FILTERED_CHAPTERS] ?: true,
+            keepScreenOn = prefs[Keys.KEEP_SCREEN_ON] ?: true,
+            einkFlashOnPageChange = prefs[Keys.EINK_FLASH_ON_PAGE_CHANGE] ?: false,
+            einkBlackAndWhite = prefs[Keys.EINK_BLACK_AND_WHITE] ?: false,
+            preloadPagesBefore = prefs[Keys.PRELOAD_PAGES_BEFORE] ?: 2,
+            preloadPagesAfter = prefs[Keys.PRELOAD_PAGES_AFTER] ?: 3,
         )
     }
 

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/ReaderPreset.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/ReaderPreset.kt
@@ -22,4 +22,11 @@ data class ReaderPreset(
     val showPageNumber: Boolean = true,
     val skipReadChapters: Boolean = false,
     val skipFilteredChapters: Boolean = true,
+    // Round 2 (#1027): device/performance settings. Defaults match the individual
+    // preference defaults so presets saved before these fields existed apply unchanged.
+    val keepScreenOn: Boolean = true,
+    val einkFlashOnPageChange: Boolean = false,
+    val einkBlackAndWhite: Boolean = false,
+    val preloadPagesBefore: Int = 2,
+    val preloadPagesAfter: Int = 3,
 )


### PR DESCRIPTION
## **User description**
## Summary

Round 2 of reader preset expansion (round 1 was PR #1017, 6 → 13 fields). Adds the five device/performance settings that were intentionally deferred:

- `keepScreenOn` — "reading" presets can keep the screen on while "browsing" presets don't
- `einkFlashOnPageChange` / `einkBlackAndWhite` — e-ink device display modes, worth saving per profile
- `preloadPagesBefore` / `preloadPagesAfter` — power users tune these; belongs in a "high-performance" preset

## Why this is safe

All five `Keys.*` entries already existed in `ReaderPreferences` — this PR only threads them through `ReaderPreset`, `captureCurrentAsPreset()`, and `applyPreset()` (inside the existing batched `dataStore.edit`). New data-class fields have defaults matching the individual preference defaults, so preset JSON saved before this change deserializes unchanged and applies identically.

## Test plan

- [x] `./gradlew :core:preferences:compileDebugKotlin :core:preferences:testDebugUnitTest` green locally
- [ ] Save a preset → JSON contains the 5 new fields
- [ ] Apply an old preset (pre-round-2 JSON) → no crash, defaults applied

Closes #1027

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Add more reader preset settings for device and performance preferences**

### What Changed
- Reader presets now save and restore screen-on behavior, e-ink display options, and page preload counts
- Presets saved before this change still open and apply with the same default values
- Capturing the current reader setup now includes the new settings, and applying a preset restores them

### Impact
`✅ More complete reader presets`
`✅ Consistent e-ink reading settings`
`✅ Fewer missing settings when switching presets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
