### PR TITLE
feat: remotely updateable extension blocklist

### DIFF
--- a/app/src/main/java/app/otakureader/MainActivity.kt
+++ b/app/src/main/java/app/otakureader/MainActivity.kt
@@ -129,6 +129,9 @@ class MainActivity : FragmentActivity() {
                     app.otakureader.data.worker.ExtensionAutoUpdateWorker.cancel(applicationContext)
                 }
 
+                // Security mechanism, not a preference — always scheduled (#1018).
+                app.otakureader.data.worker.ExtensionBlocklistRefreshWorker.schedule(applicationContext)
+
                 val autoRefresh = libraryPreferences.autoRefreshOnStart.first()
                 if (autoRefresh) {
                     libraryUpdateScheduler.enqueueNow()

--- a/core/extension/src/main/java/app/otakureader/core/extension/blocklist/ExtensionBlocklist.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/blocklist/ExtensionBlocklist.kt
@@ -1,0 +1,99 @@
+package app.otakureader.core.extension.blocklist
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import app.otakureader.core.extension.data.remote.ExtensionRemoteDataSourceImpl
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * Remotely updateable extension blocklist (#1018).
+ *
+ * A known-bad extension can pass the signer-continuity check (it was signed by the
+ * original key) yet still need revocation — e.g. the key leaked or the source turned
+ * malicious. The blocklist is a signed-repo-hosted JSON document fetched daily by
+ * [app.otakureader.data.worker — ExtensionBlocklistRefreshWorker] and cached in
+ * DataStore so enforcement works offline. The canonical document lives at the
+ * project repository root (`extension-blocklist.json`) and is served over HTTPS
+ * from raw.githubusercontent.com; only project maintainers can change it.
+ */
+@Serializable
+data class BlocklistDocument(
+    val version: Int = 1,
+    val blocked: List<BlockedExtension> = emptyList(),
+)
+
+@Serializable
+data class BlockedExtension(
+    val pkgName: String,
+    val reason: String = "",
+)
+
+/** DataStore-backed cache of the last successfully fetched blocklist. */
+class ExtensionBlocklistStore(private val dataStore: DataStore<Preferences>) {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** Blocked package names mapped to the human-readable block reason. */
+    val blockedPackages: Flow<Map<String, String>> = dataStore.data.map { prefs ->
+        prefs[Keys.BLOCKLIST_JSON]?.let { raw ->
+            runCatching { json.decodeFromString<BlocklistDocument>(raw) }
+                .getOrNull()
+                ?.blocked
+                ?.associate { it.pkgName to it.reason }
+        } ?: emptyMap()
+    }
+
+    val lastFetchedAt: Flow<Long?> = dataStore.data.map { it[Keys.BLOCKLIST_FETCHED_AT] }
+
+    suspend fun replace(document: BlocklistDocument) {
+        dataStore.edit { prefs ->
+            prefs[Keys.BLOCKLIST_JSON] = json.encodeToString(BlocklistDocument.serializer(), document)
+            prefs[Keys.BLOCKLIST_FETCHED_AT] = System.currentTimeMillis()
+        }
+    }
+
+    private object Keys {
+        val BLOCKLIST_JSON = stringPreferencesKey("extension_blocklist_json")
+        val BLOCKLIST_FETCHED_AT = longPreferencesKey("extension_blocklist_fetched_at")
+    }
+}
+
+/** Fetches the blocklist document from the project-controlled HTTPS endpoint. */
+class ExtensionBlocklistFetcher(
+    private val httpClient: OkHttpClient = ExtensionRemoteDataSourceImpl.createDefaultClient(),
+    private val blocklistUrl: String = DEFAULT_BLOCKLIST_URL,
+) {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun fetch(): Result<BlocklistDocument> = withContext(Dispatchers.IO) {
+        runCatching {
+            require(blocklistUrl.startsWith("https://")) { "Blocklist URL must use HTTPS" }
+            val request = Request.Builder().url(blocklistUrl).build()
+            httpClient.newCall(request).execute().use { response ->
+                check(response.isSuccessful) { "Blocklist fetch failed: HTTP ${response.code}" }
+                val body = response.body?.string() ?: error("Empty blocklist response")
+                json.decodeFromString<BlocklistDocument>(body)
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Canonical blocklist location — the file at the repository root on the default
+         * branch. Served over HTTPS; writable only by repository maintainers.
+         */
+        const val DEFAULT_BLOCKLIST_URL =
+            "https://raw.githubusercontent.com/Heartless-Veteran/Otaku-Reader/main/extension-blocklist.json"
+    }
+}

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepositoryImpl.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepositoryImpl.kt
@@ -7,7 +7,9 @@ import app.otakureader.core.extension.domain.model.Extension
 import app.otakureader.core.extension.domain.model.InstallStatus
 import app.otakureader.core.extension.domain.repository.ExtensionRepository
 import app.otakureader.core.extension.loader.ExtensionLoader
+import app.otakureader.core.extension.blocklist.ExtensionBlocklistStore
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -21,6 +23,7 @@ class ExtensionRepositoryImpl(
     private val localDataSource: ExtensionDao,
     private val remoteDataSource: ExtensionRemoteDataSource,
     private val extensionLoader: ExtensionLoader,
+    private val blocklistStore: ExtensionBlocklistStore? = null,
     private val mapper: ExtensionMapper = ExtensionMapper()
 ) : ExtensionRepository {
     
@@ -32,10 +35,15 @@ class ExtensionRepositoryImpl(
     }
     
     override fun getAvailableExtensions(): Flow<List<Extension>> {
-        return localDataSource.getAvailableExtensions()
+        val available = localDataSource.getAvailableExtensions()
             .map { entities ->
                 entities.map { mapper.toDomain(it) }
             }
+        // Blocklist enforcement (#1018): blocked packages never appear as installable.
+        val store = blocklistStore ?: return available
+        return combine(available, store.blockedPackages) { extensions, blocked ->
+            extensions.filter { it.pkgName !in blocked }
+        }
     }
     
     override fun getExtensionsWithUpdates(): Flow<List<Extension>> {
@@ -59,6 +67,15 @@ class ExtensionRepositoryImpl(
     
     override suspend fun installExtension(pkgName: String, apkPath: String): Result<Extension> {
         return try {
+            // Blocklist enforcement (#1018): refuse install even if the caller bypassed
+            // the filtered available list (e.g. a stale UI snapshot).
+            val blockedReason = blocklistStore?.blockedPackages?.first()?.get(pkgName)
+            if (blockedReason != null) {
+                localDataSource.updateStatus(pkgName, InstallStatus.AVAILABLE.name)
+                return Result.failure(
+                    SecurityException("Extension $pkgName is blocklisted: $blockedReason")
+                )
+            }
             // Update status to installing
             localDataSource.updateStatus(pkgName, InstallStatus.INSTALLING.name)
             

--- a/core/extension/src/main/java/app/otakureader/core/extension/di/ExtensionModule.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/di/ExtensionModule.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.room.Room
+import app.otakureader.core.extension.blocklist.ExtensionBlocklistFetcher
+import app.otakureader.core.extension.blocklist.ExtensionBlocklistStore
 import app.otakureader.core.extension.BuildConfig
 import app.otakureader.core.extension.data.local.ExtensionDao
 import app.otakureader.core.extension.data.local.ExtensionDatabase
@@ -72,9 +74,24 @@ object ExtensionModule {
     fun provideExtensionRepository(
         dao: ExtensionDao,
         remoteDataSource: ExtensionRemoteDataSource,
-        loader: ExtensionLoader
+        loader: ExtensionLoader,
+        blocklistStore: ExtensionBlocklistStore
     ): ExtensionRepository {
-        return ExtensionRepositoryImpl(dao, remoteDataSource, loader)
+        return ExtensionRepositoryImpl(dao, remoteDataSource, loader, blocklistStore)
+    }
+
+    @Provides
+    @Singleton
+    fun provideExtensionBlocklistStore(
+        dataStore: DataStore<Preferences>
+    ): ExtensionBlocklistStore {
+        return ExtensionBlocklistStore(dataStore)
+    }
+
+    @Provides
+    @Singleton
+    fun provideExtensionBlocklistFetcher(): ExtensionBlocklistFetcher {
+        return ExtensionBlocklistFetcher()
     }
 
     @Provides

--- a/data/src/main/java/app/otakureader/data/worker/ExtensionBlocklistRefreshWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/ExtensionBlocklistRefreshWorker.kt
@@ -1,0 +1,66 @@
+package app.otakureader.data.worker
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import app.otakureader.core.extension.blocklist.ExtensionBlocklistFetcher
+import app.otakureader.core.extension.blocklist.ExtensionBlocklistStore
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CancellationException
+import java.util.concurrent.TimeUnit
+
+/**
+ * Daily refresh of the remote extension blocklist (#1018).
+ *
+ * Failure is retried by WorkManager; the previously cached list keeps enforcing in
+ * the meantime, so a missed fetch never disables the blocklist. Scheduled
+ * unconditionally from MainActivity — this is a security mechanism, not a user
+ * preference.
+ */
+@HiltWorker
+class ExtensionBlocklistRefreshWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val fetcher: ExtensionBlocklistFetcher,
+    private val store: ExtensionBlocklistStore,
+) : CoroutineWorker(context, workerParams) {
+
+    override suspend fun doWork(): Result {
+        return try {
+            val document = fetcher.fetch().getOrElse { return Result.retry() }
+            store.replace(document)
+            Result.success()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Result.retry()
+        }
+    }
+
+    companion object {
+        private const val WORK_NAME = "extension_blocklist_refresh"
+
+        fun schedule(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+            val request = PeriodicWorkRequestBuilder<ExtensionBlocklistRefreshWorker>(
+                1, TimeUnit.DAYS,
+            )
+                .setConstraints(constraints)
+                .build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request,
+            )
+        }
+    }
+}

--- a/extension-blocklist.json
+++ b/extension-blocklist.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "blocked": []
+}

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
@@ -239,6 +239,7 @@ private fun ExtensionsContent(
                     isLoading = state.isLoading,
                     error = state.error,
                     signerMismatchedPackages = state.signerMismatchedPackages,
+                    blockedPackages = state.blockedPackages,
                     onInstall = { /* Already installed */ },
                     onUninstall = { onEvent(ExtensionsEvent.UninstallExtension(it)) },
                     onUpdate = { onEvent(ExtensionsEvent.UpdateExtension(it)) },
@@ -257,6 +258,7 @@ private fun ExtensionsContent(
                         isLoading = state.isLoading,
                         error = state.error,
                         signerMismatchedPackages = emptySet(),
+                        blockedPackages = state.blockedPackages,
                         onInstall = { onEvent(ExtensionsEvent.InstallExtension(it)) },
                         onUninstall = { /* Not installed */ },
                         onUpdate = { /* No update */ },
@@ -270,6 +272,7 @@ private fun ExtensionsContent(
                     isLoading = state.isLoading,
                     error = state.error,
                     signerMismatchedPackages = state.signerMismatchedPackages,
+                    blockedPackages = state.blockedPackages,
                     onInstall = { /* Already installed */ },
                     onUninstall = { onEvent(ExtensionsEvent.UninstallExtension(it)) },
                     onUpdate = { onEvent(ExtensionsEvent.UpdateExtension(it)) },
@@ -299,6 +302,7 @@ private fun ExtensionsList(
     isLoading: Boolean,
     error: String?,
     signerMismatchedPackages: Set<String>,
+    blockedPackages: Map<String, String> = emptyMap(),
     onInstall: (Extension) -> Unit,
     onUninstall: (Extension) -> Unit,
     onUpdate: (Extension) -> Unit,
@@ -324,6 +328,7 @@ private fun ExtensionsList(
                 ExtensionItem(
                     extension = extension,
                     signerMismatch = extension.pkgName in signerMismatchedPackages,
+                    blockedReason = blockedPackages[extension.pkgName],
                     onInstall = { onInstall(extension) },
                     onUninstall = { onUninstall(extension) },
                     onUpdate = { onUpdate(extension) },
@@ -353,6 +358,7 @@ private fun EmptyExtensionsView(modifier: Modifier = Modifier) {
 private fun ExtensionItem(
     extension: Extension,
     signerMismatch: Boolean,
+    blockedReason: String? = null,
     onInstall: () -> Unit,
     onUninstall: () -> Unit,
     onUpdate: () -> Unit,
@@ -419,6 +425,13 @@ private fun ExtensionItem(
                     if (signerMismatch) {
                         Text(
                             text = stringResource(R.string.extension_signer_mismatch_warning),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                    if (blockedReason != null) {
+                        Text(
+                            text = stringResource(R.string.extension_blocked_warning, blockedReason),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.error,
                         )

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsViewModel.kt
@@ -9,6 +9,7 @@ import app.otakureader.core.common.mvi.UiState
 import app.otakureader.core.extension.domain.model.Extension
 import app.otakureader.core.extension.domain.model.InstallStatus
 import app.otakureader.core.extension.domain.repository.ExtensionRepoRepository
+import app.otakureader.core.extension.blocklist.ExtensionBlocklistStore
 import app.otakureader.core.extension.domain.repository.ExtensionRepository
 import app.otakureader.core.extension.installer.ExtensionInstaller
 import app.otakureader.core.preferences.GeneralPreferences
@@ -48,6 +49,12 @@ data class ExtensionsState(
      * changed after the extension was first installed, which the UI should flag.
      */
     val signerMismatchedPackages: Set<String> = emptySet(),
+    /**
+     * Installed extensions present on the remote blocklist (#1018), mapped to the
+     * block reason. New installs of these packages are refused outright; already
+     * installed copies are flagged in the list so the user can uninstall.
+     */
+    val blockedPackages: Map<String, String> = emptyMap(),
 ) : UiState
 
 enum class SortMode {
@@ -84,7 +91,8 @@ class ExtensionsViewModel @Inject constructor(
     private val extensionInstaller: ExtensionInstaller,
     private val extensionRepoRepository: ExtensionRepoRepository,
     private val extensionManagementRepository: ExtensionManagementRepository,
-    private val generalPreferences: GeneralPreferences
+    private val generalPreferences: GeneralPreferences,
+    private val blocklistStore: ExtensionBlocklistStore
 ) : ViewModel() {
 
     private val _searchQuery = MutableStateFlow("")
@@ -155,6 +163,7 @@ class ExtensionsViewModel @Inject constructor(
             extensionRepoRepository.ensureDefaultRepository()
             loadExtensions()
             observeRepositories()
+            observeBlocklist()
             refreshExtensions()
         }
     }
@@ -323,7 +332,24 @@ class ExtensionsViewModel @Inject constructor(
         }
     }
 
+    private fun observeBlocklist() {
+        viewModelScope.launch {
+            blocklistStore.blockedPackages.collect { blocked ->
+                _state.update { it.copy(blockedPackages = blocked) }
+            }
+        }
+    }
+
     private fun installExtension(extension: Extension) {
+        val blockedReason = _state.value.blockedPackages[extension.pkgName]
+        if (blockedReason != null) {
+            viewModelScope.launch {
+                _effect.send(
+                    ExtensionsEffect.ShowError("Extension is blocklisted: $blockedReason")
+                )
+            }
+            return
+        }
         if (extension.signatureHash == null) {
             _state.update {
                 it.copy(

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -187,4 +187,6 @@
     <string name="extension_has_readme_cd">Has README documentation</string>
     <string name="extension_has_changelog">CHANGELOG</string>
     <string name="extension_has_changelog_cd">Has changelog</string>
+    <!-- Extension blocklist (#1018) -->
+    <string name="extension_blocked_warning">Blocked: %1$s</string>
 </resources>

--- a/feature/browse/src/test/java/app/otakureader/feature/browse/ExtensionsViewModelTest.kt
+++ b/feature/browse/src/test/java/app/otakureader/feature/browse/ExtensionsViewModelTest.kt
@@ -6,6 +6,7 @@ import app.otakureader.core.extension.domain.model.InstallStatus
 import app.otakureader.core.extension.domain.repository.ExtensionRepoRepository
 import app.otakureader.core.extension.domain.repository.ExtensionRepository
 import app.otakureader.core.extension.installer.ExtensionInstaller
+import app.otakureader.core.extension.blocklist.ExtensionBlocklistStore
 import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.domain.repository.ExtensionManagementRepository
 import io.mockk.coEvery
@@ -52,6 +53,7 @@ class ExtensionsViewModelTest {
     private val extensionRepoRepository: ExtensionRepoRepository = mockk(relaxed = true)
     private val extensionManagementRepository: ExtensionManagementRepository = mockk(relaxed = true)
     private val generalPreferences: GeneralPreferences = mockk(relaxed = true)
+    private val blocklistStore: ExtensionBlocklistStore = mockk(relaxed = true)
 
     private val testDispatcher = StandardTestDispatcher()
 
@@ -143,6 +145,7 @@ class ExtensionsViewModelTest {
         // Without explicit stubs the relaxed mock returns an empty Flow and .first() throws,
         // causing the catch block to set error state instead of populating installedExtensions.
         every { generalPreferences.extensionFirstSeenHashes } returns flowOf(emptyMap())
+        every { blocklistStore.blockedPackages } returns flowOf(emptyMap())
         coEvery { generalPreferences.recordExtensionFirstSeenHash(any(), any()) } just Runs
         coEvery { generalPreferences.recordExtensionFirstSeenHashes(any()) } just Runs
 
@@ -151,7 +154,8 @@ class ExtensionsViewModelTest {
             extensionInstaller = extensionInstaller,
             extensionRepoRepository = extensionRepoRepository,
             extensionManagementRepository = extensionManagementRepository,
-            generalPreferences = generalPreferences
+            generalPreferences = generalPreferences,
+            blocklistStore = blocklistStore
         )
         // Subscribe to activate stateIn(WhileSubscribed); will start collecting on first advanceUntilIdle.
         collectScope.launch { viewModel.state.collect { } }
@@ -239,7 +243,8 @@ class ExtensionsViewModelTest {
             extensionInstaller = extensionInstaller,
             extensionRepoRepository = extensionRepoRepository,
             extensionManagementRepository = extensionManagementRepository,
-            generalPreferences = generalPreferences
+            generalPreferences = generalPreferences,
+            blocklistStore = blocklistStore
         )
         // Subscribe so stateIn(WhileSubscribed) starts collecting from the combine.
         backgroundScope.launch { vm.state.collect { } }
@@ -752,7 +757,8 @@ class ExtensionsViewModelTest {
             extensionInstaller = extensionInstaller,
             extensionRepoRepository = extensionRepoRepository,
             extensionManagementRepository = extensionManagementRepository,
-            generalPreferences = generalPreferences
+            generalPreferences = generalPreferences,
+            blocklistStore = blocklistStore
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -772,7 +778,8 @@ class ExtensionsViewModelTest {
             extensionInstaller = extensionInstaller,
             extensionRepoRepository = extensionRepoRepository,
             extensionManagementRepository = extensionManagementRepository,
-            generalPreferences = generalPreferences
+            generalPreferences = generalPreferences,
+            blocklistStore = blocklistStore
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -995,7 +1002,8 @@ class ExtensionsViewModelTest {
             extensionInstaller = extensionInstaller,
             extensionRepoRepository = extensionRepoRepository,
             extensionManagementRepository = extensionManagementRepository,
-            generalPreferences = generalPreferences
+            generalPreferences = generalPreferences,
+            blocklistStore = blocklistStore
         )
         // Use backgroundScope so the infinite collect doesn't block runTest from completing.
         backgroundScope.launch { vm.state.collect { } }
@@ -1031,6 +1039,7 @@ class ExtensionsViewModelTest {
         val hash = "firsthash_112233"
 
         every { generalPreferences.extensionFirstSeenHashes } returns flowOf(emptyMap())
+        every { blocklistStore.blockedPackages } returns flowOf(emptyMap())
 
         val ext = createExtension(pkgName = pkg, signatureHash = hash)
         installedExtensionsFlow.value = listOf(ext)


### PR DESCRIPTION
## **User description**
## Summary

Closes #1018 (audit finding R1 — no revocation/blocklist mechanism).

**The gap:** signer-continuity (#1075) and repo provenance (#1082) verify an extension is *the same software from the same place* — but if the original signing key leaks or a source turns malicious, the "same" extension is the threat, and the only remedy was a full app release.

**What changed:**
- **`extension-blocklist.json`** at the repository root (empty `blocked: []` initially) — the canonical, maintainer-controlled document, fetched over HTTPS from `raw.githubusercontent.com/.../main/extension-blocklist.json`. Entries are `{pkgName, reason}`.
- **`ExtensionBlocklistFetcher` / `ExtensionBlocklistStore`** (`core/extension/blocklist/`) — HTTPS-only fetch (rejects non-HTTPS URLs), kotlinx-serialization parse with `ignoreUnknownKeys` for forward-compat, DataStore cache so enforcement keeps working offline and across fetch failures.
- **`ExtensionBlocklistRefreshWorker`** (`data/worker/`) — daily periodic refresh with network constraint and retry; scheduled unconditionally from `MainActivity` (a security mechanism shouldn't be a toggle).
- **Enforcement at three layers:**
  1. `ExtensionRepositoryImpl.getAvailableExtensions()` filters blocked packages out of the installable list entirely
  2. `installExtension()` refuses blocked packages with a `SecurityException` (defends against stale UI snapshots)
  3. `ExtensionsViewModel` shows an error snackbar on attempted install, and already-installed blocked extensions get a red **"Blocked: \<reason\>"** label so the user can uninstall

**Deferred (noted for follow-up):** detached signature (e.g. Ed25519 verified against a build-time-bundled public key) over the blocklist JSON. Current integrity rests on HTTPS transport plus GitHub repository write access — the same trust level as the app's own releases.

## Test plan

- [x] `:core:extension`, `:data`, `:feature:browse`, `:app` compile + unit tests green locally
- [ ] Add a test entry to the blocklist → after worker run, extension disappears from Available; installed copy shows the Blocked label; install attempt shows error snackbar
- [ ] Airplane mode → cached blocklist still enforces

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Remotely block known-bad extensions and warn users when they are already installed**

### What Changed
- Known-bad extensions are now removed from the installable list and cannot be installed, even if a user opens an outdated screen
- Installed blocked extensions are marked with a clear “Blocked: <reason>” warning so users can remove them
- The app now refreshes the blocklist automatically in the background each day, and keeps using the last saved list if a refresh fails

### Impact
`✅ Faster revocation of unsafe extensions`
`✅ Fewer risky installs from stale screens`
`✅ Clearer uninstall prompts for blocked extensions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
