### PR TITLE
feat: EH favorites full pagination + real orphaned file cleanup

### DIFF
--- a/core/database/src/main/java/app/otakureader/core/database/dao/ChapterDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/ChapterDao.kt
@@ -16,6 +16,9 @@ interface ChapterDao {
     @Query("SELECT * FROM chapters WHERE mangaId = :mangaId ORDER BY sourceOrder DESC")
     fun getChaptersByMangaId(mangaId: Long): Flow<List<ChapterEntity>>
 
+    @Query("SELECT * FROM chapters WHERE mangaId = :mangaId")
+    suspend fun getChaptersByMangaIdOnce(mangaId: Long): List<ChapterEntity>
+
     @Query("SELECT * FROM chapters WHERE mangaId = :mangaId AND url = :url LIMIT 1")
     suspend fun getChapterByMangaIdAndUrl(mangaId: Long, url: String): ChapterEntity?
     

--- a/core/database/src/main/java/app/otakureader/core/database/dao/ChapterDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/ChapterDao.kt
@@ -16,8 +16,8 @@ interface ChapterDao {
     @Query("SELECT * FROM chapters WHERE mangaId = :mangaId ORDER BY sourceOrder DESC")
     fun getChaptersByMangaId(mangaId: Long): Flow<List<ChapterEntity>>
 
-    @Query("SELECT * FROM chapters WHERE mangaId = :mangaId")
-    suspend fun getChaptersByMangaIdOnce(mangaId: Long): List<ChapterEntity>
+    @Query("SELECT * FROM chapters")
+    suspend fun getAllChaptersOnce(): List<ChapterEntity>
 
     @Query("SELECT * FROM chapters WHERE mangaId = :mangaId AND url = :url LIMIT 1")
     suspend fun getChapterByMangaIdAndUrl(mangaId: Long, url: String): ChapterEntity?

--- a/core/database/src/main/java/app/otakureader/core/database/dao/MangaDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/MangaDao.kt
@@ -30,6 +30,9 @@ interface MangaDao {
 
     @Query("SELECT * FROM manga WHERE id IN (:ids)")
     suspend fun getMangaByIds(ids: List<Long>): List<MangaEntity>
+
+    @Query("SELECT * FROM manga")
+    suspend fun getAllMangaOnce(): List<MangaEntity>
     
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(manga: MangaEntity): Long

--- a/data/src/main/java/app/otakureader/data/eh/EhFavoritesApi.kt
+++ b/data/src/main/java/app/otakureader/data/eh/EhFavoritesApi.kt
@@ -10,8 +10,8 @@ import javax.inject.Inject
  * Fetches and parses all pages of the E-Hentai favorites list using stored session cookies.
  *
  * This class performs synchronous OkHttp calls — callers must dispatch on an IO dispatcher.
- * Pages are fetched in a loop (up to [MAX_PAGES] pages, 25 items each) so users with more
- * than 25 favorites receive the complete list on every sync.
+ * Pages are fetched in a loop until the server returns an empty page (with a [MAX_PAGES]
+ * safety cap), so users with more than 25 favorites receive the complete list on every sync.
  *
  * The igneous cookie determines which host to use:
  *   - Non-empty igneous → ExHentai (exhentai.org) for ExHentai-only content.
@@ -19,17 +19,21 @@ import javax.inject.Inject
  *
  * @param hostOverrideForTests when non-null, bypasses [resolveHost] — used in unit tests
  *   to point requests at a [okhttp3.mockwebserver.MockWebServer].
+ * @param interPageDelayMillis pause between consecutive page requests. EH aggressively
+ *   rate-limits rapid scraping, so production keeps the default; tests pass 0.
  */
 class EhFavoritesApi(
     private val okHttpClient: OkHttpClient,
     private val hostOverrideForTests: String? = null,
+    private val interPageDelayMillis: Long = INTER_PAGE_DELAY_MS,
 ) {
-    @Inject constructor(okHttpClient: OkHttpClient) : this(okHttpClient, null)
+    @Inject constructor(okHttpClient: OkHttpClient) : this(okHttpClient, null, INTER_PAGE_DELAY_MS)
 
     fun fetchFavorites(session: EhSession): List<EhFavorite> {
         val result = mutableListOf<EhFavorite>()
         var page = 0
         while (page < MAX_PAGES) {
+            if (page > 0 && interPageDelayMillis > 0) Thread.sleep(interPageDelayMillis)
             val items = fetchFavoritesPage(session, page)
             if (items.isEmpty()) break
             result += items
@@ -116,8 +120,12 @@ class EhFavoritesApi(
         const val USER_AGENT =
             "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36"
 
-        // Hard cap: 40 pages × 25 items = 1 000 favorites max. Prevents runaway loops if EH
-        // ever changes its pagination structure and never returns an empty page.
-        const val MAX_PAGES = 40
+        // Safety cap against runaway loops if EH ever changes its pagination markup and an
+        // "empty" page never occurs. Termination is normally server-driven (first empty page
+        // stops the loop); 200 pages × 25 items = 5 000 favorites covers realistic accounts.
+        const val MAX_PAGES = 200
+
+        // EH rate-limits and can temporarily IP-ban clients making rapid sequential requests.
+        const val INTER_PAGE_DELAY_MS = 500L
     }
 }

--- a/data/src/main/java/app/otakureader/data/eh/EhFavoritesApi.kt
+++ b/data/src/main/java/app/otakureader/data/eh/EhFavoritesApi.kt
@@ -7,22 +7,41 @@ import okhttp3.Request
 import javax.inject.Inject
 
 /**
- * Fetches and parses the E-Hentai favorites page using stored session cookies.
+ * Fetches and parses all pages of the E-Hentai favorites list using stored session cookies.
  *
  * This class performs synchronous OkHttp calls — callers must dispatch on an IO dispatcher.
- * Only the first page of favorites (up to 25 entries) is fetched per call; full pagination
- * can be added in a future iteration when the requirement arises.
+ * Pages are fetched in a loop (up to [MAX_PAGES] pages, 25 items each) so users with more
+ * than 25 favorites receive the complete list on every sync.
  *
  * The igneous cookie determines which host to use:
  *   - Non-empty igneous → ExHentai (exhentai.org) for ExHentai-only content.
  *   - Empty/absent igneous → E-Hentai (e-hentai.org) public content.
+ *
+ * @param hostOverrideForTests when non-null, bypasses [resolveHost] — used in unit tests
+ *   to point requests at a [okhttp3.mockwebserver.MockWebServer].
  */
-class EhFavoritesApi @Inject constructor(private val okHttpClient: OkHttpClient) {
+class EhFavoritesApi(
+    private val okHttpClient: OkHttpClient,
+    private val hostOverrideForTests: String? = null,
+) {
+    @Inject constructor(okHttpClient: OkHttpClient) : this(okHttpClient, null)
 
     fun fetchFavorites(session: EhSession): List<EhFavorite> {
-        val host = resolveHost(session)
+        val result = mutableListOf<EhFavorite>()
+        var page = 0
+        while (page < MAX_PAGES) {
+            val items = fetchFavoritesPage(session, page)
+            if (items.isEmpty()) break
+            result += items
+            page++
+        }
+        return result
+    }
+
+    private fun fetchFavoritesPage(session: EhSession, page: Int): List<EhFavorite> {
+        val host = hostOverrideForTests ?: resolveHost(session)
         val request = Request.Builder()
-            .url("$host/favorites.php?favcat=all&page=0")
+            .url("$host/favorites.php?favcat=all&page=$page")
             .header("Cookie", buildCookieHeader(session))
             .header("User-Agent", USER_AGENT)
             .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
@@ -96,5 +115,9 @@ class EhFavoritesApi @Inject constructor(private val okHttpClient: OkHttpClient)
 
         const val USER_AGENT =
             "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36"
+
+        // Hard cap: 40 pages × 25 items = 1 000 favorites max. Prevents runaway loops if EH
+        // ever changes its pagination structure and never returns an empty page.
+        const val MAX_PAGES = 40
     }
 }

--- a/data/src/main/java/app/otakureader/data/repository/DownloadRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/DownloadRepositoryImpl.kt
@@ -208,10 +208,12 @@ class DownloadRepositoryImpl @Inject constructor(
      */
     private fun deleteEmptyParents(deletedDir: File, rootDir: File) {
         var parent = deletedDir.parentFile
-        while (parent != null && parent != rootDir) {
-            val children = parent.listFiles()
-            if (children == null || children.isNotEmpty()) break
-            if (!parent.delete()) break
+        // Stop at the downloads root, a non-empty dir, or a failed delete.
+        while (parent != null &&
+            parent != rootDir &&
+            parent.listFiles()?.isEmpty() == true &&
+            parent.delete()
+        ) {
             parent = parent.parentFile
         }
     }

--- a/data/src/main/java/app/otakureader/data/repository/DownloadRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/DownloadRepositoryImpl.kt
@@ -1,15 +1,19 @@
 package app.otakureader.data.repository
 
 import android.content.Context
+import app.otakureader.core.common.di.ApplicationScope
+import app.otakureader.core.database.dao.ChapterDao
+import app.otakureader.core.database.dao.MangaDao
 import app.otakureader.data.download.CbzCreator
 import app.otakureader.data.download.ChapterDownloadRequest
 import app.otakureader.data.download.DownloadManager
 import app.otakureader.data.download.DownloadProvider
-import app.otakureader.core.common.di.ApplicationScope
 import app.otakureader.domain.model.DownloadItem
+import app.otakureader.domain.model.OrphanScanResult
 import app.otakureader.domain.model.ReindexResult
 import app.otakureader.domain.repository.DownloadRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
@@ -23,6 +27,8 @@ import kotlinx.coroutines.withContext
 class DownloadRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
     private val downloadManager: DownloadManager,
+    private val mangaDao: MangaDao,
+    private val chapterDao: ChapterDao,
     @ApplicationScope private val scope: CoroutineScope
 ) : DownloadRepository {
 
@@ -172,6 +178,71 @@ class DownloadRepositoryImpl @Inject constructor(
             }
         }
         ReindexResult(verified, empty)
+    }
+
+    override suspend fun scanOrphanedDownloads(): OrphanScanResult = withContext(Dispatchers.IO) {
+        val orphans = findOrphanedChapterDirs()
+        val totalBytes = orphans.sumOf { dir -> dir.walkTopDown().filter { it.isFile }.sumOf { it.length() } }
+        OrphanScanResult(count = orphans.size, sizeBytes = totalBytes)
+    }
+
+    override suspend fun deleteOrphanedDownloads(): OrphanScanResult = withContext(Dispatchers.IO) {
+        val orphans = findOrphanedChapterDirs()
+        var deletedCount = 0
+        var deletedBytes = 0L
+        for (dir in orphans) {
+            val size = dir.walkTopDown().filter { it.isFile }.sumOf { it.length() }
+            if (dir.deleteRecursively()) {
+                deletedCount++
+                deletedBytes += size
+            }
+        }
+        OrphanScanResult(count = deletedCount, sizeBytes = deletedBytes)
+    }
+
+    /**
+     * Returns chapter directories on disk that have no matching record in the database.
+     * A directory is "orphaned" when its parent manga was deleted from the library without
+     * cleaning up the downloaded files.
+     *
+     * The directory path is derived from the same sanitization logic used when the download
+     * was originally created: sourceId.toString() / sanitize(title) / sanitize(name).
+     */
+    private suspend fun findOrphanedChapterDirs(): List<File> {
+        val rootDir = DownloadProvider.getRootDir(context)
+        if (!rootDir.isDirectory) return emptyList()
+
+        // Build the set of expected chapter dir absolute paths from the database.
+        val rootParent = rootDir.parentFile ?: return emptyList()
+        val expectedPaths = buildSet<String> {
+            for (manga in mangaDao.getAllMangaOnce()) {
+                for (chapter in chapterDao.getChaptersByMangaIdOnce(manga.id)) {
+                    val dir = DownloadProvider.getChapterDir(
+                        rootParent,
+                        manga.sourceId.toString(),
+                        manga.title,
+                        chapter.name,
+                    )
+                    add(dir.absolutePath)
+                }
+            }
+        }
+
+        // Walk 3 levels: source / manga / chapter
+        val orphans = mutableListOf<File>()
+        val sourceDirs = rootDir.listFiles { f -> f.isDirectory } ?: return emptyList()
+        for (sourceDir in sourceDirs) {
+            val mangaDirs = sourceDir.listFiles { f -> f.isDirectory } ?: continue
+            for (mangaDir in mangaDirs) {
+                val chapterDirs = mangaDir.listFiles { f -> f.isDirectory } ?: continue
+                for (chapterDir in chapterDirs) {
+                    if (chapterDir.absolutePath !in expectedPaths) {
+                        orphans += chapterDir
+                    }
+                }
+            }
+        }
+        return orphans
     }
 
     override suspend fun migrateChapterDownload(

--- a/data/src/main/java/app/otakureader/data/repository/DownloadRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/DownloadRepositoryImpl.kt
@@ -187,6 +187,7 @@ class DownloadRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteOrphanedDownloads(): OrphanScanResult = withContext(Dispatchers.IO) {
+        val rootDir = DownloadProvider.getRootDir(context)
         val orphans = findOrphanedChapterDirs()
         var deletedCount = 0
         var deletedBytes = 0L
@@ -195,9 +196,24 @@ class DownloadRepositoryImpl @Inject constructor(
             if (dir.deleteRecursively()) {
                 deletedCount++
                 deletedBytes += size
+                deleteEmptyParents(dir, rootDir)
             }
         }
         OrphanScanResult(count = deletedCount, sizeBytes = deletedBytes)
+    }
+
+    /**
+     * Removes now-empty manga/source directories left behind after a chapter dir was deleted,
+     * stopping at (and never deleting) the downloads root itself.
+     */
+    private fun deleteEmptyParents(deletedDir: File, rootDir: File) {
+        var parent = deletedDir.parentFile
+        while (parent != null && parent != rootDir) {
+            val children = parent.listFiles()
+            if (children == null || children.isNotEmpty()) break
+            if (!parent.delete()) break
+            parent = parent.parentFile
+        }
     }
 
     /**
@@ -213,18 +229,20 @@ class DownloadRepositoryImpl @Inject constructor(
         if (!rootDir.isDirectory) return emptyList()
 
         // Build the set of expected chapter dir absolute paths from the database.
+        // Exactly 2 queries: all manga + all chapters, joined in memory — avoids an
+        // N+1 query per manga which would stall on large libraries.
         val rootParent = rootDir.parentFile ?: return emptyList()
+        val mangaById = mangaDao.getAllMangaOnce().associateBy { it.id }
         val expectedPaths = buildSet<String> {
-            for (manga in mangaDao.getAllMangaOnce()) {
-                for (chapter in chapterDao.getChaptersByMangaIdOnce(manga.id)) {
-                    val dir = DownloadProvider.getChapterDir(
-                        rootParent,
-                        manga.sourceId.toString(),
-                        manga.title,
-                        chapter.name,
-                    )
-                    add(dir.absolutePath)
-                }
+            for (chapter in chapterDao.getAllChaptersOnce()) {
+                val manga = mangaById[chapter.mangaId] ?: continue
+                val dir = DownloadProvider.getChapterDir(
+                    rootParent,
+                    manga.sourceId.toString(),
+                    manga.title,
+                    chapter.name,
+                )
+                add(dir.absolutePath)
             }
         }
 

--- a/data/src/test/java/app/otakureader/data/eh/EhFavoritesApiTest.kt
+++ b/data/src/test/java/app/otakureader/data/eh/EhFavoritesApiTest.kt
@@ -1,6 +1,10 @@
 package app.otakureader.data.eh
 
+import app.otakureader.core.preferences.EhSession
 import io.mockk.mockk
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -90,6 +94,51 @@ class EhFavoritesApiTest {
 
         assertEquals(1, result.size)
         assertEquals("/g/555555/eee55555/", result[0].galleryUrl)
+    }
+
+    // ── Pagination tests ────────────────────────────────────────────────────────
+
+    @Test
+    fun `fetchFavorites accumulates all pages until empty page returned`() {
+        val server = MockWebServer()
+        server.use {
+            // Pages 0 and 1 have 25 items each; page 2 has 3 items; page 3 is empty → stop.
+            // Tokens must be valid hex ([a-f0-9]+) to match GALLERY_URL_REGEX.
+            val page0Html = buildMultiGalleryHtml((1..25).map { Triple("${100000 + it}", "a${it.toString().padStart(7, '0')}", "Title $it") })
+            val page1Html = buildMultiGalleryHtml((26..50).map { Triple("${100000 + it}", "b${it.toString().padStart(7, '0')}", "Title $it") })
+            val page2Html = buildMultiGalleryHtml((51..53).map { Triple("${100000 + it}", "c${it.toString().padStart(7, '0')}", "Title $it") })
+            val page3Html = "" // empty page signals end of pagination
+
+            server.enqueue(MockResponse().setBody(page0Html))
+            server.enqueue(MockResponse().setBody(page1Html))
+            server.enqueue(MockResponse().setBody(page2Html))
+            server.enqueue(MockResponse().setBody(page3Html))
+
+            val hostOverride = server.url("").toString().trimEnd('/')
+            val paginatedApi = EhFavoritesApi(OkHttpClient(), hostOverride)
+            val session = EhSession(memberId = "1", passHash = "hash", igneous = "")
+
+            val result = paginatedApi.fetchFavorites(session)
+
+            assertEquals(53, result.size)
+            assertEquals(4, server.requestCount) // pages 0, 1, 2, 3
+        }
+    }
+
+    @Test
+    fun `fetchFavorites returns empty list when first page is empty`() {
+        val server = MockWebServer()
+        server.use {
+            server.enqueue(MockResponse().setBody(""))
+
+            val paginatedApi = EhFavoritesApi(OkHttpClient(), server.url("").toString().trimEnd('/'))
+            val session = EhSession(memberId = "1", passHash = "hash", igneous = "")
+
+            val result = paginatedApi.fetchFavorites(session)
+
+            assertTrue(result.isEmpty())
+            assertEquals(1, server.requestCount)
+        }
     }
 
     // --- helpers ---

--- a/data/src/test/java/app/otakureader/data/eh/EhFavoritesApiTest.kt
+++ b/data/src/test/java/app/otakureader/data/eh/EhFavoritesApiTest.kt
@@ -115,7 +115,7 @@ class EhFavoritesApiTest {
             server.enqueue(MockResponse().setBody(page3Html))
 
             val hostOverride = server.url("").toString().trimEnd('/')
-            val paginatedApi = EhFavoritesApi(OkHttpClient(), hostOverride)
+            val paginatedApi = EhFavoritesApi(OkHttpClient(), hostOverride, interPageDelayMillis = 0)
             val session = EhSession(memberId = "1", passHash = "hash", igneous = "")
 
             val result = paginatedApi.fetchFavorites(session)
@@ -131,7 +131,11 @@ class EhFavoritesApiTest {
         server.use {
             server.enqueue(MockResponse().setBody(""))
 
-            val paginatedApi = EhFavoritesApi(OkHttpClient(), server.url("").toString().trimEnd('/'))
+            val paginatedApi = EhFavoritesApi(
+                OkHttpClient(),
+                server.url("").toString().trimEnd('/'),
+                interPageDelayMillis = 0,
+            )
             val session = EhSession(memberId = "1", passHash = "hash", igneous = "")
 
             val result = paginatedApi.fetchFavorites(session)

--- a/domain/src/main/java/app/otakureader/domain/model/OrphanScanResult.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/OrphanScanResult.kt
@@ -1,0 +1,6 @@
+package app.otakureader.domain.model
+
+data class OrphanScanResult(
+    val count: Int,
+    val sizeBytes: Long,
+)

--- a/domain/src/main/java/app/otakureader/domain/repository/DownloadRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/DownloadRepository.kt
@@ -1,6 +1,7 @@
 package app.otakureader.domain.repository
 
 import app.otakureader.domain.model.DownloadItem
+import app.otakureader.domain.model.OrphanScanResult
 import app.otakureader.domain.model.ReindexResult
 import kotlinx.coroutines.flow.Flow
 
@@ -135,6 +136,24 @@ interface DownloadRepository {
      * that exist but contain no valid page files or CBZ archive.
      */
     suspend fun reindexDownloads(): ReindexResult
+
+    /**
+     * Scans the downloads directory for chapter folders that have no matching record in
+     * the manga/chapter database. These are "orphaned" files left behind when manga entries
+     * are deleted without cleaning up their downloads.
+     *
+     * @return count of orphaned chapter dirs and their total size on disk.
+     */
+    suspend fun scanOrphanedDownloads(): OrphanScanResult
+
+    /**
+     * Deletes all orphaned chapter dirs found by the same scan logic as [scanOrphanedDownloads].
+     * Re-runs the scan internally so the result is always fresh — no stale state between
+     * scan and delete.
+     *
+     * @return the [OrphanScanResult] describing what was deleted.
+     */
+    suspend fun deleteOrphanedDownloads(): OrphanScanResult
 
     suspend fun migrateChapterDownload(
         fromSourceName: String,

--- a/domain/src/main/java/app/otakureader/domain/usecase/downloads/DeleteOrphanedDownloadsUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/downloads/DeleteOrphanedDownloadsUseCase.kt
@@ -1,0 +1,11 @@
+package app.otakureader.domain.usecase.downloads
+
+import app.otakureader.domain.model.OrphanScanResult
+import app.otakureader.domain.repository.DownloadRepository
+import javax.inject.Inject
+
+class DeleteOrphanedDownloadsUseCase @Inject constructor(
+    private val downloadRepository: DownloadRepository,
+) {
+    suspend operator fun invoke(): OrphanScanResult = downloadRepository.deleteOrphanedDownloads()
+}

--- a/domain/src/main/java/app/otakureader/domain/usecase/downloads/ScanOrphanedDownloadsUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/downloads/ScanOrphanedDownloadsUseCase.kt
@@ -1,0 +1,11 @@
+package app.otakureader.domain.usecase.downloads
+
+import app.otakureader.domain.model.OrphanScanResult
+import app.otakureader.domain.repository.DownloadRepository
+import javax.inject.Inject
+
+class ScanOrphanedDownloadsUseCase @Inject constructor(
+    private val downloadRepository: DownloadRepository,
+) {
+    suspend operator fun invoke(): OrphanScanResult = downloadRepository.scanOrphanedDownloads()
+}

--- a/feature/library/src/main/java/app/otakureader/feature/library/maintenance/LibraryMaintenanceMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/maintenance/LibraryMaintenanceMvi.kt
@@ -10,6 +10,7 @@ data class LibraryMaintenanceState(
     val orphanScanRunning: Boolean = false,
     val orphanScanResult: String? = null,
     val orphanCount: Int = 0,
+    val orphanedSizeBytes: Long = 0L,
 )
 
 sealed interface LibraryMaintenanceEvent {

--- a/feature/library/src/main/java/app/otakureader/feature/library/maintenance/LibraryMaintenanceViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/maintenance/LibraryMaintenanceViewModel.kt
@@ -108,6 +108,8 @@ class LibraryMaintenanceViewModel @Inject constructor(
     }
 
     private suspend fun scanOrphans() {
+        // Guard against repeated taps spawning concurrent disk scans.
+        if (_state.value.orphanScanRunning) return
         _state.update { it.copy(orphanScanRunning = true, orphanScanResult = null) }
         runCatching { scanOrphanedDownloadsUseCase() }
             .onSuccess { result ->
@@ -132,6 +134,8 @@ class LibraryMaintenanceViewModel @Inject constructor(
     }
 
     private suspend fun deleteOrphans() {
+        // Guard against repeated taps spawning concurrent delete operations.
+        if (_state.value.orphanScanRunning) return
         if (_state.value.orphanCount == 0) return
         _state.update { it.copy(orphanScanRunning = true, orphanScanResult = null) }
         runCatching { deleteOrphanedDownloadsUseCase() }

--- a/feature/library/src/main/java/app/otakureader/feature/library/maintenance/LibraryMaintenanceViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/maintenance/LibraryMaintenanceViewModel.kt
@@ -3,10 +3,11 @@ package app.otakureader.feature.library.maintenance
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.otakureader.domain.scheduler.LibraryUpdateScheduler
+import app.otakureader.domain.usecase.downloads.DeleteOrphanedDownloadsUseCase
 import app.otakureader.domain.usecase.downloads.ReindexDownloadsUseCase
+import app.otakureader.domain.usecase.downloads.ScanOrphanedDownloadsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -22,7 +23,9 @@ import javax.inject.Inject
  * - Refresh Covers: triggers the library update scheduler (which re-downloads covers)
  * - Refresh Metadata: triggers the library update scheduler to pull fresh metadata
  * - Reindex Downloads: calls [ReindexDownloadsUseCase] to sync download status with disk
- * - Orphan Scan / Delete: placeholder — will be backed by a real use case in a future iteration
+ * - Orphan Scan / Delete: backed by [ScanOrphanedDownloadsUseCase] /
+ *   [DeleteOrphanedDownloadsUseCase], which compare the downloads directory against the
+ *   manga/chapter database and remove stale directories
  *
  * Each task exposes a `Running` flag and a nullable `Result` string in [LibraryMaintenanceState].
  * One-shot feedback (e.g. errors) is delivered via [LibraryMaintenanceEffect].
@@ -30,6 +33,8 @@ import javax.inject.Inject
 @HiltViewModel
 class LibraryMaintenanceViewModel @Inject constructor(
     private val reindexDownloadsUseCase: ReindexDownloadsUseCase,
+    private val scanOrphanedDownloadsUseCase: ScanOrphanedDownloadsUseCase,
+    private val deleteOrphanedDownloadsUseCase: DeleteOrphanedDownloadsUseCase,
     private val libraryUpdateScheduler: LibraryUpdateScheduler,
 ) : ViewModel() {
 
@@ -53,8 +58,6 @@ class LibraryMaintenanceViewModel @Inject constructor(
 
     private suspend fun refreshCovers() {
         _state.update { it.copy(coverRefreshRunning = true, coverRefreshResult = null) }
-        // Trigger the existing library update scheduler, which re-fetches covers.
-        // The actual worker runs in the background; we report that the job was queued.
         runCatching { libraryUpdateScheduler.enqueueNow() }
             .onSuccess {
                 _state.update {
@@ -106,22 +109,57 @@ class LibraryMaintenanceViewModel @Inject constructor(
 
     private suspend fun scanOrphans() {
         _state.update { it.copy(orphanScanRunning = true, orphanScanResult = null) }
-        // Orphan scanning is not yet backed by a dedicated use case.
-        // A 500 ms delay simulates work so the progress indicator is visible.
-        delay(500)
-        _state.update {
-            it.copy(
-                orphanScanRunning = false,
-                orphanCount = 0,
-                orphanScanResult = "No orphaned files found",
-            )
-        }
+        runCatching { scanOrphanedDownloadsUseCase() }
+            .onSuccess { result ->
+                val resultText = if (result.count == 0) {
+                    "No orphaned files found"
+                } else {
+                    "${result.count} orphaned folder(s) found (${result.sizeBytes.formatBytes()})"
+                }
+                _state.update {
+                    it.copy(
+                        orphanScanRunning = false,
+                        orphanCount = result.count,
+                        orphanedSizeBytes = result.sizeBytes,
+                        orphanScanResult = resultText,
+                    )
+                }
+            }
+            .onFailure { error ->
+                _state.update { it.copy(orphanScanRunning = false) }
+                _effect.send(LibraryMaintenanceEffect.ShowSnackbar("Scan failed: ${error.message}"))
+            }
     }
 
     private suspend fun deleteOrphans() {
-        // Deletion is gated on a prior scan so users know what will be removed.
-        _effect.send(
-            LibraryMaintenanceEffect.ShowSnackbar("Orphaned file cleanup not yet implemented"),
-        )
+        if (_state.value.orphanCount == 0) return
+        _state.update { it.copy(orphanScanRunning = true, orphanScanResult = null) }
+        runCatching { deleteOrphanedDownloadsUseCase() }
+            .onSuccess { result ->
+                val resultText = if (result.count == 0) {
+                    "No orphaned files found"
+                } else {
+                    "Deleted ${result.count} folder(s) (${result.sizeBytes.formatBytes()} freed)"
+                }
+                _state.update {
+                    it.copy(
+                        orphanScanRunning = false,
+                        orphanCount = 0,
+                        orphanedSizeBytes = 0L,
+                        orphanScanResult = resultText,
+                    )
+                }
+            }
+            .onFailure { error ->
+                _state.update { it.copy(orphanScanRunning = false) }
+                _effect.send(LibraryMaintenanceEffect.ShowSnackbar("Delete failed: ${error.message}"))
+            }
+    }
+
+    private fun Long.formatBytes(): String = when {
+        this < 1_024L -> "$this B"
+        this < 1_048_576L -> "%.1f KB".format(this / 1_024.0)
+        this < 1_073_741_824L -> "%.1f MB".format(this / 1_048_576.0)
+        else -> "%.2f GB".format(this / 1_073_741_824.0)
     }
 }


### PR DESCRIPTION
## **User description**
$(cat <<'EOF'
## Summary

- **Fix 1 — Orphaned file cleanup:** The Library Maintenance screen had a placeholder that showed "Orphaned file cleanup not yet implemented." It now performs a real scan by comparing every chapter directory on disk against the manga/chapter database. Folders with no matching DB record are reported with count + size, and the delete button actually removes them.
- **Fix 3 — EH favorites full pagination:** `EhFavoritesApi` only fetched the first 25 favorites. It now loops through all pages until an empty page is returned (hard cap 40 pages = 1 000 favorites), so users with large EH favorites lists get a complete sync.

## What changed

### EH pagination (`data/eh/EhFavoritesApi.kt`)
- Replaced the single `page=0` fetch with a loop that accumulates items until a page returns 0 galleries.
- Added a `hostOverrideForTests` secondary constructor parameter (production always gets `null`; tests pass a `MockWebServer` URL).
- New tests: 53 items across 3 real pages + 1 empty sentinel; empty first page short-circuits immediately.

### Orphaned file cleanup
- `MangaDao.getAllMangaOnce()` + `ChapterDao.getChaptersByMangaIdOnce()` — one-shot suspend queries needed by the scan.
- `OrphanScanResult(count, sizeBytes)` — new domain model.
- `DownloadRepository` interface — added `scanOrphanedDownloads()` and `deleteOrphanedDownloads()`.
- `DownloadRepositoryImpl` — injects `MangaDao` + `ChapterDao`; `findOrphanedChapterDirs()` walks 3 levels of the downloads tree and returns any chapter dir whose absolute path is not in the expected-path set built from the DB.
- `ScanOrphanedDownloadsUseCase` + `DeleteOrphanedDownloadsUseCase` — thin domain wrappers.
- `LibraryMaintenanceViewModel` — now calls the real use cases; shows `"3 folder(s) found (47.2 MB)"` after scan and `"Deleted 3 folder(s) (47.2 MB freed)"` after delete. Delete button only appears when scan found orphans (unchanged UI logic).

## Test plan
- [ ] `./gradlew :data:testDebugUnitTest` — 7 EhFavoritesApiTest tests pass including the two new pagination tests.
- [ ] `./gradlew :data:compileDebugKotlin :feature:library:compileDebugKotlin` — clean compile.
- [ ] Library Maintenance → "Scan for Orphaned Files" → shows real count + size (or "No orphaned files found").
- [ ] With orphans present: "Delete Orphaned Files" button appears → tap → count resets to 0.
- [ ] EH session with >25 favorites: sync returns full list, not truncated at 25.

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Fetch all EH favorites and clean up orphaned download folders**

### What Changed
- EH favorites sync now keeps loading pages until it reaches the end, so large favorites lists are fully imported instead of stopping after the first page.
- Library Maintenance now scans the downloads folder for chapter folders with no matching library entry, shows how many were found and their total size, and deletes them for real.
- After deletion, the screen shows how much space was freed and clears the orphan count.
- Added tests for multi-page favorites syncing and for stopping immediately when the first page is empty.

### Impact
`✅ Complete EH favorites sync`
`✅ Fewer missed favorites for large collections`
`✅ Real orphaned file cleanup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
