### PR TITLE
feat: Komikku parity Phase A — Library, History, Updates, Manga Detail

### DIFF
--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import app.otakureader.core.navigation.Route
@@ -170,6 +171,13 @@ fun OtakuReaderNavHost(
             },
             onNavigateToScanLibrary = {
                 navController.navigate(Route.ScanLibrary)
+            },
+            onBrowseClick = {
+                navController.navigate(Route.Browse) {
+                    popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                    launchSingleTop = true
+                    restoreState = true
+                }
             },
         )
 

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -20,11 +20,18 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.QueryStats
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
@@ -193,6 +200,18 @@ fun DetailsScreen(
     MangaDynamicTheme(colorScheme = dynamicScheme) {
         Scaffold(
             topBar = {
+            if (state.selectedChapters.isNotEmpty()) {
+                ChapterSelectionTopBar(
+                    selectedCount = state.selectedChapters.size,
+                    onClearSelection = { viewModel.onEvent(DetailsContract.Event.ClearChapterSelection) },
+                    onSelectAll = { viewModel.onEvent(DetailsContract.Event.SelectAllChapters) },
+                    onMarkRead = { viewModel.onEvent(DetailsContract.Event.MarkSelectedAsRead) },
+                    onMarkUnread = { viewModel.onEvent(DetailsContract.Event.MarkSelectedAsUnread) },
+                    onBookmark = { viewModel.onEvent(DetailsContract.Event.BookmarkSelectedChapters) },
+                    onDownload = { viewModel.onEvent(DetailsContract.Event.DownloadSelectedChapters) },
+                    onDelete = { viewModel.onEvent(DetailsContract.Event.DeleteSelectedChapters) },
+                )
+            } else {
             TopAppBar(
                 title = {
                     Text(
@@ -336,6 +355,7 @@ fun DetailsScreen(
                     }
                 }
             )
+            }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
@@ -379,6 +399,56 @@ fun DetailsScreen(
         }
     }
 }
+}
+
+/**
+ * Contextual app bar shown while one or more chapters are selected. Surfaces the batch
+ * actions that the ViewModel already handles (select-all, mark read/unread, bookmark,
+ * download, delete) — previously these events had no entry point in the live UI.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ChapterSelectionTopBar(
+    selectedCount: Int,
+    onClearSelection: () -> Unit,
+    onSelectAll: () -> Unit,
+    onMarkRead: () -> Unit,
+    onMarkUnread: () -> Unit,
+    onBookmark: () -> Unit,
+    onDownload: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    TopAppBar(
+        title = { Text(stringResource(R.string.details_selected_count, selectedCount)) },
+        navigationIcon = {
+            IconButton(onClick = onClearSelection) {
+                Icon(Icons.Default.Close, contentDescription = stringResource(R.string.details_clear_selection))
+            }
+        },
+        actions = {
+            IconButton(onClick = onSelectAll) {
+                Icon(Icons.Default.SelectAll, contentDescription = stringResource(R.string.details_select_all))
+            }
+            IconButton(onClick = onMarkRead) {
+                Icon(Icons.Default.CheckCircle, contentDescription = stringResource(R.string.details_mark_as_read))
+            }
+            IconButton(onClick = onMarkUnread) {
+                Icon(
+                    Icons.Default.RadioButtonUnchecked,
+                    contentDescription = stringResource(R.string.details_mark_as_unread),
+                )
+            }
+            IconButton(onClick = onBookmark) {
+                Icon(Icons.Default.Bookmark, contentDescription = stringResource(R.string.details_bookmark_selected))
+            }
+            IconButton(onClick = onDownload) {
+                Icon(Icons.Default.Download, contentDescription = stringResource(R.string.details_download_selected))
+            }
+            IconButton(onClick = onDelete) {
+                Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.details_delete_selected))
+            }
+        },
+    )
 }
 
 @Composable

--- a/feature/details/src/main/res/values/strings.xml
+++ b/feature/details/src/main/res/values/strings.xml
@@ -105,9 +105,12 @@
 
     <!-- Chapter list accessibility -->
     <string name="details_clear_selection">Clear selection</string>
+    <string name="details_selected_count">%1$d selected</string>
     <string name="details_download_selected">Download selected</string>
     <string name="details_mark_as_read">Mark as read</string>
+    <string name="details_mark_as_unread">Mark as unread</string>
     <string name="details_bookmark_selected">Bookmark selected</string>
+    <string name="details_delete_selected">Delete selected</string>
     <string name="details_select_all">Select all</string>
     <string name="details_sort_chapters">Sort chapters</string>
 

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryMvi.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryMvi.kt
@@ -26,5 +26,5 @@ sealed interface HistoryEvent : UiEvent {
 
 sealed interface HistoryEffect : UiEffect {
     data class NavigateToReader(val mangaId: Long, val chapterId: Long) : HistoryEffect
-    data class ShowSnackbar(val message: String) : HistoryEffect
+    data class ShowSnackbar(val messageRes: Int, val formatArgs: List<Any> = emptyList()) : HistoryEffect
 }

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
@@ -86,6 +86,7 @@ fun HistoryScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
     val haptic = LocalHapticFeedback.current
     var showClearConfirm by remember { mutableStateOf(false) }
 
@@ -94,7 +95,12 @@ fun HistoryScreen(
             when (effect) {
                 is HistoryEffect.NavigateToReader -> onChapterClick(effect.mangaId, effect.chapterId)
                 is HistoryEffect.ShowSnackbar -> scope.launch {
-                    snackbarHostState.showSnackbar(effect.message)
+                    val msg = if (effect.formatArgs.isEmpty()) {
+                        context.getString(effect.messageRes)
+                    } else {
+                        context.getString(effect.messageRes, *effect.formatArgs.toTypedArray())
+                    }
+                    snackbarHostState.showSnackbar(msg)
                 }
             }
         }

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
@@ -74,6 +74,13 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
+/** Spacing/sizing for the History empty state. */
+private object HistoryEmptyStateDefaults {
+    val Padding = 32.dp
+    val IconSize = 64.dp
+    val Spacing = 16.dp
+}
+
 /** History screen showing recently read chapters. */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -189,15 +196,15 @@ fun HistoryScreen(
                     if (state.searchQuery.isBlank()) {
                         Column(
                             horizontalAlignment = Alignment.CenterHorizontally,
-                            modifier = Modifier.padding(32.dp),
+                            modifier = Modifier.padding(HistoryEmptyStateDefaults.Padding),
                         ) {
                             Icon(
                                 imageVector = Icons.Default.History,
                                 contentDescription = null,
-                                modifier = Modifier.size(64.dp),
+                                modifier = Modifier.size(HistoryEmptyStateDefaults.IconSize),
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
-                            Spacer(modifier = Modifier.height(16.dp))
+                            Spacer(modifier = Modifier.height(HistoryEmptyStateDefaults.Spacing))
                             Text(
                                 text = stringResource(R.string.history_empty),
                                 style = MaterialTheme.typography.bodyMedium,

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
@@ -19,8 +19,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.SelectAll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.foundation.background
@@ -43,13 +45,17 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -80,6 +86,8 @@ fun HistoryScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+    val haptic = LocalHapticFeedback.current
+    var showClearConfirm by remember { mutableStateOf(false) }
 
     LaunchedEffect(viewModel.effect) {
         viewModel.effect.collectLatest { effect ->
@@ -124,7 +132,7 @@ fun HistoryScreen(
                             IconButton(onClick = { viewModel.onEvent(HistoryEvent.SelectAll) }) {
                                 Icon(Icons.Default.SelectAll, contentDescription = stringResource(R.string.history_select_all))
                             }
-                            TextButton(onClick = { viewModel.onEvent(HistoryEvent.ClearHistory) }) {
+                            TextButton(onClick = { showClearConfirm = true }) {
                                 Text(stringResource(R.string.history_clear_all))
                             }
                         }
@@ -172,10 +180,27 @@ fun HistoryScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center
                 ) {
-                    Text(
-                        text = if (state.searchQuery.isBlank()) stringResource(R.string.history_empty)
-                        else stringResource(R.string.history_no_results, state.searchQuery)
-                    )
+                    if (state.searchQuery.isBlank()) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            modifier = Modifier.padding(32.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.History,
+                                contentDescription = null,
+                                modifier = Modifier.size(64.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Text(
+                                text = stringResource(R.string.history_empty),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    } else {
+                        Text(text = stringResource(R.string.history_no_results, state.searchQuery))
+                    }
                 }
                 else -> HistoryList(
                     history = state.history,
@@ -186,6 +211,7 @@ fun HistoryScreen(
                         )
                     },
                     onItemLongClick = { entry ->
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                         viewModel.onEvent(HistoryEvent.OnChapterLongClick(entry.chapter.id))
                     },
                     onRemoveClick = { entry ->
@@ -194,6 +220,27 @@ fun HistoryScreen(
                 )
             }
         }
+    }
+
+    if (showClearConfirm) {
+        AlertDialog(
+            onDismissRequest = { showClearConfirm = false },
+            title = { Text(stringResource(R.string.history_clear_all_confirm_title)) },
+            text = { Text(stringResource(R.string.history_clear_all_confirm_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showClearConfirm = false
+                    viewModel.onEvent(HistoryEvent.ClearHistory)
+                }) {
+                    Text(stringResource(R.string.history_clear_all_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearConfirm = false }) {
+                    Text(stringResource(R.string.history_clear_all_cancel))
+                }
+            },
+        )
     }
 }
 

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryViewModel.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
+import app.otakureader.feature.history.R
 
 @HiltViewModel
 class HistoryViewModel @Inject constructor(
@@ -105,12 +106,17 @@ class HistoryViewModel @Inject constructor(
                         chapterRepository.removeFromHistory(chapterId)
                     }
                     clearSelection()
-                    _effect.send(HistoryEffect.ShowSnackbar("Removed ${selectedIds.size} item(s) from history"))
+                    _effect.send(
+                        HistoryEffect.ShowSnackbar(
+                            R.string.history_removed_count,
+                            formatArgs = listOf(selectedIds.size),
+                        )
+                    )
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _effect.send(HistoryEffect.ShowSnackbar("Failed to remove from history"))
+                _effect.send(HistoryEffect.ShowSnackbar(R.string.history_remove_failed))
             }
         }
     }
@@ -125,11 +131,11 @@ class HistoryViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 chapterRepository.clearAllHistory()
-                _effect.send(HistoryEffect.ShowSnackbar("History cleared"))
+                _effect.send(HistoryEffect.ShowSnackbar(R.string.history_cleared))
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _effect.send(HistoryEffect.ShowSnackbar("Failed to clear history"))
+                _effect.send(HistoryEffect.ShowSnackbar(R.string.history_clear_failed))
             }
         }
     }
@@ -141,7 +147,7 @@ class HistoryViewModel @Inject constructor(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                _effect.send(HistoryEffect.ShowSnackbar("Failed to remove from history"))
+                _effect.send(HistoryEffect.ShowSnackbar(R.string.history_remove_failed))
             }
         }
     }

--- a/feature/history/src/main/res/values/strings.xml
+++ b/feature/history/src/main/res/values/strings.xml
@@ -7,6 +7,11 @@
     <string name="history_delete_selected">Delete selected</string>
     <string name="history_select_all">Select all</string>
     <string name="history_clear_all">Clear all</string>
+    <!-- Clear-all confirmation -->
+    <string name="history_clear_all_confirm_title">Clear history?</string>
+    <string name="history_clear_all_confirm_message">This removes every entry from your reading history. This cannot be undone.</string>
+    <string name="history_clear_all_confirm">Clear</string>
+    <string name="history_clear_all_cancel">Cancel</string>
     <string name="history_search_placeholder">Search history…</string>
     <string name="history_clear_search">Clear search</string>
     <string name="history_unknown_error">Unknown error</string>

--- a/feature/history/src/main/res/values/strings.xml
+++ b/feature/history/src/main/res/values/strings.xml
@@ -19,6 +19,11 @@
     <string name="history_no_results">No results for \"%1$s\".</string>
     <string name="history_remove">Remove from history</string>
     <string name="history_resume">Resume reading</string>
+    <!-- Snackbar feedback -->
+    <string name="history_cleared">History cleared</string>
+    <string name="history_clear_failed">Failed to clear history</string>
+    <string name="history_remove_failed">Failed to remove from history</string>
+    <string name="history_removed_count">Removed %1$d item(s) from history</string>
     <!-- Date group headers -->
     <string name="history_date_today">Today</string>
     <string name="history_date_yesterday">Yesterday</string>

--- a/feature/history/src/test/java/app/otakureader/feature/history/HistoryViewModelTest.kt
+++ b/feature/history/src/test/java/app/otakureader/feature/history/HistoryViewModelTest.kt
@@ -230,7 +230,7 @@ class HistoryViewModelTest {
 
             val effect = awaitItem()
             assertTrue(effect is HistoryEffect.ShowSnackbar)
-            assertEquals("History cleared", (effect as HistoryEffect.ShowSnackbar).message)
+            assertEquals(R.string.history_cleared, (effect as HistoryEffect.ShowSnackbar).messageRes)
         }
 
         coVerify(exactly = 1) { chapterRepository.clearAllHistory() }
@@ -250,7 +250,7 @@ class HistoryViewModelTest {
 
             val effect = awaitItem()
             assertTrue(effect is HistoryEffect.ShowSnackbar)
-            assertEquals("Failed to clear history", (effect as HistoryEffect.ShowSnackbar).message)
+            assertEquals(R.string.history_clear_failed, (effect as HistoryEffect.ShowSnackbar).messageRes)
         }
     }
 
@@ -286,7 +286,7 @@ class HistoryViewModelTest {
 
             val effect = awaitItem()
             assertTrue(effect is HistoryEffect.ShowSnackbar)
-            assertTrue((effect as HistoryEffect.ShowSnackbar).message.contains("2"))
+            assertTrue((effect as HistoryEffect.ShowSnackbar).formatArgs.contains(2))
         }
 
         assertTrue(viewModel.state.value.selectedItems.isEmpty())

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryEmptyState.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryEmptyState.kt
@@ -6,9 +6,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.SearchOff
+import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -22,7 +25,8 @@ import app.otakureader.core.ui.theme.OtakuReaderTheme
 
 @Composable
 internal fun EmptyLibraryMessage(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onBrowseClick: (() -> Unit)? = null,
 ) {
     Column(
         modifier = modifier.padding(32.dp),
@@ -45,6 +49,18 @@ internal fun EmptyLibraryMessage(
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
+        if (onBrowseClick != null) {
+            Spacer(modifier = Modifier.height(24.dp))
+            Button(onClick = onBrowseClick) {
+                Icon(
+                    imageVector = Icons.Default.Explore,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource(R.string.library_empty_browse_cta))
+            }
+        }
     }
 }
 

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryEmptyState.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryEmptyState.kt
@@ -23,41 +23,52 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.otakureader.core.ui.theme.OtakuReaderTheme
 
+/** Shared spacing/sizing for the library empty-state composables. */
+private object EmptyStateDefaults {
+    val ContentPadding = 32.dp
+    val IconSize = 64.dp
+    val TitleSpacing = 16.dp
+    val MessageSpacing = 8.dp
+    val CtaSpacing = 24.dp
+    val CtaIconSize = 18.dp
+    val CtaIconGap = 8.dp
+}
+
 @Composable
 internal fun EmptyLibraryMessage(
     modifier: Modifier = Modifier,
     onBrowseClick: (() -> Unit)? = null,
 ) {
     Column(
-        modifier = modifier.padding(32.dp),
+        modifier = modifier.padding(EmptyStateDefaults.ContentPadding),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Icon(
             imageVector = Icons.Default.Favorite,
             contentDescription = stringResource(R.string.library_empty_icon_description),
-            modifier = Modifier.size(64.dp),
+            modifier = Modifier.size(EmptyStateDefaults.IconSize),
             tint = MaterialTheme.colorScheme.primary
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(EmptyStateDefaults.TitleSpacing))
         Text(
             text = stringResource(R.string.library_empty_title),
             style = MaterialTheme.typography.headlineSmall
         )
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(EmptyStateDefaults.MessageSpacing))
         Text(
             text = stringResource(R.string.library_empty_message),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
         if (onBrowseClick != null) {
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(EmptyStateDefaults.CtaSpacing))
             Button(onClick = onBrowseClick) {
                 Icon(
                     imageVector = Icons.Default.Explore,
                     contentDescription = null,
-                    modifier = Modifier.size(18.dp),
+                    modifier = Modifier.size(EmptyStateDefaults.CtaIconSize),
                 )
-                Spacer(modifier = Modifier.width(8.dp))
+                Spacer(modifier = Modifier.width(EmptyStateDefaults.CtaIconGap))
                 Text(stringResource(R.string.library_empty_browse_cta))
             }
         }
@@ -70,21 +81,21 @@ internal fun EmptyLibrarySearchMessage(
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = modifier.padding(32.dp),
+        modifier = modifier.padding(EmptyStateDefaults.ContentPadding),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Icon(
             imageVector = Icons.Default.SearchOff,
             contentDescription = null,
-            modifier = Modifier.size(64.dp),
+            modifier = Modifier.size(EmptyStateDefaults.IconSize),
             tint = MaterialTheme.colorScheme.onSurfaceVariant
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(EmptyStateDefaults.TitleSpacing))
         Text(
             text = stringResource(R.string.library_search_no_results_title),
             style = MaterialTheme.typography.headlineSmall
         )
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(EmptyStateDefaults.MessageSpacing))
         Text(
             text = stringResource(R.string.library_search_no_results_message, query),
             style = MaterialTheme.typography.bodyMedium,

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -7,16 +7,21 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.scaleIn
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items as columnItems
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -40,8 +45,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.otakureader.core.ui.components.CompletedBadge
 import app.otakureader.core.ui.components.DownloadBadge
@@ -52,6 +62,7 @@ import app.otakureader.core.ui.theme.LocalOtakuColors
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
+import coil3.compose.AsyncImage
 
 /** Returns true when a manga item belongs to the manhwa/webtoon content type. */
 internal fun isManhwa(manga: LibraryMangaItem): Boolean {
@@ -70,7 +81,18 @@ internal fun MangaGrid(
     modifier: Modifier = Modifier
 ) {
     var selectedContentFilter by remember { mutableIntStateOf(0) }
-    val contentTabs = listOf("All", "Manga", "Manhwa")
+    val contentTabs = listOf(
+        stringResource(R.string.library_content_tab_all),
+        stringResource(R.string.library_content_tab_manga),
+        stringResource(R.string.library_content_tab_manhwa),
+    )
+
+    // Long-press always enters selection mode; fire a haptic tick so the gesture is felt (#L7).
+    val haptic = LocalHapticFeedback.current
+    val onMangaLongClick: (Long) -> Unit = { mangaId ->
+        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+        onEvent(LibraryEvent.OnMangaLongClick(mangaId))
+    }
 
     val displayedManga by remember(state.mangaList, selectedContentFilter) {
         derivedStateOf {
@@ -166,6 +188,35 @@ internal fun MangaGrid(
         }
     }
 
+    if (state.displayMode == LibraryDisplayMode.LIST) {
+        LazyColumn(
+            contentPadding = PaddingValues(vertical = 8.dp),
+            modifier = modifier.fillMaxSize(),
+        ) {
+            item(contentType = "header_section") { headerContent() }
+
+            columnItems(
+                items = displayedManga,
+                key = { it.id },
+                contentType = { "manga_row" },
+            ) { manga ->
+                val downloadCount = state.downloadCountByManga[manga.id] ?: 0
+                LibraryListRow(
+                    manga = manga,
+                    isSelected = manga.id in state.selectedManga,
+                    unreadCount = if (state.showBadges) manga.unreadCount else 0,
+                    downloadCount = if (state.showDownloadBadge) downloadCount else 0,
+                    onClick = {
+                        if (onMangaSelect != null) onMangaSelect(manga)
+                        else onEvent(LibraryEvent.OnMangaClick(manga.id))
+                    },
+                    onLongClick = { onMangaLongClick(manga.id) },
+                )
+            }
+        }
+        return
+    }
+
     if (state.isStaggeredGrid) {
         LazyVerticalStaggeredGrid(
             columns = StaggeredGridCells.Adaptive(130.dp),
@@ -210,7 +261,7 @@ internal fun MangaGrid(
                                 if (onMangaSelect != null) onMangaSelect(manga)
                                 else onEvent(LibraryEvent.OnMangaClick(manga.id))
                             },
-                            onLongClick = { onEvent(LibraryEvent.OnMangaLongClick(manga.id)) },
+                            onLongClick = { onMangaLongClick(manga.id) },
                             isSelected = manga.id in state.selectedManga,
                             readProgress = readProgress,
                             continueReading = continueReading,
@@ -335,6 +386,60 @@ internal fun MangaGrid(
                     cardContent()
                 }
             }
+        }
+    }
+}
+
+/**
+ * Compact single-row representation of a library entry, used when
+ * [LibraryState.displayMode] is [LibraryDisplayMode.LIST].
+ *
+ * Mirrors the grid card's interaction contract: tap opens (or toggles selection when a
+ * selection is active), long-press enters selection mode. The whole row tints with the
+ * selection container colour while selected.
+ */
+@Composable
+private fun LibraryListRow(
+    manga: LibraryMangaItem,
+    isSelected: Boolean,
+    unreadCount: Int,
+    downloadCount: Int,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                if (isSelected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent
+            )
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        AsyncImage(
+            model = manga.thumbnailUrl,
+            contentDescription = manga.title,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .width(40.dp)
+                .aspectRatio(3f / 4f)
+                .clip(RoundedCornerShape(4.dp)),
+        )
+        Text(
+            text = manga.title,
+            style = MaterialTheme.typography.bodyMedium,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        if (downloadCount > 0) {
+            DownloadBadge(count = downloadCount)
+        }
+        if (unreadCount > 0) {
+            UnreadBadge(count = unreadCount)
         }
     }
 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -64,6 +64,17 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
 import coil3.compose.AsyncImage
 
+/** Layout constants for the compact list-mode row. */
+private object LibraryListRowDefaults {
+    val HorizontalPadding = 12.dp
+    val VerticalPadding = 6.dp
+    val ItemSpacing = 12.dp
+    val ThumbnailWidth = 40.dp
+    val ThumbnailCornerRadius = 4.dp
+    const val ThumbnailAspectRatio = 3f / 4f
+    const val TitleMaxLines = 2
+}
+
 /** Returns true when a manga item belongs to the manhwa/webtoon content type. */
 internal fun isManhwa(manga: LibraryMangaItem): Boolean {
     val src = manga.sourceId.toString().lowercase()
@@ -88,10 +99,20 @@ internal fun MangaGrid(
     )
 
     // Long-press always enters selection mode; fire a haptic tick so the gesture is felt (#L7).
+    // remember keeps the lambda reference stable so item composables can skip recomposition.
     val haptic = LocalHapticFeedback.current
-    val onMangaLongClick: (Long) -> Unit = { mangaId ->
-        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-        onEvent(LibraryEvent.OnMangaLongClick(mangaId))
+    val onMangaLongClick: (Long) -> Unit = remember(haptic, onEvent) {
+        { mangaId ->
+            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+            onEvent(LibraryEvent.OnMangaLongClick(mangaId))
+        }
+    }
+    // Taps open the detail pane only in two-pane mode with no active selection; otherwise route
+    // through OnMangaClick so taps toggle selection while selection mode is active (and navigate
+    // in single-pane). Without the selection guard, two-pane taps could never toggle items.
+    val onMangaTap: (LibraryMangaItem) -> Unit = { manga ->
+        if (onMangaSelect != null && state.selectedManga.isEmpty()) onMangaSelect(manga)
+        else onEvent(LibraryEvent.OnMangaClick(manga.id))
     }
 
     val displayedManga by remember(state.mangaList, selectedContentFilter) {
@@ -206,10 +227,7 @@ internal fun MangaGrid(
                     isSelected = manga.id in state.selectedManga,
                     unreadCount = if (state.showBadges) manga.unreadCount else 0,
                     downloadCount = if (state.showDownloadBadge) downloadCount else 0,
-                    onClick = {
-                        if (onMangaSelect != null) onMangaSelect(manga)
-                        else onEvent(LibraryEvent.OnMangaClick(manga.id))
-                    },
+                    onClick = { onMangaTap(manga) },
                     onLongClick = { onMangaLongClick(manga.id) },
                 )
             }
@@ -240,10 +258,7 @@ internal fun MangaGrid(
                             coverUrl = manga.thumbnailUrl ?: "",
                             title = manga.title,
                             unreadCount = if (state.showBadges) manga.unreadCount else 0,
-                            onClick = {
-                                if (onMangaSelect != null) onMangaSelect(manga)
-                                else onEvent(LibraryEvent.OnMangaClick(manga.id))
-                            },
+                            onClick = { onMangaTap(manga) },
                             modifier = Modifier.fillMaxWidth()
                         )
                     } else {
@@ -257,10 +272,7 @@ internal fun MangaGrid(
                         MangaCard(
                             title = manga.title,
                             coverUrl = manga.thumbnailUrl,
-                            onClick = {
-                                if (onMangaSelect != null) onMangaSelect(manga)
-                                else onEvent(LibraryEvent.OnMangaClick(manga.id))
-                            },
+                            onClick = { onMangaTap(manga) },
                             onLongClick = { onMangaLongClick(manga.id) },
                             isSelected = manga.id in state.selectedManga,
                             readProgress = readProgress,
@@ -338,11 +350,8 @@ internal fun MangaGrid(
                     MangaCard(
                         title = manga.title,
                         coverUrl = manga.thumbnailUrl,
-                        onClick = {
-                            if (onMangaSelect != null) onMangaSelect(manga)
-                            else onEvent(LibraryEvent.OnMangaClick(manga.id))
-                        },
-                        onLongClick = { onEvent(LibraryEvent.OnMangaLongClick(manga.id)) },
+                        onClick = { onMangaTap(manga) },
+                        onLongClick = { onMangaLongClick(manga.id) },
                         isSelected = manga.id in state.selectedManga,
                         readProgress = readProgress,
                         continueReading = continueReading,
@@ -415,23 +424,28 @@ private fun LibraryListRow(
                 if (isSelected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent
             )
             .combinedClickable(onClick = onClick, onLongClick = onLongClick)
-            .padding(horizontal = 12.dp, vertical = 6.dp),
+            .padding(
+                horizontal = LibraryListRowDefaults.HorizontalPadding,
+                vertical = LibraryListRowDefaults.VerticalPadding,
+            ),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(LibraryListRowDefaults.ItemSpacing),
     ) {
         AsyncImage(
+            // Decorative: the title is shown as text right beside it, so a description
+            // would make screen readers announce the title twice.
             model = manga.thumbnailUrl,
-            contentDescription = manga.title,
+            contentDescription = null,
             contentScale = ContentScale.Crop,
             modifier = Modifier
-                .width(40.dp)
-                .aspectRatio(3f / 4f)
-                .clip(RoundedCornerShape(4.dp)),
+                .width(LibraryListRowDefaults.ThumbnailWidth)
+                .aspectRatio(LibraryListRowDefaults.ThumbnailAspectRatio)
+                .clip(RoundedCornerShape(LibraryListRowDefaults.ThumbnailCornerRadius)),
         )
         Text(
             text = manga.title,
             style = MaterialTheme.typography.bodyMedium,
-            maxLines = 2,
+            maxLines = LibraryListRowDefaults.TitleMaxLines,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),
         )

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -30,6 +30,20 @@ enum class LibraryBottomSheetTab {
     GROUP
 }
 
+/**
+ * Top-level layout for the library grid.
+ *
+ * - [GRID]: cover-centric grid (the [LibraryState.isStaggeredGrid] flag further selects
+ *   uniform vs. waterfall columns).
+ * - [LIST]: compact single-column rows with a small cover thumbnail, title, and badges.
+ *
+ * Persisted as an ordinal via `LibraryPreferences.libraryDisplayMode`.
+ */
+enum class LibraryDisplayMode {
+    GRID,
+    LIST,
+}
+
 data class LibraryState(
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
@@ -46,6 +60,7 @@ data class LibraryState(
     val showDownloadBadge: Boolean = true,
     val downloadCountByManga: Map<Long, Int> = emptyMap(),
     val isStaggeredGrid: Boolean = false,
+    val displayMode: LibraryDisplayMode = LibraryDisplayMode.GRID,
     val visualEffectsEnabled: Boolean = true,
     val filterHasNotes: Boolean = false,
     val sortMode: LibrarySortMode = LibrarySortMode.ALPHABETICAL,
@@ -156,6 +171,7 @@ sealed class LibraryEvent {
     data class SetShowBadges(val enabled: Boolean) : LibraryEvent()
     data class SetShowDownloadBadge(val enabled: Boolean) : LibraryEvent()
     data class SetStaggeredGrid(val enabled: Boolean) : LibraryEvent()
+    data class SetDisplayMode(val mode: LibraryDisplayMode) : LibraryEvent()
     data object ToggleFilterSheet : LibraryEvent()
     data class DismissRecommendation(val mangaId: Long) : LibraryEvent()
     data object ToggleAdvancedSearch : LibraryEvent()

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -136,6 +136,8 @@ sealed class LibraryEvent {
     data object ToggleSearchBar : LibraryEvent()
     data class OnCategorySelected(val categoryId: Long?) : LibraryEvent()
     data object ClearSelection : LibraryEvent()
+    data object SelectAllManga : LibraryEvent()
+    data object InvertSelection : LibraryEvent()
     data class ToggleFavorite(val mangaId: Long) : LibraryEvent()
     data class FilterHasNotes(val enabled: Boolean) : LibraryEvent()
     data class SetSortMode(val mode: LibrarySortMode) : LibraryEvent()

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -219,6 +219,21 @@ fun LibraryScreen(
                             onDismissRequest = { selectionOverflowExpanded = false },
                         ) {
                             DropdownMenuItem(
+                                text = { Text(stringResource(R.string.library_select_all)) },
+                                onClick = {
+                                    viewModel.onEvent(LibraryEvent.SelectAllManga)
+                                    selectionOverflowExpanded = false
+                                },
+                            )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.library_invert_selection)) },
+                                onClick = {
+                                    viewModel.onEvent(LibraryEvent.InvertSelection)
+                                    selectionOverflowExpanded = false
+                                },
+                            )
+                            androidx.compose.material3.HorizontalDivider()
+                            DropdownMenuItem(
                                 text = { Text(stringResource(R.string.library_mark_selected_completed)) },
                                 onClick = {
                                     pendingBulkAction = LibraryEvent.MarkSelectedAsCompleted

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -95,7 +95,7 @@ fun LibraryScreen(
     onNavigateToShareLibrary: () -> Unit = {},
     onNavigateToScanLibrary: () -> Unit = {},
     onNavigateToMaintenance: () -> Unit = {},
-    onBrowseClick: () -> Unit = {},
+    onBrowseClick: (() -> Unit)? = null,
     viewModel: LibraryViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -446,7 +446,7 @@ fun LibraryScreen(
 private fun LibraryContent(
     state: LibraryState,
     onEvent: (LibraryEvent) -> Unit,
-    onBrowseClick: () -> Unit = {},
+    onBrowseClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     val widthSizeClass = rememberWindowWidthSizeClass()

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -7,12 +7,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.BookmarkRemove
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.Search
@@ -93,6 +95,7 @@ fun LibraryScreen(
     onNavigateToShareLibrary: () -> Unit = {},
     onNavigateToScanLibrary: () -> Unit = {},
     onNavigateToMaintenance: () -> Unit = {},
+    onBrowseClick: () -> Unit = {},
     viewModel: LibraryViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -289,8 +292,24 @@ fun LibraryScreen(
                         IconButton(onClick = { viewModel.onEvent(LibraryEvent.ToggleIncognito) }) {
                             Icon(
                                 imageVector = Icons.Outlined.VisibilityOff,
-                                contentDescription = "Toggle incognito mode",
+                                contentDescription = stringResource(R.string.library_toggle_incognito),
                                 tint = if (state.incognitoMode) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
+                        val inListMode = state.displayMode == LibraryDisplayMode.LIST
+                        IconButton(onClick = {
+                            viewModel.onEvent(
+                                LibraryEvent.SetDisplayMode(
+                                    if (inListMode) LibraryDisplayMode.GRID else LibraryDisplayMode.LIST
+                                )
+                            )
+                        }) {
+                            Icon(
+                                imageVector = if (inListMode) Icons.Default.GridView else Icons.AutoMirrored.Filled.ViewList,
+                                contentDescription = if (inListMode)
+                                    stringResource(R.string.library_view_mode_grid)
+                                else
+                                    stringResource(R.string.library_view_mode_list),
                             )
                         }
                         IconButton(onClick = { viewModel.onEvent(LibraryEvent.ToggleSearchBar) }) {
@@ -399,6 +418,7 @@ fun LibraryScreen(
         LibraryContent(
             state = state,
             onEvent = viewModel::onEvent,
+            onBrowseClick = onBrowseClick,
             modifier = Modifier.padding(padding)
         )
     }
@@ -426,6 +446,7 @@ fun LibraryScreen(
 private fun LibraryContent(
     state: LibraryState,
     onEvent: (LibraryEvent) -> Unit,
+    onBrowseClick: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val widthSizeClass = rememberWindowWidthSizeClass()
@@ -527,7 +548,10 @@ private fun LibraryContent(
                 }
                 state.mangaList.isEmpty() -> {
                     Box(modifier = Modifier.fillMaxSize()) {
-                        EmptyLibraryMessage(modifier = Modifier.align(Alignment.Center))
+                        EmptyLibraryMessage(
+                            onBrowseClick = onBrowseClick,
+                            modifier = Modifier.align(Alignment.Center),
+                        )
                     }
                 }
                 isExpandedWidth -> {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -121,7 +121,8 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.Refresh, is LibraryEvent.OnMangaClick,
             is LibraryEvent.OnMangaLongClick, is LibraryEvent.ContinueReadingClick -> handleNavEvent(event)
             is LibraryEvent.OnSearchQueryChange, is LibraryEvent.ToggleSearchBar,
-            is LibraryEvent.OnCategorySelected, is LibraryEvent.ClearSelection -> handleUiEvent(event)
+            is LibraryEvent.OnCategorySelected, is LibraryEvent.ClearSelection,
+            is LibraryEvent.SelectAllManga, is LibraryEvent.InvertSelection -> handleUiEvent(event)
             is LibraryEvent.FilterHasNotes, is LibraryEvent.SetSortMode, is LibraryEvent.SetFilterMode,
             is LibraryEvent.SetFilterSource, is LibraryEvent.ToggleNsfw, is LibraryEvent.SetFilterReadingList,
             is LibraryEvent.SetGenreFilter, is LibraryEvent.SetSortAscending,
@@ -183,6 +184,8 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.ToggleSearchBar -> toggleSearchBar()
             is LibraryEvent.OnCategorySelected -> onCategorySelected(event.categoryId)
             is LibraryEvent.ClearSelection -> clearSelection()
+            is LibraryEvent.SelectAllManga -> selection.setAll(_state.value.mangaList.map { it.id }.toSet())
+            is LibraryEvent.InvertSelection -> selection.invert(_state.value.mangaList.map { it.id })
             else -> Unit
         }
     }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -130,12 +130,9 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.ToggleBottomSheet -> _state.update { it.copy(showBottomSheet = !it.showBottomSheet) }
             is LibraryEvent.SetBottomSheetTab -> _state.update { it.copy(bottomSheetTab = event.tab) }
             is LibraryEvent.SetGroupByCategory -> viewModelScope.launch { libraryPreferences.setGroupByCategory(event.enabled) }
-            is LibraryEvent.SetGridSize -> viewModelScope.launch { libraryPreferences.setGridSize(event.size) }
-            is LibraryEvent.SetShowBadges -> viewModelScope.launch { libraryPreferences.setShowBadges(event.enabled) }
-            is LibraryEvent.SetShowDownloadBadge ->
-                viewModelScope.launch { libraryPreferences.setShowDownloadBadge(event.enabled) }
-            is LibraryEvent.SetStaggeredGrid ->
-                viewModelScope.launch { libraryPreferences.setStaggeredGrid(event.enabled) }
+            is LibraryEvent.SetGridSize, is LibraryEvent.SetShowBadges,
+            is LibraryEvent.SetShowDownloadBadge, is LibraryEvent.SetStaggeredGrid,
+            is LibraryEvent.SetDisplayMode -> handleDisplayEvent(event)
             is LibraryEvent.ToggleIncognito -> toggleIncognitoMode()
             is LibraryEvent.DismissRecommendation -> dismissRecommendation(event.mangaId)
             is LibraryEvent.ToggleAdvancedSearch -> _state.update { it.copy(showAdvancedSearch = !it.showAdvancedSearch) }
@@ -152,6 +149,21 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.ShowSaveViewDialog, is LibraryEvent.HideSaveViewDialog,
             is LibraryEvent.UpdateSaveViewName, is LibraryEvent.ConfirmSaveView,
             is LibraryEvent.ApplySavedView, is LibraryEvent.DeleteSavedView -> handleSavedViewEvent(event)
+        }
+    }
+
+    /** Persists display-layout preference changes (grid size, badges, staggered/list mode). */
+    private fun handleDisplayEvent(event: LibraryEvent) {
+        when (event) {
+            is LibraryEvent.SetGridSize -> viewModelScope.launch { libraryPreferences.setGridSize(event.size) }
+            is LibraryEvent.SetShowBadges -> viewModelScope.launch { libraryPreferences.setShowBadges(event.enabled) }
+            is LibraryEvent.SetShowDownloadBadge ->
+                viewModelScope.launch { libraryPreferences.setShowDownloadBadge(event.enabled) }
+            is LibraryEvent.SetStaggeredGrid ->
+                viewModelScope.launch { libraryPreferences.setStaggeredGrid(event.enabled) }
+            is LibraryEvent.SetDisplayMode ->
+                viewModelScope.launch { libraryPreferences.setLibraryDisplayMode(event.mode.ordinal) }
+            else -> Unit
         }
     }
 
@@ -414,6 +426,13 @@ class LibraryViewModel @Inject constructor(
             .launchIn(viewModelScope)
         libraryPreferences.isStaggeredGrid
             .onEach { staggered -> _state.update { it.copy(isStaggeredGrid = staggered) } }
+            .launchIn(viewModelScope)
+        libraryPreferences.libraryDisplayMode
+            .onEach { modeInt ->
+                _state.update {
+                    it.copy(displayMode = LibraryDisplayMode.entries.getOrElse(modeInt) { LibraryDisplayMode.GRID })
+                }
+            }
             .launchIn(viewModelScope)
         generalPreferences.visualEffectsEnabled
             .onEach { enabled -> _state.update { it.copy(visualEffectsEnabled = enabled) } }

--- a/feature/library/src/main/java/app/otakureader/feature/library/navigation/LibraryNavigation.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/navigation/LibraryNavigation.kt
@@ -16,7 +16,7 @@ fun NavGraphBuilder.libraryScreen(
     onNavigateToShareLibrary: () -> Unit = {},
     onNavigateToScanLibrary: () -> Unit = {},
     onNavigateToMaintenance: () -> Unit = {},
-    onBrowseClick: () -> Unit = {},
+    onBrowseClick: (() -> Unit)? = null,
 ) {
     composable<Route.Library> {
         LibraryScreen(

--- a/feature/library/src/main/java/app/otakureader/feature/library/navigation/LibraryNavigation.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/navigation/LibraryNavigation.kt
@@ -16,6 +16,7 @@ fun NavGraphBuilder.libraryScreen(
     onNavigateToShareLibrary: () -> Unit = {},
     onNavigateToScanLibrary: () -> Unit = {},
     onNavigateToMaintenance: () -> Unit = {},
+    onBrowseClick: () -> Unit = {},
 ) {
     composable<Route.Library> {
         LibraryScreen(
@@ -29,6 +30,7 @@ fun NavGraphBuilder.libraryScreen(
             onNavigateToShareLibrary = onNavigateToShareLibrary,
             onNavigateToScanLibrary = onNavigateToScanLibrary,
             onNavigateToMaintenance = onNavigateToMaintenance,
+            onBrowseClick = onBrowseClick,
         )
     }
 }

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -105,6 +105,8 @@
     <string name="library_download_selected">Download selected</string>
     <string name="library_remove_selected">Remove from library</string>
     <string name="library_more_actions">More actions</string>
+    <string name="library_select_all">Select all</string>
+    <string name="library_invert_selection">Invert selection</string>
     <string name="library_mark_selected_completed">Mark as completed</string>
     <string name="library_mark_selected_dropped">Mark as dropped</string>
     <string name="library_share_manga">Share</string>

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -10,7 +10,16 @@
     <string name="library_settings">Settings</string>
     <string name="library_empty_title">Your library is empty</string>
     <string name="library_empty_message">Browse for manga to add to your collection</string>
+    <string name="library_empty_browse_cta">Browse sources</string>
     <string name="library_badge_overflow">99+</string>
+    <!-- Top bar / view controls -->
+    <string name="library_toggle_incognito">Toggle incognito mode</string>
+    <string name="library_view_mode_grid">Switch to grid view</string>
+    <string name="library_view_mode_list">Switch to list view</string>
+    <!-- Content-type filter tabs -->
+    <string name="library_content_tab_all">All</string>
+    <string name="library_content_tab_manga">Manga</string>
+    <string name="library_content_tab_manhwa">Manhwa</string>
     <!-- Bottom navigation -->
     <string name="library_nav_library">Library</string>
     <string name="library_nav_updates">Updates</string>

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -290,6 +290,37 @@ class LibraryViewModelTest {
     }
 
     @Test
+    fun onEvent_SelectAllManga_selectsEveryDisplayedManga() = runTest {
+        every { getLibraryManga() } returns flowOf(sampleMangas)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(LibraryEvent.SelectAllManga)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            sampleMangas.map { it.id }.toSet(),
+            viewModel.state.value.selectedManga
+        )
+    }
+
+    @Test
+    fun onEvent_InvertSelection_togglesSelectionAcrossDisplayedManga() = runTest {
+        every { getLibraryManga() } returns flowOf(sampleMangas)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(LibraryEvent.OnMangaLongClick(1L))
+        viewModel.onEvent(LibraryEvent.InvertSelection)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // 1 was selected, so after invert only 2 and 3 should remain selected.
+        assertEquals(setOf(2L, 3L), viewModel.state.value.selectedManga)
+    }
+
+    @Test
     fun onEvent_ToggleFavorite_callsUseCase() = runTest {
         every { getLibraryManga() } returns flowOf(sampleMangas)
         coEvery { toggleFavoriteManga(any()) } returns Unit

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -103,6 +103,7 @@ class LibraryViewModelTest {
             every { libraryFilterMode } returns flowOf(0)
             every { libraryFilterSourceId } returns flowOf(null)
             every { isStaggeredGrid } returns flowOf(false)
+            every { libraryDisplayMode } returns flowOf(0)
             every { showRecommendations } returns flowOf(false)
             every { dismissedRecommendations } returns flowOf(emptySet())
             every { groupByCategory } returns flowOf(false)

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.NewReleases
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.SelectAll
@@ -52,8 +53,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -83,6 +86,7 @@ fun UpdatesScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = androidx.compose.material3.SnackbarHostState()
+    val haptic = LocalHapticFeedback.current
 
     LaunchedEffect(viewModel.effect) {
         viewModel.effect.collectLatest { effect ->
@@ -128,6 +132,13 @@ fun UpdatesScreen(
                         }
                     },
                     actions = {
+                        // Trigger a manual library update right from the Updates screen.
+                        IconButton(onClick = { viewModel.onEvent(UpdatesEvent.StartLibraryUpdate) }) {
+                            Icon(
+                                imageVector = Icons.Default.Refresh,
+                                contentDescription = stringResource(R.string.updates_refresh_now)
+                            )
+                        }
                         // To-Be-Updated preview icon
                         IconButton(onClick = { viewModel.onEvent(UpdatesEvent.ShowPendingUpdates) }) {
                             Icon(
@@ -189,12 +200,23 @@ fun UpdatesScreen(
                     .padding(paddingValues),
                 contentAlignment = Alignment.Center
             ) {
-                Text(
-                    text = stringResource(R.string.updates_empty),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier.padding(horizontal = 32.dp)
-                )
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.NewReleases,
+                        contentDescription = null,
+                        modifier = Modifier.size(64.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = stringResource(R.string.updates_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
 
             else -> UpdatesList(
@@ -210,6 +232,7 @@ fun UpdatesScreen(
                     )
                 },
                 onChapterLongClick = { update ->
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                     viewModel.onEvent(UpdatesEvent.OnChapterLongClick(update.chapter.id))
                 },
                 onDownloadClick = { update ->

--- a/feature/updates/src/main/res/values/strings.xml
+++ b/feature/updates/src/main/res/values/strings.xml
@@ -44,6 +44,8 @@
     <string name="updates_error_clear">Clear error</string>
     <string name="updates_error_clear_all">Clear all</string>
     
+    <string name="updates_refresh_now">Update library now</string>
+
     <!-- To-Be-Updated Screen -->
     <string name="updates_view_pending">Preview next update</string>
     <string name="updates_pending_title">To Be Updated</string>


### PR DESCRIPTION
## Summary

Screen-by-screen Komikku-parity "Invisible 20%" audit, **Phase A** (high-impact micro-features). Covers four screens. Every change reuses existing ViewModel/preference plumbing where possible and is verified offline (compile + unit tests + detekt + ktlint).

### Library
| ID | Gap | Fix |
|----|-----|-----|
| L1 | No list view (grid only) | `LibraryDisplayMode` (`GRID`/`LIST`) backed by the existing-but-unused `libraryDisplayMode` pref; top-bar grid↔list toggle; compact `LibraryListRow`. |
| L4 | Hardcoded incognito `contentDescription` | → string resource. |
| L5 | Text-only empty state | "Browse sources" CTA → Browse tab (same `popUpTo`/`saveState` as bottom bar). |
| L7 | No haptics | `LongPress` tick on selection. |
| L13 | Hardcoded "All"/"Manga"/"Manhwa" tabs | → string resources. |

### History
| ID | Gap | Fix |
|----|-----|-----|
| H2 | "Clear all" wiped history with no confirmation | Confirmation dialog (destructive/irreversible). |
| H5 | Bare-text empty state | History icon added. |
| H6 | No haptics | `LongPress` tick on selection. |

### Updates
| ID | Gap | Fix |
|----|-----|-----|
| U2 | No "refresh now" (had to go to Library) | App-bar refresh action firing the already-wired `StartLibraryUpdate`. |
| U4 | Bare-text empty state | `NewReleases` icon added. |
| U6 | No haptics | `LongPress` tick on selection. |

### Manga Detail
| ID | Gap | Fix |
|----|-----|-----|
| D1/D2 | Chapters selectable but **no batch action bar** — `MarkSelectedAsRead/Unread`, `Bookmark`, `Download`, `Delete` events had no UI entry point | Added a contextual `ChapterSelectionTopBar` (count + close, select-all, mark read/unread, bookmark, download, delete), all wired to existing `DetailsContract.Event` handlers. |

## Verification

Per changed module: `compileDebugKotlin`, `testDebugUnitTest`, root `detekt`, root `ktlintCheck` — all green offline. Library VM test got a `libraryDisplayMode` stub. `onEvent` complexity kept under detekt's threshold via a `handleDisplayEvent` helper.

## Deliberately deferred ("mirror, don't invent")

History calendar/date-range picker (H1), quick filter chips (H4), and swipe-delete undo (H3) — standard Mihon/Komikku history uses date-group headers + a confirmation dialog (both present) rather than a calendar or undo snackbar. Holding until the exact Komikku interaction is confirmed.

## Next

Reader screen (per-page long-press save/share/set-cover, crop-borders in quick settings, page thumbnail strip), then Library/History Phase B.

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chapter selection mode with batch actions (mark as read/unread, bookmark, download, delete)
  * Library display mode toggle between grid and list views
  * Browse sources button in empty library state
  * Refresh library button in updates screen
  * History clear confirmation dialog

* **Improvements**
  * Enhanced haptic feedback for interactions across library, history, and updates screens
  * Improved empty state UI and messaging
  * Better navigation state preservation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->