### PR TITLE
feat(#1053): cross-source duplicate merge workflow

### DIFF
--- a/core/database/schemas/app.otakureader.core.database.OtakuReaderDatabase/36.json
+++ b/core/database/schemas/app.otakureader.core.database.OtakuReaderDatabase/36.json
@@ -1,0 +1,2008 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 36,
+    "identityHash": "18062e83f135db90071f8d5b871767e4",
+    "entities": [
+      {
+        "tableName": "manga",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `thumbnailUrl` TEXT, `author` TEXT, `artist` TEXT, `description` TEXT, `genre` TEXT, `status` INTEGER NOT NULL, `favorite` INTEGER NOT NULL, `lastUpdate` INTEGER NOT NULL, `initialized` INTEGER NOT NULL, `viewerFlags` INTEGER NOT NULL, `chapterFlags` INTEGER NOT NULL, `coverLastModified` INTEGER NOT NULL, `dateAdded` INTEGER NOT NULL, `autoDownload` INTEGER NOT NULL, `notes` TEXT, `notifyNewChapters` INTEGER NOT NULL, `readerDirection` INTEGER, `readerMode` INTEGER, `readerColorFilter` INTEGER, `readerCustomTintColor` INTEGER, `readerBackgroundColor` INTEGER, `preloadPagesBefore` INTEGER, `preloadPagesAfter` INTEGER, `contentRating` INTEGER NOT NULL, `userCompleted` INTEGER NOT NULL, `userDropped` INTEGER NOT NULL, `mangaThemeOverride` INTEGER, `userTitle` TEXT, `userDescription` TEXT, `userAuthor` TEXT, `userArtist` TEXT, `userThumbnailUrl` TEXT, `userGenre` TEXT, `userStatus` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdate",
+            "columnName": "lastUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "initialized",
+            "columnName": "initialized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewerFlags",
+            "columnName": "viewerFlags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterFlags",
+            "columnName": "chapterFlags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverLastModified",
+            "columnName": "coverLastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "dateAdded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownload",
+            "columnName": "autoDownload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notifyNewChapters",
+            "columnName": "notifyNewChapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readerDirection",
+            "columnName": "readerDirection",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerMode",
+            "columnName": "readerMode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerColorFilter",
+            "columnName": "readerColorFilter",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerCustomTintColor",
+            "columnName": "readerCustomTintColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerBackgroundColor",
+            "columnName": "readerBackgroundColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "preloadPagesBefore",
+            "columnName": "preloadPagesBefore",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "preloadPagesAfter",
+            "columnName": "preloadPagesAfter",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "contentRating",
+            "columnName": "contentRating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userCompleted",
+            "columnName": "userCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDropped",
+            "columnName": "userDropped",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaThemeOverride",
+            "columnName": "mangaThemeOverride",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "userTitle",
+            "columnName": "userTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userDescription",
+            "columnName": "userDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userAuthor",
+            "columnName": "userAuthor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userArtist",
+            "columnName": "userArtist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userThumbnailUrl",
+            "columnName": "userThumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userGenre",
+            "columnName": "userGenre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userStatus",
+            "columnName": "userStatus",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_manga_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_manga_title",
+            "unique": false,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_title` ON `${TABLE_NAME}` (`title`)"
+          },
+          {
+            "name": "index_manga_favorite",
+            "unique": false,
+            "columnNames": [
+              "favorite"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_favorite` ON `${TABLE_NAME}` (`favorite`)"
+          },
+          {
+            "name": "index_manga_sourceId_url",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_manga_sourceId_url` ON `${TABLE_NAME}` (`sourceId`, `url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mangaId` INTEGER NOT NULL, `url` TEXT NOT NULL, `name` TEXT NOT NULL, `scanlator` TEXT, `read` INTEGER NOT NULL, `bookmark` INTEGER NOT NULL, `lastPageRead` INTEGER NOT NULL, `chapterNumber` REAL NOT NULL, `sourceOrder` INTEGER NOT NULL, `dateFetch` INTEGER NOT NULL, `dateUpload` INTEGER NOT NULL, `lastModified` INTEGER NOT NULL, `userNotes` TEXT, FOREIGN KEY(`mangaId`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scanlator",
+            "columnName": "scanlator",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmark",
+            "columnName": "bookmark",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPageRead",
+            "columnName": "lastPageRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterNumber",
+            "columnName": "chapterNumber",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceOrder",
+            "columnName": "sourceOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateFetch",
+            "columnName": "dateFetch",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateUpload",
+            "columnName": "dateUpload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userNotes",
+            "columnName": "userNotes",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapters_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          },
+          {
+            "name": "index_chapters_mangaId_url",
+            "unique": true,
+            "columnNames": [
+              "mangaId",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chapters_mangaId_url` ON `${TABLE_NAME}` (`mangaId`, `url`)"
+          },
+          {
+            "name": "index_chapters_read",
+            "unique": false,
+            "columnNames": [
+              "read"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_read` ON `${TABLE_NAME}` (`read`)"
+          },
+          {
+            "name": "index_chapters_bookmark",
+            "unique": false,
+            "columnNames": [
+              "bookmark"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_bookmark` ON `${TABLE_NAME}` (`bookmark`)"
+          },
+          {
+            "name": "index_chapters_dateFetch",
+            "unique": false,
+            "columnNames": [
+              "dateFetch"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_dateFetch` ON `${TABLE_NAME}` (`dateFetch`)"
+          },
+          {
+            "name": "index_chapters_mangaId_dateFetch",
+            "unique": false,
+            "columnNames": [
+              "mangaId",
+              "dateFetch"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_mangaId_dateFetch` ON `${TABLE_NAME}` (`mangaId`, `dateFetch`)"
+          },
+          {
+            "name": "index_chapters_mangaId_read_sourceOrder",
+            "unique": false,
+            "columnNames": [
+              "mangaId",
+              "read",
+              "sourceOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_mangaId_read_sourceOrder` ON `${TABLE_NAME}` (`mangaId`, `read`, `sourceOrder`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mangaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `order` INTEGER NOT NULL, `flags` INTEGER NOT NULL, `update_frequency` INTEGER NOT NULL, `lock_type` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "flags",
+            "columnName": "flags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateFrequency",
+            "columnName": "update_frequency",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lockType",
+            "columnName": "lock_type",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "manga_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mangaId` INTEGER NOT NULL, `categoryId` INTEGER NOT NULL, PRIMARY KEY(`mangaId`, `categoryId`), FOREIGN KEY(`mangaId`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`categoryId`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "mangaId",
+            "categoryId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_manga_categories_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_categories_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          },
+          {
+            "name": "index_manga_categories_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_categories_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mangaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "categories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "categoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reading_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `chapter_id` INTEGER NOT NULL, `read_at` INTEGER NOT NULL, `read_duration_ms` INTEGER NOT NULL, FOREIGN KEY(`chapter_id`) REFERENCES `chapters`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readAt",
+            "columnName": "read_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readDurationMs",
+            "columnName": "read_duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_history_chapter_id",
+            "unique": true,
+            "columnNames": [
+              "chapter_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_reading_history_chapter_id` ON `${TABLE_NAME}` (`chapter_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chapters",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapter_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reading_streaks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `chapter_count` INTEGER NOT NULL, `read_duration_ms` INTEGER NOT NULL, `last_read_at` INTEGER NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterCount",
+            "columnName": "chapter_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readDurationMs",
+            "columnName": "read_duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadAt",
+            "columnName": "last_read_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        }
+      },
+      {
+        "tableName": "opds_servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_opds_servers_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_opds_servers_url` ON `${TABLE_NAME}` (`url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mangaId` INTEGER NOT NULL, `mangaTitle` TEXT NOT NULL, `mangaThumbnailUrl` TEXT, `chapterId` INTEGER NOT NULL, `chapterName` TEXT NOT NULL, `chapterNumber` REAL NOT NULL, `sourceId` INTEGER NOT NULL, `sourceName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `isRead` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaTitle",
+            "columnName": "mangaTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaThumbnailUrl",
+            "columnName": "mangaThumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterName",
+            "columnName": "chapterName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterNumber",
+            "columnName": "chapterNumber",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "sourceName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_feed_items_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_feed_items_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `sourceName` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `itemCount` INTEGER NOT NULL, `order` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "sourceName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_sources_sourceId",
+            "unique": true,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_feed_sources_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_saved_searches",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `sourceName` TEXT NOT NULL, `query` TEXT NOT NULL, `filtersJson` TEXT, `order` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "sourceName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filtersJson",
+            "columnName": "filtersJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_saved_searches_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_saved_searches_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tracker_sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mangaId` INTEGER NOT NULL, `trackerId` INTEGER NOT NULL, `remoteId` TEXT NOT NULL, `localLastChapterRead` REAL NOT NULL, `localTotalChapters` INTEGER NOT NULL, `localStatus` INTEGER NOT NULL, `localLastModified` INTEGER NOT NULL, `remoteLastChapterRead` REAL NOT NULL, `remoteTotalChapters` INTEGER NOT NULL, `remoteStatus` INTEGER NOT NULL, `remoteLastModified` INTEGER, `syncStatus` INTEGER NOT NULL, `lastSyncAttempt` INTEGER, `lastSuccessfulSync` INTEGER, `syncError` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerId",
+            "columnName": "trackerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localLastChapterRead",
+            "columnName": "localLastChapterRead",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localTotalChapters",
+            "columnName": "localTotalChapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localStatus",
+            "columnName": "localStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localLastModified",
+            "columnName": "localLastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteLastChapterRead",
+            "columnName": "remoteLastChapterRead",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteTotalChapters",
+            "columnName": "remoteTotalChapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteStatus",
+            "columnName": "remoteStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteLastModified",
+            "columnName": "remoteLastModified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncAttempt",
+            "columnName": "lastSyncAttempt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastSuccessfulSync",
+            "columnName": "lastSuccessfulSync",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncError",
+            "columnName": "syncError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tracker_sync_state_mangaId_trackerId",
+            "unique": true,
+            "columnNames": [
+              "mangaId",
+              "trackerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tracker_sync_state_mangaId_trackerId` ON `${TABLE_NAME}` (`mangaId`, `trackerId`)"
+          },
+          {
+            "name": "index_tracker_sync_state_syncStatus",
+            "unique": false,
+            "columnNames": [
+              "syncStatus"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracker_sync_state_syncStatus` ON `${TABLE_NAME}` (`syncStatus`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_configuration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackerId` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `syncDirection` INTEGER NOT NULL, `conflictResolution` INTEGER NOT NULL, `autoSyncInterval` INTEGER NOT NULL, `syncOnChapterRead` INTEGER NOT NULL, `syncOnMarkComplete` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerId",
+            "columnName": "trackerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncDirection",
+            "columnName": "syncDirection",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conflictResolution",
+            "columnName": "conflictResolution",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoSyncInterval",
+            "columnName": "autoSyncInterval",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncOnChapterRead",
+            "columnName": "syncOnChapterRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncOnMarkComplete",
+            "columnName": "syncOnMarkComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_configuration_trackerId",
+            "unique": true,
+            "columnNames": [
+              "trackerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_configuration_trackerId` ON `${TABLE_NAME}` (`trackerId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "page_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `manga_id` INTEGER NOT NULL, `chapter_id` INTEGER NOT NULL, `page_index` INTEGER NOT NULL, `note` TEXT, `created_at` INTEGER NOT NULL, FOREIGN KEY(`chapter_id`) REFERENCES `chapters`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`manga_id`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageIndex",
+            "columnName": "page_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_page_bookmarks_chapter_id",
+            "unique": false,
+            "columnNames": [
+              "chapter_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_bookmarks_chapter_id` ON `${TABLE_NAME}` (`chapter_id`)"
+          },
+          {
+            "name": "index_page_bookmarks_manga_id",
+            "unique": false,
+            "columnNames": [
+              "manga_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_bookmarks_manga_id` ON `${TABLE_NAME}` (`manga_id`)"
+          },
+          {
+            "name": "index_page_bookmarks_manga_id_created_at",
+            "unique": false,
+            "columnNames": [
+              "manga_id",
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_bookmarks_manga_id_created_at` ON `${TABLE_NAME}` (`manga_id`, `created_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chapters",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapter_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "manga_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reading_lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `color` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`listId` INTEGER NOT NULL, `mangaId` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, `note` TEXT, PRIMARY KEY(`listId`, `mangaId`), FOREIGN KEY(`listId`) REFERENCES `reading_lists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`mangaId`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "listId",
+            "mangaId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_list_items_listId",
+            "unique": false,
+            "columnNames": [
+              "listId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_list_items_listId` ON `${TABLE_NAME}` (`listId`)"
+          },
+          {
+            "name": "index_reading_list_items_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_list_items_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          },
+          {
+            "name": "index_reading_list_items_listId_addedAt",
+            "unique": false,
+            "columnNames": [
+              "listId",
+              "addedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_list_items_listId_addedAt` ON `${TABLE_NAME}` (`listId`, `addedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "reading_lists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mangaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "download_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chapter_id` INTEGER NOT NULL, `manga_id` INTEGER NOT NULL, `manga_title` TEXT NOT NULL, `chapter_title` TEXT NOT NULL, `source_name` TEXT NOT NULL, `page_urls_json` TEXT NOT NULL, `priority` INTEGER NOT NULL DEFAULT 1, `status` TEXT NOT NULL DEFAULT 'QUEUED', `added_at` INTEGER NOT NULL, `bytesDownloaded` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`chapter_id`))",
+        "fields": [
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaTitle",
+            "columnName": "manga_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterTitle",
+            "columnName": "chapter_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "source_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageUrlsJson",
+            "columnName": "page_urls_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'QUEUED'"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bytesDownloaded",
+            "columnName": "bytesDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chapter_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_queue_manga_id_status",
+            "unique": false,
+            "columnNames": [
+              "manga_id",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_queue_manga_id_status` ON `${TABLE_NAME}` (`manga_id`, `status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "track_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `manga_id` INTEGER NOT NULL, `tracker_id` INTEGER NOT NULL, `remote_id` INTEGER NOT NULL, `remote_url` TEXT NOT NULL, `title` TEXT NOT NULL, `status` INTEGER NOT NULL, `last_chapter_read` REAL NOT NULL, `total_chapters` INTEGER NOT NULL, `score` REAL NOT NULL, `start_date` INTEGER NOT NULL, `finish_date` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerId",
+            "columnName": "tracker_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteUrl",
+            "columnName": "remote_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChapterRead",
+            "columnName": "last_chapter_read",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalChapters",
+            "columnName": "total_chapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishDate",
+            "columnName": "finish_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_entries_manga_id",
+            "unique": false,
+            "columnNames": [
+              "manga_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_entries_manga_id` ON `${TABLE_NAME}` (`manga_id`)"
+          },
+          {
+            "name": "index_track_entries_tracker_id",
+            "unique": false,
+            "columnNames": [
+              "tracker_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_entries_tracker_id` ON `${TABLE_NAME}` (`tracker_id`)"
+          },
+          {
+            "name": "index_track_entries_manga_id_tracker_id",
+            "unique": true,
+            "columnNames": [
+              "manga_id",
+              "tracker_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_track_entries_manga_id_tracker_id` ON `${TABLE_NAME}` (`manga_id`, `tracker_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "dynamic_category_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `category_id` INTEGER NOT NULL, `rule_type` TEXT NOT NULL, `rule_params_json` TEXT NOT NULL, FOREIGN KEY(`category_id`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleType",
+            "columnName": "rule_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleParamsJson",
+            "columnName": "rule_params_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_dynamic_category_rules_category_id",
+            "unique": false,
+            "columnNames": [
+              "category_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dynamic_category_rules_category_id` ON `${TABLE_NAME}` (`category_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "categories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "category_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "manga_feature_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mangaId` INTEGER NOT NULL, `title` TEXT NOT NULL, `thumbnailUrl` TEXT, `sourceId` INTEGER NOT NULL, `genresJson` TEXT NOT NULL, `score` REAL NOT NULL, `lastComputed` INTEGER NOT NULL, PRIMARY KEY(`mangaId`))",
+        "fields": [
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genresJson",
+            "columnName": "genresJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastComputed",
+            "columnName": "lastComputed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "mangaId"
+          ]
+        }
+      },
+      {
+        "tableName": "achievements",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `definitionKey` TEXT NOT NULL, `unlockedAt` INTEGER NOT NULL, `progress` INTEGER NOT NULL, `target` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definitionKey",
+            "columnName": "definitionKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unlockedAt",
+            "columnName": "unlockedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target",
+            "columnName": "target",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "data_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `category` TEXT NOT NULL, `network` TEXT NOT NULL, `bytes` INTEGER NOT NULL, PRIMARY KEY(`date`, `category`, `network`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "network",
+            "columnName": "network",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bytes",
+            "columnName": "bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date",
+            "category",
+            "network"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `chapterId` INTEGER NOT NULL, `mangaId` INTEGER NOT NULL, `payload` TEXT NOT NULL, `attempts` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL, `lastError` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "lastError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_queue_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_queue_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "manga_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `author` TEXT, `artist` TEXT, tokenize=unicode61, content=`manga`)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "manga",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_manga_fts_BEFORE_UPDATE BEFORE UPDATE ON `manga` BEGIN DELETE FROM `manga_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_manga_fts_BEFORE_DELETE BEFORE DELETE ON `manga` BEGIN DELETE FROM `manga_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_manga_fts_AFTER_UPDATE AFTER UPDATE ON `manga` BEGIN INSERT INTO `manga_fts`(`docid`, `title`, `author`, `artist`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`author`, NEW.`artist`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_manga_fts_AFTER_INSERT AFTER INSERT ON `manga` BEGIN INSERT INTO `manga_fts`(`docid`, `title`, `author`, `artist`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`author`, NEW.`artist`); END"
+        ]
+      },
+      {
+        "tableName": "update_run_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `checkedCount` INTEGER NOT NULL, `newChaptersCount` INTEGER NOT NULL, `skippedCount` INTEGER NOT NULL, `failedCount` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checkedCount",
+            "columnName": "checkedCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newChaptersCount",
+            "columnName": "newChaptersCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skippedCount",
+            "columnName": "skippedCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failedCount",
+            "columnName": "failedCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "manga_alternative_source",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `manga_id` INTEGER NOT NULL, `alt_manga_id` INTEGER NOT NULL, FOREIGN KEY(`manga_id`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`alt_manga_id`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "altMangaId",
+            "columnName": "alt_manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_manga_alternative_source_manga_id",
+            "unique": false,
+            "columnNames": [
+              "manga_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_alternative_source_manga_id` ON `${TABLE_NAME}` (`manga_id`)"
+          },
+          {
+            "name": "index_manga_alternative_source_alt_manga_id",
+            "unique": false,
+            "columnNames": [
+              "alt_manga_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_alternative_source_alt_manga_id` ON `${TABLE_NAME}` (`alt_manga_id`)"
+          },
+          {
+            "name": "index_manga_alternative_source_manga_id_alt_manga_id",
+            "unique": true,
+            "columnNames": [
+              "manga_id",
+              "alt_manga_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_manga_alternative_source_manga_id_alt_manga_id` ON `${TABLE_NAME}` (`manga_id`, `alt_manga_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "manga_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "alt_manga_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '18062e83f135db90071f8d5b871767e4')"
+    ]
+  }
+}

--- a/core/database/src/main/java/app/otakureader/core/database/OtakuReaderDatabase.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/OtakuReaderDatabase.kt
@@ -22,7 +22,9 @@ import app.otakureader.core.database.dao.SyncQueueDao
 import app.otakureader.core.database.dao.TrackEntryDao
 import app.otakureader.core.database.dao.TrackerSyncDao
 import app.otakureader.core.database.dao.UpdateRunSummaryDao
+import app.otakureader.core.database.dao.MangaAlternativeSourceDao
 import app.otakureader.core.database.entity.AchievementEntity
+import app.otakureader.core.database.entity.MangaAlternativeSourceEntity
 import app.otakureader.core.database.entity.CategoryEntity
 import app.otakureader.core.database.entity.ChapterEntity
 import app.otakureader.core.database.entity.DataUsageEntity
@@ -86,8 +88,10 @@ import app.otakureader.core.database.entity.UpdateRunSummaryEntity
         MangaFtsEntity::class,
         // Library update run history diagnostics (#1041)
         UpdateRunSummaryEntity::class,
+        // Alternative-source linking for cross-source duplicate merge (#1053)
+        MangaAlternativeSourceEntity::class,
     ],
-    version = 35,
+    version = 36,
     exportSchema = true
 )
 @TypeConverters(DatabaseConverters::class)
@@ -113,6 +117,7 @@ abstract class OtakuReaderDatabase : RoomDatabase() {
     abstract fun dataUsageDao(): DataUsageDao
     abstract fun syncQueueDao(): SyncQueueDao
     abstract fun updateRunSummaryDao(): UpdateRunSummaryDao
+    abstract fun mangaAlternativeSourceDao(): MangaAlternativeSourceDao
 
     companion object {
         const val DATABASE_NAME = "otakureader.db"

--- a/core/database/src/main/java/app/otakureader/core/database/dao/MangaAlternativeSourceDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/MangaAlternativeSourceDao.kt
@@ -1,0 +1,27 @@
+package app.otakureader.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import app.otakureader.core.database.entity.MangaAlternativeSourceEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface MangaAlternativeSourceDao {
+
+    @Query("SELECT * FROM manga_alternative_source WHERE manga_id = :mangaId OR alt_manga_id = :mangaId")
+    fun getAlternativesForManga(mangaId: Long): Flow<List<MangaAlternativeSourceEntity>>
+
+    @Query("SELECT alt_manga_id FROM manga_alternative_source WHERE manga_id = :mangaId UNION SELECT manga_id FROM manga_alternative_source WHERE alt_manga_id = :mangaId")
+    suspend fun getAlternativeIdsForMangaSync(mangaId: Long): List<Long>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(entity: MangaAlternativeSourceEntity)
+
+    @Query("DELETE FROM manga_alternative_source WHERE (manga_id = :mangaId AND alt_manga_id = :altMangaId) OR (manga_id = :altMangaId AND alt_manga_id = :mangaId)")
+    suspend fun unlink(mangaId: Long, altMangaId: Long)
+
+    @Query("SELECT EXISTS(SELECT 1 FROM manga_alternative_source WHERE (manga_id = :mangaId AND alt_manga_id = :altMangaId) OR (manga_id = :altMangaId AND alt_manga_id = :mangaId))")
+    suspend fun areLinked(mangaId: Long, altMangaId: Long): Boolean
+}

--- a/core/database/src/main/java/app/otakureader/core/database/dao/MangaAlternativeSourceDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/MangaAlternativeSourceDao.kt
@@ -13,15 +13,35 @@ interface MangaAlternativeSourceDao {
     @Query("SELECT * FROM manga_alternative_source WHERE manga_id = :mangaId OR alt_manga_id = :mangaId")
     fun getAlternativesForManga(mangaId: Long): Flow<List<MangaAlternativeSourceEntity>>
 
-    @Query("SELECT alt_manga_id FROM manga_alternative_source WHERE manga_id = :mangaId UNION SELECT manga_id FROM manga_alternative_source WHERE alt_manga_id = :mangaId")
+    @Query(
+        """
+        SELECT alt_manga_id FROM manga_alternative_source WHERE manga_id = :mangaId
+        UNION
+        SELECT manga_id FROM manga_alternative_source WHERE alt_manga_id = :mangaId
+        """,
+    )
     suspend fun getAlternativeIdsForMangaSync(mangaId: Long): List<Long>
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(entity: MangaAlternativeSourceEntity)
 
-    @Query("DELETE FROM manga_alternative_source WHERE (manga_id = :mangaId AND alt_manga_id = :altMangaId) OR (manga_id = :altMangaId AND alt_manga_id = :mangaId)")
+    @Query(
+        """
+        DELETE FROM manga_alternative_source
+        WHERE (manga_id = :mangaId AND alt_manga_id = :altMangaId)
+           OR (manga_id = :altMangaId AND alt_manga_id = :mangaId)
+        """,
+    )
     suspend fun unlink(mangaId: Long, altMangaId: Long)
 
-    @Query("SELECT EXISTS(SELECT 1 FROM manga_alternative_source WHERE (manga_id = :mangaId AND alt_manga_id = :altMangaId) OR (manga_id = :altMangaId AND alt_manga_id = :mangaId))")
+    @Query(
+        """
+        SELECT EXISTS(
+            SELECT 1 FROM manga_alternative_source
+            WHERE (manga_id = :mangaId AND alt_manga_id = :altMangaId)
+               OR (manga_id = :altMangaId AND alt_manga_id = :mangaId)
+        )
+        """,
+    )
     suspend fun areLinked(mangaId: Long, altMangaId: Long): Boolean
 }

--- a/core/database/src/main/java/app/otakureader/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/di/DatabaseModule.kt
@@ -103,4 +103,7 @@ object DatabaseModule {
 
     @Provides
     fun provideUpdateRunSummaryDao(database: OtakuReaderDatabase): UpdateRunSummaryDao = database.updateRunSummaryDao()
+
+    @Provides
+    fun provideMangaAlternativeSourceDao(database: OtakuReaderDatabase): app.otakureader.core.database.dao.MangaAlternativeSourceDao = database.mangaAlternativeSourceDao()
 }

--- a/core/database/src/main/java/app/otakureader/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/di/DatabaseModule.kt
@@ -8,6 +8,7 @@ import app.otakureader.core.database.OtakuReaderDatabase
 import app.otakureader.core.database.dao.AchievementDao
 import app.otakureader.core.database.dao.DataUsageDao
 import app.otakureader.core.database.dao.DownloadQueueDao
+import app.otakureader.core.database.dao.MangaAlternativeSourceDao
 import app.otakureader.core.database.dao.SyncQueueDao
 import app.otakureader.core.database.dao.TrackEntryDao
 import app.otakureader.core.database.dao.UpdateRunSummaryDao
@@ -105,5 +106,7 @@ object DatabaseModule {
     fun provideUpdateRunSummaryDao(database: OtakuReaderDatabase): UpdateRunSummaryDao = database.updateRunSummaryDao()
 
     @Provides
-    fun provideMangaAlternativeSourceDao(database: OtakuReaderDatabase): app.otakureader.core.database.dao.MangaAlternativeSourceDao = database.mangaAlternativeSourceDao()
+    fun provideMangaAlternativeSourceDao(
+        database: OtakuReaderDatabase,
+    ): MangaAlternativeSourceDao = database.mangaAlternativeSourceDao()
 }

--- a/core/database/src/main/java/app/otakureader/core/database/entity/MangaAlternativeSourceEntity.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/entity/MangaAlternativeSourceEntity.kt
@@ -1,0 +1,43 @@
+package app.otakureader.core.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Persistent link between two library manga entries that represent the same series
+ * from different sources (e.g. MangaDex vs. MangaPlus). Used by
+ * LinkAlternativeSourceUseCase and FillMissingChaptersUseCase (#1053).
+ *
+ * The relationship is symmetric: (A, B) and (B, A) are the same link.
+ * The caller stores one row and queries using OR on both columns.
+ */
+@Entity(
+    tableName = "manga_alternative_source",
+    foreignKeys = [
+        ForeignKey(
+            entity = MangaEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["manga_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+        ForeignKey(
+            entity = MangaEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["alt_manga_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        Index("manga_id"),
+        Index("alt_manga_id"),
+        Index(value = ["manga_id", "alt_manga_id"], unique = true),
+    ],
+)
+data class MangaAlternativeSourceEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @ColumnInfo(name = "manga_id") val mangaId: Long,
+    @ColumnInfo(name = "alt_manga_id") val altMangaId: Long,
+)

--- a/core/database/src/main/java/app/otakureader/core/database/migrations/DatabaseMigrations.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/migrations/DatabaseMigrations.kt
@@ -442,9 +442,9 @@ internal val MIGRATION_35_36 = object : Migration(35, 36) {
             )
             """.trimIndent(),
         )
-        db.execSQL("CREATE INDEX IF NOT EXISTS idx_mas_manga_id ON manga_alternative_source(manga_id)")
-        db.execSQL("CREATE INDEX IF NOT EXISTS idx_mas_alt_manga_id ON manga_alternative_source(alt_manga_id)")
-        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS idx_mas_pair ON manga_alternative_source(manga_id, alt_manga_id)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_manga_alternative_source_manga_id ON manga_alternative_source(manga_id)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_manga_alternative_source_alt_manga_id ON manga_alternative_source(alt_manga_id)")
+        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_manga_alternative_source_manga_id_alt_manga_id ON manga_alternative_source(manga_id, alt_manga_id)")
     }
 }
 

--- a/core/database/src/main/java/app/otakureader/core/database/migrations/DatabaseMigrations.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/migrations/DatabaseMigrations.kt
@@ -428,6 +428,26 @@ internal val MIGRATION_34_35 = object : Migration(34, 35) {
     }
 }
 
+/** v35 → v36: Manga alternative-source linking table (#1053). */
+internal val MIGRATION_35_36 = object : Migration(35, 36) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS manga_alternative_source (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                manga_id INTEGER NOT NULL,
+                alt_manga_id INTEGER NOT NULL,
+                FOREIGN KEY (manga_id) REFERENCES manga(id) ON DELETE CASCADE,
+                FOREIGN KEY (alt_manga_id) REFERENCES manga(id) ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS idx_mas_manga_id ON manga_alternative_source(manga_id)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS idx_mas_alt_manga_id ON manga_alternative_source(alt_manga_id)")
+        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS idx_mas_pair ON manga_alternative_source(manga_id, alt_manga_id)")
+    }
+}
+
 /** All migrations in order, for use in [Room.databaseBuilder] and migration tests. */
 internal val ALL_MIGRATIONS = arrayOf(
     MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6,
@@ -437,5 +457,6 @@ internal val ALL_MIGRATIONS = arrayOf(
     MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
     MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
     MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30, MIGRATION_30_31,
-    MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35
+    MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35,
+    MIGRATION_35_36,
 )

--- a/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
+++ b/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
@@ -26,6 +26,7 @@ import app.otakureader.core.database.migrations.MIGRATION_28_29
 import app.otakureader.core.database.migrations.MIGRATION_29_30
 import app.otakureader.core.database.migrations.MIGRATION_30_31
 import app.otakureader.core.database.migrations.MIGRATION_31_32
+import app.otakureader.core.database.migrations.MIGRATION_35_36
 import app.otakureader.core.database.migrations.MIGRATION_9_10
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -51,7 +52,7 @@ class DatabaseMigrationTest {
     fun allMigrations_formsContiguousChain() {
         val sorted = ALL_MIGRATIONS.sortedBy { it.startVersion }
         assertEquals("Migration chain must start at version 2", 2, sorted.first().startVersion)
-        assertEquals("Migration chain must end at version 35", 35, sorted.last().endVersion)
+        assertEquals("Migration chain must end at version 36", 36, sorted.last().endVersion)
 
         for (i in 0 until sorted.size - 1) {
             val current = sorted[i]
@@ -78,7 +79,7 @@ class DatabaseMigrationTest {
 
     @Test
     fun allMigrations_count() {
-        assertEquals("Expected 33 migrations (v2→v35)", 33, ALL_MIGRATIONS.size)
+        assertEquals("Expected 34 migrations (v2→v36)", 34, ALL_MIGRATIONS.size)
     }
 
     // ── Migration 9 → 10 ────────────────────────────────────────────────────
@@ -641,6 +642,52 @@ class DatabaseMigrationTest {
         assertTrue(cursor.moveToFirst())
         assertEquals("data_usage must have one row after insert", 1, cursor.getInt(0))
         cursor.close()
+        db.close()
+    }
+
+    // ── Migration 35 → 36 ───────────────────────────────────────────────────
+    // Adds: manga_alternative_source table with indices for cross-source merge (#1053)
+
+    @Test
+    fun migration35To36_createsMangaAlternativeSourceTable() {
+        helper.createDatabase(TEST_DB, 35).close()
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 36, true, MIGRATION_35_36)
+        assertTrue(
+            "manga_alternative_source must exist after 35→36",
+            "manga_alternative_source" in db.tableNames(),
+        )
+        val cols = db.columnNames("manga_alternative_source")
+        assertTrue("manga_id must exist", "manga_id" in cols)
+        assertTrue("alt_manga_id must exist", "alt_manga_id" in cols)
+        val indexes = db.indexNames("manga_alternative_source")
+        assertTrue(
+            "index_manga_alternative_source_manga_id must exist",
+            "index_manga_alternative_source_manga_id" in indexes,
+        )
+        assertTrue(
+            "index_manga_alternative_source_alt_manga_id must exist",
+            "index_manga_alternative_source_alt_manga_id" in indexes,
+        )
+        assertTrue(
+            "index_manga_alternative_source_manga_id_alt_manga_id (unique) must exist",
+            "index_manga_alternative_source_manga_id_alt_manga_id" in indexes,
+        )
+        db.close()
+    }
+
+    @Test
+    fun migration35To36_uniqueConstraintOnMangaIdAltMangaId() {
+        helper.createDatabase(TEST_DB, 35).close()
+        val db = helper.runMigrationsAndValidate(TEST_DB, 36, true, MIGRATION_35_36)
+        db.execSQL("INSERT INTO manga_alternative_source (manga_id, alt_manga_id) VALUES (1, 2)")
+        var threw = false
+        try {
+            db.execSQL("INSERT INTO manga_alternative_source (manga_id, alt_manga_id) VALUES (1, 2)")
+        } catch (_: Exception) {
+            threw = true
+        }
+        assertTrue("Duplicate (manga_id, alt_manga_id) pair must throw", threw)
         db.close()
     }
 

--- a/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
@@ -1,8 +1,10 @@
 package app.otakureader.data.repository
 
 import app.otakureader.core.database.dao.ChapterDao
+import app.otakureader.core.database.dao.MangaAlternativeSourceDao
 import app.otakureader.core.database.dao.MangaCategoryDao
 import app.otakureader.core.database.dao.MangaDao
+import app.otakureader.core.database.entity.MangaAlternativeSourceEntity
 import app.otakureader.core.database.entity.MangaEntity
 import app.otakureader.domain.model.ContentRating
 import app.otakureader.domain.model.Manga
@@ -21,6 +23,7 @@ class MangaRepositoryImpl @Inject constructor(
     private val mangaDao: MangaDao,
     private val chapterDao: ChapterDao,
     private val mangaCategoryDao: MangaCategoryDao,
+    private val altSourceDao: MangaAlternativeSourceDao,
     private val downloadRepository: dagger.Lazy<app.otakureader.domain.repository.DownloadRepository>
 ) : MangaRepository {
 
@@ -243,6 +246,17 @@ class MangaRepositoryImpl @Inject constructor(
 
     override suspend fun getCategoryIdsForManga(mangaId: Long): List<Long> =
         mangaCategoryDao.getCategoryIdsForManga(mangaId)
+
+    override suspend fun linkAlternativeSource(mangaId: Long, altMangaId: Long) {
+        altSourceDao.insert(MangaAlternativeSourceEntity(mangaId = mangaId, altMangaId = altMangaId))
+    }
+
+    override suspend fun unlinkAlternativeSource(mangaId: Long, altMangaId: Long) {
+        altSourceDao.unlink(mangaId, altMangaId)
+    }
+
+    override suspend fun getAlternativeSourceIds(mangaId: Long): List<Long> =
+        altSourceDao.getAlternativeIdsForMangaSync(mangaId)
 
     private fun MangaEntity.toDomain(unreadCount: Int = 0) = Manga(
         id = id,

--- a/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
@@ -248,11 +248,15 @@ class MangaRepositoryImpl @Inject constructor(
         mangaCategoryDao.getCategoryIdsForManga(mangaId)
 
     override suspend fun linkAlternativeSource(mangaId: Long, altMangaId: Long) {
-        altSourceDao.insert(MangaAlternativeSourceEntity(mangaId = mangaId, altMangaId = altMangaId))
+        // Always store as (min, max) so (A,B) and (B,A) map to the same row and the
+        // unique index correctly prevents duplicate symmetric entries.
+        val (minId, maxId) = if (mangaId < altMangaId) mangaId to altMangaId else altMangaId to mangaId
+        altSourceDao.insert(MangaAlternativeSourceEntity(mangaId = minId, altMangaId = maxId))
     }
 
     override suspend fun unlinkAlternativeSource(mangaId: Long, altMangaId: Long) {
-        altSourceDao.unlink(mangaId, altMangaId)
+        val (minId, maxId) = if (mangaId < altMangaId) mangaId to altMangaId else altMangaId to mangaId
+        altSourceDao.unlink(minId, maxId)
     }
 
     override suspend fun getAlternativeSourceIds(mangaId: Long): List<Long> =

--- a/data/src/test/java/app/otakureader/data/repository/MangaRepositoryImplTest.kt
+++ b/data/src/test/java/app/otakureader/data/repository/MangaRepositoryImplTest.kt
@@ -1,6 +1,7 @@
 package app.otakureader.data.repository
 
 import app.otakureader.core.database.dao.ChapterDao
+import app.otakureader.core.database.dao.MangaAlternativeSourceDao
 import app.otakureader.core.database.dao.MangaCategoryDao
 import app.otakureader.core.database.dao.MangaDao
 import app.otakureader.core.database.entity.MangaEntity
@@ -27,6 +28,7 @@ class MangaRepositoryImplTest {
     private lateinit var mangaDao: MangaDao
     private lateinit var chapterDao: ChapterDao
     private lateinit var mangaCategoryDao: MangaCategoryDao
+    private lateinit var altSourceDao: MangaAlternativeSourceDao
     private lateinit var downloadRepository: Lazy<DownloadRepository>
     private lateinit var repository: MangaRepositoryImpl
 
@@ -51,8 +53,9 @@ class MangaRepositoryImplTest {
         mangaDao = mockk()
         chapterDao = mockk()
         mangaCategoryDao = mockk()
+        altSourceDao = mockk()
         downloadRepository = mockk()
-        repository = MangaRepositoryImpl(mangaDao, chapterDao, mangaCategoryDao, downloadRepository)
+        repository = MangaRepositoryImpl(mangaDao, chapterDao, mangaCategoryDao, altSourceDao, downloadRepository)
     }
 
     // ---- getLibraryManga ----

--- a/domain/src/main/java/app/otakureader/domain/repository/MangaRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/MangaRepository.kt
@@ -75,4 +75,14 @@ interface MangaRepository {
 
     /** Returns the category IDs that a manga belongs to. */
     suspend fun getCategoryIdsForManga(mangaId: Long): List<Long>
+
+    // Alternative source linking (#1053)
+    /** Links two library manga as alternative versions of the same series. */
+    suspend fun linkAlternativeSource(mangaId: Long, altMangaId: Long)
+
+    /** Removes the alternative-source link between two manga. */
+    suspend fun unlinkAlternativeSource(mangaId: Long, altMangaId: Long)
+
+    /** Returns IDs of all manga linked as alternatives to the given manga. */
+    suspend fun getAlternativeSourceIds(mangaId: Long): List<Long>
 }

--- a/domain/src/main/java/app/otakureader/domain/usecase/FillMissingChaptersUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/FillMissingChaptersUseCase.kt
@@ -2,7 +2,6 @@ package app.otakureader.domain.usecase
 
 import app.otakureader.domain.model.Chapter
 import app.otakureader.domain.repository.ChapterRepository
-import app.otakureader.domain.repository.MangaRepository
 import javax.inject.Inject
 
 /**
@@ -15,10 +14,10 @@ import javax.inject.Inject
  *
  * Matching is by chapter number (float equality). Chapters present in [primaryMangaId]
  * are never duplicated; only chapter numbers that appear exclusively in [altMangaId]
- * (and have a valid number ≥ 0) are inserted into the primary.
+ * (and have a valid number ≥ 0) are inserted into the primary. If the alt source itself
+ * has duplicate chapter numbers, only the first occurrence is copied.
  */
 class FillMissingChaptersUseCase @Inject constructor(
-    private val mangaRepository: MangaRepository,
     private val chapterRepository: ChapterRepository,
 ) {
     /**
@@ -34,20 +33,17 @@ class FillMissingChaptersUseCase @Inject constructor(
             .toSet()
 
         val altChapters = chapterRepository.getChaptersByMangaIdSync(altMangaId)
-        val missing = altChapters.filter { alt ->
-            alt.chapterNumber >= 0f && alt.chapterNumber !in primaryNumbers
-        }
+        val missing = altChapters
+            .filter { alt -> alt.chapterNumber >= 0f && alt.chapterNumber !in primaryNumbers }
+            .distinctBy { it.chapterNumber }
 
         if (missing.isEmpty()) return 0
 
         val toInsert = missing.map { alt ->
-            Chapter(
+            alt.copy(
                 id = 0,
                 mangaId = primaryMangaId,
-                url = alt.url,
-                name = alt.name,
                 read = false,
-                chapterNumber = alt.chapterNumber,
             )
         }
         chapterRepository.insertChapters(toInsert)

--- a/domain/src/main/java/app/otakureader/domain/usecase/FillMissingChaptersUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/FillMissingChaptersUseCase.kt
@@ -1,0 +1,56 @@
+package app.otakureader.domain.usecase
+
+import app.otakureader.domain.model.Chapter
+import app.otakureader.domain.repository.ChapterRepository
+import app.otakureader.domain.repository.MangaRepository
+import javax.inject.Inject
+
+/**
+ * Copies chapter entries from an alternative-source manga into a primary manga where
+ * chapter numbers are absent (#1053).
+ *
+ * This is a non-destructive complement to MergeDuplicateMangaUseCase: it does not delete
+ * either manga entry, only adds the chapters that the primary is missing so readers can
+ * track progress against the larger chapter list.
+ *
+ * Matching is by chapter number (float equality). Chapters present in [primaryMangaId]
+ * are never duplicated; only chapter numbers that appear exclusively in [altMangaId]
+ * (and have a valid number ≥ 0) are inserted into the primary.
+ */
+class FillMissingChaptersUseCase @Inject constructor(
+    private val mangaRepository: MangaRepository,
+    private val chapterRepository: ChapterRepository,
+) {
+    /**
+     * @return The number of chapter entries inserted into [primaryMangaId].
+     */
+    suspend operator fun invoke(primaryMangaId: Long, altMangaId: Long): Int {
+        require(primaryMangaId != altMangaId) { "Primary and alternative manga must differ" }
+
+        val primaryChapters = chapterRepository.getChaptersByMangaIdSync(primaryMangaId)
+        val primaryNumbers = primaryChapters
+            .filter { it.chapterNumber >= 0f }
+            .map { it.chapterNumber }
+            .toSet()
+
+        val altChapters = chapterRepository.getChaptersByMangaIdSync(altMangaId)
+        val missing = altChapters.filter { alt ->
+            alt.chapterNumber >= 0f && alt.chapterNumber !in primaryNumbers
+        }
+
+        if (missing.isEmpty()) return 0
+
+        val toInsert = missing.map { alt ->
+            Chapter(
+                id = 0,
+                mangaId = primaryMangaId,
+                url = alt.url,
+                name = alt.name,
+                read = false,
+                chapterNumber = alt.chapterNumber,
+            )
+        }
+        chapterRepository.insertChapters(toInsert)
+        return toInsert.size
+    }
+}

--- a/domain/src/main/java/app/otakureader/domain/usecase/LinkAlternativeSourceUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/LinkAlternativeSourceUseCase.kt
@@ -1,0 +1,26 @@
+package app.otakureader.domain.usecase
+
+import app.otakureader.domain.repository.MangaRepository
+import javax.inject.Inject
+
+/**
+ * Persists a bidirectional alternative-source link between two library manga entries (#1053).
+ *
+ * Two manga are "alternative sources" when they are the same series published on different
+ * platforms (e.g. MangaDex vs. MangaPlus). Linking them allows FillMissingChaptersUseCase
+ * to copy missing chapter entries across sources without performing a full merge.
+ */
+class LinkAlternativeSourceUseCase @Inject constructor(
+    private val mangaRepository: MangaRepository,
+) {
+    /**
+     * Links [mangaId] and [altMangaId] as alternative sources. Idempotent — calling it
+     * again for the same pair is a no-op (IGNORE conflict strategy at the DAO level).
+     *
+     * @throws IllegalArgumentException if mangaId == altMangaId.
+     */
+    suspend operator fun invoke(mangaId: Long, altMangaId: Long) {
+        require(mangaId != altMangaId) { "Cannot link a manga to itself" }
+        mangaRepository.linkAlternativeSource(mangaId, altMangaId)
+    }
+}

--- a/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesMvi.kt
@@ -13,6 +13,8 @@ data class MergeDuplicatesState(
      * "MangaDex" instead of a raw source ID.
      */
     val sourceNames: Map<Long, String> = emptyMap(),
+    /** Maps each manga ID to the set of IDs it is currently linked with as alternatives. */
+    val linkedAlternatives: Map<Long, Set<Long>> = emptyMap(),
 )
 
 /** A set of library manga entries sharing the same normalised title. */
@@ -35,6 +37,12 @@ sealed class MergeDuplicatesEvent {
     data class MergeGroup(val group: DuplicateGroup) : MergeDuplicatesEvent()
     /** Merge every group with its current primary selection. */
     data object MergeAll : MergeDuplicatesEvent()
+    /** Persist a bidirectional alternative-source link between two manga. */
+    data class LinkAsAlternative(val primaryId: Long, val altId: Long) : MergeDuplicatesEvent()
+    /** Copy missing chapter numbers from [altId] into [primaryId]. */
+    data class FillMissingChapters(val primaryId: Long, val altId: Long) : MergeDuplicatesEvent()
+    /** Remove the alternative-source link between two manga. */
+    data class UnlinkAlternative(val primaryId: Long, val altId: Long) : MergeDuplicatesEvent()
 }
 
 sealed class MergeDuplicatesEffect {

--- a/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material.icons.filled.MergeType
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material3.AssistChip
@@ -136,10 +138,20 @@ fun MergeDuplicatesScreen(
                     DuplicateGroupCard(
                         group = group,
                         sourceNames = state.sourceNames,
+                        linkedAlternatives = state.linkedAlternatives,
                         onSelectPrimary = { primaryId ->
                             viewModel.onEvent(MergeDuplicatesEvent.SelectPrimary(index, primaryId))
                         },
                         onMerge = { viewModel.onEvent(MergeDuplicatesEvent.MergeGroup(group)) },
+                        onLinkAsAlternative = { altId ->
+                            viewModel.onEvent(MergeDuplicatesEvent.LinkAsAlternative(group.primaryId, altId))
+                        },
+                        onUnlinkAlternative = { altId ->
+                            viewModel.onEvent(MergeDuplicatesEvent.UnlinkAlternative(group.primaryId, altId))
+                        },
+                        onFillMissingChapters = { altId ->
+                            viewModel.onEvent(MergeDuplicatesEvent.FillMissingChapters(group.primaryId, altId))
+                        },
                         enabled = !state.isMerging,
                     )
                 }
@@ -152,8 +164,12 @@ fun MergeDuplicatesScreen(
 private fun DuplicateGroupCard(
     group: DuplicateGroup,
     sourceNames: Map<Long, String>,
+    linkedAlternatives: Map<Long, Set<Long>>,
     onSelectPrimary: (Long) -> Unit,
     onMerge: () -> Unit,
+    onLinkAsAlternative: (altId: Long) -> Unit,
+    onUnlinkAlternative: (altId: Long) -> Unit,
+    onFillMissingChapters: (altId: Long) -> Unit,
     enabled: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -206,6 +222,58 @@ private fun DuplicateGroupCard(
                 Icon(Icons.Default.MergeType, contentDescription = null)
                 Spacer(Modifier.width(4.dp))
                 Text(stringResource(R.string.merge_duplicates_merge_group))
+            }
+
+            // Cross-source alternative linking actions (non-destructive)
+            if (group.isCrossSource) {
+                val altEntries = group.entries.filter { it.id != group.primaryId }
+                altEntries.forEach { alt ->
+                    val isLinked = linkedAlternatives[group.primaryId]?.contains(alt.id) == true
+                    Spacer(Modifier.height(4.dp))
+                    if (isLinked) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            OutlinedButton(
+                                onClick = { onUnlinkAlternative(alt.id) },
+                                enabled = enabled,
+                                modifier = Modifier.weight(1f),
+                            ) {
+                                Icon(
+                                    Icons.Default.LinkOff,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                                Spacer(Modifier.width(4.dp))
+                                Text(stringResource(R.string.merge_duplicates_unlink_alt))
+                            }
+                            OutlinedButton(
+                                onClick = { onFillMissingChapters(alt.id) },
+                                enabled = enabled,
+                                modifier = Modifier.weight(1f),
+                            ) {
+                                Text(stringResource(R.string.merge_duplicates_fill_chapters))
+                            }
+                        }
+                    } else {
+                        OutlinedButton(
+                            onClick = { onLinkAsAlternative(alt.id) },
+                            enabled = enabled,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Icon(
+                                Icons.Default.Link,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Spacer(Modifier.width(4.dp))
+                            Text(
+                                stringResource(
+                                    R.string.merge_duplicates_link_alt,
+                                    sourceNames[alt.sourceId] ?: alt.sourceId.toString(),
+                                )
+                            )
+                        }
+                    }
+                }
             }
         }
     }

--- a/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.SourceRepository
+import app.otakureader.domain.usecase.FillMissingChaptersUseCase
+import app.otakureader.domain.usecase.LinkAlternativeSourceUseCase
 import app.otakureader.domain.usecase.MergeDuplicateMangaUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
@@ -23,6 +25,8 @@ class MergeDuplicatesViewModel @Inject constructor(
     private val mangaRepository: MangaRepository,
     private val sourceRepository: SourceRepository,
     private val mergeDuplicateManga: MergeDuplicateMangaUseCase,
+    private val linkAlternativeSource: LinkAlternativeSourceUseCase,
+    private val fillMissingChapters: FillMissingChaptersUseCase,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(MergeDuplicatesState())
@@ -42,6 +46,9 @@ class MergeDuplicatesViewModel @Inject constructor(
             is MergeDuplicatesEvent.SelectPrimary -> selectPrimary(event.groupIndex, event.primaryId)
             is MergeDuplicatesEvent.MergeGroup -> mergeGroup(event.group)
             is MergeDuplicatesEvent.MergeAll -> mergeAll()
+            is MergeDuplicatesEvent.LinkAsAlternative -> linkAsAlternative(event.primaryId, event.altId)
+            is MergeDuplicatesEvent.FillMissingChapters -> fillMissing(event.primaryId, event.altId)
+            is MergeDuplicatesEvent.UnlinkAlternative -> unlinkAlternative(event.primaryId, event.altId)
         }
     }
 
@@ -131,5 +138,57 @@ class MergeDuplicatesViewModel @Inject constructor(
                 _effect.send(MergeDuplicatesEffect.NavigateBack)
             }
         }
+    }
+
+    private fun linkAsAlternative(primaryId: Long, altId: Long) {
+        viewModelScope.launch {
+            try {
+                linkAlternativeSource(primaryId, altId)
+                val linked = loadLinkedForPair(primaryId, altId)
+                _state.update { it.copy(linkedAlternatives = linked) }
+                _effect.send(MergeDuplicatesEffect.ShowSnackbar("Linked as alternative sources"))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(MergeDuplicatesEffect.ShowSnackbar("Link failed: ${e.message}"))
+            }
+        }
+    }
+
+    private fun fillMissing(primaryId: Long, altId: Long) {
+        viewModelScope.launch {
+            try {
+                val added = fillMissingChapters(primaryId, altId)
+                val msg = if (added == 0) "No missing chapters found" else "Added $added missing chapter(s)"
+                _effect.send(MergeDuplicatesEffect.ShowSnackbar(msg))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(MergeDuplicatesEffect.ShowSnackbar("Fill failed: ${e.message}"))
+            }
+        }
+    }
+
+    private fun unlinkAlternative(primaryId: Long, altId: Long) {
+        viewModelScope.launch {
+            try {
+                mangaRepository.unlinkAlternativeSource(primaryId, altId)
+                val linked = loadLinkedForPair(primaryId, altId)
+                _state.update { it.copy(linkedAlternatives = linked) }
+                _effect.send(MergeDuplicatesEffect.ShowSnackbar("Alternative link removed"))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(MergeDuplicatesEffect.ShowSnackbar("Unlink failed: ${e.message}"))
+            }
+        }
+    }
+
+    /** Refreshes the linkedAlternatives map for the two given IDs. */
+    private suspend fun loadLinkedForPair(primaryId: Long, altId: Long): Map<Long, Set<Long>> {
+        val current = _state.value.linkedAlternatives.toMutableMap()
+        current[primaryId] = mangaRepository.getAlternativeSourceIds(primaryId).toSet()
+        current[altId] = mangaRepository.getAlternativeSourceIds(altId).toSet()
+        return current
     }
 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesViewModel.kt
@@ -55,15 +55,24 @@ class MergeDuplicatesViewModel @Inject constructor(
     private fun observeDuplicates() {
         mangaRepository.findDuplicates()
             .onEach { duplicateLists ->
-                _state.update { current ->
-                    val newGroups = duplicateLists.map { entries ->
-                        // Preserve user's primary selection for groups already shown
-                        val existing = current.duplicateGroups.firstOrNull { g ->
-                            g.entries.map { it.id }.toSet() == entries.map { it.id }.toSet()
-                        }
-                        existing?.copy(entries = entries) ?: DuplicateGroup(entries)
+                val newGroups = duplicateLists.map { entries ->
+                    val existing = _state.value.duplicateGroups.firstOrNull { g ->
+                        g.entries.map { it.id }.toSet() == entries.map { it.id }.toSet()
                     }
-                    current.copy(isLoading = false, duplicateGroups = newGroups, error = null)
+                    existing?.copy(entries = entries) ?: DuplicateGroup(entries)
+                }
+                // Hydrate linkedAlternatives for every manga ID currently on screen
+                val allIds = newGroups.flatMap { g -> g.entries.map { it.id } }.distinct()
+                val linked = allIds.associate { id ->
+                    id to mangaRepository.getAlternativeSourceIds(id).toSet()
+                }
+                _state.update { current ->
+                    current.copy(
+                        isLoading = false,
+                        duplicateGroups = newGroups,
+                        linkedAlternatives = linked,
+                        error = null,
+                    )
                 }
             }
             .launchIn(viewModelScope)
@@ -144,8 +153,7 @@ class MergeDuplicatesViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 linkAlternativeSource(primaryId, altId)
-                val linked = loadLinkedForPair(primaryId, altId)
-                _state.update { it.copy(linkedAlternatives = linked) }
+                updateLinkedAlternatives(primaryId, altId)
                 _effect.send(MergeDuplicatesEffect.ShowSnackbar("Linked as alternative sources"))
             } catch (e: CancellationException) {
                 throw e
@@ -173,8 +181,7 @@ class MergeDuplicatesViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 mangaRepository.unlinkAlternativeSource(primaryId, altId)
-                val linked = loadLinkedForPair(primaryId, altId)
-                _state.update { it.copy(linkedAlternatives = linked) }
+                updateLinkedAlternatives(primaryId, altId)
                 _effect.send(MergeDuplicatesEffect.ShowSnackbar("Alternative link removed"))
             } catch (e: CancellationException) {
                 throw e
@@ -184,11 +191,15 @@ class MergeDuplicatesViewModel @Inject constructor(
         }
     }
 
-    /** Refreshes the linkedAlternatives map for the two given IDs. */
-    private suspend fun loadLinkedForPair(primaryId: Long, altId: Long): Map<Long, Set<Long>> {
-        val current = _state.value.linkedAlternatives.toMutableMap()
-        current[primaryId] = mangaRepository.getAlternativeSourceIds(primaryId).toSet()
-        current[altId] = mangaRepository.getAlternativeSourceIds(altId).toSet()
-        return current
+    /** Fetches fresh link state from the DB then applies it atomically to avoid race conditions. */
+    private suspend fun updateLinkedAlternatives(primaryId: Long, altId: Long) {
+        val primaryAlts = mangaRepository.getAlternativeSourceIds(primaryId).toSet()
+        val altAlts = mangaRepository.getAlternativeSourceIds(altId).toSet()
+        _state.update { current ->
+            val updated = current.linkedAlternatives.toMutableMap()
+            updated[primaryId] = primaryAlts
+            updated[altId] = altAlts
+            current.copy(linkedAlternatives = updated)
+        }
     }
 }

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -243,6 +243,9 @@
     <string name="merge_duplicates_unread">%1$d unread</string>
     <string name="merge_duplicates_cross_source">Cross-source</string>
     <string name="merge_duplicates_source_id">Source %1$d</string>
+    <string name="merge_duplicates_link_alt">Link as alternative (%1$s)</string>
+    <string name="merge_duplicates_unlink_alt">Remove link</string>
+    <string name="merge_duplicates_fill_chapters">Fill missing chapters</string>
 
     <!-- Saved library views (#1039) -->
     <string name="library_save_view">Save current view</string>


### PR DESCRIPTION
## **User description**
## Summary

Implements the alternative-source linking half of #1053. Two manga entries for the same series on different platforms (e.g. MangaDex vs MangaPlus) can now be linked without a destructive merge, and missing chapter numbers can be copied from the alt source into the primary.

- **Database (v35 → v36):** New `manga_alternative_source` table with FK CASCADE, bidirectional UNION lookup, and explicit Room migration
- **Domain:** `LinkAlternativeSourceUseCase` (idempotent), `FillMissingChaptersUseCase` (copies only chapter numbers absent from primary), 3 new `MangaRepository` methods
- **UI:** Cross-source duplicate groups now show "Link as alternative" / "Remove link" + "Fill missing chapters" buttons per non-primary entry

The existing destructive Merge flow is unchanged — this is purely additive.

## How linking works

`FillMissingChaptersUseCase` matches by `chapterNumber` (float). Chapters with `chapterNumber < 0` (unnumbered) are skipped. Chapters already present in the primary are never duplicated. The inserted chapters get `read = false` so the reader can track progress against the full list.

## Test plan

- [ ] Open Merge Duplicates screen with two entries for the same series from different sources
- [ ] Tap "Link as alternative (SourceName)" — button changes to "Remove link" + "Fill missing chapters"
- [ ] Tap "Fill missing chapters" — snackbar shows count added (or "No missing chapters found")
- [ ] Tap "Remove link" — reverts to "Link as alternative"
- [ ] Existing Merge flow unaffected

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Link cross-source duplicates and copy missing chapters without merging entries**

### What Changed
- Cross-source duplicate entries can now be linked as alternative versions instead of being merged and deleted
- Linked pairs can be unlinked again, and the duplicate screen updates to show the current link state
- Users can copy missing chapter numbers from the alternative source into the main entry, without duplicating chapters that already exist
- The duplicate screen now shows source-specific actions for each non-primary cross-source entry

### Impact
`✅ Safer cross-source duplicate handling`
`✅ Fewer lost manga entries`
`✅ Faster chapter list completion`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced alternative source linking to manage duplicate manga across different sources
  * Added ability to copy missing chapters from alternative sources into your primary manga
  * Added UI controls to link, unlink, and manage alternative source relationships during duplicate merging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->