### PR TITLE
feat(browse): embed real Feed, Extensions, Migrate content inline in Browse tabs

### DIFF
--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -207,6 +207,9 @@ fun OtakuReaderNavHost(
             onNavigateToOpds = {
                 navController.navigate(Route.OpdsCatalog())
             },
+            onNavigateToMigration = {
+                navController.navigate(Route.MigrationEntry)
+            },
         )
 
         // OPDS catalog

--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -210,6 +210,24 @@ fun OtakuReaderNavHost(
             onNavigateToMigration = {
                 navController.navigate(Route.MigrationEntry)
             },
+            onNavigateToReader = { mangaId, chapterId ->
+                navController.navigate(Route.Reader(mangaId, chapterId))
+            },
+            onNavigateToFeedManagement = {
+                navController.navigate(Route.FeedManagement)
+            },
+            onNavigateToExtensionSettings = {
+                navController.navigate(Route.Settings)
+            },
+            onNavigateToExtensionRepositories = {
+                navController.navigate(Route.ExtensionRepositories)
+            },
+            onNavigateToExtensionDetail = { packageName ->
+                navController.navigate(Route.ExtensionDetail(packageName))
+            },
+            onStartMigration = { selectedMangaIds ->
+                navController.navigate(Route.Migration(selectedMangaIds))
+            },
         )
 
         // OPDS catalog

--- a/core/extension/src/main/java/app/otakureader/core/extension/loader/ExtensionLoader.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/loader/ExtensionLoader.kt
@@ -7,6 +7,7 @@ import app.otakureader.core.extension.domain.model.ExtensionSource
 import app.otakureader.core.extension.domain.model.InstallStatus
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.online.HttpSource
 import java.io.File
 
 /**
@@ -396,11 +397,12 @@ class ExtensionLoader(
     /** Convert a loaded [Source] to the [ExtensionSource] domain model. */
     private fun Source.toExtensionSource(): ExtensionSource {
         val catalogue = this as? CatalogueSource
+        val http = this as? HttpSource
         return ExtensionSource(
             id = this.id,
             name = this.name,
             lang = catalogue?.lang ?: "",
-            baseUrl = catalogue?.baseUrl ?: "",
+            baseUrl = http?.baseUrl ?: "",
             supportsSearch = true,
             supportsLatest = catalogue?.supportsLatest ?: false,
         )

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
@@ -328,7 +328,7 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
         val current = prefs[Keys.LAST_USED_SOURCE_IDS]?.split("\n")?.filter { it.isNotBlank() }?.toMutableList() ?: mutableListOf()
         current.remove(sourceId)
         current.add(0, sourceId)
-        prefs[Keys.LAST_USED_SOURCE_IDS] = current.take(5).joinToString("\n")
+        prefs[Keys.LAST_USED_SOURCE_IDS] = current.take(MAX_LAST_USED_SOURCES).joinToString("\n")
     }
 
     // --- Source Pinning & Categories ---
@@ -493,5 +493,6 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
         const val DEFAULT_COIL_DISK_CACHE_MB = 512
         const val MIN_COIL_DISK_CACHE_MB = 64
         const val MAX_COIL_DISK_CACHE_MB = 2048
+        const val MAX_LAST_USED_SOURCES = 5
     }
 }

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
@@ -317,6 +317,20 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
     suspend fun setDarkModeEndMinuteOfDay(value: Int) =
         dataStore.edit { it[Keys.DARK_MODE_END_MINUTE] = value.coerceIn(0, 1439) }
 
+    // --- Last Used Sources ---
+
+    /** Most recently browsed source IDs, capped at 5, most recent first. */
+    val lastUsedSourceIds: Flow<List<String>> = dataStore.data.map { prefs ->
+        prefs[Keys.LAST_USED_SOURCE_IDS]?.split("\n")?.filter { it.isNotBlank() } ?: emptyList()
+    }
+
+    suspend fun recordSourceUsed(sourceId: String) = dataStore.edit { prefs ->
+        val current = prefs[Keys.LAST_USED_SOURCE_IDS]?.split("\n")?.filter { it.isNotBlank() }?.toMutableList() ?: mutableListOf()
+        current.remove(sourceId)
+        current.add(0, sourceId)
+        prefs[Keys.LAST_USED_SOURCE_IDS] = current.take(5).joinToString("\n")
+    }
+
     // --- Source Pinning & Categories ---
 
     /**
@@ -468,6 +482,7 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
         val DARK_MODE_SCHEDULE_ENABLED = booleanPreferencesKey("dark_mode_schedule_enabled")
         val DARK_MODE_START_MINUTE = intPreferencesKey("dark_mode_start_minute")
         val DARK_MODE_END_MINUTE = intPreferencesKey("dark_mode_end_minute")
+        val LAST_USED_SOURCE_IDS = stringPreferencesKey("last_used_source_ids")
         val PINNED_SOURCE_IDS = stringPreferencesKey("pinned_source_ids")
         val SOURCE_CATEGORY_MAP = stringPreferencesKey("source_category_map")
         val SAVED_SOURCE_SEARCHES_JSON = stringPreferencesKey("saved_source_searches_json")

--- a/feature/browse/build.gradle.kts
+++ b/feature/browse/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation(projects.core.tachiyomiCompat)
     implementation(projects.domain)
     implementation(projects.sourceApi)
+    implementation(projects.feature.feed)
+    implementation(projects.feature.migration)
     implementation(libs.paging.compose)
     implementation(libs.lifecycle.viewmodel.ktx)
     implementation(libs.kotlinx.serialization.json)

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseMvi.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseMvi.kt
@@ -7,14 +7,20 @@ import app.otakureader.domain.model.FeedSavedSearch
 import app.otakureader.domain.model.SavedSourceSearch
 import app.otakureader.domain.model.SourceHealthEntry
 import app.otakureader.sourceapi.FilterList
+import app.otakureader.sourceapi.MangaSource
 import app.otakureader.sourceapi.SourceManga
 
 enum class BrowseSearchScope { SOURCES, LIBRARY }
 
+enum class BrowseTab { FEED, SOURCES, EXTENSIONS, MIGRATE }
+
 data class BrowseState(
     val isLoading: Boolean = false,
-    val sources: List<String> = emptyList(),
+    val sources: List<MangaSource> = emptyList(),
     val currentSourceId: String? = null,
+    val selectedTab: BrowseTab = BrowseTab.SOURCES,
+    /** IDs of the last 5 sources the user browsed (most recent first). */
+    val lastUsedSourceIds: List<String> = emptyList(),
     val popularManga: List<SourceManga> = emptyList(),
     val searchQuery: String = "",
     val searchResults: List<SourceManga> = emptyList(),
