### PR TITLE
feat(reader): Komikku parity Phase A — crop-borders & incognito quick toggles

### DIFF
--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -445,10 +445,14 @@ fun ReaderScreen(
             readingDirection = state.readingDirection,
             brightness = state.brightness,
             colorFilterMode = state.colorFilterMode,
+            cropBordersEnabled = state.cropBordersEnabled,
+            incognitoMode = state.incognitoMode,
             onModeChange = { viewModel.onEvent(ReaderEvent.OnModeChange(it)) },
             onDirectionChange = { viewModel.onEvent(ReaderEvent.OnDirectionChange(it)) },
             onBrightnessChange = { viewModel.onEvent(ReaderEvent.OnBrightnessChange(it)) },
             onColorFilterChange = { viewModel.onEvent(ReaderEvent.SetColorFilterMode(it)) },
+            onToggleCropBorders = { viewModel.onEvent(ReaderEvent.ToggleSetting(ReaderSetting.CROP_BORDERS)) },
+            onToggleIncognito = { viewModel.onEvent(ReaderEvent.ToggleSetting(ReaderSetting.INCOGNITO_MODE)) },
             onDismiss = { viewModel.onEvent(ReaderEvent.ToggleSettingsOverlay) },
         )
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderSettingsOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderSettingsOverlay.kt
@@ -1,5 +1,6 @@
 package app.otakureader.feature.reader.ui
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
@@ -167,15 +168,22 @@ private fun ReaderToggleRow(
     checked: Boolean,
     onToggle: () -> Unit,
 ) {
+    // Whole row is clickable with vertical padding so the touch target meets the
+    // 48dp accessibility minimum; the Switch is driven by the row (onCheckedChange = null).
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onToggle() }
+            .padding(vertical = ToggleRowVerticalPadding),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(text = label, style = MaterialTheme.typography.bodyMedium)
-        Switch(checked = checked, onCheckedChange = { onToggle() })
+        Switch(checked = checked, onCheckedChange = null)
     }
 }
+
+private val ToggleRowVerticalPadding = 8.dp
 
 @Composable
 private fun ReaderMode.toLabel(): String = when (this) {

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderSettingsOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderSettingsOverlay.kt
@@ -1,7 +1,9 @@
 package app.otakureader.feature.reader.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -9,11 +11,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -40,10 +45,14 @@ fun ReaderSettingsOverlay(
     readingDirection: ReadingDirection,
     brightness: Float,
     colorFilterMode: ColorFilterMode,
+    cropBordersEnabled: Boolean,
+    incognitoMode: Boolean,
     onModeChange: (ReaderMode) -> Unit,
     onDirectionChange: (ReadingDirection) -> Unit,
     onBrightnessChange: (Float) -> Unit,
     onColorFilterChange: (ColorFilterMode) -> Unit,
+    onToggleCropBorders: () -> Unit,
+    onToggleIncognito: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     if (!isVisible) return
@@ -131,8 +140,40 @@ fun ReaderSettingsOverlay(
                 }
             }
 
+            Spacer(modifier = Modifier.height(8.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Toggles (state + persistence already handled by the ViewModel)
+            ReaderToggleRow(
+                label = stringResource(R.string.reader_crop_borders),
+                checked = cropBordersEnabled,
+                onToggle = onToggleCropBorders,
+            )
+            ReaderToggleRow(
+                label = stringResource(R.string.reader_incognito_mode),
+                checked = incognitoMode,
+                onToggle = onToggleIncognito,
+            )
+
             Spacer(modifier = Modifier.height(16.dp))
         }
+    }
+}
+
+@Composable
+private fun ReaderToggleRow(
+    label: String,
+    checked: Boolean,
+    onToggle: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(text = label, style = MaterialTheme.typography.bodyMedium)
+        Switch(checked = checked, onCheckedChange = { onToggle() })
     }
 }
 

--- a/feature/reader/src/main/res/values/strings.xml
+++ b/feature/reader/src/main/res/values/strings.xml
@@ -155,6 +155,8 @@
 
     <!-- Quick-settings overlay (#985) -->
     <string name="reader_quick_settings_title">Quick Settings</string>
+    <string name="reader_crop_borders">Crop borders</string>
+    <string name="reader_incognito_mode">Incognito mode</string>
     <string name="reader_direction_title">Reading Direction</string>
     <string name="reader_direction_ltr">Left to Right</string>
     <string name="reader_direction_rtl">Right to Left</string>


### PR DESCRIPTION
## **User description**
## Summary

Reader screen entry in the screen-by-screen Komikku-parity "Invisible 20%" audit. Surfaces two in-session settings that already had full ViewModel + persistence plumbing but no UI entry point:

| ID | Gap | Fix |
|----|-----|-----|
| **R2** | "Crop borders" only reachable via the full settings menu | Added a toggle to the long-press **quick-settings overlay** (`ReaderSettingsOverlay`). |
| **R3** | "Incognito mode" toggle not exposed anywhere in the reader UI (state existed) | Added a toggle to the quick-settings overlay. |

Both dispatch the existing `ReaderEvent.ToggleSetting(ReaderSetting.CROP_BORDERS / INCOGNITO_MODE)` — `ReaderDisplayDelegate` already updates state and persists. Added a small reusable `ReaderToggleRow` and two strings.

## Verification

- `./gradlew :feature:reader:compileDebugKotlin` ✅
- `./gradlew :feature:reader:testDebugUnitTest` ✅
- `./gradlew detekt` ✅
- `./gradlew ktlintCheck` ✅

(Only a pre-existing `hiltViewModel` deprecation warning, untouched by this change.)

## Deliberately deferred — R1 (own change)

The audit's headline Reader gap is a **per-page long-press context menu** (save image / set as cover / share page). That has **zero plumbing**: no MediaStore/save logic, no set-cover wiring, and `ReaderEvent.SharePage` is currently a "coming soon" stub. It needs new ViewModel/storage code + per-page gesture handling and should be its own reviewed change rather than bolted on here.

## Relationship to #1107

Separate branch off `main` so the Reader diff stays clean. #1107 carries Library/History/Updates/Manga-Detail Phase A.

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Show crop borders and incognito toggles in Reader quick settings**

### What Changed
- Added Crop borders and Incognito mode switches to the Reader quick settings sheet
- The toggles now appear directly in the in-reader overlay, instead of only being available elsewhere or not shown at all
- Added simple labels for the two new settings

### Impact
`✅ Faster access to reader appearance controls`
`✅ Quicker privacy switching while reading`
`✅ Fewer trips to the full settings screen`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
