### PR TITLE
feat: custom cover art + onboarding appearance step

### DIFF
--- a/core/database/src/main/java/app/otakureader/core/database/dao/MangaDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/MangaDao.kt
@@ -109,6 +109,10 @@ interface MangaDao {
         status: Int?,
     )
 
+    /** Update only the user cover override, leaving other user-info overrides intact. */
+    @Query("UPDATE manga SET userThumbnailUrl = :thumbnailUrl WHERE id = :id")
+    suspend fun updateUserThumbnail(id: Long, thumbnailUrl: String?)
+
     @Query("SELECT * FROM manga WHERE favorite = 1 AND userCompleted = 1 ORDER BY title ASC")
     fun getCompletedManga(): Flow<List<MangaEntity>>
 

--- a/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
@@ -229,9 +229,8 @@ class MangaRepositoryImpl @Inject constructor(
     }
 
     override suspend fun clearLocalOverrides(id: Long) {
-        // Also remove any stored custom cover file before its path reference is cleared.
-        // File I/O must run off the caller's thread (often Dispatchers.Main in a ViewModel).
-        withContext(Dispatchers.IO) { deleteCustomCoverFiles(id) }
+        // DB first: if the update fails, the stored cover file is still referenced and
+        // nothing is lost. Files are only deleted once the DB no longer points at them.
         mangaDao.updateUserOverrides(
             id = id,
             title = null,
@@ -242,6 +241,7 @@ class MangaRepositoryImpl @Inject constructor(
             genre = null,
             status = null,
         )
+        withContext(Dispatchers.IO) { deleteCustomCoverFiles(id) }
     }
 
     override suspend fun setCustomCover(id: Long, contentUri: String) = withContext(Dispatchers.IO) {
@@ -254,14 +254,16 @@ class MangaRepositoryImpl @Inject constructor(
             coverFile.outputStream().use { output -> input.copyTo(output) }
         } ?: error("Could not open selected image")
 
-        // Remove older cover files for this manga before pointing at the new one.
-        deleteCustomCoverFiles(id, except = coverFile)
+        // Point the DB at the new file first; only then clean up older files so a failed
+        // DB write can never leave the row referencing a deleted path.
         mangaDao.updateUserThumbnail(id, "file://${coverFile.absolutePath}")
+        deleteCustomCoverFiles(id, except = coverFile)
     }
 
     override suspend fun removeCustomCover(id: Long) = withContext(Dispatchers.IO) {
-        deleteCustomCoverFiles(id)
+        // DB first for the same crash-safety reason as setCustomCover.
         mangaDao.updateUserThumbnail(id, null)
+        deleteCustomCoverFiles(id)
     }
 
     /** Deletes stored custom cover files for [id], optionally keeping [except]. */
@@ -333,7 +335,10 @@ class MangaRepositoryImpl @Inject constructor(
         mangaThemeOverride = mangaThemeOverride,
         isUserEdited = userTitle != null || userDescription != null || userAuthor != null ||
             userArtist != null || userThumbnailUrl != null || userGenre != null || userStatus != null,
-        hasCustomCover = userThumbnailUrl != null,
+        // Only app-stored picker images count as a "custom cover". A manual cover URL set
+        // via Edit Info also lives in userThumbnailUrl but must not enable the
+        // "Remove custom cover" path, which would silently discard that URL override.
+        hasCustomCover = userThumbnailUrl?.contains("/$CUSTOM_COVERS_DIR/") == true,
     )
 
     private fun Manga.toEntity() = MangaEntity(

--- a/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
@@ -230,7 +230,8 @@ class MangaRepositoryImpl @Inject constructor(
 
     override suspend fun clearLocalOverrides(id: Long) {
         // Also remove any stored custom cover file before its path reference is cleared.
-        deleteCustomCoverFiles(id)
+        // File I/O must run off the caller's thread (often Dispatchers.Main in a ViewModel).
+        withContext(Dispatchers.IO) { deleteCustomCoverFiles(id) }
         mangaDao.updateUserOverrides(
             id = id,
             title = null,

--- a/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package app.otakureader.data.repository
 
+import android.content.Context
 import app.otakureader.core.database.dao.ChapterDao
 import app.otakureader.core.database.dao.MangaAlternativeSourceDao
 import app.otakureader.core.database.dao.MangaCategoryDao
@@ -10,16 +11,21 @@ import app.otakureader.domain.model.ContentRating
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.repository.MangaRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class MangaRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val mangaDao: MangaDao,
     private val chapterDao: ChapterDao,
     private val mangaCategoryDao: MangaCategoryDao,
@@ -223,6 +229,8 @@ class MangaRepositoryImpl @Inject constructor(
     }
 
     override suspend fun clearLocalOverrides(id: Long) {
+        // Also remove any stored custom cover file before its path reference is cleared.
+        deleteCustomCoverFiles(id)
         mangaDao.updateUserOverrides(
             id = id,
             title = null,
@@ -233,6 +241,33 @@ class MangaRepositoryImpl @Inject constructor(
             genre = null,
             status = null,
         )
+    }
+
+    override suspend fun setCustomCover(id: Long, contentUri: String) = withContext(Dispatchers.IO) {
+        val coversDir = File(context.filesDir, CUSTOM_COVERS_DIR).apply { mkdirs() }
+        // Timestamped filename so Coil's cache (keyed by path) never serves a stale image
+        // after the cover is replaced.
+        val coverFile = File(coversDir, "${id}_${System.currentTimeMillis()}.img")
+        val uri = android.net.Uri.parse(contentUri)
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            coverFile.outputStream().use { output -> input.copyTo(output) }
+        } ?: error("Could not open selected image")
+
+        // Remove older cover files for this manga before pointing at the new one.
+        deleteCustomCoverFiles(id, except = coverFile)
+        mangaDao.updateUserThumbnail(id, "file://${coverFile.absolutePath}")
+    }
+
+    override suspend fun removeCustomCover(id: Long) = withContext(Dispatchers.IO) {
+        deleteCustomCoverFiles(id)
+        mangaDao.updateUserThumbnail(id, null)
+    }
+
+    /** Deletes stored custom cover files for [id], optionally keeping [except]. */
+    private fun deleteCustomCoverFiles(id: Long, except: File? = null) {
+        File(context.filesDir, CUSTOM_COVERS_DIR)
+            .listFiles { f -> f.isFile && f.name.startsWith("${id}_") }
+            ?.forEach { if (it != except) it.delete() }
     }
 
     override fun findDuplicates(): Flow<List<List<Manga>>> =
@@ -297,6 +332,7 @@ class MangaRepositoryImpl @Inject constructor(
         mangaThemeOverride = mangaThemeOverride,
         isUserEdited = userTitle != null || userDescription != null || userAuthor != null ||
             userArtist != null || userThumbnailUrl != null || userGenre != null || userStatus != null,
+        hasCustomCover = userThumbnailUrl != null,
     )
 
     private fun Manga.toEntity() = MangaEntity(
@@ -330,4 +366,9 @@ class MangaRepositoryImpl @Inject constructor(
         userDropped = userDropped,
         mangaThemeOverride = mangaThemeOverride,
     )
+
+    private companion object {
+        /** App-private directory under filesDir holding user-chosen cover images. */
+        const val CUSTOM_COVERS_DIR = "custom_covers"
+    }
 }

--- a/data/src/test/java/app/otakureader/data/repository/MangaRepositoryImplTest.kt
+++ b/data/src/test/java/app/otakureader/data/repository/MangaRepositoryImplTest.kt
@@ -55,7 +55,14 @@ class MangaRepositoryImplTest {
         mangaCategoryDao = mockk()
         altSourceDao = mockk()
         downloadRepository = mockk()
-        repository = MangaRepositoryImpl(mangaDao, chapterDao, mangaCategoryDao, altSourceDao, downloadRepository)
+        repository = MangaRepositoryImpl(
+            context = mockk(relaxed = true),
+            mangaDao = mangaDao,
+            chapterDao = chapterDao,
+            mangaCategoryDao = mangaCategoryDao,
+            altSourceDao = altSourceDao,
+            downloadRepository = downloadRepository,
+        )
     }
 
     // ---- getLibraryManga ----

--- a/domain/src/main/java/app/otakureader/domain/model/Manga.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/Manga.kt
@@ -58,6 +58,9 @@ data class Manga(
 
     /** True when the user has manually overridden at least one metadata field (#998). */
     val isUserEdited: Boolean = false,
+
+    /** True when [thumbnailUrl] is a user-chosen custom cover rather than the source cover. */
+    val hasCustomCover: Boolean = false,
 )
 
 @Serializable

--- a/domain/src/main/java/app/otakureader/domain/repository/MangaRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/MangaRepository.kt
@@ -69,6 +69,17 @@ interface MangaRepository {
     /** Remove all user-info overrides for this manga, reverting to source metadata. */
     suspend fun clearLocalOverrides(id: Long)
 
+    // Custom cover art
+    /**
+     * Copies the image at [contentUri] (a `content://` URI from the system image picker)
+     * into app-private storage and sets it as this manga's cover. Other user-info
+     * overrides are left untouched.
+     */
+    suspend fun setCustomCover(id: Long, contentUri: String)
+
+    /** Deletes the stored custom cover file (if any) and reverts to the source cover. */
+    suspend fun removeCustomCover(id: Long)
+
     // Duplicate detection (#997)
     /** Groups of library manga sharing the same normalised title (≥2 entries per group). */
     fun findDuplicates(): Flow<List<List<Manga>>>

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
@@ -259,6 +259,11 @@ object DetailsContract {
             val status: MangaStatus?,
         ) : Event
         data object ResetMangaInfo : Event
+
+        // Custom cover art
+        /** [imageUri] is a content:// URI string returned by the system image picker. */
+        data class SetCustomCover(val imageUri: String) : Event
+        data object RemoveCustomCover : Event
     }
 
     /**

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -2,6 +2,8 @@
 package app.otakureader.feature.details
 
 import android.content.Intent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -217,6 +219,15 @@ fun DetailsScreen(
                         Icon(Icons.Default.QueryStats, contentDescription = stringResource(R.string.details_tracking))
                     }
                     var overflowExpanded by remember { mutableStateOf(false) }
+                    // System image picker for custom cover art. The picked content:// URI is
+                    // passed to the ViewModel, which copies the image into app storage.
+                    val coverPickerLauncher = rememberLauncherForActivityResult(
+                        ActivityResultContracts.GetContent(),
+                    ) { uri ->
+                        if (uri != null) {
+                            viewModel.onEvent(DetailsContract.Event.SetCustomCover(uri.toString()))
+                        }
+                    }
                     IconButton(onClick = { overflowExpanded = true }) {
                         Icon(Icons.Default.MoreVert, contentDescription = "More options")
                     }
@@ -306,6 +317,22 @@ fun DetailsScreen(
                                 overflowExpanded = false
                             }
                         )
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.details_set_custom_cover)) },
+                            onClick = {
+                                coverPickerLauncher.launch("image/*")
+                                overflowExpanded = false
+                            }
+                        )
+                        if (state.manga?.hasCustomCover == true) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.details_remove_custom_cover)) },
+                                onClick = {
+                                    viewModel.onEvent(DetailsContract.Event.RemoveCustomCover)
+                                    overflowExpanded = false
+                                }
+                            )
+                        }
                     }
                 }
             )

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -163,6 +163,8 @@ class DetailsViewModel @Inject constructor(
                 _state.update { it.copy(isEditInfoSheetVisible = false) }
             is DetailsContract.Event.SaveMangaInfo -> saveMangaInfo(event)
             is DetailsContract.Event.ResetMangaInfo -> resetMangaInfo()
+            is DetailsContract.Event.SetCustomCover -> setCustomCover(event.imageUri)
+            is DetailsContract.Event.RemoveCustomCover -> removeCustomCover()
         }
     }
 
@@ -1235,6 +1237,32 @@ class DetailsViewModel @Inject constructor(
                 throw e
             } catch (e: Exception) {
                 _effect.send(DetailsContract.Effect.ShowError("Failed to reset manga info: ${e.message}"))
+            }
+        }
+    }
+
+    private fun setCustomCover(imageUri: String) {
+        viewModelScope.launch {
+            try {
+                mangaRepository.setCustomCover(mangaId, imageUri)
+                _effect.send(DetailsContract.Effect.ShowSnackbar("Custom cover set"))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(DetailsContract.Effect.ShowError("Failed to set custom cover: ${e.message}"))
+            }
+        }
+    }
+
+    private fun removeCustomCover() {
+        viewModelScope.launch {
+            try {
+                mangaRepository.removeCustomCover(mangaId)
+                _effect.send(DetailsContract.Effect.ShowSnackbar("Custom cover removed"))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(DetailsContract.Effect.ShowError("Failed to remove custom cover: ${e.message}"))
             }
         }
     }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -30,6 +30,8 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.sourceapi.SourceChapter
 import kotlinx.coroutines.async
@@ -1241,10 +1243,14 @@ class DetailsViewModel @Inject constructor(
         }
     }
 
+    // Serializes set/remove cover operations: each mutates files + DB, so two running
+    // concurrently (rapid taps) could leave the DB pointing at a deleted file.
+    private val coverMutex = Mutex()
+
     private fun setCustomCover(imageUri: String) {
         viewModelScope.launch {
             try {
-                mangaRepository.setCustomCover(mangaId, imageUri)
+                coverMutex.withLock { mangaRepository.setCustomCover(mangaId, imageUri) }
                 _effect.send(DetailsContract.Effect.ShowSnackbar("Custom cover set"))
             } catch (e: CancellationException) {
                 throw e
@@ -1257,7 +1263,7 @@ class DetailsViewModel @Inject constructor(
     private fun removeCustomCover() {
         viewModelScope.launch {
             try {
-                mangaRepository.removeCustomCover(mangaId)
+                coverMutex.withLock { mangaRepository.removeCustomCover(mangaId) }
                 _effect.send(DetailsContract.Effect.ShowSnackbar("Custom cover removed"))
             } catch (e: CancellationException) {
                 throw e

--- a/feature/details/src/main/res/values/strings.xml
+++ b/feature/details/src/main/res/values/strings.xml
@@ -196,4 +196,8 @@
     <string name="details_edit_reset_confirm_title">Reset manga info?</string>
     <string name="details_edit_reset_confirm_body">This will clear all your custom edits and restore the original source data.</string>
     <string name="details_edit_reset_confirm_ok">Reset</string>
+
+    <!-- Custom cover art -->
+    <string name="details_set_custom_cover">Set custom cover</string>
+    <string name="details_remove_custom_cover">Remove custom cover</string>
 </resources>

--- a/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingScreen.kt
@@ -408,6 +408,8 @@ private fun ThemeOptionCard(
     Card(
         modifier = modifier
             .fillMaxWidth()
+            // Clip before clickable so the ripple follows the card's rounded corners.
+            .clip(CardDefaults.shape)
             .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(
             containerColor = if (selected) {

--- a/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingScreen.kt
@@ -30,11 +30,17 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.BatteryFull
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Extension
+import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.MenuBook
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.PowerSettingsNew
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -52,8 +58,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.foundation.clickable
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 
 /** Type of each onboarding page — drives which permission UI (if any) is shown. */
@@ -61,6 +70,7 @@ enum class OnboardingPageType {
     WELCOME,
     NOTIFICATIONS,  // Android 13+ only
     BATTERY,        // Battery optimisation exclusion
+    APPEARANCE,     // Theme selection (applies live)
     EXTENSIONS,     // "Install extensions" action
 }
 
@@ -77,7 +87,8 @@ data class OnboardingPage(
  *  1. Welcome
  *  2. [Android 13+] Notifications permission
  *  3. Battery-optimisation exclusion
- *  4. Install extensions
+ *  4. Appearance (theme — applies live)
+ *  5. Install extensions (with quick-start hints)
  *
  * Each permission page shows a live status icon and an action button that is
  * disabled once the permission has been granted.
@@ -89,8 +100,10 @@ fun OnboardingScreen(
     onSkip: () -> Unit = onComplete,
     onNavigateToExtensions: () -> Unit = {},
     modifier: Modifier = Modifier,
+    viewModel: OnboardingViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
+    val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
 
     // Build page list dynamically; notifications page is Android 13+ only
     val pages = remember {
@@ -119,6 +132,14 @@ fun OnboardingScreen(
                     titleRes = R.string.onboarding_title_battery,
                     descriptionRes = R.string.onboarding_desc_battery,
                     icon = Icons.Default.PowerSettingsNew,
+                ),
+            )
+            add(
+                OnboardingPage(
+                    type = OnboardingPageType.APPEARANCE,
+                    titleRes = R.string.onboarding_title_appearance,
+                    descriptionRes = R.string.onboarding_desc_appearance,
+                    icon = Icons.Default.Palette,
                 ),
             )
             add(
@@ -191,6 +212,8 @@ fun OnboardingScreen(
                 page = pages[pageIndex],
                 notificationsGranted = notificationsGranted,
                 batteryOptimizationIgnored = batteryOptimizationIgnored,
+                themeMode = themeMode,
+                onThemeModeSelected = viewModel::setThemeMode,
                 onRequestNotifications = {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                         notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
@@ -217,6 +240,8 @@ private fun OnboardingPageContent(
     page: OnboardingPage,
     notificationsGranted: Boolean,
     batteryOptimizationIgnored: Boolean,
+    themeMode: Int,
+    onThemeModeSelected: (Int) -> Unit,
     onRequestNotifications: () -> Unit,
     onRequestBatteryOptimization: () -> Unit,
     modifier: Modifier = Modifier,
@@ -335,6 +360,121 @@ private fun OnboardingPageContent(
                 )
             }
         }
+
+        if (page.type == OnboardingPageType.APPEARANCE) {
+            Spacer(modifier = Modifier.height(32.dp))
+            ThemeOptionCard(
+                label = stringResource(R.string.onboarding_theme_system),
+                icon = Icons.Default.PhoneAndroid,
+                selected = themeMode == 0,
+                onClick = { onThemeModeSelected(0) },
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            ThemeOptionCard(
+                label = stringResource(R.string.onboarding_theme_light),
+                icon = Icons.Default.LightMode,
+                selected = themeMode == 1,
+                onClick = { onThemeModeSelected(1) },
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            ThemeOptionCard(
+                label = stringResource(R.string.onboarding_theme_dark),
+                icon = Icons.Default.DarkMode,
+                selected = themeMode == 2,
+                onClick = { onThemeModeSelected(2) },
+            )
+        }
+
+        if (page.type == OnboardingPageType.EXTENSIONS) {
+            Spacer(modifier = Modifier.height(24.dp))
+            QuickStartHint(stringResource(R.string.onboarding_hint_browse))
+            Spacer(modifier = Modifier.height(8.dp))
+            QuickStartHint(stringResource(R.string.onboarding_hint_library))
+            Spacer(modifier = Modifier.height(8.dp))
+            QuickStartHint(stringResource(R.string.onboarding_hint_trackers))
+        }
+    }
+}
+
+/** A selectable card for one theme choice on the Appearance page. */
+@Composable
+private fun ThemeOptionCard(
+    label: String,
+    icon: ImageVector,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(
+            containerColor = if (selected) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceVariant
+            },
+        ),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+                tint = if (selected) {
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (selected) {
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                modifier = Modifier.weight(1f),
+            )
+            if (selected) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
+        }
+    }
+}
+
+/** A single quick-start bullet on the Extensions page. */
+@Composable
+private fun QuickStartHint(text: String, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Default.Check,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingViewModel.kt
@@ -1,0 +1,31 @@
+package app.otakureader.feature.onboarding
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.otakureader.core.preferences.GeneralPreferences
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * ViewModel for the onboarding wizard's Appearance step.
+ *
+ * Exposes the persisted theme mode reactively so the selection survives process death
+ * and the app re-themes live as the user taps an option.
+ */
+@HiltViewModel
+class OnboardingViewModel @Inject constructor(
+    private val generalPreferences: GeneralPreferences,
+) : ViewModel() {
+
+    /** Theme mode: 0 = system default, 1 = light, 2 = dark. */
+    val themeMode: StateFlow<Int> = generalPreferences.themeMode
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0)
+
+    fun setThemeMode(mode: Int) {
+        viewModelScope.launch { generalPreferences.setThemeMode(mode) }
+    }
+}

--- a/feature/onboarding/src/main/res/values/strings.xml
+++ b/feature/onboarding/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="onboarding_title_extensions">Install Extensions</string>
     <string name="onboarding_title_notifications">Notifications</string>
     <string name="onboarding_title_battery">Background Updates</string>
+    <string name="onboarding_title_appearance">Make It Yours</string>
 
     <!-- Page descriptions -->
     <string name="onboarding_desc_welcome">Your personal manga library. Track your reading, discover new series, and enjoy your favorite manga offline.</string>
@@ -17,6 +18,17 @@
     <string name="onboarding_desc_extensions">Otaku Reader uses extensions to access manga sources. Install your first extension to get started!</string>
     <string name="onboarding_desc_notifications">Get notified when new chapters of your favorite manga become available.</string>
     <string name="onboarding_desc_battery">Disable battery optimization so Otaku Reader can fetch updates reliably in the background.</string>
+    <string name="onboarding_desc_appearance">Pick a theme — it applies instantly. You can change this anytime in Settings.</string>
+
+    <!-- Appearance page theme options -->
+    <string name="onboarding_theme_system">System default</string>
+    <string name="onboarding_theme_light">Light</string>
+    <string name="onboarding_theme_dark">Dark</string>
+
+    <!-- Extensions page quick-start hints -->
+    <string name="onboarding_hint_browse">Tap Browse to search 500+ community sources</string>
+    <string name="onboarding_hint_library">Favorite a manga to add it to your Library</string>
+    <string name="onboarding_hint_trackers">Link MAL, AniList &amp; more in Settings → Tracking</string>
 
     <!-- Buttons -->
     <string name="onboarding_btn_next">Next</string>


### PR DESCRIPTION
## **User description**
## Summary

Second half of the gap-fix batch (first half is #1092):

- **Custom cover art:** Users can now pick any image from their device as a manga's cover. Power users need this for bad scraped covers, fan art, or old series with no cover. Until now the only option was pasting a URL into Edit Info.
- **Onboarding Appearance step:** New theme-selection page (System / Light / Dark) that applies live as you tap, plus three quick-start hints on the Extensions page so first-time users know what to do after "Get Started".

## How custom covers work

1. Details screen overflow → **"Set custom cover"** → system image picker opens.
2. The picked `content://` URI is copied into `filesDir/custom_covers/{mangaId}_{timestamp}.img` (app-private; no storage permission needed).
3. The `file://` path is stored in `MangaEntity.userThumbnailUrl` — the user-override field that already existed from #998, so **no DB migration**. The entity→domain mapper already resolves `userThumbnailUrl ?: thumbnailUrl`, and Coil loads `file://` URIs natively, so the cover updates everywhere (details, library grid) immediately via the existing reactive flow.
4. **"Remove custom cover"** (shown only when one is set) deletes the file and reverts to the source cover.

Design notes for review:
- Timestamped filenames mean a replaced cover gets a *new* path, so Coil's cache (keyed by path) can never serve the stale image. Old files for the same manga are cleaned up on each set/remove.
- A new targeted `MangaDao.updateUserThumbnail()` updates only that column — using the existing `updateUserOverrides()` would have nulled out the user's other metadata edits.
- `clearLocalOverrides()` ("Reset to source" in Edit Info) now also deletes the stored cover file so it doesn't leak orphaned images.

## How the onboarding changes work

- New `APPEARANCE` page type between Battery and Extensions. Three selectable cards write `GeneralPreferences.setThemeMode()` immediately — the app re-themes live, which doubles as a preview.
- The screen previously had no ViewModel; a minimal `OnboardingViewModel` now exposes `themeMode` as `StateFlow` (collected with `collectAsStateWithLifecycle`), keeping the composable stateless per the project's MVI rules.
- Page count is now 5 on Android 13+, 4 below (notifications page is conditional, unchanged).

## Test plan
- [ ] `./gradlew :feature:details:compileDebugKotlin :feature:onboarding:compileDebugKotlin :data:compileDebugKotlin` — clean.
- [ ] Detekt clean on all touched modules.
- [ ] Details → Set custom cover → pick image → cover updates in details header and library grid; persists after restart.
- [ ] Remove custom cover → reverts to scraped cover; file removed from `custom_covers/`.
- [ ] Clear app data → onboarding shows Appearance page → tapping Dark re-themes instantly → completes normally.

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS


---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Let users set a custom manga cover and choose the app theme during onboarding**

### What Changed
- Added a new “Set custom cover” option on the manga details screen so users can pick an image from their device and use it as the cover
- Added “Remove custom cover” to restore the source cover when a custom one is in use
- Custom covers now stay in app storage and remain linked to the manga without clearing other saved metadata edits
- Added an onboarding Appearance step with System, Light, and Dark theme choices that apply right away and persist after setup
- Added short onboarding hints on the Extensions page to guide first-time users on browsing, favoriting, and tracker setup

### Impact
`✅ Easier cover fixes for titles with bad or missing artwork`
`✅ Faster first-time setup with immediate theme selection`
`✅ Clearer next steps after onboarding`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