@@ -61,7 +67,9 @@ data class BrowseState(
 ) : UiState
 
 sealed interface BrowseEvent : UiEvent {
-    data class SelectSource(val sourceId: String) : BrowseEvent
+    data class SelectSource(val sourceId: String, val loadLatest: Boolean = false) : BrowseEvent
+    data object ClearSourceSelection : BrowseEvent
+    data class SelectTab(val tab: BrowseTab) : BrowseEvent
     data class OnSearchQueryChange(val query: String) : BrowseEvent
     data object Search : BrowseEvent
     data class OnMangaClick(val manga: SourceManga) : BrowseEvent

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -116,7 +116,6 @@ fun BrowseScreen(
     onNavigateToReader: (mangaId: Long, chapterId: Long) -> Unit = { _, _ -> },
     onNavigateToFeedManagement: () -> Unit = {},
     // Extensions tab callbacks
-    onNavigateToExtensionSettings: () -> Unit = {},
     onNavigateToExtensionRepositories: () -> Unit = {},
     onNavigateToExtensionDetail: (packageName: String) -> Unit = {},
     // Migrate tab callback — navigate to the migration wizard with selected manga

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -18,24 +18,30 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.ClearAll
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.LibraryAdd
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Storage
+import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -43,16 +49,19 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -61,7 +70,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -70,19 +81,18 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import app.otakureader.core.ui.theme.ContentType
-import app.otakureader.core.ui.theme.LocalOtakuColors
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.otakureader.core.ui.theme.LocalOtakuColors
 import app.otakureader.sourceapi.Filter
-import app.otakureader.sourceapi.isActive
+import app.otakureader.sourceapi.MangaSource
 import app.otakureader.sourceapi.SourceManga
+import app.otakureader.sourceapi.isActive
 import app.otakureader.sourceapi.toSourceId
 import coil3.compose.AsyncImage
-import androidx.compose.ui.tooling.preview.Preview
-import app.otakureader.core.ui.theme.OtakuReaderTheme
+import kotlinx.coroutines.launch
 
 /**
- * Browse screen for discovering manga from various sources.
+ * Browse screen — Feed | Sources | Extensions | Migrate tab layout.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -93,26 +103,38 @@ fun BrowseScreen(
     onGlobalSearchClick: () -> Unit = {},
     onOpdsClick: () -> Unit = {},
     onNavigateToLibrary: (() -> Unit)? = null,
-    modifier: Modifier = Modifier
+    onNavigateToMigration: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
 ) {
-    val otaku = LocalOtakuColors.current
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    // Handle effects
     LaunchedEffect(viewModel.effect) {
         viewModel.effect.collect { effect ->
             when (effect) {
-                is BrowseEffect.NavigateToMangaDetail -> {
-                    onMangaClick(effect.sourceId, effect.mangaUrl)
-                }
-                is BrowseEffect.ShowSnackbar -> {
-                    snackbarHostState.showSnackbar(effect.message)
-                }
-                is BrowseEffect.NavigateToLibrary -> {
-                    // Navigate to library after bulk add
-                    onNavigateToLibrary?.invoke()
-                }
+                is BrowseEffect.NavigateToMangaDetail -> onMangaClick(effect.sourceId, effect.mangaUrl)
+                is BrowseEffect.ShowSnackbar -> snackbarHostState.showSnackbar(effect.message)
+                is BrowseEffect.NavigateToLibrary -> onNavigateToLibrary?.invoke()
+            }
+        }
+    }
+
+    val tabs = BrowseTab.entries
+    val pagerState = rememberPagerState { tabs.size }
+    val scope = rememberCoroutineScope()
+
+    // Keep pager and state in sync
+    LaunchedEffect(state.selectedTab) {
+        val target = tabs.indexOf(state.selectedTab)
+        if (target >= 0 && pagerState.currentPage != target) {
+            pagerState.animateScrollToPage(target)
+        }
+    }
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.currentPage }.collect { page ->
+            val tab = tabs.getOrNull(page)
+            if (tab != null && tab != state.selectedTab) {
+                viewModel.onEvent(BrowseEvent.SelectTab(tab))
             }
         }
     }
@@ -132,54 +154,84 @@ fun BrowseScreen(
                         IconButton(onClick = { viewModel.onEvent(BrowseEvent.ClearSelection) }) {
                             Icon(Icons.Default.ClearAll, contentDescription = stringResource(R.string.browse_clear_selection))
                         }
-                    }
+                    },
                 )
             } else {
                 TopAppBar(
                     title = { Text(stringResource(R.string.browse_title)) },
                     actions = {
-                        IconButton(onClick = onOpdsClick) {
-                            Icon(Icons.Default.Storage, contentDescription = stringResource(R.string.browse_opds_catalogs))
-                        }
                         IconButton(onClick = onGlobalSearchClick) {
                             Icon(Icons.Default.Search, contentDescription = stringResource(R.string.browse_search))
                         }
-                    }
+                    },
                 )
             }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
             if (state.isBulkSelectionMode) {
-                FloatingActionButton(
-                    onClick = { viewModel.onEvent(BrowseEvent.AddSelectedToLibrary) }
-                ) {
+                FloatingActionButton(onClick = { viewModel.onEvent(BrowseEvent.AddSelectedToLibrary) }) {
                     Icon(Icons.Default.LibraryAdd, contentDescription = stringResource(R.string.browse_add_to_library))
                 }
-            } else {
-                FloatingActionButton(onClick = onInstallExtensionClick) {
-                    Icon(Icons.Default.Add, contentDescription = stringResource(R.string.browse_install_extension))
+            }
+        },
+    ) { paddingValues ->
+        Column(modifier = Modifier.padding(paddingValues)) {
+            // ── Tab Row ───────────────────────────────────────────────────────
+            ScrollableTabRow(
+                selectedTabIndex = pagerState.currentPage,
+                edgePadding = 0.dp,
+            ) {
+                tabs.forEachIndexed { index, tab ->
+                    Tab(
+                        selected = pagerState.currentPage == index,
+                        onClick = { scope.launch { pagerState.animateScrollToPage(index) } },
+                        text = {
+                            Text(
+                                when (tab) {
+                                    BrowseTab.FEED -> stringResource(R.string.browse_tab_feed)
+                                    BrowseTab.SOURCES -> stringResource(R.string.browse_tab_sources)
+                                    BrowseTab.EXTENSIONS -> stringResource(R.string.browse_tab_extensions)
+                                    BrowseTab.MIGRATE -> stringResource(R.string.browse_tab_migrate)
+                                }
+                            )
+                        },
+                    )
+                }
+            }
+
+            // ── Pager content ─────────────────────────────────────────────────
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize(),
+                userScrollEnabled = state.currentSourceId == null,
+            ) { page ->
+                when (tabs.getOrNull(page)) {
+                    BrowseTab.FEED -> FeedTabContent()
+                    BrowseTab.SOURCES -> SourcesTabContent(
+                        state = state,
+                        onEvent = viewModel::onEvent,
+                    )
+                    BrowseTab.EXTENSIONS -> ExtensionsTabContent(
+                        onManageExtensions = onInstallExtensionClick,
+                    )
+                    BrowseTab.MIGRATE -> MigrateTabContent(
+                        onNavigateToMigration = onNavigateToMigration,
+                    )
+                    null -> {}
                 }
             }
         }
-    ) { paddingValues ->
-        BrowseContent(
-            state = state,
-            onEvent = viewModel::onEvent,
-            modifier = Modifier.padding(paddingValues)
-        )
     }
 
-    // Show filter sheet
+    // Filter sheet
     if (state.showFilterSheet && state.activeFilters.filters.isNotEmpty()) {
         SourceFilterSheet(
             filters = state.activeFilters,
-            onFilterUpdate = { index, filter ->
-                viewModel.onEvent(BrowseEvent.UpdateFilter(index, filter))
-            },
+            onFilterUpdate = { index, filter -> viewModel.onEvent(BrowseEvent.UpdateFilter(index, filter)) },
             onReset = { viewModel.onEvent(BrowseEvent.ResetFilters) },
             onApply = { viewModel.onEvent(BrowseEvent.ApplyFilters) },
-            onDismiss = { viewModel.onEvent(BrowseEvent.ToggleFilterSheet) }
+            onDismiss = { viewModel.onEvent(BrowseEvent.ToggleFilterSheet) },
         )
     }
 
@@ -210,7 +262,7 @@ fun BrowseScreen(
         )
     }
 
-    // Save search dialog (#1051)
+    // Save search dialog
     if (state.showSaveSearchDialog) {
         AlertDialog(
             onDismissRequest = { viewModel.onEvent(BrowseEvent.HideSaveSearchDialog) },
@@ -238,20 +290,158 @@ fun BrowseScreen(
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Tab content composables
+// ─────────────────────────────────────────────────────────────────────────────
+
 @Composable
-private fun BrowseContent(
+private fun FeedTabContent(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = stringResource(R.string.browse_tab_feed),
+                style = MaterialTheme.typography.headlineSmall,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.browse_feed_tab_desc),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExtensionsTabContent(
+    onManageExtensions: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            Icon(
+                Icons.Default.Extension,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                text = stringResource(R.string.browse_extensions_tab_desc),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 32.dp),
+            )
+            Button(onClick = onManageExtensions) {
+                Text(stringResource(R.string.browse_manage_extensions))
+            }
+        }
+    }
+}
+
+@Composable
+private fun MigrateTabContent(
+    onNavigateToMigration: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            Icon(
+                Icons.Default.SwapHoriz,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                text = stringResource(R.string.browse_migrate_tab_desc),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 32.dp),
+            )
+            if (onNavigateToMigration != null) {
+                Button(onClick = onNavigateToMigration) {
+                    Text(stringResource(R.string.browse_go_to_migrate))
+                }
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sources tab — source list + inline manga grid
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun SourcesTabContent(
     state: BrowseState,
     onEvent: (BrowseEvent) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
-    val otaku = LocalOtakuColors.current
     Column(modifier = modifier.fillMaxSize()) {
-        // Search bar with filter button
+        when {
+            state.hasSearchResults || state.isSearching -> {
+                // Search bar + results
+                BrowseSearchBar(state = state, onEvent = onEvent)
+                SearchResultsContent(
+                    results = state.searchResults,
+                    onMangaClick = { onEvent(BrowseEvent.OnMangaClick(it)) },
+                    onLoadMore = { onEvent(BrowseEvent.LoadNextPage) },
+                    hasNextPage = state.hasNextPage,
+                    isLoading = state.isSearching || state.isLoading,
+                    onMangaLongClick = { onEvent(BrowseEvent.LongClickManga(it)) },
+                )
+            }
+            state.currentSourceId != null -> {
+                // Selected source: show manga grid with back button header
+                SelectedSourceHeader(
+                    source = state.sources.find { it.id == state.currentSourceId },
+                    sourceId = state.currentSourceId,
+                    onBack = { onEvent(BrowseEvent.ClearSourceSelection) },
+                    onSearch = {},
+                )
+                BrowseSearchBar(state = state, onEvent = onEvent)
+                if (state.isLoading && state.popularManga.isEmpty()) {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                } else {
+                    MangaGrid(
+                        manga = state.popularManga,
+                        onMangaClick = { onEvent(BrowseEvent.OnMangaClick(it)) },
+                        onLoadMore = { onEvent(BrowseEvent.LoadNextPage) },
+                        hasNextPage = state.hasNextPage,
+                        isLoading = state.isLoading,
+                        currentSourceId = state.currentSourceId,
+                        onMangaLongClick = { onEvent(BrowseEvent.LongClickManga(it)) },
+                    )
+                }
+                state.error?.let { error ->
+                    Box(modifier = Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                        Text(text = error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+            }
+            state.sources.isEmpty() -> EmptySourcesContent()
+            else -> {
+                // Source browser: search bar + source list
+                BrowseSearchBar(state = state, onEvent = onEvent)
+                SourceListContent(state = state, onEvent = onEvent)
+            }
+        }
+    }
+}
+
+@Composable
+private fun BrowseSearchBar(
+    state: BrowseState,
+    onEvent: (BrowseEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 16.dp, end = 16.dp, top = 16.dp),
-            verticalAlignment = Alignment.CenterVertically
+                .padding(start = 16.dp, end = 16.dp, top = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             OutlinedTextField(
                 value = state.searchQuery,
@@ -263,245 +453,362 @@ private fun BrowseContent(
                         Icon(Icons.Default.Search, contentDescription = stringResource(R.string.browse_search))
                     }
                 },
-                singleLine = true
+                singleLine = true,
             )
-
-            // Bookmark icon: opens the "Save search" name dialog when query is non-empty
             if (state.searchQuery.isNotBlank()) {
                 Spacer(modifier = Modifier.width(4.dp))
                 IconButton(onClick = { onEvent(BrowseEvent.ShowSaveSearchDialog) }) {
-                    Icon(
-                        Icons.Default.BookmarkBorder,
-                        contentDescription = stringResource(R.string.browse_save_search),
-                    )
+                    Icon(Icons.Default.BookmarkBorder, contentDescription = stringResource(R.string.browse_save_search))
                 }
             }
-
-            // Filter button - shown when a source has filters
             if (state.availableFilters.filters.isNotEmpty()) {
                 Spacer(modifier = Modifier.width(4.dp))
-                FilterButton(
-                    activeCount = countActiveFilters(state.activeFilters),
-                    onClick = { onEvent(BrowseEvent.ToggleFilterSheet) }
-                )
+                FilterButton(activeCount = countActiveFilters(state.activeFilters), onClick = { onEvent(BrowseEvent.ToggleFilterSheet) })
             }
         }
 
-        // Search scope segmented button
-        SingleChoiceSegmentedButtonRow(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 4.dp)
-        ) {
-            BrowseSearchScope.entries.forEachIndexed { index, scope ->
-                SegmentedButton(
-                    selected = state.searchScope == scope,
-                    onClick = { onEvent(BrowseEvent.SetSearchScope(scope)) },
-                    shape = SegmentedButtonDefaults.itemShape(index, BrowseSearchScope.entries.size),
-                    label = {
-                        Text(
-                            when (scope) {
-                                BrowseSearchScope.SOURCES -> stringResource(R.string.browse_scope_sources)
-                                BrowseSearchScope.LIBRARY -> stringResource(R.string.browse_scope_library)
-                            }
-                        )
-                    }
-                )
-            }
-        }
-
-        // Search history (shown when query is blank and scope is SOURCES)
-        if (state.searchQuery.isBlank() && state.searchHistory.isNotEmpty()) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 4.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+        // Search scope selector — only show when a source is selected
+        if (state.currentSourceId != null) {
+            SingleChoiceSegmentedButtonRow(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
             ) {
-                Text(
-                    text = stringResource(R.string.browse_search_history),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                TextButton(onClick = { onEvent(BrowseEvent.ClearSearchHistory) }) {
-                    Text(stringResource(R.string.filter_sheet_clear_all))
-                }
-            }
-            LazyRow(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                items(state.searchHistory) { query ->
-                    FilterChip(
-                        selected = false,
-                        onClick = {
-                            onEvent(BrowseEvent.OnSearchQueryChange(query))
-                            onEvent(BrowseEvent.Search)
-                        },
-                        label = { Text(query, maxLines = 1, overflow = TextOverflow.Ellipsis) },
-                        trailingIcon = {
-                            // 24.dp IconButton meets the dense-inline accessibility minimum
-                            // (the 18.dp Icon was easy to miss, and tapping near it could
-                            // trigger the chip's onClick search action by mistake).
-                            IconButton(
-                                onClick = { onEvent(BrowseEvent.DeleteSearchHistoryItem(query)) },
-                                modifier = Modifier.size(24.dp),
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Close,
-                                    contentDescription = stringResource(R.string.browse_search_history_remove),
-                                    modifier = Modifier.size(18.dp),
-                                )
-                            }
-                        },
-                    )
-                }
-            }
-        }
-
-        // Saved search chips (DB-backed FeedSavedSearch)
-        if (state.savedSearches.isNotEmpty()) {
-            LazyRow(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                items(state.savedSearches, key = { it.id }) { search ->
-                    FilterChip(
-                        selected = state.searchQuery == search.query,
-                        onClick = { onEvent(BrowseEvent.ApplySavedSearch(search)) },
-                        label = { Text(search.query, maxLines = 1, overflow = TextOverflow.Ellipsis) },
-                        leadingIcon = {
-                            Icon(
-                                Icons.Default.Bookmark,
-                                contentDescription = null,
-                                modifier = Modifier.size(16.dp),
+                BrowseSearchScope.entries.forEachIndexed { index, scope ->
+                    SegmentedButton(
+                        selected = state.searchScope == scope,
+                        onClick = { onEvent(BrowseEvent.SetSearchScope(scope)) },
+                        shape = SegmentedButtonDefaults.itemShape(index, BrowseSearchScope.entries.size),
+                        label = {
+                            Text(
+                                when (scope) {
+                                    BrowseSearchScope.SOURCES -> stringResource(R.string.browse_scope_sources)
+                                    BrowseSearchScope.LIBRARY -> stringResource(R.string.browse_scope_library)
+                                },
                             )
                         },
-                        trailingIcon = {
-                            IconButton(
-                                onClick = { onEvent(BrowseEvent.DeleteSavedSearch(search.id)) },
-                                modifier = Modifier.size(18.dp),
-                            ) {
-                                Icon(
-                                    Icons.Default.Close,
-                                    contentDescription = stringResource(R.string.browse_delete_saved_search),
-                                    modifier = Modifier.size(14.dp),
-                                )
-                            }
-                        },
                     )
                 }
-            }
-        }
-
-        // Named saved source searches (#1051) — preferences-backed, long-press to delete
-        if (state.namedSavedSearches.isNotEmpty()) {
-            Text(
-                text = stringResource(R.string.browse_saved_searches),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(start = 16.dp, top = 4.dp, bottom = 2.dp),
-            )
-            LazyRow(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                items(state.namedSavedSearches, key = { it.id }) { search ->
-                    FilterChip(
-                        selected = state.searchQuery == search.query,
-                        onClick = { onEvent(BrowseEvent.ApplyNamedSavedSearch(search)) },
-                        label = { Text(search.name, maxLines = 1, overflow = TextOverflow.Ellipsis) },
-                        leadingIcon = {
-                            Icon(
-                                Icons.Default.Bookmark,
-                                contentDescription = null,
-                                modifier = Modifier.size(16.dp),
-                            )
-                        },
-                        trailingIcon = {
-                            IconButton(
-                                onClick = { onEvent(BrowseEvent.DeleteNamedSavedSearch(search.id)) },
-                                modifier = Modifier.size(18.dp),
-                            ) {
-                                Icon(
-                                    Icons.Default.Close,
-                                    contentDescription = stringResource(R.string.browse_delete_saved_search),
-                                    modifier = Modifier.size(14.dp),
-                                )
-                            }
-                        },
-                    )
-                }
-            }
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        if (state.isSearching || state.hasSearchResults) {
-            // Show search results (isSearching acts as loading indicator within results view)
-            SearchResultsContent(
-                results = state.searchResults,
-                onMangaClick = { onEvent(BrowseEvent.OnMangaClick(it)) },
-                onLoadMore = { onEvent(BrowseEvent.LoadNextPage) },
-                hasNextPage = state.hasNextPage,
-                isLoading = state.isSearching || state.isLoading,
-                onMangaLongClick = { onEvent(BrowseEvent.LongClickManga(it)) },
-            )
-        } else {
-            // Show sources and popular manga
-            if (state.sources.isEmpty()) {
-                EmptySourcesContent()
-            } else {
-                SourcesContent(
-                    sources = state.sources,
-                    currentSourceId = state.currentSourceId,
-                    popularManga = state.popularManga,
-                    pinnedSourceIds = state.pinnedSourceIds,
-                    sourceCategoryMap = state.sourceCategoryMap,
-                    onSourceSelect = { onEvent(BrowseEvent.SelectSource(it)) },
-                    onMangaClick = { onEvent(BrowseEvent.OnMangaClick(it)) },
-                    onLoadMore = { onEvent(BrowseEvent.LoadNextPage) },
-                    hasNextPage = state.hasNextPage,
-                    isLoading = state.isLoading,
-                    onMangaLongClick = { onEvent(BrowseEvent.LongClickManga(it)) },
-                    onTogglePin = { sourceId -> onEvent(BrowseEvent.TogglePinSource(sourceId)) },
-                    onOpenSetCategory = { sourceId, current ->
-                        onEvent(BrowseEvent.OpenSetCategoryDialog(sourceId, current))
-                    },
-                )
-            }
-        }
-
-        // Show error if any
-        state.error?.let { error ->
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = error,
-                    color = otaku.danger,
-                    style = MaterialTheme.typography.bodyMedium
-                )
             }
         }
     }
 }
 
 @Composable
-private fun FilterButton(
-    activeCount: Int,
-    onClick: () -> Unit
+private fun SelectedSourceHeader(
+    source: MangaSource?,
+    sourceId: String,
+    onBack: () -> Unit,
+    onSearch: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.browse_back_to_sources))
+        }
+        val displayName = source?.name ?: sourceId.substringAfterLast(".")
+        Text(
+            text = displayName,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.weight(1f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        source?.let {
+            LanguageBadge(lang = it.lang)
+            if (it.isNsfw) {
+                Spacer(Modifier.width(4.dp))
+                NsfwBadge()
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Source list (browse mode — no source selected)
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun SourceListContent(
+    state: BrowseState,
+    onEvent: (BrowseEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Resolve last-used MangaSources from the full source list
+    val allSources = state.sources
+    val lastUsedSources = state.lastUsedSourceIds.mapNotNull { id -> allSources.find { it.id == id } }
+
+    val pinnedSources = allSources.filter { it.id.toSourceId() in state.pinnedSourceIds }
+    val unpinnedSources = allSources.filter { it.id.toSourceId() !in state.pinnedSourceIds }
+    val grouped: Map<String, List<MangaSource>> = unpinnedSources.groupBy { src ->
+        state.sourceCategoryMap[src.id.toSourceId()] ?: ""
+    }
+    val categoryOrder = grouped.keys.sortedWith(compareBy { if (it.isBlank()) "" else it })
+
+    LazyColumn(modifier = modifier.fillMaxSize()) {
+        // Recent searches
+        if (state.searchHistory.isNotEmpty()) {
+            item(key = "search_history_header") {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(R.string.browse_search_history),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    TextButton(onClick = { onEvent(BrowseEvent.ClearSearchHistory) }) {
+                        Text(stringResource(R.string.filter_sheet_clear_all))
+                    }
+                }
+            }
+            item(key = "search_history_row") {
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(state.searchHistory) { query ->
+                        FilterChip(
+                            selected = false,
+                            onClick = {
+                                onEvent(BrowseEvent.OnSearchQueryChange(query))
+                                onEvent(BrowseEvent.Search)
+                            },
+                            label = { Text(query, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                            trailingIcon = {
+                                IconButton(
+                                    onClick = { onEvent(BrowseEvent.DeleteSearchHistoryItem(query)) },
+                                    modifier = Modifier.size(24.dp),
+                                ) {
+                                    Icon(
+                                        Icons.Default.Close,
+                                        contentDescription = stringResource(R.string.browse_search_history_remove),
+                                        modifier = Modifier.size(18.dp),
+                                    )
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        }
+
+        // Last used section
+        if (lastUsedSources.isNotEmpty()) {
+            item(key = "last_used_header") {
+                SourceSectionHeader(stringResource(R.string.browse_last_used))
+            }
+            items(lastUsedSources, key = { "last_${it.id}" }) { source ->
+                SourceRow(
+                    source = source,
+                    isPinned = source.id.toSourceId() in state.pinnedSourceIds,
+                    categoryMap = state.sourceCategoryMap,
+                    onSelect = { onEvent(BrowseEvent.SelectSource(source.id)) },
+                    onLatest = { onEvent(BrowseEvent.SelectSource(source.id, loadLatest = true)) },
+                    onTogglePin = { onEvent(BrowseEvent.TogglePinSource(source.id.toSourceId())) },
+                    onOpenSetCategory = { sid, cat -> onEvent(BrowseEvent.OpenSetCategoryDialog(sid, cat)) },
+                )
+                HorizontalDivider(modifier = Modifier.padding(start = 72.dp))
+            }
+        }
+
+        // Pinned section
+        if (pinnedSources.isNotEmpty()) {
+            item(key = "pinned_header") {
+                SourceSectionHeader(stringResource(R.string.source_pinned_section))
+            }
+            items(pinnedSources, key = { "pinned_${it.id}" }) { source ->
+                SourceRow(
+                    source = source,
+                    isPinned = true,
+                    categoryMap = state.sourceCategoryMap,
+                    onSelect = { onEvent(BrowseEvent.SelectSource(source.id)) },
+                    onLatest = { onEvent(BrowseEvent.SelectSource(source.id, loadLatest = true)) },
+                    onTogglePin = { onEvent(BrowseEvent.TogglePinSource(source.id.toSourceId())) },
+                    onOpenSetCategory = { sid, cat -> onEvent(BrowseEvent.OpenSetCategoryDialog(sid, cat)) },
+                )
+                HorizontalDivider(modifier = Modifier.padding(start = 72.dp))
+            }
+        }
+
+        // Unpinned sources, grouped by category
+        for (category in categoryOrder) {
+            val catSources = grouped[category] ?: continue
+            if (category.isNotBlank()) {
+                item(key = "cat_header_$category") {
+                    SourceSectionHeader(category)
+                }
+            } else if (pinnedSources.isNotEmpty() || lastUsedSources.isNotEmpty()) {
+                // "All sources" header when there are other sections above
+                item(key = "all_sources_header") {
+                    SourceSectionHeader(stringResource(R.string.browse_all_sources))
+                }
+            }
+            items(catSources, key = { "src_${it.id}" }) { source ->
+                SourceRow(
+                    source = source,
+                    isPinned = false,
+                    categoryMap = state.sourceCategoryMap,
+                    onSelect = { onEvent(BrowseEvent.SelectSource(source.id)) },
+                    onLatest = { onEvent(BrowseEvent.SelectSource(source.id, loadLatest = true)) },
+                    onTogglePin = { onEvent(BrowseEvent.TogglePinSource(source.id.toSourceId())) },
+                    onOpenSetCategory = { sid, cat -> onEvent(BrowseEvent.OpenSetCategoryDialog(sid, cat)) },
+                )
+                HorizontalDivider(modifier = Modifier.padding(start = 72.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun SourceSectionHeader(title: String, modifier: Modifier = Modifier) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.primary,
+        fontWeight = FontWeight.SemiBold,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, top = 12.dp, bottom = 4.dp, end = 16.dp),
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SourceRow composable
+// ─────────────────────────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun SourceRow(
+    source: MangaSource,
+    isPinned: Boolean,
+    categoryMap: Map<Long, String>,
+    onSelect: () -> Unit,
+    onLatest: () -> Unit,
+    onTogglePin: () -> Unit,
+    onOpenSetCategory: (Long, String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var menuExpanded by remember { mutableStateOf(false) }
+    val sourceIdLong = source.id.toSourceId()
+    val currentCategory = categoryMap[sourceIdLong] ?: ""
+
+    Box {
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .combinedClickable(
+                    onClick = onSelect,
+                    onLongClick = { menuExpanded = true },
+                )
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            SourceAvatar(name = source.name, isPinned = isPinned)
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = source.name,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    LanguageBadge(lang = source.lang)
+                    if (source.isNsfw) NsfwBadge()
+                }
+            }
+
+            if (source.supportsLatest) {
+                TextButton(
+                    onClick = onLatest,
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                ) {
+                    Text(stringResource(R.string.browse_source_latest), style = MaterialTheme.typography.labelSmall)
+                }
+            }
+
+            IconButton(onClick = onTogglePin, modifier = Modifier.size(36.dp)) {
+                Icon(
+                    imageVector = if (isPinned) Icons.Default.PushPin else Icons.Outlined.PushPin,
+                    contentDescription = if (isPinned) stringResource(R.string.source_unpin) else stringResource(R.string.source_pin),
+                    tint = if (isPinned) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
+
+        DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+            DropdownMenuItem(
+                text = { Text(if (isPinned) stringResource(R.string.source_unpin) else stringResource(R.string.source_pin)) },
+                leadingIcon = { Icon(Icons.Default.PushPin, contentDescription = null) },
+                onClick = { menuExpanded = false; onTogglePin() },
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.source_set_category)) },
+                onClick = { menuExpanded = false; onOpenSetCategory(sourceIdLong, currentCategory) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SourceAvatar(name: String, isPinned: Boolean, modifier: Modifier = Modifier) {
+    val initial = name.firstOrNull()?.uppercaseChar() ?: '?'
+    // Derive a stable color from the source name hash
+    val hue = (name.hashCode().and(0xFFFFFF).toLong() % 360).toFloat().let { if (it < 0) it + 360f else it }
+    val bgColor = Color.hsl(hue, 0.5f, 0.4f)
+    Box(
+        modifier = modifier
+            .size(40.dp)
+            .background(color = bgColor, shape = RoundedCornerShape(10.dp)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = initial.toString(),
+            color = Color.White,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Composable
+private fun LanguageBadge(lang: String, modifier: Modifier = Modifier) {
+    Badge(
+        modifier = modifier,
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+    ) {
+        Text(lang.uppercase(), style = MaterialTheme.typography.labelSmall)
+    }
+}
+
+@Composable
+private fun NsfwBadge(modifier: Modifier = Modifier) {
+    Badge(
+        modifier = modifier,
+        containerColor = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+    ) {
+        Text(stringResource(R.string.browse_source_nsfw_badge), style = MaterialTheme.typography.labelSmall)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Manga grid + cards
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun FilterButton(activeCount: Int, onClick: () -> Unit) {
     TextButton(onClick = onClick) {
         Text(stringResource(R.string.browse_filters))
         if (activeCount > 0) {
@@ -511,12 +818,8 @@ private fun FilterButton(
     }
 }
 
-/**
- * Count the number of filters that have been changed from their default state.
- */
-private fun countActiveFilters(filters: app.otakureader.sourceapi.FilterList): Int {
-    return filters.filters.count { filter -> filter.isActive() }
-}
+private fun countActiveFilters(filters: app.otakureader.sourceapi.FilterList): Int =
+    filters.filters.count { filter -> filter.isActive() }
 
 /** Returns true when a source ID string suggests manhwa/webtoon content. */
 private fun isManhwaSource(sourceId: String): Boolean {
@@ -525,225 +828,6 @@ private fun isManhwaSource(sourceId: String): Boolean {
         normalized.contains("korean") || normalized.contains("toon") ||
         normalized.contains("naver") || normalized.contains("kakao") ||
         normalized.contains("lezhin")
-}
-
-@Composable
-private fun SourcesContent(
-    sources: List<String>,
-    currentSourceId: String?,
-    popularManga: List<SourceManga>,
-    pinnedSourceIds: Set<Long>,
-    sourceCategoryMap: Map<Long, String>,
-    onSourceSelect: (String) -> Unit,
-    onMangaClick: (SourceManga) -> Unit,
-    onLoadMore: () -> Unit,
-    hasNextPage: Boolean,
-    isLoading: Boolean,
-    onMangaLongClick: ((SourceManga) -> Unit)? = null,
-    onTogglePin: (Long) -> Unit = {},
-    onOpenSetCategory: (Long, String) -> Unit = { _, _ -> },
-) {
-    // Determine if the currently selected source is manga or manhwa for the accent bar
-    val isMangaSection = currentSourceId == null || !isManhwaSource(currentSourceId)
-
-    // Partition sources into pinned and unpinned, then group unpinned by category
-    val (pinnedIds, unpinnedIds) = sources.partition { sourceId ->
-        sourceId.toSourceId() in pinnedSourceIds
-    }
-    // Group unpinned sources by their user-defined category; sources without a category go under ""
-    val grouped: Map<String, List<String>> = unpinnedIds.groupBy { sourceId ->
-        sourceCategoryMap[sourceId.toSourceId()] ?: ""
-    }
-
-    Column {
-        // Section header with colored accent bar
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp)
-        ) {
-            Box(
-                modifier = Modifier
-                    .width(4.dp)
-                    .height(20.dp)
-                    .background(
-                        color = if (isMangaSection) Color(0xFFFF4757) else Color(0xFF9B59B6),
-                        shape = RoundedCornerShape(2.dp)
-                    )
-            )
-            Text(
-                text = stringResource(R.string.browse_title),
-                style = MaterialTheme.typography.titleMedium
-            )
-        }
-
-        // --- Pinned section ---
-        if (pinnedIds.isNotEmpty()) {
-            Text(
-                text = stringResource(R.string.source_pinned_section),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(start = 16.dp, top = 4.dp, bottom = 2.dp),
-            )
-            LazyRow(
-                contentPadding = PaddingValues(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                items(pinnedIds, key = { it }) { sourceId ->
-                    SourceChipWithMenu(
-                        sourceId = sourceId,
-                        isSelected = sourceId == currentSourceId,
-                        isPinned = true,
-                        onSelect = { onSourceSelect(sourceId) },
-                        onTogglePin = onTogglePin,
-                        onOpenSetCategory = onOpenSetCategory,
-                        categoryMap = sourceCategoryMap,
-                    )
-                }
-            }
-            Spacer(modifier = Modifier.height(4.dp))
-        }
-
-        // --- Grouped unpinned sources ---
-        // Show sources without a category first (empty key), then named categories alphabetically
-        val categoryOrder = grouped.keys.sortedWith(compareBy { if (it.isBlank()) "" else it })
-        for (category in categoryOrder) {
-            val categorySourceIds = grouped[category] ?: continue
-            if (category.isNotBlank()) {
-                Text(
-                    text = category,
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(start = 16.dp, top = 6.dp, bottom = 2.dp),
-                )
-            }
-            LazyRow(
-                contentPadding = PaddingValues(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                items(categorySourceIds, key = { it }) { sourceId ->
-                    SourceChipWithMenu(
-                        sourceId = sourceId,
-                        isSelected = sourceId == currentSourceId,
-                        isPinned = false,
-                        onSelect = { onSourceSelect(sourceId) },
-                        onTogglePin = onTogglePin,
-                        onOpenSetCategory = onOpenSetCategory,
-                        categoryMap = sourceCategoryMap,
-                    )
-                }
-            }
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        if (currentSourceId == null) {
-            // Show prompt to select a source
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = stringResource(R.string.browse_select_source),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            }
-        } else if (isLoading && popularManga.isEmpty()) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator()
-            }
-        } else {
-            // Show manga grid
-            MangaGrid(
-                manga = popularManga,
-                onMangaClick = onMangaClick,
-                onLoadMore = onLoadMore,
-                hasNextPage = hasNextPage,
-                isLoading = isLoading,
-                currentSourceId = currentSourceId,
-                onMangaLongClick = onMangaLongClick,
-            )
-        }
-    }
-}
-
-/**
- * A source [FilterChip] that shows a [DropdownMenu] on long-press with "Pin/Unpin" and
- * "Set category" options.
- *
- * Why long-press + DropdownMenu?  We want the normal tap to still select the source, so we
- * intercept the long-press via [combinedClickable] and surface the contextual actions in a
- * lightweight menu without navigating away from the screen.
- */
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun SourceChipWithMenu(
-    sourceId: String,
-    isSelected: Boolean,
-    isPinned: Boolean,
-    onSelect: () -> Unit,
-    onTogglePin: (Long) -> Unit,
-    onOpenSetCategory: (Long, String) -> Unit,
-    categoryMap: Map<Long, String>,
-) {
-    var menuExpanded by remember { mutableStateOf(false) }
-    val sourceIdLong = sourceId.toSourceId()
-    val currentCategory = categoryMap[sourceIdLong] ?: ""
-
-    Box {
-        FilterChip(
-            selected = isSelected,
-            // Tap selects the source. A combinedClickable on the chip's own modifier does NOT
-            // work: FilterChip renders an internal clickable Surface that sits above the outer
-            // modifier and swallows the tap, so onSelect never fired (the source chip appeared
-            // dead). The long-press menu is handled by the transparent overlay below instead.
-            onClick = onSelect,
-            label = { Text(sourceId.substringAfterLast(".").take(20)) },
-            leadingIcon = if (isPinned) {
-                { Icon(Icons.Default.PushPin, contentDescription = null, modifier = Modifier.size(14.dp)) }
-            } else null,
-        )
-        // Transparent overlay matching the chip: intercepts long-press for the context menu
-        // while still forwarding taps to onSelect. Drawn on top, so it reliably receives both.
-        Box(
-            modifier = Modifier
-                .matchParentSize()
-                .combinedClickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = onSelect,
-                    onLongClick = { menuExpanded = true },
-                ),
-        )
-        DropdownMenu(
-            expanded = menuExpanded,
-            onDismissRequest = { menuExpanded = false },
-        ) {
-            DropdownMenuItem(
-                text = {
-                    Text(
-                        if (isPinned) stringResource(R.string.source_unpin)
-                        else stringResource(R.string.source_pin)
-                    )
-                },
-                leadingIcon = { Icon(Icons.Default.PushPin, contentDescription = null) },
-                onClick = {
-                    menuExpanded = false
-                    onTogglePin(sourceIdLong)
-                },
-            )
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.source_set_category)) },
-                onClick = {
-                    menuExpanded = false
-                    onOpenSetCategory(sourceIdLong, currentCategory)
-                },
-            )
-        }
-    }
 }
 
 @Composable
