### PR TITLE
fix: extension repository loading — five root-cause fixes

### DIFF
--- a/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionDatabase.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionDatabase.kt
@@ -127,7 +127,12 @@ interface ExtensionDao {
     @Query("DELETE FROM extensions")
     suspend fun clearAll()
 
-    @Query("DELETE FROM extensions WHERE status = 'AVAILABLE'")
+    /**
+     * Clears cached non-installed rows before a refresh. ERROR rows (failed installs)
+     * are included: they represent nothing installed on disk, and clearing them lets
+     * the fresh AVAILABLE row make the extension reinstallable again.
+     */
+    @Query("DELETE FROM extensions WHERE status IN ('AVAILABLE', 'ERROR')")
     suspend fun deleteAllAvailable()
 
     /**

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionDatabase.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionDatabase.kt
@@ -10,6 +10,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.PrimaryKey
 import androidx.room.Query
 import androidx.room.RoomDatabase
+import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -122,9 +123,23 @@ interface ExtensionDao {
     
     @Query("SELECT * FROM extensions WHERE name LIKE '%' || :query || '%' OR pkg_name LIKE '%' || :query || '%'")
     fun searchExtensions(query: String): Flow<List<ExtensionEntity>>
-    
+
     @Query("DELETE FROM extensions")
     suspend fun clearAll()
+
+    @Query("DELETE FROM extensions WHERE status = 'AVAILABLE'")
+    suspend fun deleteAllAvailable()
+
+    /**
+     * Atomically replaces the cached AVAILABLE extension list with a fresh fetch.
+     * Without the delete step, extensions from removed/changed repositories linger
+     * in the database forever and keep showing in the Available tab.
+     */
+    @Transaction
+    suspend fun replaceAllAvailable(entities: List<ExtensionEntity>) {
+        deleteAllAvailable()
+        insertExtensions(entities)
+    }
 }
 
 @Database(

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
@@ -217,6 +217,7 @@ class ExtensionRemoteDataSourceImpl(
 
                 val extensions = mutableListOf<Extension>()
                 val failures = mutableListOf<Pair<String, Exception>>()
+                var successCount = 0
 
                 // Isolate failures per repository: one unreachable or malformed repo must
                 // not wipe out the extension list from every other configured repo.
@@ -225,6 +226,7 @@ class ExtensionRemoteDataSourceImpl(
                     try {
                         val repoExtensions = fetchFromRepository(baseUrl)
                         extensions.addAll(repoExtensions.map { it.copy(repoUrl = baseUrl) })
+                        successCount++
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
@@ -236,17 +238,19 @@ class ExtensionRemoteDataSourceImpl(
                     }
                 }
 
-                // Only report failure when every repository failed — partial results are
-                // far more useful to the user than an empty error state.
-                if (extensions.isEmpty() && failures.isNotEmpty()) {
+                // Only report failure when every repository failed — a repo that responds
+                // with a legitimately empty list still counts as a success, and partial
+                // results are far more useful to the user than an empty error state.
+                if (successCount == 0 && failures.isNotEmpty()) {
                     val (firstUrl, firstError) = failures.first()
-                    return@withContext Result.failure(
-                        ExtensionFetchException(
-                            "All ${failures.size} extension repositories failed " +
-                                "(first: $firstUrl — ${firstError.message})",
-                            firstError
-                        )
+                    val exception = ExtensionFetchException(
+                        "All ${failures.size} extension repositories failed " +
+                            "(first: $firstUrl — ${firstError.message})",
+                        firstError
                     )
+                    // Preserve the other repos' errors for debugging.
+                    failures.drop(1).forEach { (_, error) -> exception.addSuppressed(error) }
+                    return@withContext Result.failure(exception)
                 }
 
                 // Deduplicate by package name preferring highest versionCode
@@ -406,9 +410,12 @@ class ExtensionFetchException(message: String, cause: Throwable? = null) :
 
 /** Convert [ExtensionDto] to the [Extension] domain model. */
 private fun ExtensionDto.toDomain(baseUrl: String): Extension {
-    // Prefer apk_url, fall back to the minified-style apk filename. Either may be relative,
-    // so both go through resolveApkUrl which prepends the repo base + /apk/ as needed.
-    val resolvedApkUrl = (apkUrl ?: apk)?.let { resolveApkUrl(baseUrl, it) }
+    // Prefer a non-blank apk_url, fall back to the minified-style apk filename. Either may
+    // be relative, so both go through resolveApkUrl which prepends the repo base + /apk/
+    // as needed. Blank strings are treated as absent so an empty apk_url can't shadow a
+    // valid apk filename.
+    val resolvedApkUrl = (apkUrl?.takeIf { it.isNotBlank() } ?: apk?.takeIf { it.isNotBlank() })
+        ?.let { resolveApkUrl(baseUrl, it) }
     return Extension(
         id = id,
         pkgName = pkgName,

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
@@ -57,7 +57,15 @@ data class ExtensionDto(
     val sources: List<ExtensionSourceDto>,
 
     @SerialName("apk_url")
-    val apkUrl: String,
+    val apkUrl: String? = null,
+
+    /**
+     * Some repos serve standard-format index.json but use the minified field name `apk`
+     * (a bare filename) instead of `apk_url`. Accept both; [toDomain] resolves whichever
+     * is present against the repo base URL.
+     */
+    @SerialName("apk")
+    val apk: String? = null,
 
     @SerialName("icon_url")
     val iconUrl: String? = null,
@@ -208,11 +216,37 @@ class ExtensionRemoteDataSourceImpl(
                 if (repositories.isEmpty()) return@withContext Result.success(emptyList())
 
                 val extensions = mutableListOf<Extension>()
+                val failures = mutableListOf<Pair<String, Exception>>()
 
+                // Isolate failures per repository: one unreachable or malformed repo must
+                // not wipe out the extension list from every other configured repo.
                 repositories.forEach { rawUrl ->
                     val baseUrl = normalizeRepoUrl(rawUrl)
-                    val repoExtensions = fetchFromRepository(baseUrl)
-                    extensions.addAll(repoExtensions.map { it.copy(repoUrl = baseUrl) })
+                    try {
+                        val repoExtensions = fetchFromRepository(baseUrl)
+                        extensions.addAll(repoExtensions.map { it.copy(repoUrl = baseUrl) })
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        android.util.Log.w(
+                            "ExtensionRemoteDS",
+                            "Failed to fetch extensions from $baseUrl: ${e.message}"
+                        )
+                        failures.add(baseUrl to e)
+                    }
+                }
+
+                // Only report failure when every repository failed — partial results are
+                // far more useful to the user than an empty error state.
+                if (extensions.isEmpty() && failures.isNotEmpty()) {
+                    val (firstUrl, firstError) = failures.first()
+                    return@withContext Result.failure(
+                        ExtensionFetchException(
+                            "All ${failures.size} extension repositories failed " +
+                                "(first: $firstUrl — ${firstError.message})",
+                            firstError
+                        )
+                    )
                 }
 
                 // Deduplicate by package name preferring highest versionCode
@@ -305,7 +339,7 @@ class ExtensionRemoteDataSourceImpl(
             }
 
             val repoResponse = json.decodeFromString(ExtensionRepoResponse.serializer(), responseBody)
-            repoResponse.extensions.map { it.toDomain() }
+            repoResponse.extensions.map { it.toDomain(baseUrl) }
         }
     }
 
@@ -371,7 +405,10 @@ class ExtensionFetchException(message: String, cause: Throwable? = null) :
     RuntimeException(message, cause)
 
 /** Convert [ExtensionDto] to the [Extension] domain model. */
-private fun ExtensionDto.toDomain(): Extension {
+private fun ExtensionDto.toDomain(baseUrl: String): Extension {
+    // Prefer apk_url, fall back to the minified-style apk filename. Either may be relative,
+    // so both go through resolveApkUrl which prepends the repo base + /apk/ as needed.
+    val resolvedApkUrl = (apkUrl ?: apk)?.let { resolveApkUrl(baseUrl, it) }
     return Extension(
         id = id,
         pkgName = pkgName,
@@ -381,7 +418,7 @@ private fun ExtensionDto.toDomain(): Extension {
         sources = sources.map { it.toDomain() },
         status = InstallStatus.AVAILABLE,
         apkPath = null,
-        apkUrl = apkUrl,
+        apkUrl = resolvedApkUrl,
         iconUrl = iconUrl,
         lang = lang,
         isNsfw = isNsfw,

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepositoryImpl.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepositoryImpl.kt
@@ -65,7 +65,24 @@ class ExtensionRepositoryImpl(
         }
     }
     
-    override suspend fun installExtension(pkgName: String, apkPath: String): Result<Extension> {
+    override suspend fun installExtension(pkgName: String, apkPath: String): Result<Extension> =
+        installExtensionInternal(pkgName, apkPath, fallback = null)
+
+    override suspend fun installExtension(extension: Extension, apkPath: String): Result<Extension> =
+        installExtensionInternal(extension.pkgName, apkPath, fallback = extension)
+
+    /**
+     * Shared install logic. Prefers the existing database row (it carries repo-sourced
+     * metadata like apkUrl, iconUrl, and first-seen repo provenance); when no row exists
+     * and [fallback] is provided, a new row is created from the loaded extension instead
+     * of failing — this covers installs from a just-added repository whose refresh hasn't
+     * synced to the database yet.
+     */
+    private suspend fun installExtensionInternal(
+        pkgName: String,
+        apkPath: String,
+        fallback: Extension?,
+    ): Result<Extension> {
         return try {
             // Blocklist enforcement (#1018): refuse install even if the caller bypassed
             // the filtered available list (e.g. a stale UI snapshot).
@@ -78,15 +95,24 @@ class ExtensionRepositoryImpl(
             }
             // Update status to installing
             localDataSource.updateStatus(pkgName, InstallStatus.INSTALLING.name)
-            
-            // Get existing or create new extension record
+
             val existing = localDataSource.getExtensionByPkgName(pkgName)
-            val extension = existing?.copy(
-                status = InstallStatus.INSTALLED.name,
-                apkPath = apkPath,
-                installDate = System.currentTimeMillis()
-            ) ?: return Result.failure(Exception("Extension not found: $pkgName"))
-            
+            val extension = when {
+                existing != null -> existing.copy(
+                    status = InstallStatus.INSTALLED.name,
+                    apkPath = apkPath,
+                    installDate = System.currentTimeMillis()
+                )
+                fallback != null -> mapper.toEntity(
+                    fallback.copy(
+                        status = InstallStatus.INSTALLED,
+                        apkPath = apkPath,
+                        installDate = System.currentTimeMillis()
+                    )
+                )
+                else -> return Result.failure(Exception("Extension not found: $pkgName"))
+            }
+
             localDataSource.insertExtension(extension)
             Result.success(mapper.toDomain(extension))
         } catch (e: CancellationException) {
@@ -219,12 +245,14 @@ class ExtensionRepositoryImpl(
             // Filter out already installed extensions, mark as AVAILABLE
             val availableExtensions = remoteExtensions
                 .filter { it.pkgName !in installedPkgNames }
-                .map { 
+                .map {
                     mapper.toEntity(it.copy(status = InstallStatus.AVAILABLE))
                 }
-            
-            // Clear old available extensions and insert new ones
-            localDataSource.insertExtensions(availableExtensions)
+
+            // Atomically clear old available extensions and insert the fresh list.
+            // A plain upsert would leave stale entries behind forever when a repository
+            // is removed or stops offering an extension.
+            localDataSource.replaceAllAvailable(availableExtensions)
             
             Result.success(Unit)
         } catch (e: CancellationException) {

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepositoryImpl.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepositoryImpl.kt
@@ -243,8 +243,15 @@ class ExtensionRepositoryImpl(
             
             val remoteExtensions = remoteResult.getOrThrow()
             val installed = localDataSource.getInstalledExtensions().first()
-            val installedPkgNames = installed.map { it.pkgName }.toSet()
-            
+            // ERROR rows are failed installs, not installed extensions — they must NOT be
+            // filtered out here, or the extension would vanish from the Available tab and
+            // become un-reinstallable. The refresh below replaces them with a fresh
+            // AVAILABLE row.
+            val installedPkgNames = installed
+                .filter { it.status != InstallStatus.ERROR.name }
+                .map { it.pkgName }
+                .toSet()
+
             // Filter out already installed extensions, mark as AVAILABLE
             val availableExtensions = remoteExtensions
                 .filter { it.pkgName !in installedPkgNames }

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepositoryImpl.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepositoryImpl.kt
@@ -101,7 +101,10 @@ class ExtensionRepositoryImpl(
                 existing != null -> existing.copy(
                     status = InstallStatus.INSTALLED.name,
                     apkPath = apkPath,
-                    installDate = System.currentTimeMillis()
+                    installDate = System.currentTimeMillis(),
+                    // Backfill provenance for rows created before the column existed (#1019)
+                    // so the cross-repo replacement guard is active immediately.
+                    sourceRepoUrl = existing.sourceRepoUrl ?: fallback?.repoUrl
                 )
                 fallback != null -> mapper.toEntity(
                     fallback.copy(

--- a/core/extension/src/main/java/app/otakureader/core/extension/domain/repository/ExtensionRepository.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/domain/repository/ExtensionRepository.kt
@@ -42,6 +42,15 @@ interface ExtensionRepository {
      * @return Result containing the installed Extension or an error
      */
     suspend fun installExtension(pkgName: String, apkPath: String): Result<Extension>
+
+    /**
+     * Install an extension using the fully-loaded [extension] object as fallback metadata.
+     *
+     * Unlike [installExtension] (pkgName overload), this does not fail when the extension
+     * has no pre-existing database row — e.g. when installing from a just-added repository
+     * before the available-extensions refresh has synced to the database.
+     */
+    suspend fun installExtension(extension: Extension, apkPath: String): Result<Extension>
     
     /**
      * Uninstall an extension.

--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -253,7 +253,10 @@ class ExtensionInstaller(
 
                 _installationState.value = InstallationState.Installing
                 val finalExtension = extension.copy(apkPath = destFile.absolutePath)
-                val result = repository.installExtension(finalExtension.pkgName, destFile.absolutePath)
+                // Pass the fully-loaded extension so the install succeeds even when the
+                // database has no row yet (e.g. repo was just added and the available-list
+                // refresh hasn't synced).
+                val result = repository.installExtension(finalExtension, destFile.absolutePath)
                 result.onSuccess { ext ->
                     _installationState.value = InstallationState.Success(ext)
                     ExtensionInstallReceiver.notifyAdded(context, finalExtension.pkgName)

--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -124,12 +124,12 @@ class ExtensionInstaller(
 
             // Register the extension inside the app, passing the repo-verified hash so the
             // universal trust gate inside ExtensionLoader can be satisfied without a separate
-            // user confirmation step. The repo URL rides along so a fallback-created DB row
-            // still records provenance (#1019).
+            // user confirmation step. The repository-backed extension rides along so a
+            // fallback-created DB row keeps provenance (#1019) plus apkUrl/iconUrl metadata.
             val result = install(
                 downloadFile,
                 trustedHash = extension.signatureHash,
-                repoUrl = extension.repoUrl,
+                repoMetadata = extension,
             )
 
             result.onSuccess { installed ->
@@ -224,15 +224,16 @@ class ExtensionInstaller(
      *   a repository-sourced expected hash. The extension's actual loaded hash is compared
      *   against this value; the trust store is only updated **after** the extension has been
      *   successfully loaded and moved to its permanent location.
-     * @param repoUrl The repository this APK was downloaded from, when known. Recorded as
-     *   install provenance (#1019) — without it, a fallback-created DB row would have null
-     *   sourceRepoUrl and the cross-repo replacement guard would be inactive until the next
-     *   update check backfilled it.
+     * @param repoMetadata The repository-index-backed extension this APK was downloaded
+     *   for, when known. The APK loader only knows manifest-derived fields, so repoUrl
+     *   (install provenance, #1019), apkUrl, and iconUrl are merged from this object —
+     *   without it, a fallback-created DB row would have null sourceRepoUrl and the
+     *   cross-repo replacement guard would be inactive until the next update check.
      */
     suspend fun install(
         apkFile: File,
         trustedHash: String? = null,
-        repoUrl: String? = null,
+        repoMetadata: Extension? = null,
     ): Result<Extension> =
         withContext(Dispatchers.IO) {
             var tempFile: File? = null
@@ -265,9 +266,12 @@ class ExtensionInstaller(
                 extension.signatureHash?.let { loader.trustExtension(it) }
 
                 _installationState.value = InstallationState.Installing
+                // Merge repo-index metadata the APK loader can't know about.
                 val finalExtension = extension.copy(
                     apkPath = destFile.absolutePath,
-                    repoUrl = extension.repoUrl ?: repoUrl,
+                    repoUrl = extension.repoUrl ?: repoMetadata?.repoUrl,
+                    apkUrl = extension.apkUrl ?: repoMetadata?.apkUrl,
+                    iconUrl = extension.iconUrl ?: repoMetadata?.iconUrl,
                 )
                 // Pass the fully-loaded extension so the install succeeds even when the
                 // database has no row yet (e.g. repo was just added and the available-list

--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -124,8 +124,13 @@ class ExtensionInstaller(
 
             // Register the extension inside the app, passing the repo-verified hash so the
             // universal trust gate inside ExtensionLoader can be satisfied without a separate
-            // user confirmation step.
-            val result = install(downloadFile, trustedHash = extension.signatureHash)
+            // user confirmation step. The repo URL rides along so a fallback-created DB row
+            // still records provenance (#1019).
+            val result = install(
+                downloadFile,
+                trustedHash = extension.signatureHash,
+                repoUrl = extension.repoUrl,
+            )
 
             result.onSuccess { installed ->
                 installed.apkPath?.let { path ->
@@ -219,8 +224,16 @@ class ExtensionInstaller(
      *   a repository-sourced expected hash. The extension's actual loaded hash is compared
      *   against this value; the trust store is only updated **after** the extension has been
      *   successfully loaded and moved to its permanent location.
+     * @param repoUrl The repository this APK was downloaded from, when known. Recorded as
+     *   install provenance (#1019) — without it, a fallback-created DB row would have null
+     *   sourceRepoUrl and the cross-repo replacement guard would be inactive until the next
+     *   update check backfilled it.
      */
-    suspend fun install(apkFile: File, trustedHash: String? = null): Result<Extension> =
+    suspend fun install(
+        apkFile: File,
+        trustedHash: String? = null,
+        repoUrl: String? = null,
+    ): Result<Extension> =
         withContext(Dispatchers.IO) {
             var tempFile: File? = null
             try {
@@ -252,7 +265,10 @@ class ExtensionInstaller(
                 extension.signatureHash?.let { loader.trustExtension(it) }
 
                 _installationState.value = InstallationState.Installing
-                val finalExtension = extension.copy(apkPath = destFile.absolutePath)
+                val finalExtension = extension.copy(
+                    apkPath = destFile.absolutePath,
+                    repoUrl = extension.repoUrl ?: repoUrl,
+                )
                 // Pass the fully-loaded extension so the install succeeds even when the
                 // database has no row yet (e.g. repo was just added and the available-list
                 // refresh hasn't synced).

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/repos/ExtensionRepositoriesViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/repos/ExtensionRepositoriesViewModel.kt
@@ -100,12 +100,9 @@ class ExtensionRepositoriesViewModel @Inject constructor(
         if (parsed.scheme != "https" && parsed.scheme != "http") {
             return "URL must start with http:// or https://"
         }
-        // Repos point at a directory; the loader appends index.min.json/index.json itself.
-        // We just check the URL doesn't itself end with one of those filenames.
-        val path = parsed.encodedPath
-        if (path.endsWith("/index.json") || path.endsWith("/index.min.json")) {
-            return "Drop the trailing /index.json — point to the directory"
-        }
+        // Full index URLs (…/index.min.json) are accepted — that's the form repo links are
+        // shared in across the Tachiyomi/Komikku ecosystem. The repository layer strips the
+        // filename via normalizeRepoUrl() before storage, so no error is needed here.
         return null
     }
 }


### PR DESCRIPTION
## **User description**
## Why

Repeated reports that adding an extension repository "never works right." A full audit of the pipeline (repo URL entry → index fetch → parse → APK download → install → classload) found five distinct failure modes. Each one alone can make repos appear broken; together they explain the flaky behavior with multi-repo setups like Keiyoushi + Yūzōnō + Suwayomi + Kavita + TheNano.

## The five fixes

### 1. One bad repo no longer kills all repos (most likely root cause)
`ExtensionRemoteDataSourceImpl.fetchAvailableExtensions()` looped over every configured repository with **no per-repo error handling**. If any single repo was unreachable, rate-limited, or served unexpected JSON, the exception propagated up and the *entire* Available list came back as a failure — extensions from the six healthy repos included. Failures are now caught per repository, logged, and surfaced only if *every* repo fails.

### 2. Full index URLs are accepted when adding a repo
The add-repository validator rejected URLs ending in `/index.min.json` with "Drop the trailing /index.json". But that's exactly the form repo links are shared in everywhere in the Tachiyomi/Komikku ecosystem — pasting a repo link the normal way produced an error. The repository layer already strips the filename via `normalizeRepoUrl()` before storage, so the validator now accepts both forms.

### 3. Stale extensions are purged on refresh
`refreshAvailableExtensions()` only upserted rows (`OnConflictStrategy.REPLACE`), never deleting. Extensions from removed or changed repositories lingered in the Available tab forever, and the cache polluted over time. New `@Transaction replaceAllAvailable()` atomically deletes all AVAILABLE rows and inserts the fresh list — installed extensions are untouched.

### 4. Installing right after adding a repo no longer fails
`installExtension(pkgName, apkPath)` required a pre-existing DB row and failed with "Extension not found" when the available-list refresh hadn't synced yet (a race the user hits by adding a repo and immediately installing). A new `installExtension(extension, apkPath)` overload carries the fully-loaded `Extension` from the APK as fallback metadata and creates the row when missing. The existing DB row is still preferred when present (it carries repo provenance per #1019).

### 5. Standard-format `index.json` field tolerance
`ExtensionDto.apkUrl` was hardcoded to `apk_url` and assumed an absolute URL. Repos that serve standard-format JSON with the minified field name `apk` (bare filename) silently produced extensions with no usable download URL. Both names are now accepted and resolved against the repo base URL through the same `resolveApkUrl()` the minified path uses.

## Not changed (verified fine)
- Lib version gate (1.4–1.5) already matches Komikku exactly.
- The minified `index.min.json` parser matches the Keiyoushi/Komikku format field-for-field (`pkg`/`apk`/`code`/`version`/`nsfw` int/`sources[]`).
- Refresh failures already surface via `ExtensionsState.error`.
- No changes to `source-api/` or `core/tachiyomi-compat/` — extension ABI untouched.

## Test plan
- [ ] `./gradlew :core:extension:compileDebugKotlin :feature:browse:compileDebugKotlin` + Detekt — clean.
- [ ] Add a repo by pasting its full `…/index.min.json` URL → accepted, extensions appear.
- [ ] Configure one good repo + one dead URL → good repo's extensions still listed.
- [ ] Remove a repo → its extensions disappear from Available after refresh.
- [ ] Add repo → immediately install an extension → succeeds (no "Extension not found").

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS


---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Fix extension repositories loading, parsing, and installs from fresh repos**

### What Changed
- Adding a repository now accepts full `.../index.min.json` links instead of rejecting them.
- Loading extensions from multiple repositories no longer fails all at once when one repo is broken; working repos still show their extensions.
- Refreshing the Available list now removes extensions that are no longer offered by a repository, so outdated entries do not stick around.
- Installing an extension right after adding its repository now works even if the database has not caught up yet.
- Repositories that return a standard index file with the `apk` field now load correctly, including relative APK links.

### Impact
`✅ Fewer broken repository adds`
`✅ Fewer empty extension lists from one bad repo`
`✅ Less stale content in Available`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
