### PR TITLE
fix: extension Trust flow + "No sources" display

### DIFF
--- a/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionDatabase.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionDatabase.kt
@@ -120,6 +120,9 @@ interface ExtensionDao {
 
     @Query("UPDATE extensions SET is_enabled = :enabled WHERE pkg_name = :pkgName")
     suspend fun updateEnabled(pkgName: String, enabled: Boolean)
+
+    @Query("UPDATE extensions SET signature_hash = :hash WHERE pkg_name = :pkgName")
+    suspend fun updateSignatureHash(pkgName: String, hash: String)
     
     @Query("SELECT * FROM extensions WHERE name LIKE '%' || :query || '%' OR pkg_name LIKE '%' || :query || '%'")
     fun searchExtensions(query: String): Flow<List<ExtensionEntity>>

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepositoryImpl.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepositoryImpl.kt
@@ -6,12 +6,12 @@ import app.otakureader.core.extension.data.remote.ExtensionRemoteDataSource
 import app.otakureader.core.extension.domain.model.Extension
 import app.otakureader.core.extension.domain.model.InstallStatus
 import app.otakureader.core.extension.domain.repository.ExtensionRepository
+import app.otakureader.core.extension.loader.ExtensionLoadResult
 import app.otakureader.core.extension.loader.ExtensionLoader
 import app.otakureader.core.extension.blocklist.ExtensionBlocklistStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.CancellationException
 
@@ -221,9 +221,25 @@ class ExtensionRepositoryImpl(
     override suspend fun trustExtension(pkgName: String): Result<Unit> = runCatching {
         val ext = localDataSource.getExtensionByPkgName(pkgName)
             ?: error("Extension $pkgName not found")
-        val hash = ext.signatureHash
-            ?: error("Extension $pkgName has no signature hash — cannot trust")
+        val hash = ext.signatureHash ?: run {
+            // Hash not yet in DB (e.g. installed from a minified-index repo that doesn't
+            // include the signing-cert hash). Load the installed APK to compute it.
+            val apkPath = ext.apkPath
+                ?: error("Extension $pkgName has no installed APK — install it before trusting")
+            val loadResult = extensionLoader.loadExtension(apkPath)
+            when (loadResult) {
+                is ExtensionLoadResult.Untrusted -> loadResult.extension.signatureHash
+                is ExtensionLoadResult.Success -> loadResult.extension.signatureHash
+                is ExtensionLoadResult.Error ->
+                    error("Cannot read extension to determine its signature: ${loadResult.message}")
+            } ?: error("Extension $pkgName has no signature hash — cannot trust")
+        }
         extensionLoader.trustExtension(hash)
+        // Persist the hash so isTrusted reflects the new state immediately and future
+        // trust/revoke calls don't need to re-parse the APK.
+        if (ext.signatureHash == null) {
+            localDataSource.updateSignatureHash(pkgName, hash)
+        }
     }
 
     override suspend fun revokeExtensionTrust(pkgName: String): Result<Unit> = runCatching {

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepositoryImpl.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/repository/ExtensionRepositoryImpl.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Implementation of ExtensionRepository.
@@ -218,27 +220,38 @@ class ExtensionRepositoryImpl(
         localDataSource.updateEnabled(pkgName, enabled)
     }
 
-    override suspend fun trustExtension(pkgName: String): Result<Unit> = runCatching {
-        val ext = localDataSource.getExtensionByPkgName(pkgName)
-            ?: error("Extension $pkgName not found")
-        val hash = ext.signatureHash ?: run {
-            // Hash not yet in DB (e.g. installed from a minified-index repo that doesn't
-            // include the signing-cert hash). Load the installed APK to compute it.
-            val apkPath = ext.apkPath
-                ?: error("Extension $pkgName has no installed APK — install it before trusting")
-            val loadResult = extensionLoader.loadExtension(apkPath)
-            when (loadResult) {
-                is ExtensionLoadResult.Untrusted -> loadResult.extension.signatureHash
-                is ExtensionLoadResult.Success -> loadResult.extension.signatureHash
-                is ExtensionLoadResult.Error ->
-                    error("Cannot read extension to determine its signature: ${loadResult.message}")
-            } ?: error("Extension $pkgName has no signature hash — cannot trust")
-        }
-        extensionLoader.trustExtension(hash)
-        // Persist the hash so isTrusted reflects the new state immediately and future
-        // trust/revoke calls don't need to re-parse the APK.
-        if (ext.signatureHash == null) {
-            localDataSource.updateSignatureHash(pkgName, hash)
+    // Dispatched to IO: loadExtension() parses an APK from disk (blocking file I/O), so this
+    // must not run on the caller's (likely Main) thread. A plain try/catch rethrows
+    // CancellationException to keep structured-concurrency cancellation working (runCatching
+    // would swallow it).
+    override suspend fun trustExtension(pkgName: String): Result<Unit> = withContext(Dispatchers.IO) {
+        try {
+            val ext = localDataSource.getExtensionByPkgName(pkgName)
+                ?: error("Extension $pkgName not found")
+            val hash = ext.signatureHash ?: run {
+                // Hash not yet in DB (e.g. installed from a minified-index repo that doesn't
+                // include the signing-cert hash). Load the installed APK to compute it.
+                val apkPath = ext.apkPath
+                    ?: error("Extension $pkgName has no installed APK — install it before trusting")
+                val loadResult = extensionLoader.loadExtension(apkPath)
+                when (loadResult) {
+                    is ExtensionLoadResult.Untrusted -> loadResult.extension.signatureHash
+                    is ExtensionLoadResult.Success -> loadResult.extension.signatureHash
+                    is ExtensionLoadResult.Error ->
+                        error("Cannot read extension to determine its signature: ${loadResult.message}")
+                } ?: error("Extension $pkgName has no signature hash — cannot trust")
+            }
+            extensionLoader.trustExtension(hash)
+            // Persist the hash so isTrusted reflects the new state immediately and future
+            // trust/revoke calls don't need to re-parse the APK.
+            if (ext.signatureHash == null) {
+                localDataSource.updateSignatureHash(pkgName, hash)
+            }
+            Result.success(Unit)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Result.failure(e)
         }
     }
 

--- a/core/extension/src/main/java/app/otakureader/core/extension/domain/model/Extension.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/domain/model/Extension.kt
@@ -2,6 +2,7 @@ package app.otakureader.core.extension.domain.model
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
 
 /**
  * Represents an installed extension package.
@@ -94,6 +95,7 @@ data class Extension(
         get() = signatureHash != null
 }
 
+@Serializable
 @Parcelize
 data class ExtensionSource(
     /** Unique identifier for this source within the extension */

--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -263,7 +263,13 @@ class ExtensionInstaller(
                 }
                 tempFile = null
 
-                extension.signatureHash?.let { loader.trustExtension(it) }
+                // Auto-trust only when the repo provided a matching expected hash.
+                // Repos using the minified index.min.json format (e.g. Keiyoushi) don't
+                // include a signing-cert hash, so trustedHash is null — in that case the
+                // user must trust the extension manually via the detail screen.
+                if (trustedHash != null && extension.signatureHash == trustedHash) {
+                    loader.trustExtension(trustedHash)
+                }
 
                 _installationState.value = InstallationState.Installing
                 // Merge repo-index metadata the APK loader can't know about.
@@ -310,13 +316,15 @@ class ExtensionInstaller(
         }
         is ExtensionLoadResult.Untrusted -> {
             val ext = loadResult.extension
-            if (trustedHash != null && ext.signatureHash == trustedHash) {
-                Result.success(ext)
+            // Reject only on a real hash mismatch — someone could be swapping the APK.
+            // When no trusted hash is available (e.g. Keiyoushi/Mihon minified index.min.json
+            // doesn't include a signing-cert hash), install the APK anyway so the user can
+            // review it and tap "Trust" on the detail screen.
+            if (trustedHash != null && ext.signatureHash != trustedHash) {
+                _installationState.value = InstallationState.Error("Extension trust hash mismatch", null)
+                Result.failure(SecurityException("Trust hash mismatch for ${ext.pkgName}"))
             } else {
-                _installationState.value = InstallationState.Error(
-                    "Extension is not trusted. Please verify its signature before installing.", null
-                )
-                Result.failure(IllegalStateException("Untrusted extension: ${ext.pkgName}"))
+                Result.success(ext)
             }
         }
         is ExtensionLoadResult.Error -> {

--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -324,7 +324,13 @@ class ExtensionInstaller(
                 _installationState.value = InstallationState.Error("Extension trust hash mismatch", null)
                 Result.failure(SecurityException("Trust hash mismatch for ${ext.pkgName}"))
             } else {
-                Result.success(ext)
+                // The extension is NOT trusted yet. Persist it with a null signatureHash so
+                // Extension.isTrusted (== signatureHash != null) stays false and the UI shows
+                // "Unverified" + Trust button. trustExtension() recomputes the hash from the
+                // installed APK when the user taps Trust. Without this, the APK-derived hash
+                // would be stored and the UI would falsely show "Verified" while the loader
+                // still rejects the source as untrusted (state mismatch → "No sources").
+                Result.success(ext.copy(signatureHash = null))
             }
         }
         is ExtensionLoadResult.Error -> {

--- a/core/extension/src/main/java/app/otakureader/core/extension/receiver/ExtensionInstallReceiver.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/receiver/ExtensionInstallReceiver.kt
@@ -97,7 +97,10 @@ class ExtensionInstallReceiver : BroadcastReceiver() {
             // was already trusted from a prior install.
             val extension = when (loadResult) {
                 is ExtensionLoadResult.Success -> loadResult.extension
-                is ExtensionLoadResult.Untrusted -> loadResult.extension
+                // Persist untrusted extensions with a null signatureHash so the UI shows them
+                // as "Unverified" with a Trust button rather than falsely "Verified"
+                // (Extension.isTrusted == signatureHash != null).
+                is ExtensionLoadResult.Untrusted -> loadResult.extension.copy(signatureHash = null)
                 is ExtensionLoadResult.Error -> {
                     Log.w(TAG, "Cannot load extension $packageName: ${loadResult.message}")
                     return
@@ -108,7 +111,13 @@ class ExtensionInstallReceiver : BroadcastReceiver() {
                 Log.w(TAG, "Extension $packageName loaded but has no APK path; skipping install")
                 return
             }
-            extensionRepository.installExtension(packageName, apkPath)
+            // Use the fallback overload: a first-time system-installed extension has no DB row
+            // yet, so passing the loaded extension lets the repository create one instead of
+            // failing with "Extension not found".
+            val result = extensionRepository.installExtension(extension, apkPath)
+            result.onFailure { e ->
+                Log.e(TAG, "Failed to register extension $packageName in DB", e)
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/core/extension/src/main/java/app/otakureader/core/extension/receiver/ExtensionInstallReceiver.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/receiver/ExtensionInstallReceiver.kt
@@ -92,14 +92,23 @@ class ExtensionInstallReceiver : BroadcastReceiver() {
     private suspend fun handlePackageAdded(packageName: String) {
         try {
             val loadResult = extensionLoader.loadExtensionFromPkgName(packageName)
-            if (loadResult is ExtensionLoadResult.Success) {
-                val apkPath = loadResult.extension.apkPath
-                if (apkPath.isNullOrBlank()) {
-                    Log.w(TAG, "Extension $packageName loaded but has no APK path; skipping install")
+            // Accept both Success and Untrusted — untrusted extensions are installed in the DB
+            // so the user can see them and tap Trust. A Success result means the signing cert
+            // was already trusted from a prior install.
+            val extension = when (loadResult) {
+                is ExtensionLoadResult.Success -> loadResult.extension
+                is ExtensionLoadResult.Untrusted -> loadResult.extension
+                is ExtensionLoadResult.Error -> {
+                    Log.w(TAG, "Cannot load extension $packageName: ${loadResult.message}")
                     return
                 }
-                extensionRepository.installExtension(packageName, apkPath)
             }
+            val apkPath = extension.apkPath
+            if (apkPath.isNullOrBlank()) {
+                Log.w(TAG, "Extension $packageName loaded but has no APK path; skipping install")
+                return
+            }
+            extensionRepository.installExtension(packageName, apkPath)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {


### PR DESCRIPTION
## **User description**
## Summary

Fixes two bugs that prevented Tachiyomi extensions (especially from Keiyoushi/Mihon repos) from installing and being trusted on-device.

### Bug 1 — "No sources" on every extension

`ExtensionSource` was missing `@Serializable`. `ExtensionMapper.serializeSources()` silently stored `"[]"` for every extension's source list because the Kotlinx Serialization library threw an exception that the `try/catch` swallowed. Result: every extension showed **"No sources"** in the detail screen.

**Fix:** add `@Serializable` to `ExtensionSource`. Existing DB rows with `"[]"` will be refreshed on the next "Refresh repositories" pull.

### Bug 2 — Trust button shows "no signature hash — cannot trust"

The Keiyoushi `index.min.json` (minified format) does **not** include a signing-certificate hash — only the standard `index.json` does. The install flow passed `trustedHash = null` to `resolveLoadResult()`, which then rejected every Untrusted extension unconditionally. The APK was never written to disk, so `signatureHash` stayed `null` in the DB, and `trustExtension()` hit the "no signature hash" guard.

**Fixes:**
- `resolveLoadResult()`: only reject an Untrusted extension when there's an **actual hash mismatch** (supply-chain protection stays intact). When no hash is available (`trustedHash = null`), install proceeds and the user trusts manually.
- `install()`: auto-trust only when the repo provided a matching expected hash; minified-index extensions require an explicit user Trust tap.
- `trustExtension()`: fall back to loading the installed APK to compute the signing-cert hash when it's absent from the DB, then persist it via the new `updateSignatureHash()` DAO method.
- `ExtensionInstallReceiver.handlePackageAdded()`: register both `Success` and `Untrusted` results in the DB so system-installed extensions also appear for the user to trust.

## Test plan

- [ ] Add Keiyoushi repo (`https://raw.githubusercontent.com/keiyoushi/extensions/main/docs/repo`), refresh — extensions list shows with source names (not "No sources")
- [ ] Install any extension (e.g. MangaDex) — install succeeds, extension appears with "Unverified" badge and Trust button
- [ ] Tap Trust — shows "Verified" badge, sources appear, extension usable in browse
- [ ] Install an extension from a repo that provides a `signature` field (standard `index.json`) — auto-trusted, no manual Trust needed
- [ ] Existing installations: refresh repos → sources now appear correctly

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
Fix extension installs and trust checks for repos that do not provide a signing hash

### What Changed
- Extensions now keep their source list instead of showing “No sources” on the detail screen
- Extensions from repos that do not include a signing hash can now install and appear in the app for manual trust
- Trusting an installed extension now reads the installed APK when the saved hash is missing, then saves that hash for future use
- System-installed extensions are now listed in the app so users can trust them from the UI
- Extensions are only auto-trusted when the repo-provided hash matches the installed APK

### Impact
`✅ Fewer "No sources" extension pages`
`✅ Successful installs from minified index repos`
`✅ Clearer trust flow for manually installed extensions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extensions can now be manually trusted even when signature information is initially unavailable

* **Bug Fixes**
  * Improved handling of untrusted extensions to allow user-initiated trust decisions
  * Better support for extensions with missing signature data

* **Chores**
  * Enhanced serialization support for extension data models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->