### PR TITLE
feat: extension repository provenance tracking

### DIFF
--- a/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionDatabase.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionDatabase.kt
@@ -64,7 +64,17 @@ data class ExtensionEntity(
     val remoteVersionCode: Int?, // For tracking available updates
 
     @ColumnInfo(name = "is_enabled")
-    val isEnabled: Boolean = true
+    val isEnabled: Boolean = true,
+
+    /**
+     * The repository URL this extension was first installed from (#1019).
+     * Recorded at install time and kept sticky across updates so a different
+     * repository offering the same package name cannot silently replace the
+     * extension via the update path. Null for rows created before this column
+     * existed; backfilled on the next update check.
+     */
+    @ColumnInfo(name = "source_repo_url")
+    val sourceRepoUrl: String? = null
 )
 
 @Dao
@@ -103,6 +113,10 @@ interface ExtensionDao {
     @Query("UPDATE extensions SET remote_version_code = :remoteVersion WHERE pkg_name = :pkgName")
     suspend fun updateRemoteVersion(pkgName: String, remoteVersion: Int)
 
+    /** Backfills first-seen repo provenance for rows created before the column existed (#1019). */
+    @Query("UPDATE extensions SET source_repo_url = :repoUrl WHERE pkg_name = :pkgName AND source_repo_url IS NULL")
+    suspend fun backfillSourceRepoUrl(pkgName: String, repoUrl: String)
+
     @Query("UPDATE extensions SET is_enabled = :enabled WHERE pkg_name = :pkgName")
     suspend fun updateEnabled(pkgName: String, enabled: Boolean)
     
@@ -115,7 +129,7 @@ interface ExtensionDao {
 
 @Database(
     entities = [ExtensionEntity::class],
-    version = 3,
+    version = 4,
     exportSchema = false
 )
 abstract class ExtensionDatabase : RoomDatabase() {

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionMapper.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionMapper.kt
@@ -33,7 +33,8 @@ class ExtensionMapper {
             isNsfw = entity.isNsfw,
             installDate = entity.installDate,
             signatureHash = entity.signatureHash,
-            isEnabled = entity.isEnabled
+            isEnabled = entity.isEnabled,
+            repoUrl = entity.sourceRepoUrl
         )
     }
     
@@ -54,7 +55,8 @@ class ExtensionMapper {
             installDate = domain.installDate,
             signatureHash = domain.signatureHash,
             remoteVersionCode = if (domain.hasUpdate) domain.versionCode else null,
-            isEnabled = domain.isEnabled
+            isEnabled = domain.isEnabled,
+            sourceRepoUrl = domain.repoUrl
         )
     }
     

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepositoryImpl.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepositoryImpl.kt
@@ -126,8 +126,30 @@ class ExtensionRepositoryImpl(
             var updateCount = 0
             
             installed.forEach { localExt ->
-                val remoteExt = remoteExtensions.find { it.pkgName == localExt.pkgName }
-                if (remoteExt != null && remoteExt.versionCode > localExt.versionCode) {
+                val candidates = remoteExtensions.filter { it.pkgName == localExt.pkgName }
+                // Provenance guard (#1019): prefer the listing from the repository this
+                // extension was originally installed from. A different repository offering
+                // the same package name must not silently become the update source — that
+                // is the cross-repo replacement attack this guard exists to stop.
+                val sameRepo = candidates.firstOrNull {
+                    localExt.sourceRepoUrl != null && it.repoUrl == localExt.sourceRepoUrl
+                }
+                val remoteExt = sameRepo
+                    ?: candidates.firstOrNull().takeIf { localExt.sourceRepoUrl == null }
+                if (remoteExt == null) {
+                    if (candidates.isNotEmpty()) {
+                        android.util.Log.w(
+                            "ExtensionRepository",
+                            "Skipping update for ${localExt.pkgName}: offered only by " +
+                                "${candidates.mapNotNull { it.repoUrl }} but installed from " +
+                                "${localExt.sourceRepoUrl}"
+                        )
+                    }
+                    return@forEach
+                }
+                // First sighting of a pre-provenance install: adopt this repo as baseline.
+                remoteExt.repoUrl?.let { localDataSource.backfillSourceRepoUrl(localExt.pkgName, it) }
+                if (remoteExt.versionCode > localExt.versionCode) {
                     localDataSource.updateRemoteVersion(localExt.pkgName, remoteExt.versionCode)
                     localDataSource.updateStatus(localExt.pkgName, InstallStatus.HAS_UPDATE.name)
                     updateCount++

--- a/core/extension/src/main/java/app/otakureader/core/extension/di/ExtensionModule.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/di/ExtensionModule.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import app.otakureader.core.extension.BuildConfig
 import app.otakureader.core.extension.data.local.ExtensionDao
 import app.otakureader.core.extension.data.local.ExtensionDatabase
@@ -23,6 +25,13 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
+/** v3 -> v4: repository provenance column (#1019). */
+private val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE extensions ADD COLUMN source_repo_url TEXT DEFAULT NULL")
+    }
+}
+
 @Module
 @InstallIn(SingletonComponent::class)
 object ExtensionModule {
@@ -37,6 +46,7 @@ object ExtensionModule {
             ExtensionDatabase::class.java,
             "extension_database"
         )
+        builder.addMigrations(MIGRATION_3_4)
         // Only allow destructive migration in debug builds to avoid silently wiping
         // extension metadata in production if a migration is missing.
         if (BuildConfig.DEBUG) {


### PR DESCRIPTION
## **User description**
## Summary

Closes #1019 (audit finding R1 — no repository provenance tracking beyond signer identity).

**The threat:** the extension system verified *who signed* an APK but never recorded *which repository* it came from. A second repository could publish `eu.kanade.tachiyomi.extension.en.somesite` with a higher versionCode, and `checkForUpdates()` — which matched installed packages against listings from **all** repos — would offer it as a normal update, silently swapping the extension's source.

**What changed:**
- `ExtensionEntity.source_repo_url` column (extension DB v3 → v4, explicit `ALTER TABLE` migration registered via `addMigrations` — the debug-only destructive fallback is unchanged and production never falls back destructively).
- `ExtensionMapper` now persists `Extension.repoUrl` in both directions. Because `refreshAvailableExtensions()` stamps each AVAILABLE row with its repo and `installExtension()` copies that row, **provenance is recorded at install time with no installer changes**. The Extension Detail Screen's existing repo-URL row now shows it for installed extensions too.
- `checkForUpdates()` provenance guard: update listings are only accepted from the extension's first-seen repository. If a package is offered *only* by a different repo, the update is skipped and logged at WARN with both URLs. Installs that predate the column adopt the first matching repo as their baseline (write-once backfill query).

**Why skip rather than a confirm dialog:** a dialog would still normalize clicking through a supply-chain replacement. Skipping closes the attack path entirely; a user who genuinely wants to switch repos can uninstall and reinstall from the new repo, which records fresh provenance (and trips the signer-hash continuity warning from #1075 if the certificate differs).

## Test plan

- [x] `:core:extension:compileDebugKotlin` + unit tests, `:feature:browse:compileDebugKotlin` green locally
- [ ] Fresh install from repo A → `source_repo_url` populated; detail screen shows repo
- [ ] Same pkg offered by repo B only → no HAS_UPDATE, WARN logged
- [ ] Pre-existing install (null column) → first update check backfills baseline

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Track extensions by the repository they came from and block cross-repo update swaps**

### What Changed
- Installed extensions now keep the repository URL they were first installed from, so their source stays attached to the extension record.
- Existing installs without repository history are filled in the next time updates are checked.
- Update checks now ignore the same package name if it is offered only by a different repository, preventing a silent repository swap through the update path.
- The extension database is updated to store this new source information without wiping existing data.

### Impact
`✅ Prevents silent extension replacement from another repository`
`✅ Safer extension updates`
`✅ Preserves repository source history for installed extensions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