@@ -761,7 +845,7 @@ private fun MangaGrid(
         columns = GridCells.Adaptive(minSize = 120.dp),
         contentPadding = PaddingValues(16.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         items(manga, key = { it.url }) { mangaItem ->
             MangaCard(
@@ -771,14 +855,11 @@ private fun MangaGrid(
                 onLongClick = onMangaLongClick?.let { { it(mangaItem) } },
             )
         }
-
         if (hasNextPage || isLoading) {
             item {
                 Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    contentAlignment = Alignment.Center
+                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    contentAlignment = Alignment.Center,
                 ) {
                     if (isLoading) {
                         CircularProgressIndicator()
@@ -786,7 +867,7 @@ private fun MangaGrid(
                         Text(
                             text = stringResource(R.string.browse_load_more),
                             modifier = Modifier.clickable { onLoadMore() },
-                            color = otaku.accent
+                            color = otaku.accent,
                         )
                     }
                 }
@@ -807,21 +888,16 @@ private fun MangaCard(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick),
     ) {
         Column {
             Box {
-                // Manga cover
                 AsyncImage(
                     model = manga.thumbnailUrl,
                     contentDescription = manga.title,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(0.7f),
-                    contentScale = ContentScale.Crop
+                    modifier = Modifier.fillMaxWidth().aspectRatio(0.7f),
+                    contentScale = ContentScale.Crop,
                 )
-
-                // Content-type badge pill
                 if (currentSourceId != null) {
                     Box(
                         modifier = Modifier
@@ -829,27 +905,25 @@ private fun MangaCard(
                             .padding(6.dp)
                             .background(
                                 color = if (isManga) Color(0xFFFF4757).copy(alpha = 0.15f)
-                                        else Color(0xFF9B59B6).copy(alpha = 0.15f),
-                                shape = RoundedCornerShape(6.dp)
+                                else Color(0xFF9B59B6).copy(alpha = 0.15f),
+                                shape = RoundedCornerShape(6.dp),
                             )
-                            .padding(horizontal = 8.dp, vertical = 3.dp)
+                            .padding(horizontal = 8.dp, vertical = 3.dp),
                     ) {
                         Text(
                             text = if (isManga) "MANGA" else "MANHWA",
                             style = MaterialTheme.typography.labelSmall,
-                            color = if (isManga) Color(0xFFFF4757) else Color(0xFF9B59B6)
+                            color = if (isManga) Color(0xFFFF4757) else Color(0xFF9B59B6),
                         )
                     }
                 }
             }
-
-            // Manga title
             Text(
                 text = manga.title,
                 modifier = Modifier.padding(8.dp),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 2,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
             )
         }
     }
@@ -865,13 +939,10 @@ private fun SearchResultsContent(
     onMangaLongClick: ((SourceManga) -> Unit)? = null,
 ) {
     if (results.isEmpty() && !isLoading) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Text(
                 text = stringResource(R.string.browse_no_results),
-                style = MaterialTheme.typography.bodyLarge
+                style = MaterialTheme.typography.bodyLarge,
             )
         }
     } else {
@@ -888,29 +959,17 @@ private fun SearchResultsContent(
 
 @Composable
 private fun EmptySourcesContent() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
                 text = stringResource(R.string.browse_no_sources_title),
-                style = MaterialTheme.typography.headlineSmall
+                style = MaterialTheme.typography.headlineSmall,
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = stringResource(R.string.browse_no_sources_message),
-                style = MaterialTheme.typography.bodyMedium
+                style = MaterialTheme.typography.bodyMedium,
             )
         }
     }
 }
-
-@Preview(showBackground = true, backgroundColor = 0xFF12121A)
-@Composable
-private fun EmptySourcesContentPreview() {
-    OtakuReaderTheme {
-        EmptySourcesContent()
-    }
-}
-

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.LibraryAdd
 import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material.icons.outlined.PushPin
@@ -103,7 +104,7 @@ fun BrowseScreen(
     onGlobalSearchClick: () -> Unit = {},
     onOpdsClick: () -> Unit = {},
     onNavigateToLibrary: (() -> Unit)? = null,
-    onNavigateToMigration: (() -> Unit)? = null,
+    onNavigateToMigration: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -131,7 +132,7 @@ fun BrowseScreen(
         }
     }
     LaunchedEffect(pagerState) {
-        snapshotFlow { pagerState.currentPage }.collect { page ->
+        snapshotFlow { pagerState.settledPage }.collect { page ->
             val tab = tabs.getOrNull(page)
             if (tab != null && tab != state.selectedTab) {
                 viewModel.onEvent(BrowseEvent.SelectTab(tab))
@@ -160,6 +161,9 @@ fun BrowseScreen(
                 TopAppBar(
                     title = { Text(stringResource(R.string.browse_title)) },
                     actions = {
+                        IconButton(onClick = onOpdsClick) {
+                            Icon(Icons.Default.Language, contentDescription = stringResource(R.string.browse_opds_catalogs))
+                        }
                         IconButton(onClick = onGlobalSearchClick) {
                             Icon(Icons.Default.Search, contentDescription = stringResource(R.string.browse_search))
                         }
@@ -340,7 +344,7 @@ private fun ExtensionsTabContent(
 
 @Composable
 private fun MigrateTabContent(
-    onNavigateToMigration: (() -> Unit)?,
+    onNavigateToMigration: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -357,10 +361,8 @@ private fun MigrateTabContent(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 32.dp),
             )
-            if (onNavigateToMigration != null) {
-                Button(onClick = onNavigateToMigration) {
-                    Text(stringResource(R.string.browse_go_to_migrate))
-                }
+            Button(onClick = onNavigateToMigration) {
+                Text(stringResource(R.string.browse_go_to_migrate))
             }
         }
     }
@@ -455,13 +457,13 @@ private fun BrowseSearchBar(
                 },
                 singleLine = true,
             )
-            if (state.searchQuery.isNotBlank()) {
+            if (state.searchQuery.isNotBlank() && state.currentSourceId != null) {
                 Spacer(modifier = Modifier.width(4.dp))
                 IconButton(onClick = { onEvent(BrowseEvent.ShowSaveSearchDialog) }) {
                     Icon(Icons.Default.BookmarkBorder, contentDescription = stringResource(R.string.browse_save_search))
                 }
             }
-            if (state.availableFilters.filters.isNotEmpty()) {
+            if (state.currentSourceId != null && state.availableFilters.filters.isNotEmpty()) {
                 Spacer(modifier = Modifier.width(4.dp))
                 FilterButton(activeCount = countActiveFilters(state.activeFilters), onClick = { onEvent(BrowseEvent.ToggleFilterSheet) })
             }
@@ -539,7 +541,14 @@ private fun SourceListContent(
     modifier: Modifier = Modifier,
 ) {
     // Resolve last-used MangaSources from the full source list
-    val allSources = state.sources
+    val allSources = if (state.searchQuery.isBlank()) {
+        state.sources
+    } else {
+        state.sources.filter {
+            it.name.contains(state.searchQuery, ignoreCase = true) ||
+                it.lang.contains(state.searchQuery, ignoreCase = true)
+        }
+    }
     val lastUsedSources = state.lastUsedSourceIds.mapNotNull { id -> allSources.find { it.id == id } }
 
     val pinnedSources = allSources.filter { it.id.toSourceId() in state.pinnedSourceIds }
@@ -589,6 +598,39 @@ private fun SourceListContent(
                                     Icon(
                                         Icons.Default.Close,
                                         contentDescription = stringResource(R.string.browse_search_history_remove),
+                                        modifier = Modifier.size(18.dp),
+                                    )
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        }
+
+        // Named saved searches — only shown when there are saved searches for any source
+        if (state.namedSavedSearches.isNotEmpty()) {
+            item(key = "named_searches_header") {
+                SourceSectionHeader(stringResource(R.string.browse_saved_searches))
+            }
+            item(key = "named_searches_row") {
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(state.namedSavedSearches, key = { "ns_${it.id}" }) { search ->
+                        FilterChip(
+                            selected = false,
+                            onClick = { onEvent(BrowseEvent.ApplyNamedSavedSearch(search)) },
+                            label = { Text(search.name, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                            trailingIcon = {
+                                IconButton(
+                                    onClick = { onEvent(BrowseEvent.DeleteNamedSavedSearch(search.id)) },
+                                    modifier = Modifier.size(24.dp),
+                                ) {
+                                    Icon(
+                                        Icons.Default.Close,
+                                        contentDescription = stringResource(R.string.browse_delete_saved_search),
                                         modifier = Modifier.size(18.dp),
                                     )
                                 }
@@ -711,7 +753,7 @@ private fun SourceRow(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            SourceAvatar(name = source.name, isPinned = isPinned)
+            SourceAvatar(name = source.name)
 
             Column(modifier = Modifier.weight(1f)) {
                 Text(
@@ -760,11 +802,15 @@ private fun SourceRow(
     }
 }
 
+private const val AVATAR_HUE_MASK = 0xFFFFFF
+private const val AVATAR_HUE_DEGREES = 360
+
 @Composable
-private fun SourceAvatar(name: String, isPinned: Boolean, modifier: Modifier = Modifier) {
+private fun SourceAvatar(name: String, modifier: Modifier = Modifier) {
     val initial = name.firstOrNull()?.uppercaseChar() ?: '?'
     // Derive a stable color from the source name hash
-    val hue = (name.hashCode().and(0xFFFFFF).toLong() % 360).toFloat().let { if (it < 0) it + 360f else it }
+    val hue = (name.hashCode().and(AVATAR_HUE_MASK).toLong() % AVATAR_HUE_DEGREES).toFloat()
+        .let { if (it < 0) it + AVATAR_HUE_DEGREES else it }
     val bgColor = Color.hsl(hue, 0.5f, 0.4f)
     Box(
         modifier = modifier
@@ -911,7 +957,8 @@ private fun MangaCard(
                             .padding(horizontal = 8.dp, vertical = 3.dp),
                     ) {
                         Text(
-                            text = if (isManga) "MANGA" else "MANHWA",
+                            text = if (isManga) stringResource(R.string.browse_manga_type_badge)
+                            else stringResource(R.string.browse_manhwa_type_badge),
                             style = MaterialTheme.typography.labelSmall,
                             color = if (isManga) Color(0xFFFF4757) else Color(0xFF9B59B6),
                         )

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -439,11 +439,13 @@ private fun BrowseSearchBar(
                 onValueChange = { onEvent(BrowseEvent.OnSearchQueryChange(it)) },
                 modifier = Modifier.weight(1f),
                 placeholder = { Text(stringResource(R.string.browse_search_placeholder)) },
-                trailingIcon = {
-                    IconButton(onClick = { onEvent(BrowseEvent.Search) }) {
-                        Icon(Icons.Default.Search, contentDescription = stringResource(R.string.browse_search))
+                trailingIcon = if (state.currentSourceId != null) {
+                    {
+                        IconButton(onClick = { onEvent(BrowseEvent.Search) }) {
+                            Icon(Icons.Default.Search, contentDescription = stringResource(R.string.browse_search))
+                        }
                     }
-                },
+                } else null,
                 singleLine = true,
             )
             if (state.searchQuery.isNotBlank() && state.currentSourceId != null) {

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -33,16 +33,13 @@ import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.ClearAll
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.LibraryAdd
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -82,14 +79,25 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.core.ui.theme.LocalOtakuColors
+import app.otakureader.feature.feed.FeedContent
+import app.otakureader.feature.feed.FeedEffect
+import app.otakureader.feature.feed.FeedEvent
+import app.otakureader.feature.feed.FeedViewModel
+import app.otakureader.feature.migration.MigrationEntryContent
+import app.otakureader.feature.migration.MigrationEntryEffect
+import app.otakureader.feature.migration.MigrationEntryEvent
+import app.otakureader.feature.migration.MigrationEntryItem
+import app.otakureader.feature.migration.MigrationEntryViewModel
 import app.otakureader.sourceapi.Filter
 import app.otakureader.sourceapi.MangaSource
 import app.otakureader.sourceapi.SourceManga
 import app.otakureader.sourceapi.isActive
 import app.otakureader.sourceapi.toSourceId
 import coil3.compose.AsyncImage
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 /**
@@ -105,6 +113,15 @@ fun BrowseScreen(
     onOpdsClick: () -> Unit = {},
     onNavigateToLibrary: (() -> Unit)? = null,
     onNavigateToMigration: () -> Unit = {},
+    // Feed tab callbacks
+    onNavigateToReader: (mangaId: Long, chapterId: Long) -> Unit = { _, _ -> },
+    onNavigateToFeedManagement: () -> Unit = {},
+    // Extensions tab callbacks
+    onNavigateToExtensionSettings: () -> Unit = {},
+    onNavigateToExtensionRepositories: () -> Unit = {},
+    onNavigateToExtensionDetail: (packageName: String) -> Unit = {},
+    // Migrate tab callback — navigate to the migration wizard with selected manga
+    onStartMigration: (List<Long>) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -181,7 +198,7 @@ fun BrowseScreen(
         },
     ) { paddingValues ->
         Column(modifier = Modifier.padding(paddingValues)) {
-            // ── Tab Row ───────────────────────────────────────────────────────
+            // ── Tab Row ──────────────────────────────────────────────────────────────────
             ScrollableTabRow(
                 selectedTabIndex = pagerState.currentPage,
                 edgePadding = 0.dp,
@@ -204,24 +221,70 @@ fun BrowseScreen(
                 }
             }
 
-            // ── Pager content ─────────────────────────────────────────────────
+            // ── Pager content ──────────────────────────────────────────────────────────────
             HorizontalPager(
                 state = pagerState,
                 modifier = Modifier.fillMaxSize(),
                 userScrollEnabled = state.currentSourceId == null,
             ) { page ->
                 when (tabs.getOrNull(page)) {
-                    BrowseTab.FEED -> FeedTabContent()
+                    BrowseTab.FEED -> {
+                        val feedVm: FeedViewModel = hiltViewModel()
+                        val feedState by feedVm.state.collectAsStateWithLifecycle()
+                        LaunchedEffect(feedVm) {
+                            feedVm.effect.collectLatest { effect ->
+                                when (effect) {
+                                    is FeedEffect.NavigateToReader ->
+                                        onNavigateToReader(effect.mangaId, effect.chapterId)
+                                    is FeedEffect.ShowSnackbar ->
+                                        snackbarHostState.showSnackbar(effect.message)
+                                    FeedEffect.NavigateToFeedManagement ->
+                                        onNavigateToFeedManagement()
+                                }
+                            }
+                        }
+                        FeedContent(
+                            state = feedState,
+                            onEvent = feedVm::onEvent,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
                     BrowseTab.SOURCES -> SourcesTabContent(
                         state = state,
                         onEvent = viewModel::onEvent,
                     )
-                    BrowseTab.EXTENSIONS -> ExtensionsTabContent(
-                        onManageExtensions = onInstallExtensionClick,
-                    )
-                    BrowseTab.MIGRATE -> MigrateTabContent(
-                        onNavigateToMigration = onNavigateToMigration,
-                    )
+                    BrowseTab.EXTENSIONS -> {
+                        ExtensionsTabBody(
+                            onNavigateToSettings = onNavigateToExtensionSettings,
+                            onNavigateToRepositories = onNavigateToExtensionRepositories,
+                            onNavigateToExtensionDetail = onNavigateToExtensionDetail,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+                    BrowseTab.MIGRATE -> {
+                        val migVm: MigrationEntryViewModel = hiltViewModel()
+                        val migState by migVm.state.collectAsStateWithLifecycle()
+                        val migFiltered = remember(migState.mangaList, migState.searchQuery) {
+                            migVm.filteredList(migState)
+                        }
+                        LaunchedEffect(migVm) {
+                            migVm.effect.collectLatest { effect ->
+                                when (effect) {
+                                    is MigrationEntryEffect.NavigateToMigration ->
+                                        onStartMigration(effect.selectedMangaIds)
+                                    MigrationEntryEffect.NavigateBack -> { /* embedded — no back */ }
+                                    is MigrationEntryEffect.ShowError ->
+                                        snackbarHostState.showSnackbar(effect.message)
+                                }
+                            }
+                        }
+                        MigrationEntryContent(
+                            state = migState,
+                            filtered = migFiltered,
+                            onEvent = migVm::onEvent,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
                     null -> {}
                 }
             }
@@ -294,83 +357,9 @@ fun BrowseScreen(
     }
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Tab content composables
-// ─────────────────────────────────────────────────────────────────────────────
-
-@Composable
-private fun FeedTabContent(modifier: Modifier = Modifier) {
-    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(
-                text = stringResource(R.string.browse_tab_feed),
-                style = MaterialTheme.typography.headlineSmall,
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = stringResource(R.string.browse_feed_tab_desc),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-    }
-}
-
-@Composable
-private fun ExtensionsTabContent(
-    onManageExtensions: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(16.dp)) {
-            Icon(
-                Icons.Default.Extension,
-                contentDescription = null,
-                modifier = Modifier.size(64.dp),
-                tint = MaterialTheme.colorScheme.primary,
-            )
-            Text(
-                text = stringResource(R.string.browse_extensions_tab_desc),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(horizontal = 32.dp),
-            )
-            Button(onClick = onManageExtensions) {
-                Text(stringResource(R.string.browse_manage_extensions))
-            }
-        }
-    }
-}
-
-@Composable
-private fun MigrateTabContent(
-    onNavigateToMigration: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(16.dp)) {
-            Icon(
-                Icons.Default.SwapHoriz,
-                contentDescription = null,
-                modifier = Modifier.size(64.dp),
-                tint = MaterialTheme.colorScheme.primary,
-            )
-            Text(
-                text = stringResource(R.string.browse_migrate_tab_desc),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(horizontal = 32.dp),
-            )
-            Button(onClick = onNavigateToMigration) {
-                Text(stringResource(R.string.browse_go_to_migrate))
-            }
-        }
-    }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
+// ────────────────────────────────────────────────────────────────────────────────
 // Sources tab — source list + inline manga grid
-// ─────────────────────────────────────────────────────────────────────────────
+// ────────────────────────────────────────────────────────────────────────────────
 
 @Composable
 private fun SourcesTabContent(
@@ -530,9 +519,9 @@ private fun SelectedSourceHeader(
     }
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
+// ────────────────────────────────────────────────────────────────────────────────
 // Source list (browse mode — no source selected)
-// ─────────────────────────────────────────────────────────────────────────────
+// ────────────────────────────────────────────────────────────────────────────────
 
 @Composable
 private fun SourceListContent(
@@ -721,9 +710,9 @@ private fun SourceSectionHeader(title: String, modifier: Modifier = Modifier) {
     )
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
+// ────────────────────────────────────────────────────────────────────────────────
 // SourceRow composable
-// ─────────────────────────────────────────────────────────────────────────────
+// ────────────────────────────────────────────────────────────────────────────────
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -849,9 +838,9 @@ private fun NsfwBadge(modifier: Modifier = Modifier) {
     }
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
+// ────────────────────────────────────────────────────────────────────────────────
 // Manga grid + cards
-// ─────────────────────────────────────────────────────────────────────────────
+// ────────────────────────────────────────────────────────────────────────────────
 
 @Composable
 private fun FilterButton(activeCount: Int, onClick: () -> Unit) {

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
@@ -108,11 +109,9 @@ import kotlinx.coroutines.launch
 fun BrowseScreen(
     viewModel: BrowseViewModel,
     onMangaClick: (sourceId: String, mangaUrl: String) -> Unit,
-    onInstallExtensionClick: () -> Unit,
     onGlobalSearchClick: () -> Unit = {},
     onOpdsClick: () -> Unit = {},
     onNavigateToLibrary: (() -> Unit)? = null,
-    onNavigateToMigration: () -> Unit = {},
     // Feed tab callbacks
     onNavigateToReader: (mangaId: Long, chapterId: Long) -> Unit = { _, _ -> },
     onNavigateToFeedManagement: () -> Unit = {},
@@ -255,7 +254,6 @@ fun BrowseScreen(
                     )
                     BrowseTab.EXTENSIONS -> {
                         ExtensionsTabBody(
-                            onNavigateToSettings = onNavigateToExtensionSettings,
                             onNavigateToRepositories = onNavigateToExtensionRepositories,
                             onNavigateToExtensionDetail = onNavigateToExtensionDetail,
                             modifier = Modifier.fillMaxSize(),
@@ -387,7 +385,6 @@ private fun SourcesTabContent(
                     source = state.sources.find { it.id == state.currentSourceId },
                     sourceId = state.currentSourceId,
                     onBack = { onEvent(BrowseEvent.ClearSourceSelection) },
-                    onSearch = {},
                 )
                 BrowseSearchBar(state = state, onEvent = onEvent)
                 if (state.isLoading && state.popularManga.isEmpty()) {
@@ -490,7 +487,6 @@ private fun SelectedSourceHeader(
     source: MangaSource?,
     sourceId: String,
     onBack: () -> Unit,
-    onSearch: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -893,7 +889,7 @@ private fun MangaGrid(
             )
         }
         if (hasNextPage || isLoading) {
-            item {
+            item(span = { GridItemSpan(maxLineSpan) }) {
                 Box(
                     modifier = Modifier.fillMaxWidth().padding(16.dp),
                     contentAlignment = Alignment.Center,
@@ -941,8 +937,8 @@ private fun MangaCard(
                             .align(Alignment.TopStart)
                             .padding(6.dp)
                             .background(
-                                color = if (isManga) Color(0xFFFF4757).copy(alpha = 0.15f)
-                                else Color(0xFF9B59B6).copy(alpha = 0.15f),
+                                color = if (isManga) MaterialTheme.colorScheme.errorContainer
+                                else MaterialTheme.colorScheme.tertiaryContainer,
                                 shape = RoundedCornerShape(6.dp),
                             )
                             .padding(horizontal = 8.dp, vertical = 3.dp),
@@ -951,7 +947,8 @@ private fun MangaCard(
                             text = if (isManga) stringResource(R.string.browse_manga_type_badge)
                             else stringResource(R.string.browse_manhwa_type_badge),
                             style = MaterialTheme.typography.labelSmall,
-                            color = if (isManga) Color(0xFFFF4757) else Color(0xFF9B59B6),
+                            color = if (isManga) MaterialTheme.colorScheme.onErrorContainer
+                            else MaterialTheme.colorScheme.onTertiaryContainer,
                         )
                     }
                 }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
@@ -335,11 +335,11 @@ class BrowseViewModel @Inject constructor(
     }
 
     private fun loadLatestUpdates(sourceId: String? = null) {
-        val sourceId = sourceId ?: _state.value.currentSourceId ?: return
+        val resolvedSourceId = sourceId ?: _state.value.currentSourceId ?: return
 
         viewModelScope.launch {
             _state.update { it.copy(isLoading = true, error = null) }
-            getLatestUpdatesUseCase(sourceId, 1)
+            getLatestUpdatesUseCase(resolvedSourceId, 1)
                 .onSuccess { mangaPage ->
                     _state.update {
                         it.copy(

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
@@ -122,6 +122,9 @@ class BrowseViewModel @Inject constructor(
                         hasSearchResults = false,
                         searchResults = emptyList(),
                         error = null,
+                        availableFilters = FilterList(),
+                        activeFilters = FilterList(),
+                        showFilterSheet = false,
                     )
                 }
             }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.core.ui.selection.SelectionManager
+import app.otakureader.domain.repository.ExtensionManagementRepository
 import app.otakureader.domain.repository.FeedRepository
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.usecase.library.AddMangaToLibraryUseCase
@@ -49,6 +50,7 @@ class BrowseViewModel @Inject constructor(
     private val feedRepository: FeedRepository,
     private val generalPreferences: GeneralPreferences,
     private val searchLibraryMangaUseCase: SearchLibraryMangaUseCase,
+    private val extensionManagementRepository: ExtensionManagementRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(BrowseState())
@@ -73,14 +75,10 @@ class BrowseViewModel @Inject constructor(
                 getSourcesUseCase(),
                 generalPreferences.showNsfwContent
             ) { sources, showNsfw ->
-                if (showNsfw) {
-                    sources
-                } else {
-                    sources.filter { !it.isNsfw }
-                }
+                if (showNsfw) sources else sources.filter { !it.isNsfw }
             }.collect { filteredSources ->
                 _sources.value = filteredSources
-                _state.update { it.copy(sources = filteredSources.map { s -> s.id }) }
+                _state.update { it.copy(sources = filteredSources) }
             }
         }
         observeSavedSearches()
@@ -94,12 +92,14 @@ class BrowseViewModel @Inject constructor(
         observeSearchHistory()
         observeSourcePinning()
         observeNamedSavedSearches()
+        observeLastUsedSources()
     }
 
     @Suppress("LongMethod", "CyclomaticComplexMethod")
     fun onEvent(event: BrowseEvent) {
         when (event) {
             is BrowseEvent.SelectSource -> {
+                viewModelScope.launch { generalPreferences.recordSourceUsed(event.sourceId) }
                 _state.update {
                     it.copy(
                         currentSourceId = event.sourceId,
@@ -110,8 +110,23 @@ class BrowseViewModel @Inject constructor(
                         searchResults = emptyList()
                     )
                 }
-                loadPopularManga(event.sourceId)
+                if (event.loadLatest) loadLatestUpdates(event.sourceId) else loadPopularManga(event.sourceId)
                 loadSourceFilters(event.sourceId)
+            }
+            is BrowseEvent.ClearSourceSelection -> {
+                _state.update {
+                    it.copy(
+                        currentSourceId = null,
+                        popularManga = emptyList(),
+                        searchQuery = "",
+                        hasSearchResults = false,
+                        searchResults = emptyList(),
+                        error = null,
+                    )
+                }
+            }
+            is BrowseEvent.SelectTab -> {
+                _state.update { it.copy(selectedTab = event.tab) }
             }
             is BrowseEvent.OnMangaClick -> {
                 val sourceId = _state.value.currentSourceId ?: return
@@ -316,8 +331,8 @@ class BrowseViewModel @Inject constructor(
         }
     }
 
-    private fun loadLatestUpdates() {
-        val sourceId = _state.value.currentSourceId ?: return
+    private fun loadLatestUpdates(sourceId: String? = null) {
+        val sourceId = sourceId ?: _state.value.currentSourceId ?: return
 
         viewModelScope.launch {
             _state.update { it.copy(isLoading = true, error = null) }
@@ -381,8 +396,9 @@ class BrowseViewModel @Inject constructor(
 
     private fun refreshSources() {
         viewModelScope.launch {
-            // Sources are automatically refreshed through the flow
-            _effect.send(BrowseEffect.ShowSnackbar("Sources refreshed"))
+            extensionManagementRepository.refreshSources()
+                .onSuccess { _effect.send(BrowseEffect.ShowSnackbar("Sources refreshed")) }
+                .onFailure { _effect.send(BrowseEffect.ShowSnackbar("Failed to refresh sources")) }
         }
     }
 
@@ -491,6 +507,12 @@ class BrowseViewModel @Inject constructor(
             .launchIn(viewModelScope)
         generalPreferences.sourceCategoryMap
             .onEach { map -> _state.update { it.copy(sourceCategoryMap = map) } }
+            .launchIn(viewModelScope)
+    }
+
+    private fun observeLastUsedSources() {
+        generalPreferences.lastUsedSourceIds
+            .onEach { ids -> _state.update { it.copy(lastUsedSourceIds = ids) } }
             .launchIn(viewModelScope)
     }
 

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
@@ -139,7 +139,11 @@ private fun ExtensionsBody(
     modifier: Modifier = Modifier,
 ) {
     val selectedTab = state.selectedTab
-    val tabs = listOf("Installed", "Available", "Updates")
+    val tabs = listOf(
+        stringResource(R.string.extensions_tab_installed),
+        stringResource(R.string.extensions_tab_available),
+        stringResource(R.string.extensions_tab_updates),
+    )
 
     Column(modifier = modifier) {
         // Search bar
@@ -321,7 +325,6 @@ private fun ExtensionsContent(
  */
 @Composable
 internal fun ExtensionsTabBody(
-    onNavigateToSettings: () -> Unit = {},
     onNavigateToRepositories: () -> Unit = {},
     onNavigateToExtensionDetail: (packageName: String) -> Unit = {},
     modifier: Modifier = Modifier,
@@ -329,13 +332,12 @@ internal fun ExtensionsTabBody(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
 
     LaunchedEffect(Unit) {
         viewModel.effect.collect { effect ->
             when (effect) {
-                is ExtensionsEffect.ShowSnackbar -> scope.launch { snackbarHostState.showSnackbar(effect.message) }
-                is ExtensionsEffect.ShowError -> scope.launch { snackbarHostState.showSnackbar(effect.message) }
+                is ExtensionsEffect.ShowSnackbar -> snackbarHostState.showSnackbar(effect.message)
+                is ExtensionsEffect.ShowError -> snackbarHostState.showSnackbar(effect.message)
             }
         }
     }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
@@ -126,6 +126,151 @@ fun ExtensionsBottomSheet(
     }
 }
 
+/**
+ * Scaffold-free body used both by [ExtensionsContent] (inside the bottom sheet Scaffold) and
+ * by [ExtensionsTabBody] (embedded directly in Browse's Extensions tab).
+ */
+@Composable
+private fun ExtensionsBody(
+    state: ExtensionsState,
+    onEvent: (ExtensionsEvent) -> Unit,
+    onNavigateToRepositories: () -> Unit,
+    onNavigateToExtensionDetail: (packageName: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val selectedTab = state.selectedTab
+    val tabs = listOf("Installed", "Available", "Updates")
+
+    Column(modifier = modifier) {
+        // Search bar
+        TextField(
+            value = state.searchQuery,
+            onValueChange = { onEvent(ExtensionsEvent.OnSearchQueryChange(it)) },
+            placeholder = { Text(stringResource(R.string.extensions_search_placeholder)) },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = stringResource(R.string.extensions_search_cd)) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        )
+
+        // Filter & Sort controls
+        FilterAndSortRow(
+            showNsfw = state.showNsfw,
+            sortMode = state.sortMode,
+            onToggleNsfw = { onEvent(ExtensionsEvent.ToggleNsfw(it)) },
+            onSetSortMode = { onEvent(ExtensionsEvent.SetSortMode(it)) }
+        )
+
+        // Update All button (only in Updates tab, visible whenever updates exist)
+        if (selectedTab == 2 && state.updateCount > 0) {
+            UpdateAllButton(
+                updateCount = state.updateCount,
+                isUpdating = state.isUpdatingAll,
+                onUpdateAll = { onEvent(ExtensionsEvent.UpdateAllExtensions) }
+            )
+        }
+
+        RepositoryManager(
+            repositories = state.repositories,
+            onAdd = { onEvent(ExtensionsEvent.AddRepository(it)) },
+            onRemove = { onEvent(ExtensionsEvent.RemoveRepository(it)) },
+            onOpenFullManager = onNavigateToRepositories,
+        )
+
+        // Tabs
+        TabRow(selectedTabIndex = selectedTab) {
+            tabs.forEachIndexed { index, title ->
+                Tab(
+                    selected = selectedTab == index,
+                    onClick = { onEvent(ExtensionsEvent.SelectTab(index)) },
+                    text = {
+                        when (index) {
+                            2 -> if (state.updateCount > 0) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Text(title)
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                    Surface(
+                                        shape = CircleShape,
+                                        color = MaterialTheme.colorScheme.error
+                                    ) {
+                                        Text(
+                                            text = state.updateCount.toString(),
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onError,
+                                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                                        )
+                                    }
+                                }
+                            } else Text(title)
+                            else -> Text(title)
+                        }
+                    }
+                )
+            }
+        }
+
+        when (selectedTab) {
+            0 -> ExtensionsList(
+                extensions = state.installedExtensions,
+                isLoading = state.isLoading,
+                error = state.error,
+                signerMismatchedPackages = state.signerMismatchedPackages,
+                blockedPackages = state.blockedPackages,
+                onInstall = { /* Already installed */ },
+                onUninstall = { onEvent(ExtensionsEvent.UninstallExtension(it)) },
+                onUpdate = { onEvent(ExtensionsEvent.UpdateExtension(it)) },
+                onToggleEnabled = { ext, enabled ->
+                    onEvent(ExtensionsEvent.ToggleExtensionEnabled(ext, enabled))
+                },
+                onRefresh = { onEvent(ExtensionsEvent.Refresh) },
+                onViewDetails = { onNavigateToExtensionDetail(it.pkgName) }
+            )
+            1 -> Column {
+                if (state.hasUnverifiedExtensions) {
+                    TrustBanner(visible = true)
+                }
+                ExtensionsList(
+                    extensions = state.availableExtensions,
+                    isLoading = state.isLoading,
+                    error = state.error,
+                    signerMismatchedPackages = emptySet(),
+                    blockedPackages = state.blockedPackages,
+                    onInstall = { onEvent(ExtensionsEvent.InstallExtension(it)) },
+                    onUninstall = { /* Not installed */ },
+                    onUpdate = { /* No update */ },
+                    onToggleEnabled = { _, _ -> },
+                    onRefresh = { onEvent(ExtensionsEvent.Refresh) },
+                    onViewDetails = { onNavigateToExtensionDetail(it.pkgName) }
+                )
+            }
+            2 -> ExtensionsList(
+                extensions = state.extensionsWithUpdates,
+                isLoading = state.isLoading,
+                error = state.error,
+                signerMismatchedPackages = state.signerMismatchedPackages,
+                blockedPackages = state.blockedPackages,
+                onInstall = { /* Already installed */ },
+                onUninstall = { onEvent(ExtensionsEvent.UninstallExtension(it)) },
+                onUpdate = { onEvent(ExtensionsEvent.UpdateExtension(it)) },
+                onToggleEnabled = { ext, enabled ->
+                    onEvent(ExtensionsEvent.ToggleExtensionEnabled(ext, enabled))
+                },
+                onRefresh = { onEvent(ExtensionsEvent.Refresh) },
+                onViewDetails = { onNavigateToExtensionDetail(it.pkgName) }
+            )
+        }
+
+        // Unverified install confirmation dialog
+        if (state.showUnverifiedInstallDialog) {
+            UnverifiedInstallDialog(
+                extension = state.pendingUnverifiedExtension,
+                onDismiss = { onEvent(ExtensionsEvent.DismissUnverifiedDialog) },
+                onConfirm = { onEvent(ExtensionsEvent.ConfirmUnverifiedInstall) }
+            )
+        }
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ExtensionsContent(
@@ -137,9 +282,6 @@ private fun ExtensionsContent(
     onNavigateToRepositories: () -> Unit = {},
     onNavigateToExtensionDetail: (packageName: String) -> Unit = {},
 ) {
-    val selectedTab = state.selectedTab
-    val tabs = listOf("Installed", "Available", "Updates")
-
     Scaffold(
         topBar = {
             TopAppBar(
@@ -161,138 +303,55 @@ private fun ExtensionsContent(
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { paddingValues ->
-        Column(
+        ExtensionsBody(
+            state = state,
+            onEvent = onEvent,
+            onNavigateToRepositories = onNavigateToRepositories,
+            onNavigateToExtensionDetail = onNavigateToExtensionDetail,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues)
-        ) {
-            // Search bar
-            TextField(
-                value = state.searchQuery,
-                onValueChange = { onEvent(ExtensionsEvent.OnSearchQueryChange(it)) },
-                placeholder = { Text(stringResource(R.string.extensions_search_placeholder)) },
-                leadingIcon = { Icon(Icons.Default.Search, contentDescription = stringResource(R.string.extensions_search_cd)) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-            )
+                .padding(paddingValues),
+        )
+    }
+}
 
-            // Filter & Sort controls
-            FilterAndSortRow(
-                showNsfw = state.showNsfw,
-                sortMode = state.sortMode,
-                onToggleNsfw = { onEvent(ExtensionsEvent.ToggleNsfw(it)) },
-                onSetSortMode = { onEvent(ExtensionsEvent.SetSortMode(it)) }
-            )
+/**
+ * Scaffold-free Extensions content for embedding in Browse's Extensions tab.
+ * Manages its own [ExtensionsViewModel] and snackbar; no TopAppBar.
+ */
+@Composable
+internal fun ExtensionsTabBody(
+    onNavigateToSettings: () -> Unit = {},
+    onNavigateToRepositories: () -> Unit = {},
+    onNavigateToExtensionDetail: (packageName: String) -> Unit = {},
+    modifier: Modifier = Modifier,
+    viewModel: ExtensionsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
-            // Update All button (only in Updates tab, visible whenever updates exist)
-            if (selectedTab == 2 && state.updateCount > 0) {
-                UpdateAllButton(
-                    updateCount = state.updateCount,
-                    isUpdating = state.isUpdatingAll,
-                    onUpdateAll = { onEvent(ExtensionsEvent.UpdateAllExtensions) }
-                )
-            }
-
-            RepositoryManager(
-                repositories = state.repositories,
-                onAdd = { onEvent(ExtensionsEvent.AddRepository(it)) },
-                onRemove = { onEvent(ExtensionsEvent.RemoveRepository(it)) },
-                onOpenFullManager = onNavigateToRepositories,
-            )
-
-            // Tabs
-            TabRow(selectedTabIndex = selectedTab) {
-                tabs.forEachIndexed { index, title ->
-                    Tab(
-                        selected = selectedTab == index,
-                        onClick = { onEvent(ExtensionsEvent.SelectTab(index)) },
-                        text = {
-                            when (index) {
-                                2 -> if (state.updateCount > 0) {
-                                    Row(verticalAlignment = Alignment.CenterVertically) {
-                                        Text(title)
-                                        Spacer(modifier = Modifier.width(4.dp))
-                                        Surface(
-                                            shape = CircleShape,
-                                            color = MaterialTheme.colorScheme.error
-                                        ) {
-                                            Text(
-                                                text = state.updateCount.toString(),
-                                                style = MaterialTheme.typography.labelSmall,
-                                                color = MaterialTheme.colorScheme.onError,
-                                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
-                                            )
-                                        }
-                                    }
-                                } else Text(title)
-                                else -> Text(title)
-                            }
-                        }
-                    )
-                }
-            }
-
-            when (selectedTab) {
-                0 -> ExtensionsList(
-                    extensions = state.installedExtensions,
-                    isLoading = state.isLoading,
-                    error = state.error,
-                    signerMismatchedPackages = state.signerMismatchedPackages,
-                    blockedPackages = state.blockedPackages,
-                    onInstall = { /* Already installed */ },
-                    onUninstall = { onEvent(ExtensionsEvent.UninstallExtension(it)) },
-                    onUpdate = { onEvent(ExtensionsEvent.UpdateExtension(it)) },
-                    onToggleEnabled = { ext, enabled ->
-                        onEvent(ExtensionsEvent.ToggleExtensionEnabled(ext, enabled))
-                    },
-                    onRefresh = { onEvent(ExtensionsEvent.Refresh) },
-                    onViewDetails = { onNavigateToExtensionDetail(it.pkgName) }
-                )
-                1 -> Column {
-                    if (state.hasUnverifiedExtensions) {
-                        TrustBanner(visible = true)
-                    }
-                    ExtensionsList(
-                        extensions = state.availableExtensions,
-                        isLoading = state.isLoading,
-                        error = state.error,
-                        signerMismatchedPackages = emptySet(),
-                        blockedPackages = state.blockedPackages,
-                        onInstall = { onEvent(ExtensionsEvent.InstallExtension(it)) },
-                        onUninstall = { /* Not installed */ },
-                        onUpdate = { /* No update */ },
-                        onToggleEnabled = { _, _ -> },
-                        onRefresh = { onEvent(ExtensionsEvent.Refresh) },
-                        onViewDetails = { onNavigateToExtensionDetail(it.pkgName) }
-                    )
-                }
-                2 -> ExtensionsList(
-                    extensions = state.extensionsWithUpdates,
-                    isLoading = state.isLoading,
-                    error = state.error,
-                    signerMismatchedPackages = state.signerMismatchedPackages,
-                    blockedPackages = state.blockedPackages,
-                    onInstall = { /* Already installed */ },
-                    onUninstall = { onEvent(ExtensionsEvent.UninstallExtension(it)) },
-                    onUpdate = { onEvent(ExtensionsEvent.UpdateExtension(it)) },
-                    onToggleEnabled = { ext, enabled ->
-                        onEvent(ExtensionsEvent.ToggleExtensionEnabled(ext, enabled))
-                    },
-                    onRefresh = { onEvent(ExtensionsEvent.Refresh) },
-                    onViewDetails = { onNavigateToExtensionDetail(it.pkgName) }
-                )
-            }
-
-            // Unverified install confirmation dialog
-            if (state.showUnverifiedInstallDialog) {
-                UnverifiedInstallDialog(
-                    extension = state.pendingUnverifiedExtension,
-                    onDismiss = { onEvent(ExtensionsEvent.DismissUnverifiedDialog) },
-                    onConfirm = { onEvent(ExtensionsEvent.ConfirmUnverifiedInstall) }
-                )
+    LaunchedEffect(Unit) {
+        viewModel.effect.collect { effect ->
+            when (effect) {
+                is ExtensionsEffect.ShowSnackbar -> scope.launch { snackbarHostState.showSnackbar(effect.message) }
+                is ExtensionsEffect.ShowError -> scope.launch { snackbarHostState.showSnackbar(effect.message) }
             }
         }
+    }
+
+    Box(modifier = modifier) {
+        ExtensionsBody(
+            state = state,
+            onEvent = viewModel::onEvent,
+            onNavigateToRepositories = onNavigateToRepositories,
+            onNavigateToExtensionDetail = onNavigateToExtensionDetail,
+            modifier = Modifier.fillMaxSize(),
+        )
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
     }
 }
 

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/extension/ExtensionDetailViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/extension/ExtensionDetailViewModel.kt
@@ -7,6 +7,7 @@ import androidx.navigation.toRoute
 import app.otakureader.core.extension.domain.model.Extension
 import app.otakureader.core.extension.domain.repository.ExtensionRepository
 import app.otakureader.core.navigation.Route
+import app.otakureader.domain.repository.ExtensionManagementRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
@@ -37,6 +38,7 @@ sealed interface ExtensionDetailEffect {
 class ExtensionDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val extensionRepository: ExtensionRepository,
+    private val extensionManagementRepository: ExtensionManagementRepository,
 ) : ViewModel() {
 
     private val route: Route.ExtensionDetail = savedStateHandle.toRoute()
@@ -92,6 +94,10 @@ class ExtensionDetailViewModel @Inject constructor(
                 result.fold(
                     onSuccess = {
                         loadExtension()
+                        if (!ext.isTrusted) {
+                            // Trust granted — reload sources so the extension's sources appear immediately
+                            extensionManagementRepository.refreshSources()
+                        }
                         val msg = if (!ext.isTrusted) "Extension trusted" else "Extension trust revoked"
                         _effect.send(ExtensionDetailEffect.ShowSnackbar(msg))
                     },

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/extension/ExtensionDetailViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/extension/ExtensionDetailViewModel.kt
@@ -94,11 +94,12 @@ class ExtensionDetailViewModel @Inject constructor(
                 result.fold(
                     onSuccess = {
                         loadExtension()
-                        if (!ext.isTrusted) {
-                            // Trust granted — reload sources so the extension's sources appear immediately
-                            extensionManagementRepository.refreshSources()
+                        val msg = if (!ext.isTrusted) {
+                            val refreshOk = extensionManagementRepository.refreshSources().isSuccess
+                            if (refreshOk) "Extension trusted" else "Extension trusted — sources reload failed"
+                        } else {
+                            "Extension trust revoked"
                         }
-                        val msg = if (!ext.isTrusted) "Extension trusted" else "Extension trust revoked"
                         _effect.send(ExtensionDetailEffect.ShowSnackbar(msg))
                     },
                     onFailure = { e ->

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
@@ -23,6 +23,7 @@ fun NavGraphBuilder.browseScreen(
     onNavigateToExtensions: () -> Unit,
     onNavigateToGlobalSearch: () -> Unit,
     onNavigateToOpds: () -> Unit = {},
+    onNavigateToMigration: () -> Unit = {},
 ) {
     composable<Route.Browse> {
         BrowseScreen(
@@ -32,7 +33,8 @@ fun NavGraphBuilder.browseScreen(
             },
             onInstallExtensionClick = onNavigateToExtensions,
             onGlobalSearchClick = onNavigateToGlobalSearch,
-            onOpdsClick = onNavigateToOpds
+            onOpdsClick = onNavigateToOpds,
+            onNavigateToMigration = onNavigateToMigration,
         )
     }
 }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
@@ -24,6 +24,15 @@ fun NavGraphBuilder.browseScreen(
     onNavigateToGlobalSearch: () -> Unit,
     onNavigateToOpds: () -> Unit = {},
     onNavigateToMigration: () -> Unit = {},
+    // Feed tab
+    onNavigateToReader: (mangaId: Long, chapterId: Long) -> Unit = { _, _ -> },
+    onNavigateToFeedManagement: () -> Unit = {},
+    // Extensions tab
+    onNavigateToExtensionSettings: () -> Unit = {},
+    onNavigateToExtensionRepositories: () -> Unit = {},
+    onNavigateToExtensionDetail: (packageName: String) -> Unit = {},
+    // Migrate tab
+    onStartMigration: (List<Long>) -> Unit = {},
 ) {
     composable<Route.Browse> {
         BrowseScreen(
@@ -35,6 +44,12 @@ fun NavGraphBuilder.browseScreen(
             onGlobalSearchClick = onNavigateToGlobalSearch,
             onOpdsClick = onNavigateToOpds,
             onNavigateToMigration = onNavigateToMigration,
+            onNavigateToReader = onNavigateToReader,
+            onNavigateToFeedManagement = onNavigateToFeedManagement,
+            onNavigateToExtensionSettings = onNavigateToExtensionSettings,
+            onNavigateToExtensionRepositories = onNavigateToExtensionRepositories,
+            onNavigateToExtensionDetail = onNavigateToExtensionDetail,
+            onStartMigration = onStartMigration,
         )
     }
 }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
@@ -40,10 +40,8 @@ fun NavGraphBuilder.browseScreen(
             onMangaClick = { sourceId, mangaUrl ->
                 onMangaClick(sourceId, mangaUrl, "")
             },
-            onInstallExtensionClick = onNavigateToExtensions,
             onGlobalSearchClick = onNavigateToGlobalSearch,
             onOpdsClick = onNavigateToOpds,
-            onNavigateToMigration = onNavigateToMigration,
             onNavigateToReader = onNavigateToReader,
             onNavigateToFeedManagement = onNavigateToFeedManagement,
             onNavigateToExtensionSettings = onNavigateToExtensionSettings,

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
@@ -44,7 +44,6 @@ fun NavGraphBuilder.browseScreen(
             onOpdsClick = onNavigateToOpds,
             onNavigateToReader = onNavigateToReader,
             onNavigateToFeedManagement = onNavigateToFeedManagement,
-            onNavigateToExtensionSettings = onNavigateToExtensionSettings,
             onNavigateToExtensionRepositories = onNavigateToExtensionRepositories,
             onNavigateToExtensionDetail = onNavigateToExtensionDetail,
             onStartMigration = onStartMigration,

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -207,4 +207,8 @@
     <string name="extension_has_changelog_cd">Has changelog</string>
     <!-- Extension blocklist (#1018) -->
     <string name="extension_blocked_warning">Blocked: %1$s</string>
+
+    <!-- Manga/Manhwa type badges on source cards -->
+    <string name="browse_manga_type_badge">MANGA</string>
+    <string name="browse_manhwa_type_badge">MANHWA</string>
 </resources>

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -6,6 +6,24 @@
     <string name="extensions_sort_recently_added">Recently Added</string>
     <string name="extensions_sort_language">Language</string>
 
+    <!-- Browse tab labels -->
+    <string name="browse_tab_feed">Feed</string>
+    <string name="browse_tab_sources">Sources</string>
+    <string name="browse_tab_extensions">Extensions</string>
+    <string name="browse_tab_migrate">Migrate</string>
+
+    <!-- Browse source list sections -->
+    <string name="browse_last_used">Last used</string>
+    <string name="browse_all_sources">All sources</string>
+    <string name="browse_source_latest">Latest</string>
+    <string name="browse_back_to_sources">Back to sources</string>
+    <string name="browse_source_nsfw_badge">18+</string>
+    <string name="browse_manage_extensions">Manage Extensions</string>
+    <string name="browse_extensions_tab_desc">Install, update, and manage manga source extensions</string>
+    <string name="browse_feed_tab_desc">Your activity feed will appear here</string>
+    <string name="browse_migrate_tab_desc">Migrate manga between sources</string>
+    <string name="browse_go_to_migrate">Open Migration Tool</string>
+
     <!-- Browse screen -->
     <string name="browse_title">Browse</string>
     <string name="browse_search">Search</string>

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -120,6 +120,9 @@
     <string name="browse_global_search_idle_hint">Enter a query to search all sources</string>
 
     <!-- ExtensionsBottomSheet -->
+    <string name="extensions_tab_installed">Installed</string>
+    <string name="extensions_tab_available">Available</string>
+    <string name="extensions_tab_updates">Updates</string>
     <string name="extensions_sheet_title">Extensions</string>
     <string name="extensions_search_placeholder">Search extensions...</string>
     <string name="extensions_repo_url_placeholder">https://raw.githubusercontent.com/komikku-app/extensions/repo</string>

--- a/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
+++ b/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
@@ -89,6 +89,8 @@ class BrowseViewModelTest {
         every { generalPreferences.sourceCategoryMap } returns flowOf(emptyMap())
         every { generalPreferences.savedSourceSearchesJson } returns flowOf("[]")
         coEvery { generalPreferences.setSavedSourceSearchesJson(any()) } just Awaits
+        every { generalPreferences.lastUsedSourceIds } returns flowOf(emptyList())
+        coEvery { generalPreferences.recordSourceUsed(any()) } just Awaits
 
         // observeLibraryFavorites() is called in ViewModel.init and subscribes to this flow.
         every { mangaRepository.getLibraryManga() } returns flowOf(emptyList())

--- a/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
+++ b/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
@@ -12,6 +12,7 @@ import app.otakureader.domain.usecase.source.GetLatestUpdatesUseCase
 import app.otakureader.domain.usecase.source.GetPopularMangaUseCase
 import app.otakureader.domain.usecase.source.GetSourceFiltersUseCase
 import app.otakureader.domain.usecase.source.GetSourcesUseCase
+import app.otakureader.domain.repository.ExtensionManagementRepository
 import app.otakureader.domain.usecase.SearchLibraryMangaUseCase
 import app.otakureader.domain.usecase.source.SearchMangaUseCase
 import app.otakureader.sourceapi.FilterList
@@ -52,6 +53,7 @@ class BrowseViewModelTest {
     private val mangaRepository: MangaRepository = mockk()
     private val feedRepository: FeedRepository = mockk()
     private val generalPreferences: GeneralPreferences = mockk()
+    private val extensionManagementRepository: ExtensionManagementRepository = mockk(relaxed = true)
 
     // Real use cases wired to repository mocks
     private val getSourcesUseCase = GetSourcesUseCase(sourceRepository)
@@ -114,6 +116,7 @@ class BrowseViewModelTest {
             feedRepository = feedRepository,
             generalPreferences = generalPreferences,
             searchLibraryMangaUseCase = searchLibraryMangaUseCase,
+            extensionManagementRepository = extensionManagementRepository,
         )
         // Subscribe to activate stateIn(WhileSubscribed); will start collecting on first advanceUntilIdle.
         collectScope.launch { viewModel.state.collect { } }
@@ -410,6 +413,7 @@ class BrowseViewModelTest {
             feedRepository = feedRepository,
             generalPreferences = generalPreferences,
             searchLibraryMangaUseCase = searchLibraryMangaUseCase,
+            extensionManagementRepository = extensionManagementRepository,
         )
         activateStateCollection()
 
@@ -446,6 +450,7 @@ class BrowseViewModelTest {
             feedRepository = feedRepository,
             generalPreferences = generalPreferences,
             searchLibraryMangaUseCase = searchLibraryMangaUseCase,
+            extensionManagementRepository = extensionManagementRepository,
         )
         activateStateCollection()
 

--- a/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
+++ b/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
@@ -91,6 +91,7 @@ class BrowseViewModelTest {
         coEvery { generalPreferences.setSavedSourceSearchesJson(any()) } just Awaits
         every { generalPreferences.lastUsedSourceIds } returns flowOf(emptyList())
         coEvery { generalPreferences.recordSourceUsed(any()) } just Awaits
+        coEvery { extensionManagementRepository.refreshSources() } returns Result.success(Unit)
 
         // observeLibraryFavorites() is called in ViewModel.init and subscribes to this flow.
         every { mangaRepository.getLibraryManga() } returns flowOf(emptyList())

--- a/feature/feed/src/main/java/app/otakureader/feature/feed/FeedScreen.kt
+++ b/feature/feed/src/main/java/app/otakureader/feature/feed/FeedScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -52,6 +53,74 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
+/**
+ * Scaffold-free content for embedding inside Browse's Feed tab.
+ * Callers are responsible for handling [FeedEffect] via the ViewModel.
+ */
+@Composable
+fun FeedContent(
+    state: FeedState,
+    onEvent: (FeedEvent) -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+) {
+    val formatter = remember {
+        DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
+            .withZone(ZoneId.systemDefault())
+    }
+    when {
+        state.isLoading -> Box(
+            modifier = modifier.fillMaxSize().padding(contentPadding),
+            contentAlignment = Alignment.Center,
+        ) { CircularProgressIndicator() }
+
+        state.error != null -> Box(
+            modifier = modifier.fillMaxSize().padding(contentPadding),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = state.error ?: stringResource(R.string.feed_error_unknown),
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+
+        state.feedItems.isEmpty() -> Box(
+            modifier = modifier.fillMaxSize().padding(contentPadding),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = stringResource(R.string.feed_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        else -> LazyColumn(
+            modifier = modifier.fillMaxSize(),
+            contentPadding = contentPadding,
+        ) {
+            item(key = "discovery_chips") {
+                DiscoveryModeChips(
+                    selected = state.discoveryMode,
+                    onSelect = { onEvent(FeedEvent.SetDiscoveryMode(it)) },
+                )
+            }
+            items(items = state.feedItems, key = { it.id }) { item ->
+                FeedItemRow(
+                    item = item,
+                    formatter = formatter,
+                    isFavorited = item.mangaId in state.favoritedMangaIds,
+                    onClick = { onEvent(FeedEvent.OnFeedItemClick(item.mangaId, item.chapterId)) },
+                    onMarkAsRead = { onEvent(FeedEvent.OnMarkAsRead(item.id)) },
+                    onLongClick = { onEvent(FeedEvent.LongClickManga(item.mangaId)) },
+                )
+                HorizontalDivider()
+            }
+        }
+    }
+}
+
 /** Feed screen showing the latest chapters across all configured feed sources. */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -65,10 +134,6 @@ fun FeedScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
-    val formatter = remember {
-        DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
-            .withZone(ZoneId.systemDefault())
-    }
 
     LaunchedEffect(viewModel.effect) {
         viewModel.effect.collectLatest { effect ->
@@ -120,77 +185,12 @@ fun FeedScreen(
             )
         }
     ) { paddingValues ->
-        when {
-            state.isLoading -> Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator()
-            }
-
-            state.error != null -> Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = state.error ?: stringResource(R.string.feed_error_unknown),
-                    color = MaterialTheme.colorScheme.error,
-                    style = MaterialTheme.typography.bodyMedium
-                )
-            }
-
-            state.feedItems.isEmpty() -> Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = stringResource(R.string.feed_empty),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-
-            else -> LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-            ) {
-                item(key = "discovery_chips") {
-                    DiscoveryModeChips(
-                        selected = state.discoveryMode,
-                        onSelect = { viewModel.onEvent(FeedEvent.SetDiscoveryMode(it)) },
-                    )
-                }
-                items(
-                    items = state.feedItems,
-                    key = { it.id }
-                ) { item ->
-                    FeedItemRow(
-                        item = item,
-                        formatter = formatter,
-                        isFavorited = item.mangaId in state.favoritedMangaIds,
-                        onClick = {
-                            viewModel.onEvent(
-                                FeedEvent.OnFeedItemClick(item.mangaId, item.chapterId)
-                            )
-                        },
-                        onMarkAsRead = {
-                            viewModel.onEvent(FeedEvent.OnMarkAsRead(item.id))
-                        },
-                        onLongClick = {
-                            viewModel.onEvent(FeedEvent.LongClickManga(item.mangaId))
-                        },
-                    )
-                    HorizontalDivider()
-                }
-            }
-        }
+        FeedContent(
+            state = state,
+            onEvent = viewModel::onEvent,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = paddingValues,
+        )
     }
 }
 

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryScreen.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryScreen.kt
@@ -49,6 +49,102 @@ import coil3.compose.AsyncImage
 import kotlinx.coroutines.flow.collectLatest
 
 /**
+ * Scaffold-free content for embedding in Browse's Migrate tab.
+ * Callers are responsible for handling [MigrationEntryEffect] (navigation, errors).
+ */
+@Composable
+fun MigrationEntryContent(
+    state: MigrationEntryState,
+    filtered: List<MigrationEntryItem>,
+    onEvent: (MigrationEntryEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        OutlinedTextField(
+            value = state.searchQuery,
+            onValueChange = { onEvent(MigrationEntryEvent.OnSearchQueryChange(it)) },
+            placeholder = { Text(stringResource(R.string.migration_entry_search_placeholder)) },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = stringResource(R.string.migration_search)) },
+            trailingIcon = {
+                if (state.searchQuery.isNotEmpty()) {
+                    IconButton(onClick = { onEvent(MigrationEntryEvent.OnSearchQueryChange("")) }) {
+                        Icon(Icons.Default.Close, contentDescription = stringResource(R.string.migration_clear_search))
+                    }
+                }
+            },
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        )
+
+        Box(modifier = Modifier.weight(1f)) {
+            when {
+                state.isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+                state.error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = state.error ?: "",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                        OutlinedButton(
+                            onClick = { onEvent(MigrationEntryEvent.Retry) },
+                            modifier = Modifier.padding(top = 8.dp),
+                        ) {
+                            Text(stringResource(R.string.migration_entry_retry))
+                        }
+                    }
+                }
+                filtered.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = if (state.searchQuery.isBlank()) {
+                            stringResource(R.string.migration_entry_library_empty)
+                        } else {
+                            stringResource(R.string.migration_entry_no_results)
+                        },
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                else -> LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(filtered, key = { it.id }) { manga ->
+                        MigrationEntryMangaRow(
+                            manga = manga,
+                            isSelected = manga.id in state.selectedIds,
+                            onToggle = { onEvent(MigrationEntryEvent.OnMangaToggle(manga.id)) },
+                        )
+                    }
+                }
+            }
+        }
+
+        if (state.selectedIds.isNotEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+            ) {
+                Button(
+                    onClick = { onEvent(MigrationEntryEvent.OnStartMigration) },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        androidx.compose.ui.res.pluralStringResource(
+                            R.plurals.migration_entry_migrate_count,
+                            state.selectedIds.size,
+                            state.selectedIds.size,
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
  * Entry-point screen for migration that allows users to pick manga from their library
  * before proceeding to the [MigrationScreen].
  *
@@ -112,102 +208,15 @@ fun MigrationEntryScreen(
                 }
             )
         },
-        bottomBar = {
-            if (state.selectedIds.isNotEmpty()) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 12.dp)
-                ) {
-                    Button(
-                        onClick = { viewModel.onEvent(MigrationEntryEvent.OnStartMigration) },
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text(
-                            androidx.compose.ui.res.pluralStringResource(
-                                R.plurals.migration_entry_migrate_count,
-                                state.selectedIds.size,
-                                state.selectedIds.size
-                            )
-                        )
-                    }
-                }
-            }
-        }
     ) { paddingValues ->
-        Column(
+        MigrationEntryContent(
+            state = state,
+            filtered = filtered,
+            onEvent = viewModel::onEvent,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues)
-        ) {
-            OutlinedTextField(
-                value = state.searchQuery,
-                onValueChange = { viewModel.onEvent(MigrationEntryEvent.OnSearchQueryChange(it)) },
-                placeholder = { Text(stringResource(R.string.migration_entry_search_placeholder)) },
-                leadingIcon = { Icon(Icons.Default.Search, contentDescription = stringResource(R.string.migration_search)) },
-                trailingIcon = {
-                    if (state.searchQuery.isNotEmpty()) {
-                        IconButton(onClick = { viewModel.onEvent(MigrationEntryEvent.OnSearchQueryChange("")) }) {
-                            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.migration_clear_search))
-                        }
-                    }
-                },
-                singleLine = true,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-            )
-
-            when {
-                state.isLoading -> {
-                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator()
-                    }
-                }
-                state.error != null -> {
-                    val errorMessage = state.error ?: ""
-                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(
-                                text = errorMessage,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.error
-                            )
-                            OutlinedButton(
-                                onClick = { viewModel.onEvent(MigrationEntryEvent.Retry) },
-                                modifier = Modifier.padding(top = 8.dp)
-                            ) {
-                                Text(stringResource(R.string.migration_entry_retry))
-                            }
-                        }
-                    }
-                }
-                filtered.isEmpty() -> {
-                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        Text(
-                            text = if (state.searchQuery.isBlank()) {
-                                stringResource(R.string.migration_entry_library_empty)
-                            } else {
-                                stringResource(R.string.migration_entry_no_results)
-                            },
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
-                else -> {
-                    LazyColumn(modifier = Modifier.fillMaxSize()) {
-                        items(filtered, key = { it.id }) { manga ->
-                            MigrationEntryMangaRow(
-                                manga = manga,
-                                isSelected = manga.id in state.selectedIds,
-                                onToggle = { viewModel.onEvent(MigrationEntryEvent.OnMangaToggle(manga.id)) }
-                            )
-                        }
-                    }
-                }
-            }
-        }
+                .padding(paddingValues),
+        )
     }
 }
 

--- a/feature/more/src/main/java/app/otakureader/feature/more/MoreScreen.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/MoreScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material.icons.filled.QrCode
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.QueryStats
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -54,7 +53,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import app.otakureader.core.ui.R as CoreUiR
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import app.otakureader.core.ui.theme.LocalOtakuColors
 
@@ -107,17 +105,8 @@ fun MoreScreen(
             AppLogoCard(versionName = versionName)
             Spacer(modifier = Modifier.height(8.dp))
 
-            MoreListItem(
-                icon = Icons.Default.Settings,
-                iconContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                iconTint = MaterialTheme.colorScheme.onPrimaryContainer,
-                headline = stringResource(R.string.more_settings),
-                supporting = stringResource(R.string.more_settings_desc),
-                onClick = onNavigateToSettings
-            )
-
-            HorizontalDivider()
-
+            // ── Library Tools ──────────────────────────────────────────────────
+            MoreSectionHeader(stringResource(R.string.more_section_library_tools))
             MoreListItem(
                 icon = Icons.Default.Extension,
                 iconContainerColor = MaterialTheme.colorScheme.tertiaryContainer,
@@ -126,9 +115,7 @@ fun MoreScreen(
                 supporting = stringResource(R.string.more_extensions_desc),
                 onClick = onNavigateToExtensions
             )
-
             HorizontalDivider()
-
             MoreListItem(
                 icon = Icons.AutoMirrored.Filled.LibraryBooks,
                 iconContainerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -137,43 +124,16 @@ fun MoreScreen(
                 supporting = stringResource(R.string.more_reading_lists_desc),
                 onClick = onNavigateToReadingLists,
             )
-
             HorizontalDivider()
-
             MoreListItem(
-                icon = Icons.Default.Notifications,
-                iconContainerColor = MaterialTheme.colorScheme.secondaryContainer,
-                iconTint = MaterialTheme.colorScheme.onSecondaryContainer,
-                headline = stringResource(R.string.more_feed),
-                supporting = stringResource(R.string.more_feed_desc),
-                onClick = onNavigateToFeed
+                icon = Icons.Default.Download,
+                iconContainerColor = MaterialTheme.colorScheme.errorContainer,
+                iconTint = MaterialTheme.colorScheme.onErrorContainer,
+                headline = stringResource(R.string.more_downloads),
+                supporting = stringResource(R.string.more_downloads_desc),
+                onClick = onNavigateToDownloads
             )
-
             HorizontalDivider()
-
-            MoreListItem(
-                icon = Icons.Default.CloudUpload,
-                iconContainerColor = MaterialTheme.colorScheme.secondaryContainer,
-                iconTint = MaterialTheme.colorScheme.onSecondaryContainer,
-                headline = stringResource(R.string.more_backup),
-                supporting = stringResource(R.string.more_backup_desc),
-                onClick = onNavigateToBackup
-            )
-
-            HorizontalDivider()
-
-            // QR Library Sharing (#711)
-            MoreListItem(
-                icon = Icons.Default.QrCode,
-                iconContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                iconTint = MaterialTheme.colorScheme.onPrimaryContainer,
-                headline = stringResource(R.string.more_share_library),
-                supporting = stringResource(R.string.more_share_library_desc),
-                onClick = onNavigateToShareLibrary
-            )
-
-            HorizontalDivider()
-
             MoreListItem(
                 icon = Icons.Default.PhotoCamera,
                 iconContainerColor = MaterialTheme.colorScheme.tertiaryContainer,
@@ -183,19 +143,26 @@ fun MoreScreen(
                 onClick = onNavigateToScanLibrary
             )
 
-            HorizontalDivider()
-
+            // ── Backup & Sync ──────────────────────────────────────────────────
+            MoreSectionHeader(stringResource(R.string.more_section_backup_sync))
             MoreListItem(
-                icon = Icons.Default.Download,
-                iconContainerColor = MaterialTheme.colorScheme.errorContainer,
-                iconTint = MaterialTheme.colorScheme.onErrorContainer,
-                headline = stringResource(R.string.more_downloads),
-                supporting = stringResource(R.string.more_downloads_desc),
-                onClick = onNavigateToDownloads
+                icon = Icons.Default.CloudUpload,
+                iconContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                iconTint = MaterialTheme.colorScheme.onSecondaryContainer,
+                headline = stringResource(R.string.more_backup),
+                supporting = stringResource(R.string.more_backup_desc),
+                onClick = onNavigateToBackup
             )
-
             HorizontalDivider()
-
+            MoreListItem(
+                icon = Icons.Default.QrCode,
+                iconContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                iconTint = MaterialTheme.colorScheme.onPrimaryContainer,
+                headline = stringResource(R.string.more_share_library),
+                supporting = stringResource(R.string.more_share_library_desc),
+                onClick = onNavigateToShareLibrary
+            )
+            HorizontalDivider()
             MoreListItem(
                 icon = Icons.Default.ErrorOutline,
                 iconContainerColor = MaterialTheme.colorScheme.errorContainer,
@@ -205,8 +172,26 @@ fun MoreScreen(
                 onClick = onNavigateToUpdateErrors
             )
 
+            // ── Personalization ────────────────────────────────────────────────
+            MoreSectionHeader(stringResource(R.string.more_section_personalization))
+            MoreListItem(
+                icon = Icons.Default.Notifications,
+                iconContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                iconTint = MaterialTheme.colorScheme.onSecondaryContainer,
+                headline = stringResource(R.string.more_feed),
+                supporting = stringResource(R.string.more_feed_desc),
+                onClick = onNavigateToFeed
+            )
             HorizontalDivider()
-
+            MoreListItem(
+                icon = Icons.Default.Bookmark,
+                iconContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                iconTint = MaterialTheme.colorScheme.onSecondaryContainer,
+                headline = stringResource(R.string.more_bookmarks),
+                supporting = stringResource(R.string.more_bookmarks_description),
+                onClick = onNavigateToBookmarks
+            )
+            HorizontalDivider()
             MoreListItem(
                 icon = Icons.Default.QueryStats,
                 iconContainerColor = MaterialTheme.colorScheme.tertiaryContainer,
@@ -216,19 +201,17 @@ fun MoreScreen(
                 onClick = onNavigateToStatistics
             )
 
-            HorizontalDivider()
-
+            // ── Info & Settings ────────────────────────────────────────────────
+            MoreSectionHeader(stringResource(R.string.more_section_info_settings))
             MoreListItem(
-                icon = Icons.Default.Bookmark,
-                iconContainerColor = MaterialTheme.colorScheme.secondaryContainer,
-                iconTint = MaterialTheme.colorScheme.onSecondaryContainer,
-                headline = stringResource(R.string.more_bookmarks),
-                supporting = stringResource(R.string.more_bookmarks_description),
-                onClick = onNavigateToBookmarks
+                icon = Icons.Default.Settings,
+                iconContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                iconTint = MaterialTheme.colorScheme.onPrimaryContainer,
+                headline = stringResource(R.string.more_settings),
+                supporting = stringResource(R.string.more_settings_desc),
+                onClick = onNavigateToSettings
             )
-
             HorizontalDivider()
-
             MoreListItem(
                 icon = Icons.Default.Info,
                 iconContainerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -240,6 +223,19 @@ fun MoreScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
         }
+    }
+}
+
+@Composable
+private fun MoreSectionHeader(title: String, modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(start = 16.dp, top = 12.dp, bottom = 4.dp),
+        )
     }
 }
 
@@ -280,8 +276,6 @@ private fun AppLogoCard(
                         .background(Color.White.copy(alpha = 0.18f)),
                     contentAlignment = Alignment.Center,
                 ) {
-                    // Brand logo in place of the previous generic AutoAwesome placeholder.
-                    // No tint — keep the marketing-logo colours intact.
                     Image(
                         painter = painterResource(CoreUiR.drawable.ic_otaku_logo),
                         contentDescription = stringResource(R.string.more_app_name),

--- a/feature/more/src/main/java/app/otakureader/feature/more/MoreScreen.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/MoreScreen.kt
@@ -226,15 +226,24 @@ fun MoreScreen(
     }
 }
 
+private val SectionDividerTopPadding = 8.dp
+private val SectionTitleStartPadding = 16.dp
+private val SectionTitleTopPadding = 12.dp
+private val SectionTitleBottomPadding = 4.dp
+
 @Composable
 private fun MoreSectionHeader(title: String, modifier: Modifier = Modifier) {
     Column(modifier = modifier) {
-        HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
+        HorizontalDivider(modifier = Modifier.padding(top = SectionDividerTopPadding))
         Text(
             text = title,
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(start = 16.dp, top = 12.dp, bottom = 4.dp),
+            modifier = Modifier.padding(
+                start = SectionTitleStartPadding,
+                top = SectionTitleTopPadding,
+                bottom = SectionTitleBottomPadding,
+            ),
         )
     }
 }

--- a/feature/more/src/main/res/values/strings.xml
+++ b/feature/more/src/main/res/values/strings.xml
@@ -58,6 +58,12 @@
     <!-- Version footer -->
     <string name="more_version_label">Otaku Reader v%s</string>
 
+    <!-- Section headers -->
+    <string name="more_section_library_tools">Library Tools</string>
+    <string name="more_section_backup_sync">Backup &amp; Sync</string>
+    <string name="more_section_personalization">Personalization</string>
+    <string name="more_section_info_settings">Info &amp; Settings</string>
+
     <!-- Update Errors -->
     <string name="more_update_errors">Update Errors</string>
     <string name="more_update_errors_desc">Review and clear update failures</string>


### PR DESCRIPTION
## Summary

- **Feed tab**: Extracts `FeedContent` (Scaffold-free) from `FeedScreen`; Browse embeds it with a scoped `FeedViewModel` and handles all `FeedEffect` navigation inline (reader, feed management, snackbar)
- **Extensions tab**: Extracts `ExtensionsBody` (private) and `ExtensionsTabBody` (internal) from `ExtensionsBottomSheet`; Browse embeds `ExtensionsTabBody` which owns its own ViewModel and snackbar overlay — no Scaffold duplication
- **Migrate tab**: Extracts `MigrationEntryContent` (Scaffold-free) from `MigrationEntryScreen`; Browse embeds it with a scoped `MigrationEntryViewModel`; "Start migration" effect navigates to the wizard with selected IDs
- **Build**: `feature/browse/build.gradle.kts` gains `projects.feature.feed` + `projects.feature.migration` deps (no circular dependencies)
- **Nav wiring**: `BrowseNavigation.browseScreen()` + `OtakuReaderNavHost` gain 6 new callbacks (reader, feed management, ext settings, ext repos, ext detail, migration start)

Standalone routes (`Route.Feed`, `Route.ExtensionCatalog`, `Route.MigrationEntry`) are untouched — still reachable from the More screen and other entry points.

## Test plan

- [ ] Browse → Feed tab shows real feed items or empty state (not placeholder text)
- [ ] Browse → Feed tab: tapping a chapter navigates to the reader
- [ ] Browse → Extensions tab shows installed/available/updates lists
- [ ] Browse → Migrate tab shows library manga selection with checkboxes
- [ ] Browse → Migrate tab: selecting manga and tapping "Migrate N" opens the migration wizard
- [ ] More → Feed still navigates to standalone `FeedScreen` (not broken)
- [ ] More → Extensions still opens the `ExtensionCatalog` bottom sheet (not broken)
- [ ] More → Migrate still opens standalone `MigrationEntryScreen` (not broken)
- [ ] CI green

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browse now uses tabs for Feed, Sources, Extensions, and Migrate, with quicker access to reader, feed management, migration, and extension settings/details.
  * Added recent/last-used sources, saved search handling, and richer source management actions.
  * More and Feed screens now use clearer sectioned layouts.

* **Bug Fixes**
  * Source refreshes now show success or failure feedback.
  * Extension details and source browsing stay in sync with the latest available data.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->