### PR TITLE
chore: real coverage gates (Kover 0.9.8), F-Droid reproducible flags, ROADMAP cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,11 @@ jobs:
       - name: 🔑 Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: 📊 Verify coverage ≥60% on :domain and :data
-        run: ./gradlew :domain:koverVerify :data:koverVerify --no-daemon
+      - name: 📊 Verify coverage gates (per-module ratchet floors)
+        run: >-
+          ./gradlew :domain:koverVerify :data:koverVerify :core:database:koverVerify
+          :feature:reader:koverVerify :feature:tracking:koverVerify :feature:settings:koverVerify
+          --no-daemon
         env:
           CI: true
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -171,17 +171,17 @@ Mihon/Komikku parity improvements and reader enhancements shipped alongside the 
 
 ---
 
-## 🏗️ Architecture Maintenance (Ongoing)
+## 🏗️ Architecture Maintenance
 
-These are not feature issues but ongoing maintenance tasks:
+Status as of 2026-06-10:
 
-- [ ] F-Droid metadata + reproducible builds
-- [ ] Macrobenchmark module to prevent regressions
-- [ ] Baseline profile re-generation after P0 fixes
-- [ ] `<queries>` element in manifest for Android 11+ package visibility
-- [ ] WorkManager `PendingIntent` mutability flags for API 31+
-- [ ] 8 remaining import-level layer violations (see legacy `AUDIT_ARCHITECTURE.md` in archive)
-- [ ] Kover coverage gates for `:feature:reader`, `:feature:tracking`, `:feature:settings`
+- [x] F-Droid metadata (fastlane) + reproducible-build flags (`dependenciesInfo` disabled in app/build.gradle.kts)
+- [x] Macrobenchmark harness — `StartupBenchmarks`/`PerformanceBenchmarks` in `baselineprofile/`, runnable via benchmark.yml manual dispatch
+- [x] Baseline profile — curated `app/src/main/baseline-prof.txt` shipped (PR #1080); regenerate on-device when startup code changes significantly
+- [x] `<queries>` element in manifest for Android 11+ package visibility
+- [x] WorkManager `PendingIntent` mutability flags for API 31+ (all 5 usages use FLAG_IMMUTABLE)
+- [x] Import-level layer violations — actually 0; enforced by Detekt ForbiddenImport rules (the "8 remaining" note was stale)
+- [x] Kover coverage gates for all of `:domain`, `:data`, `:core:database`, `:feature:reader`, `:feature:tracking`, `:feature:settings` — **note:** Kover 0.8.x could not instrument AGP 9 modules, so the old 60% gates passed vacuously. Kover 0.9.8 now measures for real; gates are honest per-module ratchet floors (domain 60 · data 35 · database 25 · reader 15 · tracking 15 · settings 5). Raise floors as coverage improves; never lower them.
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,14 @@ android {
             applicationIdSuffix = ".debug"
         }
     }
+
+    // F-Droid reproducible builds: the dependency-info block is encrypted with a
+    // Google Play key and makes APKs unreproducible byte-for-byte. F-Droid docs
+    // require it disabled; Play does not need it for non-Play distribution.
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
 }
 
 // CycloneDX v3.x - simplified configuration

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -43,7 +43,8 @@ kover {
     reports {
         verify {
             rule {
-                minBound(60)
+                // Ratchet floor from measured coverage (Kover 0.9.8, 2026-06-10). The previous 60% gate passed vacuously because Kover 0.8.x could not instrument AGP 9 modules. Raise this as coverage improves; never lower it.
+                minBound(25)
             }
         }
     }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -85,7 +85,8 @@ kover {
     reports {
         verify {
             rule {
-                minBound(60)
+                // Ratchet floor from measured coverage (Kover 0.9.8, 2026-06-10). The previous 60% gate passed vacuously because Kover 0.8.x could not instrument AGP 9 modules. Raise this as coverage improves; never lower it.
+                minBound(35)
             }
         }
     }

--- a/feature/reader/build.gradle.kts
+++ b/feature/reader/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.otakureader.android.feature)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.kover)
 }
 
 android {
@@ -37,4 +38,15 @@ dependencies {
     testImplementation(libs.roborazzi.core)
     testImplementation(libs.roborazzi.compose)
     testImplementation(libs.roborazzi.junit)
+}
+
+kover {
+    reports {
+        verify {
+            rule {
+                // Ratchet floor from measured coverage (Kover 0.9.8, 2026-06-10). The previous 60% gate passed vacuously because Kover 0.8.x could not instrument AGP 9 modules. Raise this as coverage improves; never lower it.
+                minBound(15)
+            }
+        }
+    }
 }

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.otakureader.android.feature)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.kover)
 }
 
 android {
@@ -19,4 +20,15 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
+}
+
+kover {
+    reports {
+        verify {
+            rule {
+                // Ratchet floor from measured coverage (Kover 0.9.8, 2026-06-10). The previous 60% gate passed vacuously because Kover 0.8.x could not instrument AGP 9 modules. Raise this as coverage improves; never lower it.
+                minBound(5)
+            }
+        }
+    }
 }

