### PR TITLE
fix: full-app bug sweep — backup data loss, pager crashes, Keystore recovery, sync retries, WebView hardening

### DIFF
--- a/app/src/main/java/app/otakureader/crash/CrashHandler.kt
+++ b/app/src/main/java/app/otakureader/crash/CrashHandler.kt
@@ -2,8 +2,7 @@ package app.otakureader.crash
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
+import app.otakureader.core.preferences.EncryptedPrefsFactory
 import app.otakureader.core.preferences.CrashReportingStore
 
 /**
@@ -109,16 +108,11 @@ object CrashHandler {
     @Volatile private var cachedPrefs: SharedPreferences? = null
 
     private fun prefs(context: Context): SharedPreferences {
+        // EncryptedPrefsFactory recovers from Keystore corruption — essential here:
+        // a crash handler that itself crashes hides the original crash report.
         return cachedPrefs ?: synchronized(this) {
-            cachedPrefs ?: EncryptedSharedPreferences.create(
-                context.applicationContext,
-                PREFS_NAME,
-                MasterKey.Builder(context.applicationContext)
-                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                    .build(),
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-            ).also { cachedPrefs = it }
+            cachedPrefs ?: EncryptedPrefsFactory.create(context.applicationContext, PREFS_NAME)
+                .also { cachedPrefs = it }
         }
     }
 }

--- a/core/extension/src/main/java/app/otakureader/core/extension/loader/TrustedSignatureStore.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/loader/TrustedSignatureStore.kt
@@ -3,8 +3,7 @@ package app.otakureader.core.extension.loader
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
+import app.otakureader.core.preferences.EncryptedPrefsFactory
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -26,17 +25,11 @@ import javax.inject.Singleton
 @Singleton
 class TrustedSignatureStore @Inject constructor(@ApplicationContext context: Context) {
 
+    // Created via EncryptedPrefsFactory so Keystore corruption recovers instead of
+    // crash-looping the app. A reset trust list means previously trusted extensions
+    // prompt for trust again — safe-by-default.
     private val prefs: SharedPreferences by lazy {
-        val masterKey = MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-        EncryptedSharedPreferences.create(
-            context,
-            PREFS_NAME,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-        )
+        EncryptedPrefsFactory.create(context, PREFS_NAME)
     }
 
     fun isTrusted(signatureHash: String): Boolean =

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/CbzEncryptionStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/CbzEncryptionStore.kt
@@ -2,8 +2,6 @@ package app.otakureader.core.preferences
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -18,20 +16,11 @@ import javax.inject.Singleton
 @Singleton
 class CbzEncryptionStore @Inject constructor(@ApplicationContext private val context: Context) {
 
-    private val masterKey: MasterKey by lazy {
-        MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-    }
 
+    // Created via EncryptedPrefsFactory so Keystore corruption recovers instead of
+    // crash-looping the app (stored secrets are reset; the user re-authenticates).
     private val prefs: SharedPreferences by lazy {
-        EncryptedSharedPreferences.create(
-            context,
-            "cbz_encryption",
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-        )
+        EncryptedPrefsFactory.create(context, "cbz_encryption")
     }
 
     fun getPassphrase(): String? = prefs.getString(KEY_PASSPHRASE, null)

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/CloudBackupCredentialsStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/CloudBackupCredentialsStore.kt
@@ -2,8 +2,6 @@ package app.otakureader.core.preferences
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -18,20 +16,11 @@ import javax.inject.Singleton
 @Singleton
 class CloudBackupCredentialsStore @Inject constructor(private val context: Context) {
 
-    private val masterKey: MasterKey by lazy {
-        MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-    }
 
+    // Created via EncryptedPrefsFactory so Keystore corruption recovers instead of
+    // crash-looping the app (stored secrets are reset; the user re-authenticates).
     private val prefs: SharedPreferences by lazy {
-        EncryptedSharedPreferences.create(
-            context,
-            "cloud_backup_credentials",
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
+        EncryptedPrefsFactory.create(context, "cloud_backup_credentials")
     }
 
     fun saveWebDavCredentials(url: String, username: String, password: String) {

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/CrashReportingStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/CrashReportingStore.kt
@@ -2,8 +2,6 @@ package app.otakureader.core.preferences
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -17,16 +15,10 @@ import javax.inject.Singleton
 @Singleton
 class CrashReportingStore @Inject constructor(context: Context) {
 
+    // Created via EncryptedPrefsFactory so Keystore corruption recovers instead of
+    // crash-looping the app (stored secrets are reset; the user re-authenticates).
     private val prefs: SharedPreferences by lazy {
-        EncryptedSharedPreferences.create(
-            context.applicationContext,
-            STORE_NAME,
-            MasterKey.Builder(context.applicationContext)
-                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                .build(),
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-        )
+        EncryptedPrefsFactory.create(context.applicationContext, STORE_NAME)
     }
 
     /** Sentry DSN supplied by the user. Empty/blank → reporting cannot start regardless of opt-in. */

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/EhSessionStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/EhSessionStore.kt
@@ -2,8 +2,6 @@ package app.otakureader.core.preferences
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -19,20 +17,11 @@ import javax.inject.Singleton
 @Singleton
 class EhSessionStore @Inject constructor(@ApplicationContext private val context: Context) {
 
-    private val masterKey: MasterKey by lazy {
-        MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-    }
 
+    // Created via EncryptedPrefsFactory so Keystore corruption recovers instead of
+    // crash-looping the app (stored secrets are reset; the user re-authenticates).
     private val prefs: SharedPreferences by lazy {
-        EncryptedSharedPreferences.create(
-            context,
-            "eh_session_credentials",
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
+        EncryptedPrefsFactory.create(context, "eh_session_credentials")
     }
 
     fun saveSession(memberId: String, passHash: String, igneous: String = "") {

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/EncryptedOpdsCredentialStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/EncryptedOpdsCredentialStore.kt
@@ -2,8 +2,6 @@ package app.otakureader.core.preferences
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -21,20 +19,11 @@ class EncryptedOpdsCredentialStore @Inject constructor(
     private val context: Context
 ) {
 
-    private val masterKey: MasterKey by lazy {
-        MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-    }
 
+    // Created via EncryptedPrefsFactory so Keystore corruption recovers instead of
+    // crash-looping the app (stored secrets are reset; the user re-authenticates).
     private val sharedPreferences: SharedPreferences by lazy {
-        EncryptedSharedPreferences.create(
-            context,
-            FILE_NAME,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
+        EncryptedPrefsFactory.create(context, FILE_NAME)
     }
 
     /** Retrieves the stored username for the given server, or empty string. */

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/EncryptedPrefsFactory.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/EncryptedPrefsFactory.kt
@@ -1,0 +1,56 @@
+package app.otakureader.core.preferences
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+/**
+ * Creates [EncryptedSharedPreferences] with recovery from Android Keystore corruption.
+ *
+ * On some devices the Keystore-backed master key or the encrypted prefs file becomes
+ * undecryptable (after OS updates, backup/restore, or vendor Keystore bugs). The stock
+ * `EncryptedSharedPreferences.create()` then throws on every app start — a permanent
+ * crash loop. This factory recovers instead:
+ *
+ *  1. Try to open normally.
+ *  2. On failure, delete the corrupted prefs file and retry once with a fresh file
+ *     (stored secrets are lost — the user re-authenticates — but the app works).
+ *  3. If even a fresh encrypted file cannot be created (Keystore itself broken),
+ *     fall back to plain SharedPreferences under a distinct name so the app stays
+ *     usable; secrets stored there are unencrypted, which is the lesser evil vs.
+ *     a permanently crashing app.
+ */
+object EncryptedPrefsFactory {
+
+    private const val TAG = "EncryptedPrefs"
+
+    fun create(context: Context, fileName: String): SharedPreferences {
+        return try {
+            createEncrypted(context, fileName)
+        } catch (first: Exception) {
+            Log.w(TAG, "Encrypted prefs '$fileName' unreadable (${first.message}); resetting file")
+            context.deleteSharedPreferences(fileName)
+            try {
+                createEncrypted(context, fileName)
+            } catch (second: Exception) {
+                Log.e(TAG, "Keystore unusable for '$fileName' (${second.message}); using plain fallback")
+                context.getSharedPreferences("${fileName}_fallback", Context.MODE_PRIVATE)
+            }
+        }
+    }
+
+    private fun createEncrypted(context: Context, fileName: String): SharedPreferences {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        return EncryptedSharedPreferences.create(
+            context,
+            fileName,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+}

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/EncryptedPrefsFactory.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/EncryptedPrefsFactory.kt
@@ -26,6 +26,10 @@ object EncryptedPrefsFactory {
 
     private const val TAG = "EncryptedPrefs"
 
+    // Keystore corruption surfaces as several unrelated exception types (GeneralSecurityException,
+    // IOException, KeyStoreException, even InvalidProtocolBufferException from Tink) — catching
+    // anything narrower would leave crash-loop paths open.
+    @Suppress("TooGenericExceptionCaught")
     fun create(context: Context, fileName: String): SharedPreferences {
         return try {
             createEncrypted(context, fileName)

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/PendingOAuthStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/PendingOAuthStore.kt
@@ -2,8 +2,6 @@ package app.otakureader.core.preferences
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -31,20 +29,11 @@ class PendingOAuthStore @Inject constructor(
         private const val SESSION_TTL_MS = 10 * 60 * 1000L
     }
 
-    private val masterKey: MasterKey by lazy {
-        MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-    }
 
+    // Created via EncryptedPrefsFactory so Keystore corruption recovers instead of
+    // crash-looping the app (stored secrets are reset; the user re-authenticates).
     private val prefs: SharedPreferences by lazy {
-        EncryptedSharedPreferences.create(
-            context,
-            FILE_NAME,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
+        EncryptedPrefsFactory.create(context, FILE_NAME)
     }
 
     /** Persists an OAuth PKCE session before opening the browser. */

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/TrackerTokenStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/TrackerTokenStore.kt
@@ -2,8 +2,6 @@ package app.otakureader.core.preferences
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -18,20 +16,11 @@ import javax.inject.Singleton
 @Singleton
 class TrackerTokenStore @Inject constructor(private val context: Context) {
 
-    private val masterKey: MasterKey by lazy {
-        MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-    }
 
+    // Created via EncryptedPrefsFactory so Keystore corruption recovers instead of
+    // crash-looping the app (stored secrets are reset; the user re-authenticates).
     private val prefs: SharedPreferences by lazy {
-        EncryptedSharedPreferences.create(
-            context,
-            "tracker_tokens",
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
+        EncryptedPrefsFactory.create(context, "tracker_tokens")
     }
 
     fun saveTokens(

--- a/data/src/main/java/app/otakureader/data/backup/mapper/BackupMappers.kt
+++ b/data/src/main/java/app/otakureader/data/backup/mapper/BackupMappers.kt
@@ -50,6 +50,24 @@ fun MangaEntity.toBackupManga(
     notes = notes,
     readerBackgroundColor = readerBackgroundColor,
     contentRating = contentRating,
+    autoDownload = autoDownload,
+    notifyNewChapters = notifyNewChapters,
+    readerDirection = readerDirection,
+    readerMode = readerMode,
+    readerColorFilter = readerColorFilter,
+    readerCustomTintColor = readerCustomTintColor,
+    preloadPagesBefore = preloadPagesBefore,
+    preloadPagesAfter = preloadPagesAfter,
+    userCompleted = userCompleted,
+    userDropped = userDropped,
+    mangaThemeOverride = mangaThemeOverride,
+    userTitle = userTitle,
+    userDescription = userDescription,
+    userAuthor = userAuthor,
+    userArtist = userArtist,
+    userThumbnailUrl = userThumbnailUrl,
+    userGenre = userGenre,
+    userStatus = userStatus,
 )
 
 /**
@@ -77,6 +95,26 @@ fun BackupManga.toMangaEntity(): MangaEntity = MangaEntity(
     notes = notes,
     readerBackgroundColor = readerBackgroundColor,
     contentRating = contentRating,
+    autoDownload = autoDownload,
+    notifyNewChapters = notifyNewChapters,
+    readerDirection = readerDirection,
+    readerMode = readerMode,
+    readerColorFilter = readerColorFilter,
+    readerCustomTintColor = readerCustomTintColor,
+    preloadPagesBefore = preloadPagesBefore,
+    preloadPagesAfter = preloadPagesAfter,
+    userCompleted = userCompleted,
+    userDropped = userDropped,
+    mangaThemeOverride = mangaThemeOverride,
+    userTitle = userTitle,
+    userDescription = userDescription,
+    userAuthor = userAuthor,
+    userArtist = userArtist,
+    // Custom covers are app-private file:// paths that won't exist on a different
+    // device/install; restoring them would show a broken cover. URL overrides survive.
+    userThumbnailUrl = userThumbnailUrl?.takeUnless { it.startsWith("file://") },
+    userGenre = userGenre,
+    userStatus = userStatus,
 )
 
 /**
@@ -97,7 +135,8 @@ fun ChapterEntity.toBackupChapter(
     dateFetch = dateFetch,
     dateUpload = dateUpload,
     lastModified = lastModified,
-    readingHistory = readingHistory
+    readingHistory = readingHistory,
+    userNotes = userNotes,
 )
 
 /**
@@ -117,7 +156,8 @@ fun BackupChapter.toChapterEntity(mangaId: Long): ChapterEntity = ChapterEntity(
     sourceOrder = sourceOrder,
     dateFetch = dateFetch,
     dateUpload = dateUpload,
-    lastModified = lastModified
+    lastModified = lastModified,
+    userNotes = userNotes,
 )
 
 /**
@@ -146,7 +186,9 @@ fun CategoryEntity.toBackupCategory(): BackupCategory = BackupCategory(
     id = id,
     name = name,
     order = order,
-    flags = flags
+    flags = flags,
+    updateFrequency = updateFrequency,
+    lockType = lockType,
 )
 
 /**
@@ -157,7 +199,9 @@ fun BackupCategory.toCategoryEntity(): CategoryEntity = CategoryEntity(
     id = id,
     name = name,
     order = order,
-    flags = flags
+    flags = flags,
+    updateFrequency = updateFrequency,
+    lockType = lockType,
 )
 
 fun OpdsServerEntity.toBackupOpdsServer(): BackupOpdsServer = BackupOpdsServer(

--- a/data/src/main/java/app/otakureader/data/backup/model/BackupData.kt
+++ b/data/src/main/java/app/otakureader/data/backup/model/BackupData.kt
@@ -20,7 +20,10 @@ data class BackupData(
     val syncConfigurations: List<BackupSyncConfiguration> = emptyList()
 ) {
     companion object {
-        const val CURRENT_VERSION = 3
+        // v4 (2026-06-11): added per-manga user overrides (#998), per-manga reader settings,
+        // auto-download/notification flags, chapter user notes, and category
+        // updateFrequency/lockType. Older backups deserialize via field defaults.
+        const val CURRENT_VERSION = 4
     }
 }
 
@@ -50,6 +53,26 @@ data class BackupManga(
     val notes: String? = null,
     val readerBackgroundColor: Long? = null,
     val contentRating: Int = 0,
+    // v4 fields — all defaulted so v3 and older backups still deserialize.
+    val autoDownload: Boolean = false,
+    val notifyNewChapters: Boolean = true,
+    val readerDirection: Int? = null,
+    val readerMode: Int? = null,
+    val readerColorFilter: Int? = null,
+    val readerCustomTintColor: Long? = null,
+    val preloadPagesBefore: Int? = null,
+    val preloadPagesAfter: Int? = null,
+    val userCompleted: Boolean = false,
+    val userDropped: Boolean = false,
+    val mangaThemeOverride: Boolean? = null,
+    // User-info overrides (#998)
+    val userTitle: String? = null,
+    val userDescription: String? = null,
+    val userAuthor: String? = null,
+    val userArtist: String? = null,
+    val userThumbnailUrl: String? = null,
+    val userGenre: String? = null,
+    val userStatus: Int? = null,
 )
 
 /**
@@ -68,7 +91,9 @@ data class BackupChapter(
     val dateFetch: Long = 0,
     val dateUpload: Long = 0,
     val lastModified: Long = 0,
-    val readingHistory: BackupReadingHistory? = null
+    val readingHistory: BackupReadingHistory? = null,
+    /** v4: per-chapter user notes. */
+    val userNotes: String? = null,
 )
 
 /**
@@ -88,7 +113,11 @@ data class BackupCategory(
     val id: Long,
     val name: String,
     val order: Int = 0,
-    val flags: Int = 0
+    val flags: Int = 0,
+    /** v4: per-category update frequency (CategoryUpdateFrequency ordinal). */
+    val updateFrequency: Int = 1,
+    /** v4: per-category lock type (null = unlocked). */
+    val lockType: String? = null,
 )
 
 /**

--- a/data/src/main/java/app/otakureader/data/eh/EhFavoritesApi.kt
+++ b/data/src/main/java/app/otakureader/data/eh/EhFavoritesApi.kt
@@ -53,7 +53,11 @@ class EhFavoritesApi(
             .build()
 
         val body = okHttpClient.newCall(request).execute().use { response ->
-            check(response.isSuccessful) { "EH returned HTTP ${response.code}" }
+            // IOException (not check()'s IllegalStateException) so the sync worker's
+            // IOException → Result.retry() path applies to transient EH errors.
+            if (!response.isSuccessful) {
+                throw java.io.IOException("EH returned HTTP ${response.code}")
+            }
             response.body?.string() ?: return emptyList()
         }
 

--- a/data/src/main/java/app/otakureader/data/worker/TrackerSyncWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/TrackerSyncWorker.kt
@@ -34,6 +34,9 @@ class TrackerSyncWorker @AssistedInject constructor(
 ) : CoroutineWorker(context, workerParams) {
 
     override suspend fun doWork(): Result {
+        // Cap retries: a permanently failing tracker (e.g. revoked token) must not
+        // retry-loop until the next period, draining battery and hammering the API.
+        if (runAttemptCount >= MAX_RETRIES) return Result.failure()
         return try {
             val summary = trackerSyncRepository.syncAllPending()
             // Retry if any hard failures occurred; conflicts are handled by the user
@@ -47,6 +50,7 @@ class TrackerSyncWorker @AssistedInject constructor(
 
     companion object {
         const val WORK_NAME = "tracker_2way_sync"
+        private const val MAX_RETRIES = 3
 
         /**
          * Schedules (or reschedules) the periodic tracker sync job.

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/modes/SinglePageReader.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/modes/SinglePageReader.kt
@@ -71,8 +71,10 @@ fun SinglePageReader(
                 .background(MaterialTheme.colorScheme.background),
             contentAlignment = Alignment.Center
         ) {
-            val page = pages[pageIndex]
-            
+            // The pager can briefly compose an index past the end while the page list
+            // shrinks (e.g. chapter transition); skip the frame instead of crashing.
+            val page = pages.getOrNull(pageIndex) ?: return@Box
+
             ZoomableImage(
                 imageUrl = page.imageUrl,
                 contentDescription = stringResource(R.string.reader_page_content, page.pageNumber),

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/modes/SmartPanelsReader.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/modes/SmartPanelsReader.kt
@@ -67,7 +67,9 @@ fun SmartPanelsReader(
         beyondViewportPageCount = 1,
         modifier = modifier.fillMaxSize()
     ) { pageIndex ->
-        val page = pages[pageIndex]
+        // The pager can briefly compose an index past the end while the page list
+        // shrinks (e.g. chapter transition); skip the frame instead of crashing.
+        val page = pages.getOrNull(pageIndex) ?: return@HorizontalPager
         val panels = page.panels
         
         Box(

--- a/feature/webview/src/main/java/app/otakureader/feature/webview/WebViewScreen.kt
+++ b/feature/webview/src/main/java/app/otakureader/feature/webview/WebViewScreen.kt
@@ -165,13 +165,20 @@ fun WebViewScreen(
                         onGo = {
                             val targetUrl = urlText.trim()
                             if (targetUrl.isNotBlank()) {
-                                val resolvedUrl = if (targetUrl.startsWith("http://") || targetUrl.startsWith("https://")) {
-                                    targetUrl
-                                } else {
+                                // Prefix bare hosts with https://, then validate the final
+                                // scheme: anything else (javascript:, data:, file:, intent:)
+                                // typed into the address bar must never reach loadUrl, where
+                                // it would execute script or read local content.
+                                val resolvedUrl = if (Uri.parse(targetUrl).scheme == null) {
                                     "https://$targetUrl"
+                                } else {
+                                    targetUrl
                                 }
-                                committedUrl = resolvedUrl
-                                webViewRef?.loadUrl(resolvedUrl)
+                                val scheme = Uri.parse(resolvedUrl).scheme?.lowercase()
+                                if (scheme == "http" || scheme == "https") {
+                                    committedUrl = resolvedUrl
+                                    webViewRef?.loadUrl(resolvedUrl)
+                                }
                             }
                             focusManager.clearFocus()
                         },


### PR DESCRIPTION
## **User description**
## Summary

Full-app bug sweep of main before the APK build. Four parallel review agents covered reader+downloads, library+database, browse+extensions, and settings+sync+workers; every finding was hand-verified against the source before fixing. Android Lint also ran clean (no errors).

## Fixes (one commit each)

### 1. Backup silently discarded user customization — **data loss** (`fix(backup)`)
**What was wrong:** `BackupManga` was missing 18 fields that exist on `MangaEntity` — custom titles/descriptions/authors/covers, per-manga reader direction/mode/color filter, preload settings, auto-download, completed/dropped flags. `BackupChapter` was missing `userNotes`; `BackupCategory` was missing `updateFrequency`/`lockType`. A backup → restore cycle wiped all of it.
**Why the fix works:** Every field is added to the backup models *with a default value*, so old v3 backup files still deserialize (Kotlinx Serialization fills missing JSON keys from defaults). Version bumped to 4. One deliberate exception: custom cover `file://` paths are not restored, because those files don't exist on a different device — restoring the path would show a broken cover.

### 2. Reader crash at chapter transitions (`fix(reader)`)
**What was wrong:** `SinglePageReader` and `SmartPanelsReader` indexed `pages[pageIndex]`. When the page list shrinks during a chapter transition, Compose's `HorizontalPager` can compose one frame with the old (now out-of-range) index → `IndexOutOfBoundsException`.
**Why the fix works:** `pages.getOrNull(pageIndex) ?: return` skips that single stale frame; the pager settles on a valid index on the next frame.

### 3. Keystore corruption crash-looped the app (`fix(preferences)`)
**What was wrong:** Nine stores create `EncryptedSharedPreferences` directly. A corrupted Android Keystore (a known platform bug after OS updates or device restores) makes that constructor throw — at app startup, forever.
**Why the fix works:** New `EncryptedPrefsFactory` with three tiers: normal creation → delete the pref file and retry with a fresh key → plain SharedPreferences fallback. Worst case the user re-authenticates trackers instead of losing the app. Applied to all token/session/credential stores, the extension trust list, and the crash handler.

### 4. Tracker sync retried forever; EH errors mis-routed (`fix(sync)`)
**What was wrong:** `TrackerSyncWorker` returned `Result.retry()` unconditionally on failure — a revoked token retried until the next sync period, draining battery. Separately, `EhFavoritesApi` used `check(response.isSuccessful)`, which throws `IllegalStateException`; the EH sync worker only treats `IOException` as transient, so a temporary EH 5xx was treated as permanent failure.
**Why the fix works:** `runAttemptCount >= 3 → Result.failure()` caps the loop (WorkManager increments `runAttemptCount` per retry). EH HTTP errors now throw `IOException`, which the worker's existing catch routes to `Result.retry()`.

### 5. WebView address bar executed `javascript:` URLs (`fix(webview)`)
**What was wrong:** The Go action prefixed non-`http(s)`-prefixed input with `https://` using case-sensitive `startsWith` string checks, then passed the result straight to `loadUrl()`. Crafted scheme input (`javascript:`, `data:`, `file:`, `intent:`) could reach the WebView and execute.
**Why the fix works:** The input is parsed with `Uri`, bare hosts get the `https://` prefix, and the *final* scheme is validated case-insensitively — anything that isn't `http`/`https` is ignored.

## Observed, not fixed
- Library category filter can reference a category deleted in another session (rare wrong-behavior edge case, no crash).
- `BackupRestorer` writes preferences outside the Room transaction — intentional; DataStore can't join Room transactions (documented in code).
- FTS search passes `*`, `-`, `()` through unescaped — these are valid FTS4 operators, not bugs.

## Verification
- All changed modules compile: `:data`, `:feature:reader`, `:feature:webview`, `:core:preferences`, `:core:extension`, `:app` — exit 0.
- Android Lint: no errors.

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
Fix backup restores, startup crashes, sync retries, and WebView URL safety

### What Changed
- Backup and restore now keep per-manga overrides, reader settings, chapter notes, and category settings instead of wiping them
- Reader pages no longer crash during chapter changes when the page list shrinks
- Encrypted app stores now recover from broken Android Keystore data so the app can still start; affected secrets are reset and users sign in again
- Tracker sync stops retrying forever on permanent failures and now retries transient EH HTTP errors
- The WebView address bar only opens http and https links; typed script, file, data, and intent URLs are ignored

### Impact
`✅ Fewer backup restore surprises`
`✅ Fewer reader crashes during chapter switches`
`✅ Fewer startup crash loops after device restore or OS update`
`✅ Lower battery drain from failed syncs`
`✅ Safer WebView navigation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Backup and restore now includes reader preferences (direction, mode, color filters, page preload), manga metadata overrides, chapter notes, and category settings.

**Bug Fixes**
- Fixed reader crashes during chapter and page transitions.
- Added retry limit for tracker synchronization to prevent infinite loops.
- Improved WebView URL validation to block unsafe schemes.
- Enhanced error recovery for encrypted user data to prevent data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->