### PR TITLE
fix: library bulk download missing sourceName + locale-safe byte formatting

### DIFF
--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -667,6 +667,10 @@ class LibraryViewModel @Inject constructor(
                     downloadRepository.enqueueChapter(
                         mangaId = mangaId,
                         chapterId = chapter.id,
+                        // Must match the sourceId-based directory key used everywhere else;
+                        // omitting it stored files under a malformed path that
+                        // isChapterDownloaded()/deleteChapterDownload() could never find.
+                        sourceName = manga.sourceId.toString(),
                         mangaTitle = manga.title,
                         chapterTitle = chapter.name
                     )

--- a/feature/library/src/main/java/app/otakureader/feature/library/maintenance/LibraryMaintenanceViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/maintenance/LibraryMaintenanceViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.util.Locale
 import javax.inject.Inject
 
 /**
@@ -160,10 +161,12 @@ class LibraryMaintenanceViewModel @Inject constructor(
             }
     }
 
+    // Locale.US keeps the decimal separator deterministic — the default-locale overload
+    // produces "47,2 MB" on e.g. Turkish devices and trips lint's DefaultLocale check.
     private fun Long.formatBytes(): String = when {
         this < 1_024L -> "$this B"
-        this < 1_048_576L -> "%.1f KB".format(this / 1_024.0)
-        this < 1_073_741_824L -> "%.1f MB".format(this / 1_048_576.0)
-        else -> "%.2f GB".format(this / 1_073_741_824.0)
+        this < 1_048_576L -> String.format(Locale.US, "%.1f KB", this / 1_024.0)
+        this < 1_073_741_824L -> String.format(Locale.US, "%.1f MB", this / 1_048_576.0)
+        else -> String.format(Locale.US, "%.2f GB", this / 1_073_741_824.0)
     }
 }


### PR DESCRIPTION
## **User description**
## Summary

Two fixes from a pre-APK bug sweep of main:

1. **Library bulk download stored files in the wrong place (pre-existing bug).** `LibraryViewModel.downloadSelected()` was the only one of five `enqueueChapter` call sites that omitted `sourceName`, so it defaulted to `""`. The download directory is `OtakuReader/{sourceName}/{manga}/{chapter}` — with an empty source segment, the manga title ended up at the source level. `isChapterDownloaded()` and `deleteChapterDownload()` build their lookup paths with `sourceId.toString()`, so chapters downloaded via library multi-select were never detected as downloaded and could never be deleted from the UI. Now passes `manga.sourceId.toString()` like Details, Updates, Reader download-ahead, and Smart Download already do.

2. **Deterministic byte formatting.** `formatBytes()` in the maintenance ViewModel used the default-locale `String.format`, which renders `47,2 MB` on comma-decimal locales and trips lint's DefaultLocale check. Now uses `Locale.US` explicitly.

## Review notes

The sweep also re-verified the orphan-scan path derivation (`getChapterDir(rootParent, …)` prepends exactly one `OtakuReader/`, matching the walked tree — no double-segment bug), the custom-cover filename prefix matching (`"${id}_"` delimiter prevents id 1 matching id 12), the extension ERROR-row refresh cycle, and the onboarding pager indices — all clean.

## Test plan
- [ ] `./gradlew :feature:library:compileDebugKotlin :feature:library:detekt` — clean.
- [ ] Library → select manga → Download: chapters appear under `OtakuReader/{sourceId}/{title}/…` and the chapter list shows them as downloaded.

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS


---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Fix library bulk downloads and byte size formatting**

### What Changed
- Library multi-select downloads now save chapters in the same folder layout as other download paths, so downloaded chapters are found correctly and can be deleted from the app.
- File size labels on the library maintenance screen now use a consistent decimal format across device languages.

### Impact
`✅ Downloaded library chapters show up correctly`
`✅ Working delete and downloaded-status checks for bulk downloads`
`✅ Consistent file size display on all devices`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed file size formatting in the library to display consistent decimal separators across all devices, regardless of device locale settings.
* Corrected download storage directory assignment to ensure downloaded chapters are stored and organized correctly for retrieval and cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->