--- a/feature/tracking/build.gradle.kts
+++ b/feature/tracking/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.otakureader.android.feature)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.kover)
 }
 
 android {
@@ -21,4 +22,15 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
+}
+
+kover {
+    reports {
+        verify {
+            rule {
+                // Ratchet floor from measured coverage (Kover 0.9.8, 2026-06-10). The previous 60% gate passed vacuously because Kover 0.8.x could not instrument AGP 9 modules. Raise this as coverage improves; never lower it.
+                minBound(15)
+            }
+        }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -108,7 +108,7 @@ espresso = "3.7.0"
 mockk = "1.14.9"
 turbine = "1.2.1"
 robolectric = "4.16.1"
-kover = "0.8.3"
+kover = "0.9.8"
 
 [libraries]
 # Kotlin


### PR DESCRIPTION
## **User description**
## Summary

Completes the ROADMAP "Architecture Maintenance" checklist. One significant finding inside:

**The coverage gates were fake.** Kover 0.8.3 cannot instrument AGP 9 Android modules — every module's report measured 0/0 lines, so `minBound(60)` passed vacuously and CI's "Coverage Gate (≥60%)" has been green without measuring anything. This PR:

- Bumps Kover to **0.9.8** (instrumentation verified working — `:data` actually measures 39.3% lines, `domain` 64.0%, `feature/reader` 18.5%, `feature/tracking` 20.3%, `feature/settings` 6.3%, `core:database` 27.1%)
- Replaces the aspirational-but-fake 60% gates with **honest ratchet floors** set just under measured coverage: domain 60 · data 35 · database 25 · reader 15 · tracking 15 · settings 5 — each annotated "raise as coverage improves; never lower"
- Adds the three previously-ungated feature modules to CI's `koverVerify` step (job display name kept unchanged in case it's a required status check)

**Also:**
- F-Droid reproducible builds: `dependenciesInfo { includeInApk = false; includeInBundle = false }` — the Play-encrypted dependency blob makes APKs unreproducible byte-for-byte and is useless outside Play distribution. Fastlane metadata already exists.
- ROADMAP maintenance checklist updated to verified reality: `<queries>` element ✅ (already present), PendingIntent flags ✅ (all 5 usages IMMUTABLE), layer violations ✅ (actually 0, enforced by Detekt ForbiddenImport — the "8 remaining" note was stale), macrobenchmark harness ✅ (exists in `baselineprofile/`), baseline profile ✅ (shipped in #1080).

## Test plan

- [x] All six `koverVerify` tasks pass locally at the new floors with real measurement
- [x] `./gradlew :app:assembleDebug` green with `dependenciesInfo` disabled
- [ ] CI coverage job green

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Make coverage checks real and keep Android builds reproducible**

### What Changed
- Coverage checks now run against all six affected modules, including the reader, tracking, settings, and database areas
- The old 60% gates were replaced with lower module-specific floors based on measured coverage, so CI only passes when real test coverage is present
- The app no longer includes Play-only dependency information in release builds, which keeps APKs and bundles reproducible for F-Droid
- The roadmap checklist was updated to reflect what is actually in place today

### Impact
`✅ Real coverage checks in CI`
`✅ Fewer false-green coverage builds`
`✅ Reproducible F-Droid release builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality verification infrastructure to enforce coverage metrics across all application modules.
  * Upgraded code coverage tooling and enabled measurement for additional features.
  * Enhanced build configuration to support reproducible builds.
  * Refined CI workflow to enforce consistent quality standards across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->