### PR TITLE
feat(reader): local reader comments overlay with chapter/book scopes

### DIFF
--- a/core/database/schemas/app.otakureader.core.database.OtakuReaderDatabase/37.json
+++ b/core/database/schemas/app.otakureader.core.database.OtakuReaderDatabase/37.json
@@ -1,0 +1,2099 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 37,
+    "identityHash": "dff3378ec8ce01c3073771b38d9188d7",
+    "entities": [
+      {
+        "tableName": "manga",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `thumbnailUrl` TEXT, `author` TEXT, `artist` TEXT, `description` TEXT, `genre` TEXT, `status` INTEGER NOT NULL, `favorite` INTEGER NOT NULL, `lastUpdate` INTEGER NOT NULL, `initialized` INTEGER NOT NULL, `viewerFlags` INTEGER NOT NULL, `chapterFlags` INTEGER NOT NULL, `coverLastModified` INTEGER NOT NULL, `dateAdded` INTEGER NOT NULL, `autoDownload` INTEGER NOT NULL, `notes` TEXT, `notifyNewChapters` INTEGER NOT NULL, `readerDirection` INTEGER, `readerMode` INTEGER, `readerColorFilter` INTEGER, `readerCustomTintColor` INTEGER, `readerBackgroundColor` INTEGER, `preloadPagesBefore` INTEGER, `preloadPagesAfter` INTEGER, `contentRating` INTEGER NOT NULL, `userCompleted` INTEGER NOT NULL, `userDropped` INTEGER NOT NULL, `mangaThemeOverride` INTEGER, `userTitle` TEXT, `userDescription` TEXT, `userAuthor` TEXT, `userArtist` TEXT, `userThumbnailUrl` TEXT, `userGenre` TEXT, `userStatus` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdate",
+            "columnName": "lastUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "initialized",
+            "columnName": "initialized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewerFlags",
+            "columnName": "viewerFlags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterFlags",
+            "columnName": "chapterFlags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverLastModified",
+            "columnName": "coverLastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "dateAdded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownload",
+            "columnName": "autoDownload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notifyNewChapters",
+            "columnName": "notifyNewChapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readerDirection",
+            "columnName": "readerDirection",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerMode",
+            "columnName": "readerMode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerColorFilter",
+            "columnName": "readerColorFilter",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerCustomTintColor",
+            "columnName": "readerCustomTintColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "readerBackgroundColor",
+            "columnName": "readerBackgroundColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "preloadPagesBefore",
+            "columnName": "preloadPagesBefore",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "preloadPagesAfter",
+            "columnName": "preloadPagesAfter",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "contentRating",
+            "columnName": "contentRating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userCompleted",
+            "columnName": "userCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userDropped",
+            "columnName": "userDropped",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaThemeOverride",
+            "columnName": "mangaThemeOverride",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "userTitle",
+            "columnName": "userTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userDescription",
+            "columnName": "userDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userAuthor",
+            "columnName": "userAuthor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userArtist",
+            "columnName": "userArtist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userThumbnailUrl",
+            "columnName": "userThumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userGenre",
+            "columnName": "userGenre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userStatus",
+            "columnName": "userStatus",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_manga_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_manga_title",
+            "unique": false,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_title` ON `${TABLE_NAME}` (`title`)"
+          },
+          {
+            "name": "index_manga_favorite",
+            "unique": false,
+            "columnNames": [
+              "favorite"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_favorite` ON `${TABLE_NAME}` (`favorite`)"
+          },
+          {
+            "name": "index_manga_sourceId_url",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_manga_sourceId_url` ON `${TABLE_NAME}` (`sourceId`, `url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mangaId` INTEGER NOT NULL, `url` TEXT NOT NULL, `name` TEXT NOT NULL, `scanlator` TEXT, `read` INTEGER NOT NULL, `bookmark` INTEGER NOT NULL, `lastPageRead` INTEGER NOT NULL, `chapterNumber` REAL NOT NULL, `sourceOrder` INTEGER NOT NULL, `dateFetch` INTEGER NOT NULL, `dateUpload` INTEGER NOT NULL, `lastModified` INTEGER NOT NULL, `userNotes` TEXT, FOREIGN KEY(`mangaId`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scanlator",
+            "columnName": "scanlator",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmark",
+            "columnName": "bookmark",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPageRead",
+            "columnName": "lastPageRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterNumber",
+            "columnName": "chapterNumber",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceOrder",
+            "columnName": "sourceOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateFetch",
+            "columnName": "dateFetch",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateUpload",
+            "columnName": "dateUpload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userNotes",
+            "columnName": "userNotes",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chapters_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          },
+          {
+            "name": "index_chapters_mangaId_url",
+            "unique": true,
+            "columnNames": [
+              "mangaId",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_chapters_mangaId_url` ON `${TABLE_NAME}` (`mangaId`, `url`)"
+          },
+          {
+            "name": "index_chapters_read",
+            "unique": false,
+            "columnNames": [
+              "read"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_read` ON `${TABLE_NAME}` (`read`)"
+          },
+          {
+            "name": "index_chapters_bookmark",
+            "unique": false,
+            "columnNames": [
+              "bookmark"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_bookmark` ON `${TABLE_NAME}` (`bookmark`)"
+          },
+          {
+            "name": "index_chapters_dateFetch",
+            "unique": false,
+            "columnNames": [
+              "dateFetch"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_dateFetch` ON `${TABLE_NAME}` (`dateFetch`)"
+          },
+          {
+            "name": "index_chapters_mangaId_dateFetch",
+            "unique": false,
+            "columnNames": [
+              "mangaId",
+              "dateFetch"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_mangaId_dateFetch` ON `${TABLE_NAME}` (`mangaId`, `dateFetch`)"
+          },
+          {
+            "name": "index_chapters_mangaId_read_sourceOrder",
+            "unique": false,
+            "columnNames": [
+              "mangaId",
+              "read",
+              "sourceOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chapters_mangaId_read_sourceOrder` ON `${TABLE_NAME}` (`mangaId`, `read`, `sourceOrder`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mangaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `order` INTEGER NOT NULL, `flags` INTEGER NOT NULL, `update_frequency` INTEGER NOT NULL, `lock_type` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "flags",
+            "columnName": "flags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateFrequency",
+            "columnName": "update_frequency",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lockType",
+            "columnName": "lock_type",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "manga_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mangaId` INTEGER NOT NULL, `categoryId` INTEGER NOT NULL, PRIMARY KEY(`mangaId`, `categoryId`), FOREIGN KEY(`mangaId`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`categoryId`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "mangaId",
+            "categoryId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_manga_categories_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_categories_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          },
+          {
+            "name": "index_manga_categories_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_categories_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mangaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "categories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "categoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reading_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `chapter_id` INTEGER NOT NULL, `read_at` INTEGER NOT NULL, `read_duration_ms` INTEGER NOT NULL, FOREIGN KEY(`chapter_id`) REFERENCES `chapters`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readAt",
+            "columnName": "read_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readDurationMs",
+            "columnName": "read_duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_history_chapter_id",
+            "unique": true,
+            "columnNames": [
+              "chapter_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_reading_history_chapter_id` ON `${TABLE_NAME}` (`chapter_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chapters",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapter_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reading_streaks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `chapter_count` INTEGER NOT NULL, `read_duration_ms` INTEGER NOT NULL, `last_read_at` INTEGER NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterCount",
+            "columnName": "chapter_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readDurationMs",
+            "columnName": "read_duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadAt",
+            "columnName": "last_read_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        }
+      },
+      {
+        "tableName": "opds_servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_opds_servers_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_opds_servers_url` ON `${TABLE_NAME}` (`url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mangaId` INTEGER NOT NULL, `mangaTitle` TEXT NOT NULL, `mangaThumbnailUrl` TEXT, `chapterId` INTEGER NOT NULL, `chapterName` TEXT NOT NULL, `chapterNumber` REAL NOT NULL, `sourceId` INTEGER NOT NULL, `sourceName` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `isRead` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaTitle",
+            "columnName": "mangaTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaThumbnailUrl",
+            "columnName": "mangaThumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterName",
+            "columnName": "chapterName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterNumber",
+            "columnName": "chapterNumber",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "sourceName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_feed_items_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_feed_items_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `sourceName` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `itemCount` INTEGER NOT NULL, `order` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "sourceName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_sources_sourceId",
+            "unique": true,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_feed_sources_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_saved_searches",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `sourceName` TEXT NOT NULL, `query` TEXT NOT NULL, `filtersJson` TEXT, `order` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "sourceName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filtersJson",
+            "columnName": "filtersJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_saved_searches_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_saved_searches_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tracker_sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mangaId` INTEGER NOT NULL, `trackerId` INTEGER NOT NULL, `remoteId` TEXT NOT NULL, `localLastChapterRead` REAL NOT NULL, `localTotalChapters` INTEGER NOT NULL, `localStatus` INTEGER NOT NULL, `localLastModified` INTEGER NOT NULL, `remoteLastChapterRead` REAL NOT NULL, `remoteTotalChapters` INTEGER NOT NULL, `remoteStatus` INTEGER NOT NULL, `remoteLastModified` INTEGER, `syncStatus` INTEGER NOT NULL, `lastSyncAttempt` INTEGER, `lastSuccessfulSync` INTEGER, `syncError` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerId",
+            "columnName": "trackerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localLastChapterRead",
+            "columnName": "localLastChapterRead",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localTotalChapters",
+            "columnName": "localTotalChapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localStatus",
+            "columnName": "localStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localLastModified",
+            "columnName": "localLastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteLastChapterRead",
+            "columnName": "remoteLastChapterRead",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteTotalChapters",
+            "columnName": "remoteTotalChapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteStatus",
+            "columnName": "remoteStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteLastModified",
+            "columnName": "remoteLastModified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncAttempt",
+            "columnName": "lastSyncAttempt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastSuccessfulSync",
+            "columnName": "lastSuccessfulSync",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncError",
+            "columnName": "syncError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tracker_sync_state_mangaId_trackerId",
+            "unique": true,
+            "columnNames": [
+              "mangaId",
+              "trackerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tracker_sync_state_mangaId_trackerId` ON `${TABLE_NAME}` (`mangaId`, `trackerId`)"
+          },
+          {
+            "name": "index_tracker_sync_state_syncStatus",
+            "unique": false,
+            "columnNames": [
+              "syncStatus"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracker_sync_state_syncStatus` ON `${TABLE_NAME}` (`syncStatus`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_configuration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackerId` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `syncDirection` INTEGER NOT NULL, `conflictResolution` INTEGER NOT NULL, `autoSyncInterval` INTEGER NOT NULL, `syncOnChapterRead` INTEGER NOT NULL, `syncOnMarkComplete` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerId",
+            "columnName": "trackerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncDirection",
+            "columnName": "syncDirection",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conflictResolution",
+            "columnName": "conflictResolution",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoSyncInterval",
+            "columnName": "autoSyncInterval",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncOnChapterRead",
+            "columnName": "syncOnChapterRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncOnMarkComplete",
+            "columnName": "syncOnMarkComplete",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_configuration_trackerId",
+            "unique": true,
+            "columnNames": [
+              "trackerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_configuration_trackerId` ON `${TABLE_NAME}` (`trackerId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "page_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `manga_id` INTEGER NOT NULL, `chapter_id` INTEGER NOT NULL, `page_index` INTEGER NOT NULL, `note` TEXT, `created_at` INTEGER NOT NULL, FOREIGN KEY(`chapter_id`) REFERENCES `chapters`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`manga_id`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageIndex",
+            "columnName": "page_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_page_bookmarks_chapter_id",
+            "unique": false,
+            "columnNames": [
+              "chapter_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_bookmarks_chapter_id` ON `${TABLE_NAME}` (`chapter_id`)"
+          },
+          {
+            "name": "index_page_bookmarks_manga_id",
+            "unique": false,
+            "columnNames": [
+              "manga_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_bookmarks_manga_id` ON `${TABLE_NAME}` (`manga_id`)"
+          },
+          {
+            "name": "index_page_bookmarks_manga_id_created_at",
+            "unique": false,
+            "columnNames": [
+              "manga_id",
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_bookmarks_manga_id_created_at` ON `${TABLE_NAME}` (`manga_id`, `created_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chapters",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapter_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "manga_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reading_lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `color` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_list_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`listId` INTEGER NOT NULL, `mangaId` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, `note` TEXT, PRIMARY KEY(`listId`, `mangaId`), FOREIGN KEY(`listId`) REFERENCES `reading_lists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`mangaId`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "listId",
+            "mangaId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_list_items_listId",
+            "unique": false,
+            "columnNames": [
+              "listId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_list_items_listId` ON `${TABLE_NAME}` (`listId`)"
+          },
+          {
+            "name": "index_reading_list_items_mangaId",
+            "unique": false,
+            "columnNames": [
+              "mangaId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_list_items_mangaId` ON `${TABLE_NAME}` (`mangaId`)"
+          },
+          {
+            "name": "index_reading_list_items_listId_addedAt",
+            "unique": false,
+            "columnNames": [
+              "listId",
+              "addedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_list_items_listId_addedAt` ON `${TABLE_NAME}` (`listId`, `addedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "reading_lists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "listId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mangaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "download_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chapter_id` INTEGER NOT NULL, `manga_id` INTEGER NOT NULL, `manga_title` TEXT NOT NULL, `chapter_title` TEXT NOT NULL, `source_name` TEXT NOT NULL, `page_urls_json` TEXT NOT NULL, `priority` INTEGER NOT NULL DEFAULT 1, `status` TEXT NOT NULL DEFAULT 'QUEUED', `added_at` INTEGER NOT NULL, `bytesDownloaded` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`chapter_id`))",
+        "fields": [
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaTitle",
+            "columnName": "manga_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterTitle",
+            "columnName": "chapter_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceName",
+            "columnName": "source_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageUrlsJson",
+            "columnName": "page_urls_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'QUEUED'"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bytesDownloaded",
+            "columnName": "bytesDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chapter_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_queue_manga_id_status",
+            "unique": false,
+            "columnNames": [
+              "manga_id",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_queue_manga_id_status` ON `${TABLE_NAME}` (`manga_id`, `status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "track_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `manga_id` INTEGER NOT NULL, `tracker_id` INTEGER NOT NULL, `remote_id` INTEGER NOT NULL, `remote_url` TEXT NOT NULL, `title` TEXT NOT NULL, `status` INTEGER NOT NULL, `last_chapter_read` REAL NOT NULL, `total_chapters` INTEGER NOT NULL, `score` REAL NOT NULL, `start_date` INTEGER NOT NULL, `finish_date` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerId",
+            "columnName": "tracker_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remote_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteUrl",
+            "columnName": "remote_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastChapterRead",
+            "columnName": "last_chapter_read",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalChapters",
+            "columnName": "total_chapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finishDate",
+            "columnName": "finish_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_entries_manga_id",
+            "unique": false,
+            "columnNames": [
+              "manga_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_entries_manga_id` ON `${TABLE_NAME}` (`manga_id`)"
+          },
+          {
+            "name": "index_track_entries_tracker_id",
+            "unique": false,
+            "columnNames": [
+              "tracker_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_entries_tracker_id` ON `${TABLE_NAME}` (`tracker_id`)"
+          },
+          {
+            "name": "index_track_entries_manga_id_tracker_id",
+            "unique": true,
+            "columnNames": [
+              "manga_id",
+              "tracker_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_track_entries_manga_id_tracker_id` ON `${TABLE_NAME}` (`manga_id`, `tracker_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "dynamic_category_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `category_id` INTEGER NOT NULL, `rule_type` TEXT NOT NULL, `rule_params_json` TEXT NOT NULL, FOREIGN KEY(`category_id`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleType",
+            "columnName": "rule_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleParamsJson",
+            "columnName": "rule_params_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_dynamic_category_rules_category_id",
+            "unique": false,
+            "columnNames": [
+              "category_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_dynamic_category_rules_category_id` ON `${TABLE_NAME}` (`category_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "categories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "category_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "manga_feature_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mangaId` INTEGER NOT NULL, `title` TEXT NOT NULL, `thumbnailUrl` TEXT, `sourceId` INTEGER NOT NULL, `genresJson` TEXT NOT NULL, `score` REAL NOT NULL, `lastComputed` INTEGER NOT NULL, PRIMARY KEY(`mangaId`))",
+        "fields": [
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genresJson",
+            "columnName": "genresJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastComputed",
+            "columnName": "lastComputed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "mangaId"
+          ]
+        }
+      },
+      {
+        "tableName": "achievements",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `definitionKey` TEXT NOT NULL, `unlockedAt` INTEGER NOT NULL, `progress` INTEGER NOT NULL, `target` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "definitionKey",
+            "columnName": "definitionKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unlockedAt",
+            "columnName": "unlockedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target",
+            "columnName": "target",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "data_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `category` TEXT NOT NULL, `network` TEXT NOT NULL, `bytes` INTEGER NOT NULL, PRIMARY KEY(`date`, `category`, `network`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "network",
+            "columnName": "network",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bytes",
+            "columnName": "bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date",
+            "category",
+            "network"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `chapterId` INTEGER NOT NULL, `mangaId` INTEGER NOT NULL, `payload` TEXT NOT NULL, `attempts` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL, `lastError` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapterId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "mangaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "lastError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_queue_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_queue_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "manga_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `author` TEXT, `artist` TEXT, tokenize=unicode61, content=`manga`)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "manga",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_manga_fts_BEFORE_UPDATE BEFORE UPDATE ON `manga` BEGIN DELETE FROM `manga_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_manga_fts_BEFORE_DELETE BEFORE DELETE ON `manga` BEGIN DELETE FROM `manga_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_manga_fts_AFTER_UPDATE AFTER UPDATE ON `manga` BEGIN INSERT INTO `manga_fts`(`docid`, `title`, `author`, `artist`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`author`, NEW.`artist`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_manga_fts_AFTER_INSERT AFTER INSERT ON `manga` BEGIN INSERT INTO `manga_fts`(`docid`, `title`, `author`, `artist`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`author`, NEW.`artist`); END"
+        ]
+      },
+      {
+        "tableName": "update_run_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `checkedCount` INTEGER NOT NULL, `newChaptersCount` INTEGER NOT NULL, `skippedCount` INTEGER NOT NULL, `failedCount` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checkedCount",
+            "columnName": "checkedCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newChaptersCount",
+            "columnName": "newChaptersCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skippedCount",
+            "columnName": "skippedCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failedCount",
+            "columnName": "failedCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "manga_alternative_source",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `manga_id` INTEGER NOT NULL, `alt_manga_id` INTEGER NOT NULL, FOREIGN KEY(`manga_id`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`alt_manga_id`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "altMangaId",
+            "columnName": "alt_manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_manga_alternative_source_manga_id",
+            "unique": false,
+            "columnNames": [
+              "manga_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_alternative_source_manga_id` ON `${TABLE_NAME}` (`manga_id`)"
+          },
+          {
+            "name": "index_manga_alternative_source_alt_manga_id",
+            "unique": false,
+            "columnNames": [
+              "alt_manga_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_manga_alternative_source_alt_manga_id` ON `${TABLE_NAME}` (`alt_manga_id`)"
+          },
+          {
+            "name": "index_manga_alternative_source_manga_id_alt_manga_id",
+            "unique": true,
+            "columnNames": [
+              "manga_id",
+              "alt_manga_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_manga_alternative_source_manga_id_alt_manga_id` ON `${TABLE_NAME}` (`manga_id`, `alt_manga_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "manga_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "alt_manga_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reader_comments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `manga_id` INTEGER NOT NULL, `chapter_id` INTEGER, `body` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, FOREIGN KEY(`manga_id`) REFERENCES `manga`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`chapter_id`) REFERENCES `chapters`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mangaId",
+            "columnName": "manga_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterId",
+            "columnName": "chapter_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reader_comments_manga_id",
+            "unique": false,
+            "columnNames": [
+              "manga_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reader_comments_manga_id` ON `${TABLE_NAME}` (`manga_id`)"
+          },
+          {
+            "name": "index_reader_comments_chapter_id",
+            "unique": false,
+            "columnNames": [
+              "chapter_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reader_comments_chapter_id` ON `${TABLE_NAME}` (`chapter_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "manga",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "manga_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "chapters",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chapter_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'dff3378ec8ce01c3073771b38d9188d7')"
+    ]
+  }
+}

--- a/core/database/src/main/java/app/otakureader/core/database/OtakuReaderDatabase.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/OtakuReaderDatabase.kt
@@ -14,6 +14,7 @@ import app.otakureader.core.database.dao.MangaCategoryDao
 import app.otakureader.core.database.dao.MangaDao
 import app.otakureader.core.database.dao.OpdsServerDao
 import app.otakureader.core.database.dao.PageBookmarkDao
+import app.otakureader.core.database.dao.ReaderCommentDao
 import app.otakureader.core.database.dao.ReadingHistoryDao
 import app.otakureader.core.database.dao.ReadingListDao
 import app.otakureader.core.database.dao.ReadingStreakDao
@@ -38,6 +39,7 @@ import app.otakureader.core.database.entity.MangaEntity
 import app.otakureader.core.database.entity.MangaFtsEntity
 import app.otakureader.core.database.entity.OpdsServerEntity
 import app.otakureader.core.database.entity.PageBookmarkEntity
+import app.otakureader.core.database.entity.ReaderCommentEntity
 import app.otakureader.core.database.entity.ReadingHistoryEntity
 import app.otakureader.core.database.entity.ReadingListEntity
 import app.otakureader.core.database.entity.ReadingListItemEntity
@@ -90,8 +92,10 @@ import app.otakureader.core.database.entity.UpdateRunSummaryEntity
         UpdateRunSummaryEntity::class,
         // Alternative-source linking for cross-source duplicate merge (#1053)
         MangaAlternativeSourceEntity::class,
+        // Local reader comments (chapter + book scoped)
+        ReaderCommentEntity::class,
     ],
-    version = 36,
+    version = 37,
     exportSchema = true
 )
 @TypeConverters(DatabaseConverters::class)
@@ -118,6 +122,7 @@ abstract class OtakuReaderDatabase : RoomDatabase() {
     abstract fun syncQueueDao(): SyncQueueDao
     abstract fun updateRunSummaryDao(): UpdateRunSummaryDao
     abstract fun mangaAlternativeSourceDao(): MangaAlternativeSourceDao
+    abstract fun readerCommentDao(): ReaderCommentDao
 
     companion object {
         const val DATABASE_NAME = "otakureader.db"

--- a/core/database/src/main/java/app/otakureader/core/database/dao/ReaderCommentDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/ReaderCommentDao.kt
@@ -1,0 +1,25 @@
+package app.otakureader.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import app.otakureader.core.database.entity.ReaderCommentEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ReaderCommentDao {
+
+    /** Book-level comments for a manga (chapter_id IS NULL), oldest first so it reads like a thread. */
+    @Query("SELECT * FROM reader_comments WHERE manga_id = :mangaId AND chapter_id IS NULL ORDER BY created_at ASC")
+    fun getBookComments(mangaId: Long): Flow<List<ReaderCommentEntity>>
+
+    /** Chapter-level comments, oldest first. */
+    @Query("SELECT * FROM reader_comments WHERE chapter_id = :chapterId ORDER BY created_at ASC")
+    fun getChapterComments(chapterId: Long): Flow<List<ReaderCommentEntity>>
+
+    @Insert
+    suspend fun insert(comment: ReaderCommentEntity): Long
+
+    @Query("DELETE FROM reader_comments WHERE id = :id")
+    suspend fun deleteById(id: Long)
+}

--- a/core/database/src/main/java/app/otakureader/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/di/DatabaseModule.kt
@@ -109,4 +109,7 @@ object DatabaseModule {
     fun provideMangaAlternativeSourceDao(
         database: OtakuReaderDatabase,
     ): MangaAlternativeSourceDao = database.mangaAlternativeSourceDao()
+
+    @Provides
+    fun provideReaderCommentDao(database: OtakuReaderDatabase) = database.readerCommentDao()
 }

--- a/core/database/src/main/java/app/otakureader/core/database/entity/ReaderCommentEntity.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/entity/ReaderCommentEntity.kt
@@ -1,0 +1,54 @@
+package app.otakureader.core.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Room entity for local reader comments — private, on-device notes written from the
+ * reader's comments overlay.
+ *
+ * Scope is encoded by [chapterId]: a null chapter id is a book-level comment (visible
+ * from any chapter of the manga), a non-null chapter id ties the comment to one chapter.
+ * Comments cascade-delete with their manga or chapter.
+ */
+@Entity(
+    tableName = "reader_comments",
+    foreignKeys = [
+        ForeignKey(
+            entity = MangaEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["manga_id"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = ChapterEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["chapter_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(value = ["manga_id"]),
+        Index(value = ["chapter_id"])
+    ]
+)
+data class ReaderCommentEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    @ColumnInfo(name = "manga_id")
+    val mangaId: Long,
+    /** Null for book-level comments; the owning chapter for chapter-level comments. */
+    @ColumnInfo(name = "chapter_id")
+    val chapterId: Long? = null,
+    @ColumnInfo(name = "body")
+    val body: String,
+    /** Epoch millis when the comment was created. */
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long = System.currentTimeMillis(),
+    /** Epoch millis of the last edit; equals [createdAt] until editing ships. */
+    @ColumnInfo(name = "updated_at")
+    val updatedAt: Long = System.currentTimeMillis()
+)

--- a/core/database/src/main/java/app/otakureader/core/database/migrations/DatabaseMigrations.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/migrations/DatabaseMigrations.kt
@@ -448,6 +448,28 @@ internal val MIGRATION_35_36 = object : Migration(35, 36) {
     }
 }
 
+/** v36 → v37: Local reader comments table (chapter + book scoped). */
+internal val MIGRATION_36_37 = object : Migration(36, 37) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS reader_comments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                manga_id INTEGER NOT NULL,
+                chapter_id INTEGER,
+                body TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                FOREIGN KEY (manga_id) REFERENCES manga(id) ON DELETE CASCADE,
+                FOREIGN KEY (chapter_id) REFERENCES chapters(id) ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_reader_comments_manga_id ON reader_comments(manga_id)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_reader_comments_chapter_id ON reader_comments(chapter_id)")
+    }
+}
+
 /** All migrations in order, for use in [Room.databaseBuilder] and migration tests. */
 internal val ALL_MIGRATIONS = arrayOf(
     MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6,
@@ -458,5 +480,5 @@ internal val ALL_MIGRATIONS = arrayOf(
     MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
     MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30, MIGRATION_30_31,
     MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35,
-    MIGRATION_35_36,
+    MIGRATION_35_36, MIGRATION_36_37,
 )

--- a/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
+++ b/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
@@ -39,6 +39,8 @@ import org.junit.runner.RunWith
 private const val TEST_DB = "migration-test"
 
 @RunWith(AndroidJUnit4::class)
+// One test class per migration chain: it grows by design with every schema version.
+@Suppress("LargeClass")
 class DatabaseMigrationTest {
 
     @get:Rule

--- a/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
+++ b/core/database/src/test/java/app/otakureader/core/database/DatabaseMigrationTest.kt
@@ -27,6 +27,7 @@ import app.otakureader.core.database.migrations.MIGRATION_29_30
 import app.otakureader.core.database.migrations.MIGRATION_30_31
 import app.otakureader.core.database.migrations.MIGRATION_31_32
 import app.otakureader.core.database.migrations.MIGRATION_35_36
+import app.otakureader.core.database.migrations.MIGRATION_36_37
 import app.otakureader.core.database.migrations.MIGRATION_9_10
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -52,7 +53,7 @@ class DatabaseMigrationTest {
     fun allMigrations_formsContiguousChain() {
         val sorted = ALL_MIGRATIONS.sortedBy { it.startVersion }
         assertEquals("Migration chain must start at version 2", 2, sorted.first().startVersion)
-        assertEquals("Migration chain must end at version 36", 36, sorted.last().endVersion)
+        assertEquals("Migration chain must end at version 37", 37, sorted.last().endVersion)
 
         for (i in 0 until sorted.size - 1) {
             val current = sorted[i]
@@ -79,7 +80,7 @@ class DatabaseMigrationTest {
 
     @Test
     fun allMigrations_count() {
-        assertEquals("Expected 34 migrations (v2→v36)", 34, ALL_MIGRATIONS.size)
+        assertEquals("Expected 35 migrations (v2→v37)", 35, ALL_MIGRATIONS.size)
     }
 
     // ── Migration 9 → 10 ────────────────────────────────────────────────────
@@ -688,6 +689,36 @@ class DatabaseMigrationTest {
             threw = true
         }
         assertTrue("Duplicate (manga_id, alt_manga_id) pair must throw", threw)
+        db.close()
+    }
+
+    // ── Migration 36 → 37 ───────────────────────────────────────────────────
+    // Adds: reader_comments table (chapter + book scoped local comments)
+
+    @Test
+    fun migration36To37_createsReaderCommentsTable() {
+        helper.createDatabase(TEST_DB, 36).close()
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 37, true, MIGRATION_36_37)
+        assertTrue(
+            "reader_comments must exist after 36→37",
+            "reader_comments" in db.tableNames(),
+        )
+        val cols = db.columnNames("reader_comments")
+        assertTrue("manga_id must exist", "manga_id" in cols)
+        assertTrue("chapter_id must exist", "chapter_id" in cols)
+        assertTrue("body must exist", "body" in cols)
+        assertTrue("created_at must exist", "created_at" in cols)
+        assertTrue("updated_at must exist", "updated_at" in cols)
+        val indexes = db.indexNames("reader_comments")
+        assertTrue(
+            "index_reader_comments_manga_id must exist",
+            "index_reader_comments_manga_id" in indexes,
+        )
+        assertTrue(
+            "index_reader_comments_chapter_id must exist",
+            "index_reader_comments_chapter_id" in indexes,
+        )
         db.close()
     }
 

--- a/core/database/src/test/java/app/otakureader/core/database/dao/ReaderCommentDaoTest.kt
+++ b/core/database/src/test/java/app/otakureader/core/database/dao/ReaderCommentDaoTest.kt
@@ -1,0 +1,104 @@
+package app.otakureader.core.database.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.otakureader.core.database.OtakuReaderDatabase
+import app.otakureader.core.database.entity.ChapterEntity
+import app.otakureader.core.database.entity.MangaEntity
+import app.otakureader.core.database.entity.ReaderCommentEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReaderCommentDaoTest {
+
+    private lateinit var database: OtakuReaderDatabase
+    private lateinit var readerCommentDao: ReaderCommentDao
+    private lateinit var mangaDao: MangaDao
+    private lateinit var chapterDao: ChapterDao
+
+    private val mangaId = 1L
+    private val chapterId = 10L
+
+    @Before
+    fun setup() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            OtakuReaderDatabase::class.java
+        ).allowMainThreadQueries().build()
+        readerCommentDao = database.readerCommentDao()
+        mangaDao = database.mangaDao()
+        chapterDao = database.chapterDao()
+
+        runBlocking {
+            mangaDao.insert(MangaEntity(id = mangaId, title = "Test Manga", sourceId = 1L, url = "url", favorite = true))
+            chapterDao.insert(
+                ChapterEntity(id = chapterId, mangaId = mangaId, url = "ch_url", name = "Chapter 1", read = false, chapterNumber = 1f)
+            )
+        }
+    }
+
+    @After
+    fun teardown() {
+        database.close()
+    }
+
+    @Test
+    fun bookAndChapterScopesAreSeparate() = runBlocking {
+        readerCommentDao.insert(ReaderCommentEntity(mangaId = mangaId, chapterId = null, body = "book thought"))
+        readerCommentDao.insert(ReaderCommentEntity(mangaId = mangaId, chapterId = chapterId, body = "chapter thought"))
+
+        val book = readerCommentDao.getBookComments(mangaId).first()
+        val chapter = readerCommentDao.getChapterComments(chapterId).first()
+
+        assertEquals(listOf("book thought"), book.map { it.body })
+        assertEquals(listOf("chapter thought"), chapter.map { it.body })
+    }
+
+    @Test
+    fun commentsAreOrderedOldestFirst() = runBlocking {
+        readerCommentDao.insert(ReaderCommentEntity(mangaId = mangaId, body = "second", createdAt = 2_000L))
+        readerCommentDao.insert(ReaderCommentEntity(mangaId = mangaId, body = "first", createdAt = 1_000L))
+
+        val book = readerCommentDao.getBookComments(mangaId).first()
+        assertEquals(listOf("first", "second"), book.map { it.body })
+    }
+
+    @Test
+    fun deleteByIdRemovesComment() = runBlocking {
+        val id = readerCommentDao.insert(ReaderCommentEntity(mangaId = mangaId, body = "to delete"))
+
+        readerCommentDao.deleteById(id)
+
+        assertTrue(readerCommentDao.getBookComments(mangaId).first().isEmpty())
+    }
+
+    @Test
+    fun deletingChapterCascadesChapterCommentsOnly() = runBlocking {
+        readerCommentDao.insert(ReaderCommentEntity(mangaId = mangaId, chapterId = chapterId, body = "chapter"))
+        readerCommentDao.insert(ReaderCommentEntity(mangaId = mangaId, chapterId = null, body = "book"))
+
+        chapterDao.deleteByMangaId(mangaId)
+
+        assertTrue(readerCommentDao.getChapterComments(chapterId).first().isEmpty())
+        assertEquals(1, readerCommentDao.getBookComments(mangaId).first().size)
+    }
+
+    @Test
+    fun deletingMangaCascadesAllComments() = runBlocking {
+        readerCommentDao.insert(ReaderCommentEntity(mangaId = mangaId, chapterId = chapterId, body = "chapter"))
+        readerCommentDao.insert(ReaderCommentEntity(mangaId = mangaId, chapterId = null, body = "book"))
+
+        mangaDao.deleteById(mangaId)
+
+        assertTrue(readerCommentDao.getBookComments(mangaId).first().isEmpty())
+        assertTrue(readerCommentDao.getChapterComments(chapterId).first().isEmpty())
+    }
+}

--- a/data/src/main/java/app/otakureader/data/di/RepositoryModule.kt
+++ b/data/src/main/java/app/otakureader/data/di/RepositoryModule.kt
@@ -44,6 +44,8 @@ import app.otakureader.domain.history.ReadingHistoryScheduler
 import app.otakureader.domain.loader.PageLoader
 import app.otakureader.domain.repository.ReaderSettingsRepository as ReaderSettingsRepositoryInterface
 import app.otakureader.data.repository.PageBookmarkRepositoryImpl
+import app.otakureader.data.repository.ReaderCommentRepositoryImpl
+import app.otakureader.domain.repository.ReaderCommentRepository
 import app.otakureader.data.repository.ReadingListRepositoryImpl
 import app.otakureader.data.repository.SourceRepositoryImpl
 import app.otakureader.data.repository.StatisticsRepositoryImpl
@@ -113,6 +115,9 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun bindPageBookmarkRepository(impl: PageBookmarkRepositoryImpl): PageBookmarkRepository
+
+    @Binds
+    abstract fun bindReaderCommentRepository(impl: ReaderCommentRepositoryImpl): ReaderCommentRepository
 
     @Binds
     abstract fun bindSourceRepository(impl: SourceRepositoryImpl): SourceRepository

--- a/data/src/main/java/app/otakureader/data/repository/ReaderCommentRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/ReaderCommentRepositoryImpl.kt
@@ -1,0 +1,54 @@
+package app.otakureader.data.repository
+
+import app.otakureader.core.database.dao.ReaderCommentDao
+import app.otakureader.core.database.entity.ReaderCommentEntity
+import app.otakureader.domain.model.ReaderComment
+import app.otakureader.domain.repository.ReaderCommentRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReaderCommentRepositoryImpl @Inject constructor(
+    private val readerCommentDao: ReaderCommentDao,
+) : ReaderCommentRepository {
+
+    override fun observeBookComments(mangaId: Long): Flow<List<ReaderComment>> {
+        return readerCommentDao.getBookComments(mangaId).map { list ->
+            list.map { it.toDomain() }
+        }
+    }
+
+    override fun observeChapterComments(chapterId: Long): Flow<List<ReaderComment>> {
+        return readerCommentDao.getChapterComments(chapterId).map { list ->
+            list.map { it.toDomain() }
+        }
+    }
+
+    override suspend fun addComment(mangaId: Long, chapterId: Long?, body: String) {
+        val now = System.currentTimeMillis()
+        readerCommentDao.insert(
+            ReaderCommentEntity(
+                mangaId = mangaId,
+                chapterId = chapterId,
+                body = body,
+                createdAt = now,
+                updatedAt = now,
+            ),
+        )
+    }
+
+    override suspend fun deleteComment(commentId: Long) {
+        readerCommentDao.deleteById(commentId)
+    }
+
+    private fun ReaderCommentEntity.toDomain() = ReaderComment(
+        id = id,
+        mangaId = mangaId,
+        chapterId = chapterId,
+        body = body,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+    )
+}

--- a/domain/src/main/java/app/otakureader/domain/model/ReaderComment.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/ReaderComment.kt
@@ -1,0 +1,18 @@
+package app.otakureader.domain.model
+
+/**
+ * A private, on-device comment written from the reader's comments overlay.
+ *
+ * Scope is encoded by [chapterId]: null means a book-level comment that is visible from
+ * any chapter of the manga; non-null ties the comment to one chapter.
+ */
+data class ReaderComment(
+    val id: Long = 0,
+    val mangaId: Long,
+    val chapterId: Long? = null,
+    val body: String,
+    val createdAt: Long = System.currentTimeMillis(),
+    val updatedAt: Long = System.currentTimeMillis(),
+) {
+    val isBookScoped: Boolean get() = chapterId == null
+}

--- a/domain/src/main/java/app/otakureader/domain/repository/ReaderCommentRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/ReaderCommentRepository.kt
@@ -1,0 +1,17 @@
+package app.otakureader.domain.repository
+
+import app.otakureader.domain.model.ReaderComment
+import kotlinx.coroutines.flow.Flow
+
+interface ReaderCommentRepository {
+    /** Book-level comments for a manga, oldest first. */
+    fun observeBookComments(mangaId: Long): Flow<List<ReaderComment>>
+
+    /** Chapter-level comments, oldest first. */
+    fun observeChapterComments(chapterId: Long): Flow<List<ReaderComment>>
+
+    /** Adds a comment; a null [chapterId] creates a book-level comment. */
+    suspend fun addComment(mangaId: Long, chapterId: Long?, body: String)
+
+    suspend fun deleteComment(commentId: Long)
+}

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderMvi.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderMvi.kt
@@ -53,6 +53,9 @@ data class ReaderState(
     /** Whether the chapter-list overlay is visible (slide-in from right edge) */
     val isChapterListOverlayVisible: Boolean = false,
 
+    /** Whether the reader comments bottom sheet is visible */
+    val isCommentsOverlayVisible: Boolean = false,
+
     /** Number of columns displayed in the gallery grid (2, 3, or 4) */
     val galleryColumns: Int = 3,
 
@@ -265,6 +268,7 @@ data class ReaderState(
             showTapZonesOverlay = showTapZonesOverlay,
             isSettingsOverlayVisible = isSettingsOverlayVisible,
             isChapterListOverlayVisible = isChapterListOverlayVisible,
+            isCommentsOverlayVisible = isCommentsOverlayVisible,
         )
 
     /** Display and rendering settings — changes infrequently. */
@@ -322,6 +326,7 @@ data class OverlayState(
     val showTapZonesOverlay: Boolean,
     val isSettingsOverlayVisible: Boolean = false,
     val isChapterListOverlayVisible: Boolean = false,
+    val isCommentsOverlayVisible: Boolean = false,
 )
 
 /** Projection of rendering and display preference fields. */
@@ -353,6 +358,12 @@ data class WebtoonState(
     val webtoonMenuHideSensitivity: Int,
     val webtoonDoubleTapZoom: Boolean,
     val webtoonDisableZoomOut: Boolean
+)
+
+/** An "Open <tracker>" button in the comments overlay, built from an existing tracker link. */
+data class ExternalDiscussionLink(
+    val trackerName: String,
+    val url: String,
 )
 
 /**
@@ -508,6 +519,9 @@ sealed interface ReaderEvent {
 
     /** Toggle the chapter-list overlay (slide-in panel from right edge). */
     data object ToggleChapterListOverlay : OverlayControl
+
+    /** Toggle the reader comments bottom sheet. */
+    data object ToggleCommentsOverlay : OverlayControl
 
     /** Toggle auto-scroll (webtoon mode). */
     data object ToggleAutoScroll : AutoScrollControl

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -55,6 +55,7 @@ import app.otakureader.core.ui.theme.ContentType
 import app.otakureader.feature.reader.ui.BatteryTimeOverlay
 import app.otakureader.feature.reader.ui.BrightnessSliderOverlay
 import app.otakureader.feature.reader.ui.ChapterFilterBottomSheet
+import app.otakureader.feature.reader.ui.ReaderCommentsOverlay
 import app.otakureader.feature.reader.ui.FullPageGallery
 import app.otakureader.feature.reader.ui.PageSlider
 import app.otakureader.feature.reader.ui.PageThumbnailStrip
@@ -334,9 +335,27 @@ fun ReaderScreen(
             onToggleFullscreen = { viewModel.onEvent(ReaderEvent.ToggleFullscreen) },
             onToggleChapterFilter = { showChapterFilterSheet = true },
             onToggleChapterList = { viewModel.onEvent(ReaderEvent.ToggleChapterListOverlay) },
+            onToggleComments = { viewModel.onEvent(ReaderEvent.ToggleCommentsOverlay) },
             presets = state.presets,
             onApplyPreset = { viewModel.onEvent(ReaderEvent.ApplyPreset(it)) },
         )
+
+        if (state.isCommentsOverlayVisible) {
+            val chapterComments by viewModel.chapterComments.collectAsStateWithLifecycle()
+            val bookComments by viewModel.bookComments.collectAsStateWithLifecycle()
+            val chapterNote by viewModel.currentChapterNote.collectAsStateWithLifecycle()
+            val externalLinks by viewModel.externalDiscussionLinks.collectAsStateWithLifecycle()
+            ReaderCommentsOverlay(
+                chapterComments = chapterComments,
+                bookComments = bookComments,
+                chapterNote = chapterNote,
+                externalLinks = externalLinks,
+                onAddComment = { body, chapterScoped -> viewModel.addComment(body, chapterScoped) },
+                onDeleteComment = { viewModel.deleteComment(it) },
+                onSaveChapterNote = { viewModel.saveChapterNote(it) },
+                onDismiss = { viewModel.onEvent(ReaderEvent.ToggleCommentsOverlay) },
+            )
+        }
 
         if (showChapterFilterSheet) {
             ChapterFilterBottomSheet(

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -18,8 +18,12 @@ import app.otakureader.domain.model.ColorFilterMode
 import app.otakureader.domain.model.ReaderMode
 import app.otakureader.feature.reader.model.ReaderPage
 import app.otakureader.domain.model.ReadingDirection
+import app.otakureader.domain.model.ReaderComment
+import app.otakureader.domain.repository.ReaderCommentRepository
 import app.otakureader.domain.repository.ReaderSettingsRepository
 import app.otakureader.domain.repository.TrackerSyncRepository
+import app.otakureader.domain.tracking.TrackManager
+import app.otakureader.domain.tracking.TrackRepository
 import app.otakureader.feature.reader.prefetch.ReadingBehaviorTracker
 import app.otakureader.feature.reader.viewmodel.delegate.ReaderChapterLoaderDelegate
 import app.otakureader.feature.reader.viewmodel.delegate.ReaderDiscordDelegate
@@ -39,6 +43,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
@@ -87,6 +92,9 @@ class ReaderViewModel @Inject constructor(
     private val prefetchDelegate: ReaderPrefetchDelegate,
     private val downloadAheadDelegate: ReaderDownloadAheadDelegate,
     private val trackerSyncRepository: TrackerSyncRepository,
+    private val readerCommentRepository: ReaderCommentRepository,
+    private val trackRepository: TrackRepository,
+    private val trackManager: TrackManager,
     private val displayDelegate: ReaderDisplayDelegate,
     private val readerPreferences: ReaderPreferences,
     savedStateHandle: SavedStateHandle
@@ -111,6 +119,69 @@ class ReaderViewModel @Inject constructor(
     val chapters: StateFlow<List<Chapter>> = chapterRepository
         .getChaptersByMangaId(mangaId)
         .stateIn(viewModelScope, sharing, emptyList())
+
+    // ── Reader comments overlay ─────────────────────────────────────────────
+
+    /** Book-level comments — visible from any chapter of this manga. */
+    val bookComments: StateFlow<List<ReaderComment>> = readerCommentRepository
+        .observeBookComments(mangaId)
+        .stateIn(viewModelScope, sharing, emptyList())
+
+    /**
+     * Comments for the chapter currently on screen. flatMapLatest re-subscribes on
+     * every chapter switch, so navigating chapters changes the thread automatically.
+     */
+    val chapterComments: StateFlow<List<ReaderComment>> = state
+        .map { it.currentChapterId }
+        .distinctUntilChanged()
+        .flatMapLatest { id -> readerCommentRepository.observeChapterComments(id) }
+        .stateIn(viewModelScope, sharing, emptyList())
+
+    /** The current chapter's private note (ChapterEntity.userNotes), editable in the overlay. */
+    val currentChapterNote: StateFlow<String> = combine(
+        chapters,
+        state.map { it.currentChapterId }.distinctUntilChanged(),
+    ) { allChapters, id ->
+        allChapters.find { it.id == id }?.userNotes.orEmpty()
+    }.stateIn(viewModelScope, sharing, "")
+
+    /** "Open <tracker>" buttons for every linked tracker that has a remote page URL. */
+    val externalDiscussionLinks: StateFlow<List<ExternalDiscussionLink>> = trackRepository
+        .observeEntriesForManga(mangaId)
+        .map { entries ->
+            entries.mapNotNull { entry ->
+                val name = trackManager.get(entry.trackerId)?.name
+                if (name != null && entry.remoteUrl.isNotBlank()) {
+                    ExternalDiscussionLink(trackerName = name, url = entry.remoteUrl)
+                } else {
+                    null
+                }
+            }
+        }
+        .stateIn(viewModelScope, sharing, emptyList())
+
+    fun addComment(body: String, chapterScoped: Boolean) {
+        val trimmed = body.trim()
+        if (trimmed.isEmpty()) return
+        viewModelScope.launch {
+            readerCommentRepository.addComment(
+                mangaId = mangaId,
+                chapterId = if (chapterScoped) _state.value.currentChapterId else null,
+                body = trimmed,
+            )
+        }
+    }
+
+    fun deleteComment(comment: ReaderComment) {
+        viewModelScope.launch { readerCommentRepository.deleteComment(comment.id) }
+    }
+
+    fun saveChapterNote(text: String) {
+        val targetChapterId = _state.value.currentChapterId
+        viewModelScope.launch {
+            chapterRepository.updateChapterNotes(targetChapterId, text.trim().ifEmpty { null })
+        }
+    }
 
     private var currentManga: Manga? = null
     private var currentChapter: Chapter? = null
@@ -416,6 +487,7 @@ class ReaderViewModel @Inject constructor(
             ReaderEvent.ToggleFullscreen -> displayDelegate.toggleFullscreen()
             ReaderEvent.ToggleSettingsOverlay -> displayDelegate.toggleSettingsOverlay()
             ReaderEvent.ToggleChapterListOverlay -> displayDelegate.toggleChapterListOverlay()
+            ReaderEvent.ToggleCommentsOverlay -> displayDelegate.toggleCommentsOverlay()
         }
     }
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderCommentsOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderCommentsOverlay.kt
@@ -1,0 +1,257 @@
+package app.otakureader.feature.reader.ui
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.core.net.toUri
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import app.otakureader.domain.model.ReaderComment
+import app.otakureader.feature.reader.ExternalDiscussionLink
+import app.otakureader.feature.reader.R
+import java.text.DateFormat
+import java.util.Date
+
+private const val TAB_CHAPTER = 0
+private const val TAB_BOOK = 1
+
+/**
+ * Bottom-sheet overlay for private reader comments.
+ *
+ * Two tabs: Chapter (comments tied to the chapter on screen, plus the existing
+ * chapter note) and Book (comments tied to the manga as a whole). External
+ * tracker pages open in the browser via the buttons at the bottom.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReaderCommentsOverlay(
+    chapterComments: List<ReaderComment>,
+    bookComments: List<ReaderComment>,
+    chapterNote: String,
+    externalLinks: List<ExternalDiscussionLink>,
+    onAddComment: (body: String, chapterScoped: Boolean) -> Unit,
+    onDeleteComment: (ReaderComment) -> Unit,
+    onSaveChapterNote: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var selectedTab by remember { mutableIntStateOf(TAB_CHAPTER) }
+    var composerText by remember { mutableStateOf("") }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    ) {
+        Column(modifier = Modifier.padding(bottom = 16.dp)) {
+            Text(
+                text = stringResource(R.string.reader_comments_title),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+            TabRow(selectedTabIndex = selectedTab) {
+                Tab(
+                    selected = selectedTab == TAB_CHAPTER,
+                    onClick = { selectedTab = TAB_CHAPTER },
+                    text = { Text(stringResource(R.string.reader_comments_tab_chapter)) },
+                )
+                Tab(
+                    selected = selectedTab == TAB_BOOK,
+                    onClick = { selectedTab = TAB_BOOK },
+                    text = { Text(stringResource(R.string.reader_comments_tab_book)) },
+                )
+            }
+
+            val comments = if (selectedTab == TAB_CHAPTER) chapterComments else bookComments
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 320.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                if (selectedTab == TAB_CHAPTER) {
+                    item(key = "chapter_note") {
+                        ChapterNoteCard(
+                            note = chapterNote,
+                            onSave = onSaveChapterNote,
+                        )
+                    }
+                }
+                if (comments.isEmpty()) {
+                    item(key = "empty") {
+                        Text(
+                            text = stringResource(R.string.reader_comments_empty),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(16.dp),
+                        )
+                    }
+                } else {
+                    items(comments, key = { it.id }) { comment ->
+                        CommentRow(comment = comment, onDelete = { onDeleteComment(comment) })
+                    }
+                }
+            }
+
+            // Composer
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.Bottom,
+            ) {
+                OutlinedTextField(
+                    value = composerText,
+                    onValueChange = { composerText = it },
+                    modifier = Modifier.weight(1f),
+                    placeholder = { Text(stringResource(R.string.reader_comments_hint)) },
+                    maxLines = 4,
+                )
+                TextButton(
+                    onClick = {
+                        onAddComment(composerText, selectedTab == TAB_CHAPTER)
+                        composerText = ""
+                    },
+                    enabled = composerText.isNotBlank(),
+                ) {
+                    Text(stringResource(R.string.reader_comments_add))
+                }
+            }
+
+            if (externalLinks.isNotEmpty()) {
+                HorizontalDivider()
+                Text(
+                    text = stringResource(R.string.reader_comments_external_title),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+                val context = LocalContext.current
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    externalLinks.forEach { link ->
+                        OutlinedButton(
+                            onClick = {
+                                runCatching {
+                                    context.startActivity(Intent(Intent.ACTION_VIEW, link.url.toUri()))
+                                }
+                            },
+                        ) {
+                            Icon(
+                                Icons.AutoMirrored.Filled.OpenInNew,
+                                contentDescription = null,
+                                modifier = Modifier.padding(end = 4.dp),
+                            )
+                            Text(link.trackerName)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChapterNoteCard(
+    note: String,
+    onSave: (String) -> Unit,
+) {
+    var text by remember { mutableStateOf(note) }
+    // Re-sync the editor when the chapter (and therefore its saved note) changes.
+    LaunchedEffect(note) { text = note }
+
+    Card(modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp, vertical = 4.dp)) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                text = stringResource(R.string.reader_comments_note_label),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = { Text(stringResource(R.string.reader_comments_note_hint)) },
+                maxLines = 3,
+            )
+            TextButton(
+                onClick = { onSave(text) },
+                enabled = text != note,
+                modifier = Modifier.align(Alignment.End),
+            ) {
+                Text(stringResource(R.string.reader_comments_note_save))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CommentRow(
+    comment: ReaderComment,
+    onDelete: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = comment.body,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Text(
+                text = remember(comment.createdAt) {
+                    DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT)
+                        .format(Date(comment.createdAt))
+                },
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        IconButton(onClick = onDelete) {
+            Icon(
+                Icons.Default.Delete,
+                contentDescription = stringResource(R.string.reader_comments_delete),
+            )
+        }
+    }
+}

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderMenuOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderMenuOverlay.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Comment
 import androidx.compose.material.icons.automirrored.filled.NavigateNext
 import androidx.compose.material.icons.filled.Brightness6
 import androidx.compose.material.icons.filled.FitScreen
@@ -104,6 +105,7 @@ fun ReaderMenuOverlay(
     onToggleFullscreen: () -> Unit,
     onToggleChapterFilter: (() -> Unit)? = null,
     onToggleChapterList: (() -> Unit)? = null,
+    onToggleComments: (() -> Unit)? = null,
     presets: List<ReaderPreset> = emptyList(),
     onApplyPreset: (ReaderPreset) -> Unit = {},
     modifier: Modifier = Modifier
@@ -152,6 +154,14 @@ fun ReaderMenuOverlay(
                         if (onToggleChapterList != null) {
                             IconButton(onClick = onToggleChapterList) {
                                 Icon(Icons.Default.MenuBook, contentDescription = stringResource(R.string.reader_chapter_list_title))
+                            }
+                        }
+                        if (onToggleComments != null) {
+                            IconButton(onClick = onToggleComments) {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.Comment,
+                                    contentDescription = stringResource(R.string.reader_comments_title)
+                                )
                             }
                         }
                         IconButton(onClick = onToggleFullscreen) {

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDisplayDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDisplayDelegate.kt
@@ -103,6 +103,10 @@ class ReaderDisplayDelegate @Inject constructor(
         update { it.copy(isChapterListOverlayVisible = !it.isChapterListOverlayVisible) }
     }
 
+    fun toggleCommentsOverlay() {
+        update { it.copy(isCommentsOverlayVisible = !it.isCommentsOverlayVisible) }
+    }
+
     // ── Brightness ───────────────────────────────────────────────────────────
 
     fun updateBrightness(brightness: Float) {

--- a/feature/reader/src/main/res/values/strings.xml
+++ b/feature/reader/src/main/res/values/strings.xml
@@ -165,4 +165,17 @@
 
     <!-- Reader presets quick-switch -->
     <string name="reader_presets_quick">Presets</string>
+
+    <!-- Reader comments overlay -->
+    <string name="reader_comments_title">Reader comments</string>
+    <string name="reader_comments_tab_chapter">Chapter</string>
+    <string name="reader_comments_tab_book">Book</string>
+    <string name="reader_comments_empty">No comments yet. Add your first thought below.</string>
+    <string name="reader_comments_hint">Write a comment…</string>
+    <string name="reader_comments_add">Add</string>
+    <string name="reader_comments_delete">Delete comment</string>
+    <string name="reader_comments_note_label">Chapter note</string>
+    <string name="reader_comments_note_hint">Private note for this chapter</string>
+    <string name="reader_comments_note_save">Save note</string>
+    <string name="reader_comments_external_title">Discussions elsewhere</string>
 </resources>

--- a/feature/reader/src/test/java/app/otakureader/feature/reader/ReaderViewModelTest.kt
+++ b/feature/reader/src/test/java/app/otakureader/feature/reader/ReaderViewModelTest.kt
@@ -91,6 +91,9 @@ class ReaderViewModelTest {
     private lateinit var chapterPrefetcher: AdaptiveChapterPrefetcher
     private lateinit var panelDetectionService: PanelDetectionService
     private lateinit var trackerSyncRepository: TrackerSyncRepository
+    private lateinit var readerCommentRepository: app.otakureader.domain.repository.ReaderCommentRepository
+    private lateinit var trackRepository: app.otakureader.domain.tracking.TrackRepository
+    private lateinit var trackManager: app.otakureader.domain.tracking.TrackManager
     private lateinit var historyScheduler: ReadingHistoryScheduler
     private lateinit var displayDelegate: ReaderDisplayDelegate
     private lateinit var readerPreferences: ReaderPreferences
@@ -119,6 +122,12 @@ class ReaderViewModelTest {
         panelDetectionService = mockk()
         historyScheduler = mockk(relaxed = true)
         trackerSyncRepository = mockk(relaxed = true)
+        readerCommentRepository = mockk(relaxed = true)
+        every { readerCommentRepository.observeBookComments(any()) } returns flowOf(emptyList())
+        every { readerCommentRepository.observeChapterComments(any()) } returns flowOf(emptyList())
+        trackRepository = mockk(relaxed = true)
+        every { trackRepository.observeEntriesForManga(any()) } returns flowOf(emptyList())
+        trackManager = mockk(relaxed = true)
         readerPreferences = mockk()
         every { readerPreferences.presets } returns flowOf(emptyList())
         displayDelegate = ReaderDisplayDelegate(
@@ -248,6 +257,9 @@ class ReaderViewModelTest {
             ),
             displayDelegate = displayDelegate,
             trackerSyncRepository = trackerSyncRepository,
+            readerCommentRepository = readerCommentRepository,
+            trackRepository = trackRepository,
+            trackManager = trackManager,
             readerPreferences = readerPreferences,
             savedStateHandle = SavedStateHandle(
                 mapOf("mangaId" to mangaId, "chapterId" to chapterId)
@@ -840,4 +852,67 @@ class ReaderViewModelTest {
 
     // ── OCR text search tests ────────────────────────────────────────────────
 
+    // ── Reader comments ──────────────────────────────────────────────────────
+
+    @Test
+    fun `ToggleCommentsOverlay flips visibility`() = runTest {
+        val vm = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertFalse(vm.state.value.isCommentsOverlayVisible)
+
+        vm.onEvent(ReaderEvent.ToggleCommentsOverlay)
+        assertTrue(vm.state.value.isCommentsOverlayVisible)
+
+        vm.onEvent(ReaderEvent.ToggleCommentsOverlay)
+        assertFalse(vm.state.value.isCommentsOverlayVisible)
+    }
+
+    @Test
+    fun `addComment chapter-scoped uses current chapter id`() = runTest {
+        coEvery { readerCommentRepository.addComment(any(), any(), any()) } just runs
+        val vm = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.addComment("  great fight scene  ", chapterScoped = true)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { readerCommentRepository.addComment(mangaId, chapterId, "great fight scene") }
+    }
+
+    @Test
+    fun `addComment book-scoped passes null chapter id`() = runTest {
+        coEvery { readerCommentRepository.addComment(any(), any(), any()) } just runs
+        val vm = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.addComment("series-wide thought", chapterScoped = false)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { readerCommentRepository.addComment(mangaId, null, "series-wide thought") }
+    }
+
+    @Test
+    fun `addComment ignores blank input`() = runTest {
+        val vm = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.addComment("   ", chapterScoped = true)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 0) { readerCommentRepository.addComment(any(), any(), any()) }
+    }
+
+    @Test
+    fun `saveChapterNote persists trimmed note and clears empty text`() = runTest {
+        coEvery { chapterRepository.updateChapterNotes(any(), any()) } just runs
+        val vm = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.saveChapterNote(" remember this cliffhanger ")
+        vm.saveChapterNote("   ")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { chapterRepository.updateChapterNotes(chapterId, "remember this cliffhanger") }
+        coVerify { chapterRepository.updateChapterNotes(chapterId, null) }
+    }
 }


### PR DESCRIPTION
## **User description**
## Summary

Implements the Reader Comments feature plan (V1 scope): private, on-device comments you can open from the reader without leaving the page. Branched on top of `fix/main-bug-sweep` (#1097) — merge that first; this PR will then show only the feature diff.

## What you get

- A new **comment icon in the reader menu** (next to the chapter list button) opens a bottom sheet.
- **Chapter tab**: comments tied to the chapter on screen, plus your existing chapter note (the same one the Details screen edits) editable in place. Navigating chapters switches the thread automatically.
- **Book tab**: comments tied to the manga as a whole, visible from any chapter.
- Add and delete comments, each with a timestamp. Editing is a deliberate follow-up.
- **"Discussions elsewhere"**: one button per linked tracker (MAL, AniList, Kitsu, MangaUpdates, Shikimori) that opens its page in the browser — built entirely from existing `TrackEntry.remoteUrl` data, no new sync.

## How it's built (for review)

Every layer copies a proven template from the codebase:

| Piece | Template followed |
|---|---|
| `ReaderCommentEntity` + `ReaderCommentDao` (DB v36→37, explicit migration) | `PageBookmarkEntity` — same dual cascade FKs to `manga`/`chapters` |
| `ReaderCommentRepository` interface + impl + `@Binds` | `PageBookmarkRepository` trio |
| `isCommentsOverlayVisible` + `ToggleCommentsOverlay` | The four existing reader overlay flags/events |
| `ReaderCommentsOverlay` bottom sheet | `ChapterFilterBottomSheet` |

Design choices worth knowing:
- **No `scope` column** — a null `chapter_id` *is* book scope. One less invariant that could disagree with itself.
- **`chapterComments` uses `flatMapLatest` on `currentChapterId`**, so the chapter thread re-subscribes on every chapter switch with no manual wiring.
- **Notes and comments coexist**: the chapter note stays a single editable blob (used by Details and backups); comments are the new multi-entry timeline. The overlay shows both so there's one place in the reader for everything you've written.

## Tests

- `ReaderCommentDaoTest` (in-memory Room): scope separation, oldest-first ordering, delete, chapter-cascade leaves book comments intact, manga-cascade removes everything.
- `ReaderViewModelTest`: overlay toggle, chapter-scoped vs book-scoped add, blank input ignored, note save trims and nulls empty text.
- Full local gate green: `:core:database` + `:feature:reader` unit tests, `:data`/`:app` compile (validates the Hilt graph), Detekt.

## Deferred (noted, not forgotten)

- **Backup coverage for comments**: restoring comments requires remapping chapter ids at restore time (ids change across devices). That needs its own careful pass rather than riding along here.
- Comment editing (V1 is add/view/delete per the plan).

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Add reader comments and restore more app data safely**

### What Changed
- Added a reader comments sheet with separate Chapter and Book tabs, comment timestamps, delete actions, and a chapter note editor
- Added quick access to the comments sheet from the reader menu, plus browser links to related tracker discussion pages
- Backups now include more user settings and notes, including manga overrides, chapter notes, and category settings; custom file-based covers are not restored on other devices
- If encrypted storage or the Android Keystore is corrupted, the app now recovers instead of getting stuck in a crash loop
- WebView address input now opens only web links, and reader page transitions no longer crash when the page list shrinks

### Impact
`✅ Reader notes and comments without leaving the page`
`✅ Fewer crash loops after backup restore or device updates`
`✅ Safer link handling in the in-app browser`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
