### PR TITLE
feat: Komikku parity Phase B — History undo, batch mark-read, Updates pull-to-refresh & undo

### DIFF
--- a/core/ui/src/main/java/app/otakureader/core/ui/components/ManhwaCard.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/components/ManhwaCard.kt
@@ -6,7 +6,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Box
@@ -46,7 +46,8 @@ fun ManhwaCard(
     title: String,
     unreadCount: Int,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onLongClick: (() -> Unit)? = null,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isHovered by interactionSource.collectIsHoveredAsState()
@@ -72,10 +73,11 @@ fun ManhwaCard(
                 scaleY = scale
                 shadowElevation = if (isHovered) 24f else 8f
             }
-            .clickable(
+            .combinedClickable(
                 interactionSource = interactionSource,
                 indication = null,
-                onClick = onClick
+                onClick = onClick,
+                onLongClick = onLongClick,
             ),
         shape = RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -34,4 +34,6 @@
     <string name="offline_message">Check your internet connection and try again</string>
     <string name="offline_action">Retry</string>
     <string name="incognito_banner_text">Incognito — history, stats, tracking &amp; backups paused</string>
+    <!-- Generic actions shared across features -->
+    <string name="action_undo">Undo</string>
 </resources>

--- a/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
@@ -281,7 +281,11 @@ internal fun MangaHeader(
                             onClick = { isOverriddenManhwa = !isOverriddenManhwa },
                             label = {
                                 Text(
-                                    if (contentType == ContentType.MANGA) "Manga" else "Manhwa",
+                                    if (contentType == ContentType.MANGA) {
+                                        stringResource(R.string.details_content_type_manga)
+                                    } else {
+                                        stringResource(R.string.details_content_type_manhwa)
+                                    },
                                     style = MaterialTheme.typography.labelSmall
                                 )
                             }

--- a/feature/details/src/main/res/values/strings.xml
+++ b/feature/details/src/main/res/values/strings.xml
@@ -206,4 +206,7 @@
     <string name="details_more_options">More options</string>
     <string name="details_download_all_chapters">Download all chapters</string>
     <string name="details_download_unread_chapters">Download unread chapters</string>
+    <!-- Content-type chip in manga header (L13) -->
+    <string name="details_content_type_manga">Manga</string>
+    <string name="details_content_type_manhwa">Manhwa</string>
 </resources>

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryMvi.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryMvi.kt
@@ -15,6 +15,7 @@ data class HistoryState(
     val dateFilterStart: Long? = null,
     /** End of the active date filter (epoch-ms, inclusive), or null if no filter set. */
     val dateFilterEnd: Long? = null,
+    val isPullRefreshing: Boolean = false,
 ) : UiState
 
 sealed interface HistoryEvent : UiEvent {
@@ -33,6 +34,8 @@ sealed interface HistoryEvent : UiEvent {
     data class SetDateFilter(val start: Long?, val end: Long?) : HistoryEvent
     /** Remove the active date range filter and show all history entries. */
     data object ClearDateFilter : HistoryEvent
+    /** Triggered by pull-to-refresh; re-exposes current history after a brief spinner. */
+    data object RefreshHistory : HistoryEvent
 }
 
 sealed interface HistoryEffect : UiEffect {

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryMvi.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryMvi.kt
@@ -11,8 +11,6 @@ data class HistoryState(
     val searchQuery: String = "",
     val error: String? = null,
     val selectedItems: Set<Long> = emptySet(),
-    /** Chapter ID buffered for swipe-delete undo; null when no deletion is pending. */
-    val pendingDeleteChapterId: Long? = null,
 ) : UiState
 
 sealed interface HistoryEvent : UiEvent {
@@ -23,10 +21,8 @@ sealed interface HistoryEvent : UiEvent {
     data object SelectAll : HistoryEvent
     data class OnSearchQueryChange(val query: String) : HistoryEvent
     data class RemoveFromHistory(val chapterId: Long) : HistoryEvent
-    /** Commit the pending swipe-delete — called when the undo snackbar is dismissed. */
-    data object ConfirmRemoveFromHistory : HistoryEvent
-    /** Cancel the pending swipe-delete — called when the user taps Undo. */
-    data object UndoRemoveFromHistory : HistoryEvent
+    /** Cancel the pending swipe-delete; carries chapterId so the ViewModel knows which timer to cancel. */
+    data class UndoRemoveFromHistory(val chapterId: Long) : HistoryEvent
     data object RemoveSelectedFromHistory : HistoryEvent
     data object MarkSelectedAsRead : HistoryEvent
 }
@@ -34,6 +30,10 @@ sealed interface HistoryEvent : UiEvent {
 sealed interface HistoryEffect : UiEffect {
     data class NavigateToReader(val mangaId: Long, val chapterId: Long) : HistoryEffect
     data class ShowSnackbar(val messageRes: Int, val formatArgs: List<Any> = emptyList()) : HistoryEffect
-    /** Snackbar with an Undo action for swipe-delete. Awaited inline by the screen. */
-    data class ShowUndoSnackbar(val messageRes: Int) : HistoryEffect
+    /**
+     * Snackbar with an Undo action for swipe-delete. Carries the chapterId so the screen can
+     * pass it back in [HistoryEvent.UndoRemoveFromHistory] without keeping extra UI state.
+     * The ViewModel auto-commits after [HistoryViewModel.UNDO_TIMEOUT_MS] regardless of UI state.
+     */
+    data class ShowUndoSnackbar(val messageRes: Int, val chapterId: Long) : HistoryEffect
 }

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryMvi.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryMvi.kt
@@ -11,6 +11,10 @@ data class HistoryState(
     val searchQuery: String = "",
     val error: String? = null,
     val selectedItems: Set<Long> = emptySet(),
+    /** Start of the active date filter (epoch-ms, inclusive), or null if no filter set. */
+    val dateFilterStart: Long? = null,
+    /** End of the active date filter (epoch-ms, inclusive), or null if no filter set. */
+    val dateFilterEnd: Long? = null,
 ) : UiState
 
 sealed interface HistoryEvent : UiEvent {
@@ -25,6 +29,10 @@ sealed interface HistoryEvent : UiEvent {
     data class UndoRemoveFromHistory(val chapterId: Long) : HistoryEvent
     data object RemoveSelectedFromHistory : HistoryEvent
     data object MarkSelectedAsRead : HistoryEvent
+    /** Apply an explicit date range filter. Pass null for either bound to leave it open-ended. */
+    data class SetDateFilter(val start: Long?, val end: Long?) : HistoryEvent
+    /** Remove the active date range filter and show all history entries. */
+    data object ClearDateFilter : HistoryEvent
 }
 
 sealed interface HistoryEffect : UiEffect {

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryMvi.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryMvi.kt
@@ -10,7 +10,9 @@ data class HistoryState(
     val history: List<ChapterWithHistory> = emptyList(),
     val searchQuery: String = "",
     val error: String? = null,
-    val selectedItems: Set<Long> = emptySet()
+    val selectedItems: Set<Long> = emptySet(),
+    /** Chapter ID buffered for swipe-delete undo; null when no deletion is pending. */
+    val pendingDeleteChapterId: Long? = null,
 ) : UiState
 
 sealed interface HistoryEvent : UiEvent {
@@ -21,10 +23,17 @@ sealed interface HistoryEvent : UiEvent {
     data object SelectAll : HistoryEvent
     data class OnSearchQueryChange(val query: String) : HistoryEvent
     data class RemoveFromHistory(val chapterId: Long) : HistoryEvent
+    /** Commit the pending swipe-delete — called when the undo snackbar is dismissed. */
+    data object ConfirmRemoveFromHistory : HistoryEvent
+    /** Cancel the pending swipe-delete — called when the user taps Undo. */
+    data object UndoRemoveFromHistory : HistoryEvent
     data object RemoveSelectedFromHistory : HistoryEvent
+    data object MarkSelectedAsRead : HistoryEvent
 }
 
 sealed interface HistoryEffect : UiEffect {
     data class NavigateToReader(val mangaId: Long, val chapterId: Long) : HistoryEffect
     data class ShowSnackbar(val messageRes: Int, val formatArgs: List<Any> = emptyList()) : HistoryEffect
+    /** Snackbar with an Undo action for swipe-delete. Awaited inline by the screen. */
+    data class ShowUndoSnackbar(val messageRes: Int) : HistoryEffect
 }

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.History
@@ -36,8 +37,10 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -109,6 +112,19 @@ fun HistoryScreen(
                     }
                     snackbarHostState.showSnackbar(msg)
                 }
+                // Inline await so collectLatest cancels it if a new swipe fires (which is correct —
+                // the ViewModel commits the previous pending item automatically on a new swipe).
+                is HistoryEffect.ShowUndoSnackbar -> {
+                    val result = snackbarHostState.showSnackbar(
+                        message = context.getString(effect.messageRes),
+                        actionLabel = context.getString(R.string.history_undo_action),
+                        duration = SnackbarDuration.Short,
+                    )
+                    when (result) {
+                        SnackbarResult.ActionPerformed -> viewModel.onEvent(HistoryEvent.UndoRemoveFromHistory)
+                        SnackbarResult.Dismissed -> viewModel.onEvent(HistoryEvent.ConfirmRemoveFromHistory)
+                    }
+                }
             }
         }
     }
@@ -137,6 +153,9 @@ fun HistoryScreen(
                 },
                 actions = {
                     if (state.selectedItems.isNotEmpty()) {
+                        IconButton(onClick = { viewModel.onEvent(HistoryEvent.MarkSelectedAsRead) }) {
+                            Icon(Icons.Default.CheckCircle, contentDescription = stringResource(R.string.history_mark_read))
+                        }
                         IconButton(onClick = { viewModel.onEvent(HistoryEvent.RemoveSelectedFromHistory) }) {
                             Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.history_delete_selected))
                         }

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
@@ -15,8 +15,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
@@ -27,10 +30,14 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.foundation.background
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DateRangePicker
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.rememberDateRangePickerState
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -99,6 +106,8 @@ fun HistoryScreen(
     val context = LocalContext.current
     val haptic = LocalHapticFeedback.current
     var showClearConfirm by remember { mutableStateOf(false) }
+    var showDateRangePicker by remember { mutableStateOf(false) }
+    val dateRangePickerState = rememberDateRangePickerState()
 
     LaunchedEffect(viewModel.effect) {
         viewModel.effect.collectLatest { effect ->
@@ -161,6 +170,9 @@ fun HistoryScreen(
                             Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.history_delete_selected))
                         }
                     } else {
+                        IconButton(onClick = { showDateRangePicker = true }) {
+                            Icon(Icons.Default.CalendarToday, contentDescription = stringResource(R.string.history_filter_calendar))
+                        }
                         if (state.history.isNotEmpty()) {
                             IconButton(onClick = { viewModel.onEvent(HistoryEvent.SelectAll) }) {
                                 Icon(Icons.Default.SelectAll, contentDescription = stringResource(R.string.history_select_all))
@@ -192,6 +204,56 @@ fun HistoryScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 8.dp)
             )
+
+            // Date filter chips (H1 + H4)
+            val hasDateFilter = state.dateFilterStart != null || state.dateFilterEnd != null
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 4.dp)
+            ) {
+                val now = System.currentTimeMillis()
+                // Quick chip: last 7 days
+                FilterChip(
+                    selected = state.dateFilterStart == now - 7L * 24 * 60 * 60 * 1000 && state.dateFilterEnd == null,
+                    onClick = {
+                        if (state.dateFilterStart == now - 7L * 24 * 60 * 60 * 1000 && state.dateFilterEnd == null) {
+                            viewModel.onEvent(HistoryEvent.ClearDateFilter)
+                        } else {
+                            viewModel.onEvent(HistoryEvent.SetDateFilter(now - 7L * 24 * 60 * 60 * 1000, null))
+                        }
+                    },
+                    label = { Text(stringResource(R.string.history_filter_last_7_days)) },
+                )
+                // Quick chip: last 30 days
+                FilterChip(
+                    selected = state.dateFilterStart == now - 30L * 24 * 60 * 60 * 1000 && state.dateFilterEnd == null,
+                    onClick = {
+                        if (state.dateFilterStart == now - 30L * 24 * 60 * 60 * 1000 && state.dateFilterEnd == null) {
+                            viewModel.onEvent(HistoryEvent.ClearDateFilter)
+                        } else {
+                            viewModel.onEvent(HistoryEvent.SetDateFilter(now - 30L * 24 * 60 * 60 * 1000, null))
+                        }
+                    },
+                    label = { Text(stringResource(R.string.history_filter_last_30_days)) },
+                )
+                // Active custom date range chip (shown when a range picker result is set)
+                val filterStart = state.dateFilterStart
+                val filterEnd = state.dateFilterEnd
+                if (hasDateFilter && filterStart != null && filterEnd != null) {
+                    val fmt = DateTimeFormatter.ofPattern("MMM d", Locale.getDefault())
+                    val startLabel = Instant.ofEpochMilli(filterStart).atZone(ZoneId.systemDefault()).toLocalDate().format(fmt)
+                    val endLabel = Instant.ofEpochMilli(filterEnd).atZone(ZoneId.systemDefault()).toLocalDate().format(fmt)
+                    FilterChip(
+                        selected = true,
+                        onClick = { viewModel.onEvent(HistoryEvent.ClearDateFilter) },
+                        label = { Text(stringResource(R.string.history_filter_active, startLabel, endLabel)) },
+                        trailingIcon = { Icon(Icons.Default.Close, contentDescription = stringResource(R.string.history_filter_clear), modifier = Modifier.size(16.dp)) },
+                    )
+                }
+            }
 
             when {
                 state.isLoading -> Box(
@@ -274,6 +336,32 @@ fun HistoryScreen(
                 }
             },
         )
+    }
+
+    if (showDateRangePicker) {
+        DatePickerDialog(
+            onDismissRequest = { showDateRangePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    val start = dateRangePickerState.selectedStartDateMillis
+                    val end = dateRangePickerState.selectedEndDateMillis?.let { it + 24 * 60 * 60 * 1000 - 1 }
+                    viewModel.onEvent(HistoryEvent.SetDateFilter(start, end))
+                    showDateRangePicker = false
+                }) {
+                    Text(stringResource(R.string.history_filter_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDateRangePicker = false }) {
+                    Text(stringResource(R.string.history_filter_cancel))
+                }
+            },
+        ) {
+            DateRangePicker(
+                state = dateRangePickerState,
+                modifier = Modifier.weight(1f),
+            )
+        }
     }
 }
 

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -261,64 +262,70 @@ fun HistoryScreen(
                 }
             }
 
-            when {
-                state.isLoading -> Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator()
-                }
-                state.error != null -> Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = state.error ?: stringResource(R.string.history_unknown_error),
-                        color = MaterialTheme.colorScheme.error
+            PullToRefreshBox(
+                isRefreshing = state.isPullRefreshing,
+                onRefresh = { viewModel.onEvent(HistoryEvent.RefreshHistory) },
+                modifier = Modifier.weight(1f),
+            ) {
+                when {
+                    state.isLoading -> Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                    state.error != null -> Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = state.error ?: stringResource(R.string.history_unknown_error),
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                    state.history.isEmpty() -> Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (state.searchQuery.isBlank()) {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                modifier = Modifier.padding(HistoryEmptyStateDefaults.Padding),
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.History,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(HistoryEmptyStateDefaults.IconSize),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Spacer(modifier = Modifier.height(HistoryEmptyStateDefaults.Spacing))
+                                Text(
+                                    text = stringResource(R.string.history_empty),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        } else {
+                            Text(text = stringResource(R.string.history_no_results, state.searchQuery))
+                        }
+                    }
+                    else -> HistoryList(
+                        history = state.history,
+                        selectedItems = state.selectedItems,
+                        onItemClick = { entry ->
+                            viewModel.onEvent(
+                                HistoryEvent.OnChapterClick(entry.chapter.mangaId, entry.chapter.id)
+                            )
+                        },
+                        onItemLongClick = { entry ->
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            viewModel.onEvent(HistoryEvent.OnChapterLongClick(entry.chapter.id))
+                        },
+                        onRemoveClick = { entry ->
+                            viewModel.onEvent(HistoryEvent.RemoveFromHistory(entry.chapter.id))
+                        }
                     )
                 }
-                state.history.isEmpty() -> Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    if (state.searchQuery.isBlank()) {
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            modifier = Modifier.padding(HistoryEmptyStateDefaults.Padding),
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.History,
-                                contentDescription = null,
-                                modifier = Modifier.size(HistoryEmptyStateDefaults.IconSize),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Spacer(modifier = Modifier.height(HistoryEmptyStateDefaults.Spacing))
-                            Text(
-                                text = stringResource(R.string.history_empty),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    } else {
-                        Text(text = stringResource(R.string.history_no_results, state.searchQuery))
-                    }
-                }
-                else -> HistoryList(
-                    history = state.history,
-                    selectedItems = state.selectedItems,
-                    onItemClick = { entry ->
-                        viewModel.onEvent(
-                            HistoryEvent.OnChapterClick(entry.chapter.mangaId, entry.chapter.id)
-                        )
-                    },
-                    onItemLongClick = { entry ->
-                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        viewModel.onEvent(HistoryEvent.OnChapterLongClick(entry.chapter.id))
-                    },
-                    onRemoveClick = { entry ->
-                        viewModel.onEvent(HistoryEvent.RemoveFromHistory(entry.chapter.id))
-                    }
-                )
             }
         }
     }

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
@@ -250,7 +250,13 @@ fun HistoryScreen(
                         selected = true,
                         onClick = { viewModel.onEvent(HistoryEvent.ClearDateFilter) },
                         label = { Text(stringResource(R.string.history_filter_active, startLabel, endLabel)) },
-                        trailingIcon = { Icon(Icons.Default.Close, contentDescription = stringResource(R.string.history_filter_clear), modifier = Modifier.size(16.dp)) },
+                        trailingIcon = {
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = stringResource(R.string.history_filter_clear),
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
                     )
                 }
             }

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
@@ -112,18 +112,19 @@ fun HistoryScreen(
                     }
                     snackbarHostState.showSnackbar(msg)
                 }
-                // Inline await so collectLatest cancels it if a new swipe fires (which is correct —
-                // the ViewModel commits the previous pending item automatically on a new swipe).
-                is HistoryEffect.ShowUndoSnackbar -> {
+                // Launch in a separate coroutine so collectLatest cancelling on the next swipe
+                // does not cut the snackbar short. The ViewModel owns the auto-commit timer;
+                // the screen only needs to signal Undo if the user taps the action.
+                is HistoryEffect.ShowUndoSnackbar -> scope.launch {
                     val result = snackbarHostState.showSnackbar(
                         message = context.getString(effect.messageRes),
                         actionLabel = context.getString(R.string.history_undo_action),
                         duration = SnackbarDuration.Short,
                     )
-                    when (result) {
-                        SnackbarResult.ActionPerformed -> viewModel.onEvent(HistoryEvent.UndoRemoveFromHistory)
-                        SnackbarResult.Dismissed -> viewModel.onEvent(HistoryEvent.ConfirmRemoveFromHistory)
+                    if (result == SnackbarResult.ActionPerformed) {
+                        viewModel.onEvent(HistoryEvent.UndoRemoveFromHistory(effect.chapterId))
                     }
+                    // Dismissed → VM auto-commits after UNDO_TIMEOUT_MS; no UI action needed.
                 }
             }
         }

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryViewModel.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryViewModel.kt
@@ -35,11 +35,15 @@ class HistoryViewModel @Inject constructor(
 
     private val searchQuery = MutableStateFlow("")
 
+    /** Chapter ID currently staged for swipe-delete; filtered from the displayed list. */
+    private val pendingDeleteId = MutableStateFlow<Long?>(null)
+
     init {
         _state.update { it.copy(isLoading = true) }
-        combine(getHistoryUseCase(), searchQuery) { allEntries, query ->
-            if (query.isBlank()) allEntries
+        combine(getHistoryUseCase(), searchQuery, pendingDeleteId) { allEntries, query, pendingId ->
+            val filtered = if (query.isBlank()) allEntries
             else allEntries.filter { it.chapter.name.contains(query, ignoreCase = true) }
+            if (pendingId != null) filtered.filter { it.chapter.id != pendingId } else filtered
         }
             .onEach { filtered ->
                 _state.update { it.copy(isLoading = false, history = filtered, error = null) }
@@ -61,8 +65,11 @@ class HistoryViewModel @Inject constructor(
                 searchQuery.value = event.query
                 _state.update { it.copy(searchQuery = event.query) }
             }
-            is HistoryEvent.RemoveFromHistory -> removeFromHistory(event.chapterId)
+            is HistoryEvent.RemoveFromHistory -> scheduleRemoveFromHistory(event.chapterId)
+            is HistoryEvent.UndoRemoveFromHistory -> undoRemoveFromHistory()
+            is HistoryEvent.ConfirmRemoveFromHistory -> confirmRemoveFromHistory()
             is HistoryEvent.RemoveSelectedFromHistory -> removeSelectedFromHistory()
+            is HistoryEvent.MarkSelectedAsRead -> markSelectedAsRead()
         }
     }
 
@@ -94,6 +101,61 @@ class HistoryViewModel @Inject constructor(
         _state.update { state ->
             val allIds = state.history.map { it.chapter.id }.toSet()
             state.copy(selectedItems = allIds)
+        }
+    }
+
+    /**
+     * Buffer the chapter for deletion. If another chapter was already pending,
+     * it is committed first so only one undo is active at a time.
+     */
+    private fun scheduleRemoveFromHistory(chapterId: Long) {
+        val previousPending = pendingDeleteId.value
+        if (previousPending != null && previousPending != chapterId) {
+            viewModelScope.launch {
+                try { chapterRepository.removeFromHistory(previousPending) } catch (_: Exception) { }
+            }
+        }
+        pendingDeleteId.value = chapterId
+        _state.update { it.copy(pendingDeleteChapterId = chapterId) }
+        viewModelScope.launch {
+            _effect.send(HistoryEffect.ShowUndoSnackbar(R.string.history_removed_undo))
+        }
+    }
+
+    private fun undoRemoveFromHistory() {
+        pendingDeleteId.value = null
+        _state.update { it.copy(pendingDeleteChapterId = null) }
+    }
+
+    private fun confirmRemoveFromHistory() {
+        val chapterId = _state.value.pendingDeleteChapterId ?: return
+        pendingDeleteId.value = null
+        _state.update { it.copy(pendingDeleteChapterId = null) }
+        viewModelScope.launch {
+            try {
+                chapterRepository.removeFromHistory(chapterId)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(HistoryEffect.ShowSnackbar(R.string.history_remove_failed))
+            }
+        }
+    }
+
+    private fun markSelectedAsRead() {
+        val selected = _state.value.selectedItems
+        if (selected.isEmpty()) return
+        val count = selected.size
+        viewModelScope.launch {
+            try {
+                chapterRepository.updateChapterProgress(selected, read = true, lastPageRead = 0)
+                _state.update { it.copy(selectedItems = it.selectedItems - selected) }
+                _effect.send(HistoryEffect.ShowSnackbar(R.string.history_marked_read_count, listOf(count)))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(HistoryEffect.ShowSnackbar(R.string.history_mark_read_failed))
+            }
         }
     }
 
@@ -136,18 +198,6 @@ class HistoryViewModel @Inject constructor(
                 throw e
             } catch (e: Exception) {
                 _effect.send(HistoryEffect.ShowSnackbar(R.string.history_clear_failed))
-            }
-        }
-    }
-
-    private fun removeFromHistory(chapterId: Long) {
-        viewModelScope.launch {
-            try {
-                chapterRepository.removeFromHistory(chapterId)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                _effect.send(HistoryEffect.ShowSnackbar(R.string.history_remove_failed))
             }
         }
     }

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryViewModel.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.viewModelScope
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.usecase.GetHistoryUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -27,6 +29,10 @@ class HistoryViewModel @Inject constructor(
     private val chapterRepository: ChapterRepository
 ) : ViewModel() {
 
+    companion object {
+        const val UNDO_TIMEOUT_MS = 4_000L
+    }
+
     private val _state = MutableStateFlow(HistoryState())
     val state: StateFlow<HistoryState> = _state.asStateFlow()
 
@@ -35,15 +41,19 @@ class HistoryViewModel @Inject constructor(
 
     private val searchQuery = MutableStateFlow("")
 
-    /** Chapter ID currently staged for swipe-delete; filtered from the displayed list. */
-    private val pendingDeleteId = MutableStateFlow<Long?>(null)
+    /** Chapters currently staged for swipe-delete; filtered from the displayed list. */
+    private val pendingDeleteIds = MutableStateFlow<Set<Long>>(emptySet())
+
+    /** The one chapter whose undo timer is currently running. */
+    private var pendingDeleteJob: Job? = null
+    private var pendingDeleteJobChapterId: Long? = null
 
     init {
         _state.update { it.copy(isLoading = true) }
-        combine(getHistoryUseCase(), searchQuery, pendingDeleteId) { allEntries, query, pendingId ->
+        combine(getHistoryUseCase(), searchQuery, pendingDeleteIds) { allEntries, query, pendingIds ->
             val filtered = if (query.isBlank()) allEntries
             else allEntries.filter { it.chapter.name.contains(query, ignoreCase = true) }
-            if (pendingId != null) filtered.filter { it.chapter.id != pendingId } else filtered
+            if (pendingIds.isEmpty()) filtered else filtered.filter { it.chapter.id !in pendingIds }
         }
             .onEach { filtered ->
                 _state.update { it.copy(isLoading = false, history = filtered, error = null) }
@@ -66,8 +76,7 @@ class HistoryViewModel @Inject constructor(
                 _state.update { it.copy(searchQuery = event.query) }
             }
             is HistoryEvent.RemoveFromHistory -> scheduleRemoveFromHistory(event.chapterId)
-            is HistoryEvent.UndoRemoveFromHistory -> undoRemoveFromHistory()
-            is HistoryEvent.ConfirmRemoveFromHistory -> confirmRemoveFromHistory()
+            is HistoryEvent.UndoRemoveFromHistory -> undoRemoveFromHistory(event.chapterId)
             is HistoryEvent.RemoveSelectedFromHistory -> removeSelectedFromHistory()
             is HistoryEvent.MarkSelectedAsRead -> markSelectedAsRead()
         }
@@ -105,40 +114,57 @@ class HistoryViewModel @Inject constructor(
     }
 
     /**
-     * Buffer the chapter for deletion. If another chapter was already pending,
-     * it is committed first so only one undo is active at a time.
+     * Buffer the chapter for deletion. If a different chapter was already pending,
+     * commit it immediately so only one undo timer is active at a time.
+     * The auto-commit fires after [UNDO_TIMEOUT_MS] unless the user taps Undo first.
      */
     private fun scheduleRemoveFromHistory(chapterId: Long) {
-        val previousPending = pendingDeleteId.value
-        if (previousPending != null && previousPending != chapterId) {
+        val previousId = pendingDeleteJobChapterId
+        if (previousId != null && previousId != chapterId) {
+            pendingDeleteJob?.cancel()
             viewModelScope.launch {
-                try { chapterRepository.removeFromHistory(previousPending) } catch (_: Exception) { }
+                try { chapterRepository.removeFromHistory(previousId) } catch (_: Exception) {}
+                pendingDeleteIds.update { it - previousId }
             }
         }
-        pendingDeleteId.value = chapterId
-        _state.update { it.copy(pendingDeleteChapterId = chapterId) }
-        viewModelScope.launch {
-            _effect.send(HistoryEffect.ShowUndoSnackbar(R.string.history_removed_undo))
+        pendingDeleteIds.update { it + chapterId }
+        pendingDeleteJobChapterId = chapterId
+        pendingDeleteJob = viewModelScope.launch {
+            _effect.send(HistoryEffect.ShowUndoSnackbar(R.string.history_removed_undo, chapterId))
+            delay(UNDO_TIMEOUT_MS)
+            doRemoveFromHistory(chapterId)
         }
     }
 
-    private fun undoRemoveFromHistory() {
-        pendingDeleteId.value = null
-        _state.update { it.copy(pendingDeleteChapterId = null) }
+    private fun undoRemoveFromHistory(chapterId: Long) {
+        if (pendingDeleteJobChapterId != chapterId) return
+        pendingDeleteJob?.cancel()
+        pendingDeleteJob = null
+        pendingDeleteJobChapterId = null
+        pendingDeleteIds.update { it - chapterId }
     }
 
-    private fun confirmRemoveFromHistory() {
-        val chapterId = _state.value.pendingDeleteChapterId ?: return
-        pendingDeleteId.value = null
-        _state.update { it.copy(pendingDeleteChapterId = null) }
+    private suspend fun doRemoveFromHistory(chapterId: Long) {
+        try {
+            chapterRepository.removeFromHistory(chapterId)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            pendingDeleteIds.update { it - chapterId }
+            _effect.send(HistoryEffect.ShowSnackbar(R.string.history_remove_failed))
+            return
+        }
+        pendingDeleteIds.update { it - chapterId }
+        if (pendingDeleteJobChapterId == chapterId) pendingDeleteJobChapterId = null
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        val chapterId = pendingDeleteJobChapterId ?: return
+        pendingDeleteJobChapterId = null
         viewModelScope.launch {
-            try {
-                chapterRepository.removeFromHistory(chapterId)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                _effect.send(HistoryEffect.ShowSnackbar(R.string.history_remove_failed))
-            }
+            try { chapterRepository.removeFromHistory(chapterId) } catch (_: Exception) {}
+            pendingDeleteIds.update { it - chapterId }
         }
     }
 
@@ -153,7 +179,7 @@ class HistoryViewModel @Inject constructor(
                 _effect.send(HistoryEffect.ShowSnackbar(R.string.history_marked_read_count, listOf(count)))
             } catch (e: CancellationException) {
                 throw e
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 _effect.send(HistoryEffect.ShowSnackbar(R.string.history_mark_read_failed))
             }
         }
@@ -177,7 +203,7 @@ class HistoryViewModel @Inject constructor(
                 }
             } catch (e: CancellationException) {
                 throw e
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 _effect.send(HistoryEffect.ShowSnackbar(R.string.history_remove_failed))
             }
         }
@@ -196,7 +222,7 @@ class HistoryViewModel @Inject constructor(
                 _effect.send(HistoryEffect.ShowSnackbar(R.string.history_cleared))
             } catch (e: CancellationException) {
                 throw e
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 _effect.send(HistoryEffect.ShowSnackbar(R.string.history_clear_failed))
             }
         }

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryViewModel.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryViewModel.kt
@@ -92,6 +92,13 @@ class HistoryViewModel @Inject constructor(
                 dateFilter.value = Pair(null, null)
                 _state.update { it.copy(dateFilterStart = null, dateFilterEnd = null) }
             }
+            HistoryEvent.RefreshHistory -> {
+                _state.update { it.copy(isPullRefreshing = true) }
+                viewModelScope.launch {
+                    delay(1_000L)
+                    _state.update { it.copy(isPullRefreshing = false) }
+                }
+            }
         }
     }
 

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryViewModel.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryViewModel.kt
@@ -48,11 +48,16 @@ class HistoryViewModel @Inject constructor(
     private var pendingDeleteJob: Job? = null
     private var pendingDeleteJobChapterId: Long? = null
 
+    /** Active date filter: (start, end) epoch-ms. Null means unset (open-ended). */
+    private val dateFilter = MutableStateFlow(Pair<Long?, Long?>(null, null))
+
     init {
         _state.update { it.copy(isLoading = true) }
-        combine(getHistoryUseCase(), searchQuery, pendingDeleteIds) { allEntries, query, pendingIds ->
-            val filtered = if (query.isBlank()) allEntries
+        combine(getHistoryUseCase(), searchQuery, pendingDeleteIds, dateFilter) { allEntries, query, pendingIds, (start, end) ->
+            var filtered = if (query.isBlank()) allEntries
             else allEntries.filter { it.chapter.name.contains(query, ignoreCase = true) }
+            if (start != null) filtered = filtered.filter { it.readAt >= start }
+            if (end != null) filtered = filtered.filter { it.readAt <= end }
             if (pendingIds.isEmpty()) filtered else filtered.filter { it.chapter.id !in pendingIds }
         }
             .onEach { filtered ->
@@ -79,6 +84,14 @@ class HistoryViewModel @Inject constructor(
             is HistoryEvent.UndoRemoveFromHistory -> undoRemoveFromHistory(event.chapterId)
             is HistoryEvent.RemoveSelectedFromHistory -> removeSelectedFromHistory()
             is HistoryEvent.MarkSelectedAsRead -> markSelectedAsRead()
+            is HistoryEvent.SetDateFilter -> {
+                dateFilter.value = Pair(event.start, event.end)
+                _state.update { it.copy(dateFilterStart = event.start, dateFilterEnd = event.end) }
+            }
+            HistoryEvent.ClearDateFilter -> {
+                dateFilter.value = Pair(null, null)
+                _state.update { it.copy(dateFilterStart = null, dateFilterEnd = null) }
+            }
         }
     }
 

--- a/feature/history/src/main/res/values/strings.xml
+++ b/feature/history/src/main/res/values/strings.xml
@@ -24,6 +24,13 @@
     <string name="history_clear_failed">Failed to clear history</string>
     <string name="history_remove_failed">Failed to remove from history</string>
     <string name="history_removed_count">Removed %1$d item(s) from history</string>
+    <!-- Batch mark as read -->
+    <string name="history_mark_read">Mark as read</string>
+    <string name="history_marked_read_count">Marked %1$d chapter(s) as read</string>
+    <string name="history_mark_read_failed">Failed to mark as read</string>
+    <!-- Swipe-delete undo -->
+    <string name="history_removed_undo">Removed from history</string>
+    <string name="history_undo_action">Undo</string>
     <!-- Date group headers -->
     <string name="history_date_today">Today</string>
     <string name="history_date_yesterday">Yesterday</string>

--- a/feature/history/src/main/res/values/strings.xml
+++ b/feature/history/src/main/res/values/strings.xml
@@ -31,6 +31,16 @@
     <!-- Swipe-delete undo -->
     <string name="history_removed_undo">Removed from history</string>
     <string name="history_undo_action">Undo</string>
+    <!-- Date filter -->
+    <string name="history_filter_date_range">Date range</string>
+    <string name="history_filter_last_7_days">Last 7 days</string>
+    <string name="history_filter_last_30_days">Last 30 days</string>
+    <string name="history_filter_active">%1$s – %2$s</string>
+    <string name="history_filter_clear">Clear date filter</string>
+    <string name="history_filter_calendar">Select date range</string>
+    <string name="history_filter_confirm">OK</string>
+    <string name="history_filter_cancel">Cancel</string>
+
     <!-- Date group headers -->
     <string name="history_date_today">Today</string>
     <string name="history_date_yesterday">Yesterday</string>

--- a/feature/history/src/test/java/app/otakureader/feature/history/HistoryViewModelTest.kt
+++ b/feature/history/src/test/java/app/otakureader/feature/history/HistoryViewModelTest.kt
@@ -391,4 +391,48 @@ class HistoryViewModelTest {
 
         coVerify(exactly = 0) { chapterRepository.removeFromHistory(any()) }
     }
+
+    @Test
+    fun onEvent_SetDateFilter_updatesDateFilterState() = runTest {
+        every { getHistoryUseCase() } returns flowOf(sampleHistory)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(HistoryEvent.SetDateFilter(start = 1_000L, end = 3_000L))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1_000L, viewModel.state.value.dateFilterStart)
+        assertEquals(3_000L, viewModel.state.value.dateFilterEnd)
+    }
+
+    @Test
+    fun onEvent_ClearDateFilter_removesDateFilterState() = runTest {
+        every { getHistoryUseCase() } returns flowOf(sampleHistory)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(HistoryEvent.SetDateFilter(start = 1_000L, end = 3_000L))
+        testDispatcher.scheduler.advanceUntilIdle()
+        viewModel.onEvent(HistoryEvent.ClearDateFilter)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(viewModel.state.value.dateFilterStart)
+        assertNull(viewModel.state.value.dateFilterEnd)
+    }
+
+    @Test
+    fun onEvent_RefreshHistory_setsPullRefreshingThenClearsIt() = runTest {
+        every { getHistoryUseCase() } returns flowOf(sampleHistory)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(HistoryEvent.RefreshHistory)
+        assertTrue(viewModel.state.value.isPullRefreshing)
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertFalse(viewModel.state.value.isPullRefreshing)
+    }
 }

--- a/feature/history/src/test/java/app/otakureader/feature/history/HistoryViewModelTest.kt
+++ b/feature/history/src/test/java/app/otakureader/feature/history/HistoryViewModelTest.kt
@@ -255,17 +255,90 @@ class HistoryViewModelTest {
     }
 
     @Test
-    fun onEvent_RemoveFromHistory_invokesRepository() = runTest {
+    fun onEvent_RemoveFromHistory_setsPendingDeleteAndEmitsUndoEffect() = runTest {
+        every { getHistoryUseCase() } returns flowOf(sampleHistory)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.effect.test {
+            viewModel.onEvent(HistoryEvent.RemoveFromHistory(chapterId = 1L))
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(1L, viewModel.state.value.pendingDeleteChapterId)
+            val effect = awaitItem()
+            assertTrue(effect is HistoryEffect.ShowUndoSnackbar)
+        }
+        // Repo must NOT be called yet — deletion is buffered until confirmed
+        coVerify(exactly = 0) { chapterRepository.removeFromHistory(any()) }
+    }
+
+    @Test
+    fun onEvent_ConfirmRemoveFromHistory_callsRepositoryAndClearsPending() = runTest {
         every { getHistoryUseCase() } returns flowOf(sampleHistory)
         coEvery { chapterRepository.removeFromHistory(any()) } returns Unit
 
         val viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
 
-        viewModel.onEvent(HistoryEvent.RemoveFromHistory(chapterId = 1L))
+        // Stage a deletion
+        viewModel.effect.test {
+            viewModel.onEvent(HistoryEvent.RemoveFromHistory(chapterId = 1L))
+            testDispatcher.scheduler.advanceUntilIdle()
+            awaitItem() // consume ShowUndoSnackbar
+        }
+        assertEquals(1L, viewModel.state.value.pendingDeleteChapterId)
+
+        viewModel.onEvent(HistoryEvent.ConfirmRemoveFromHistory)
         testDispatcher.scheduler.advanceUntilIdle()
 
+        assertNull(viewModel.state.value.pendingDeleteChapterId)
         coVerify(exactly = 1) { chapterRepository.removeFromHistory(1L) }
+    }
+
+    @Test
+    fun onEvent_UndoRemoveFromHistory_clearsPendingWithoutDeletion() = runTest {
+        every { getHistoryUseCase() } returns flowOf(sampleHistory)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.effect.test {
+            viewModel.onEvent(HistoryEvent.RemoveFromHistory(chapterId = 2L))
+            testDispatcher.scheduler.advanceUntilIdle()
+            awaitItem()
+        }
+        assertEquals(2L, viewModel.state.value.pendingDeleteChapterId)
+
+        viewModel.onEvent(HistoryEvent.UndoRemoveFromHistory)
+
+        assertNull(viewModel.state.value.pendingDeleteChapterId)
+        coVerify(exactly = 0) { chapterRepository.removeFromHistory(any()) }
+    }
+
+    @Test
+    fun onEvent_MarkSelectedAsRead_callsRepositoryAndClearsSelection() = runTest {
+        every { getHistoryUseCase() } returns flowOf(sampleHistory)
+        coEvery { chapterRepository.updateChapterProgress(any<Collection<Long>>(), any(), any()) } returns Unit
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(HistoryEvent.OnChapterLongClick(1L))
+        viewModel.onEvent(HistoryEvent.OnChapterLongClick(2L))
+        assertEquals(2, viewModel.state.value.selectedItems.size)
+
+        viewModel.effect.test {
+            viewModel.onEvent(HistoryEvent.MarkSelectedAsRead)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val effect = awaitItem()
+            assertTrue(effect is HistoryEffect.ShowSnackbar)
+            assertTrue((effect as HistoryEffect.ShowSnackbar).formatArgs.contains(2))
+        }
+
+        assertTrue(viewModel.state.value.selectedItems.isEmpty())
+        coVerify(exactly = 1) { chapterRepository.updateChapterProgress(match<Collection<Long>> { it.containsAll(listOf(1L, 2L)) }, true, 0) }
     }
 
     @Test

--- a/feature/history/src/test/java/app/otakureader/feature/history/HistoryViewModelTest.kt
+++ b/feature/history/src/test/java/app/otakureader/feature/history/HistoryViewModelTest.kt
@@ -255,45 +255,52 @@ class HistoryViewModelTest {
     }
 
     @Test
-    fun onEvent_RemoveFromHistory_setsPendingDeleteAndEmitsUndoEffect() = runTest {
+    fun onEvent_RemoveFromHistory_hidesItemAndEmitsUndoEffect() = runTest {
         every { getHistoryUseCase() } returns flowOf(sampleHistory)
 
         val viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(3, viewModel.state.value.history.size)
 
         viewModel.effect.test {
             viewModel.onEvent(HistoryEvent.RemoveFromHistory(chapterId = 1L))
-            testDispatcher.scheduler.advanceUntilIdle()
+            // runCurrent() processes tasks at t=0 (combine re-emit + effect send)
+            // without advancing through delay(UNDO_TIMEOUT_MS) at t=4000.
+            testDispatcher.scheduler.runCurrent()
 
-            assertEquals(1L, viewModel.state.value.pendingDeleteChapterId)
+            // Chapter is hidden from the list while the undo timer is running
+            assertEquals(2, viewModel.state.value.history.size)
+
             val effect = awaitItem()
             assertTrue(effect is HistoryEffect.ShowUndoSnackbar)
+            assertEquals(1L, (effect as HistoryEffect.ShowUndoSnackbar).chapterId)
+
+            cancelAndIgnoreRemainingEvents()
         }
-        // Repo must NOT be called yet — deletion is buffered until confirmed
+        // Repo must NOT be called yet — deletion auto-commits after UNDO_TIMEOUT_MS
         coVerify(exactly = 0) { chapterRepository.removeFromHistory(any()) }
     }
 
     @Test
-    fun onEvent_ConfirmRemoveFromHistory_callsRepositoryAndClearsPending() = runTest {
+    fun onEvent_RemoveFromHistory_autoCommitsAfterTimeout() = runTest {
         every { getHistoryUseCase() } returns flowOf(sampleHistory)
         coEvery { chapterRepository.removeFromHistory(any()) } returns Unit
 
         val viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
 
-        // Stage a deletion
         viewModel.effect.test {
             viewModel.onEvent(HistoryEvent.RemoveFromHistory(chapterId = 1L))
-            testDispatcher.scheduler.advanceUntilIdle()
+            testDispatcher.scheduler.runCurrent()  // send effect, suspend at delay
             awaitItem() // consume ShowUndoSnackbar
+
+            // Advance the virtual clock past the auto-commit delay
+            testDispatcher.scheduler.advanceTimeBy(HistoryViewModel.UNDO_TIMEOUT_MS + 1)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            coVerify(exactly = 1) { chapterRepository.removeFromHistory(1L) }
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(1L, viewModel.state.value.pendingDeleteChapterId)
-
-        viewModel.onEvent(HistoryEvent.ConfirmRemoveFromHistory)
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        assertNull(viewModel.state.value.pendingDeleteChapterId)
-        coVerify(exactly = 1) { chapterRepository.removeFromHistory(1L) }
     }
 
     @Test
@@ -305,15 +312,19 @@ class HistoryViewModelTest {
 
         viewModel.effect.test {
             viewModel.onEvent(HistoryEvent.RemoveFromHistory(chapterId = 2L))
+            testDispatcher.scheduler.runCurrent()  // send effect, suspend at delay
+            awaitItem() // consume ShowUndoSnackbar
+
+            // Undo cancels the pending job; the delay coroutine is now cancelled.
+            viewModel.onEvent(HistoryEvent.UndoRemoveFromHistory(chapterId = 2L))
+
+            // Advance past where auto-commit would have fired — nothing happens.
+            testDispatcher.scheduler.advanceTimeBy(HistoryViewModel.UNDO_TIMEOUT_MS + 1)
             testDispatcher.scheduler.advanceUntilIdle()
-            awaitItem()
+
+            coVerify(exactly = 0) { chapterRepository.removeFromHistory(any()) }
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(2L, viewModel.state.value.pendingDeleteChapterId)
-
-        viewModel.onEvent(HistoryEvent.UndoRemoveFromHistory)
-
-        assertNull(viewModel.state.value.pendingDeleteChapterId)
-        coVerify(exactly = 0) { chapterRepository.removeFromHistory(any()) }
     }
 
     @Test

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -119,9 +119,17 @@ internal fun MangaGrid(
     // Taps open the detail pane only in two-pane mode with no active selection; otherwise route
     // through OnMangaClick so taps toggle selection while selection mode is active (and navigate
     // in single-pane). Without the selection guard, two-pane taps could never toggle items.
-    val onMangaTap: (LibraryMangaItem) -> Unit = { manga ->
-        if (onMangaSelect != null && state.selectedManga.isEmpty()) onMangaSelect(manga)
-        else onEvent(LibraryEvent.OnMangaClick(manga.id))
+    val onMangaTap: (LibraryMangaItem) -> Unit = remember(haptic, onMangaSelect, onEvent, state.selectedManga.isEmpty()) {
+        { manga ->
+            if (onMangaSelect != null && state.selectedManga.isEmpty()) {
+                onMangaSelect(manga)
+            } else {
+                if (state.selectedManga.isNotEmpty()) {
+                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                }
+                onEvent(LibraryEvent.OnMangaClick(manga.id))
+            }
+        }
     }
 
     val displayedManga by remember(state.mangaList, selectedContentFilter) {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -62,6 +62,16 @@ import app.otakureader.core.ui.theme.LocalOtakuColors
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material.icons.filled.TouchApp
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
 import coil3.compose.AsyncImage
 
 /** Layout constants for the compact list-mode row. */
@@ -98,13 +108,12 @@ internal fun MangaGrid(
         stringResource(R.string.library_content_tab_manhwa),
     )
 
-    // Long-press always enters selection mode; fire a haptic tick so the gesture is felt (#L7).
-    // remember keeps the lambda reference stable so item composables can skip recomposition.
+    // Long-press opens the quick context menu. Fire haptic so the gesture is felt (#L7).
     val haptic = LocalHapticFeedback.current
     val onMangaLongClick: (Long) -> Unit = remember(haptic, onEvent) {
         { mangaId ->
             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-            onEvent(LibraryEvent.OnMangaLongClick(mangaId))
+            onEvent(LibraryEvent.ShowContextMenu(mangaId))
         }
     }
     // Taps open the detail pane only in two-pane mode with no active selection; otherwise route
@@ -222,14 +231,21 @@ internal fun MangaGrid(
                 contentType = { "manga_row" },
             ) { manga ->
                 val downloadCount = state.downloadCountByManga[manga.id] ?: 0
-                LibraryListRow(
-                    manga = manga,
-                    isSelected = manga.id in state.selectedManga,
-                    unreadCount = if (state.showBadges) manga.unreadCount else 0,
-                    downloadCount = if (state.showDownloadBadge) downloadCount else 0,
-                    onClick = { onMangaTap(manga) },
-                    onLongClick = { onMangaLongClick(manga.id) },
-                )
+                Box {
+                    LibraryListRow(
+                        manga = manga,
+                        isSelected = manga.id in state.selectedManga,
+                        unreadCount = if (state.showBadges) manga.unreadCount else 0,
+                        downloadCount = if (state.showDownloadBadge) downloadCount else 0,
+                        onClick = { onMangaTap(manga) },
+                        onLongClick = { onMangaLongClick(manga.id) },
+                    )
+                    MangaContextMenu(
+                        expanded = state.contextMenuMangaId == manga.id,
+                        mangaId = manga.id,
+                        onEvent = onEvent,
+                    )
+                }
             }
         }
         return
@@ -259,6 +275,7 @@ internal fun MangaGrid(
                             title = manga.title,
                             unreadCount = if (state.showBadges) manga.unreadCount else 0,
                             onClick = { onMangaTap(manga) },
+                            onLongClick = { onMangaLongClick(manga.id) },
                             modifier = Modifier.fillMaxWidth()
                         )
                     } else {
@@ -279,7 +296,8 @@ internal fun MangaGrid(
                             continueReading = continueReading,
                             isNew = manga.unreadCount > 0,
                             badge = when {
-                                state.showBadges && manga.unreadCount > 0 && state.showDownloadBadge && downloadCount > 0 -> {
+                                state.showBadges && manga.unreadCount > 0 &&
+                                    state.showDownloadBadge && downloadCount > 0 -> {
                                     {
                                         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                                             UnreadBadge(count = manga.unreadCount)
@@ -304,18 +322,25 @@ internal fun MangaGrid(
                         )
                     }
                 }
-                if (state.visualEffectsEnabled) {
-                    AnimatedVisibility(
-                        visible = true,
-                        enter = fadeIn(tween(300)) + scaleIn(
-                            initialScale = 0.92f,
-                            animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
-                        )
-                    ) {
+                Box {
+                    if (state.visualEffectsEnabled) {
+                        AnimatedVisibility(
+                            visible = true,
+                            enter = fadeIn(tween(300)) + scaleIn(
+                                initialScale = 0.92f,
+                                animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
+                            )
+                        ) {
+                            cardContent()
+                        }
+                    } else {
                         cardContent()
                     }
-                } else {
-                    cardContent()
+                    MangaContextMenu(
+                        expanded = state.contextMenuMangaId == manga.id,
+                        mangaId = manga.id,
+                        onEvent = onEvent,
+                    )
                 }
             }
         }
@@ -357,7 +382,8 @@ internal fun MangaGrid(
                         continueReading = continueReading,
                         isNew = manga.unreadCount > 0,
                         badge = when {
-                            state.showBadges && manga.unreadCount > 0 && state.showDownloadBadge && downloadCount > 0 -> {
+                            state.showBadges && manga.unreadCount > 0 &&
+                                state.showDownloadBadge && downloadCount > 0 -> {
                                 {
                                     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                                         UnreadBadge(count = manga.unreadCount)
@@ -381,18 +407,25 @@ internal fun MangaGrid(
                         modifier = Modifier.fillMaxWidth()
                     )
                 }
-                if (state.visualEffectsEnabled) {
-                    AnimatedVisibility(
-                        visible = true,
-                        enter = fadeIn(tween(300)) + scaleIn(
-                            initialScale = 0.92f,
-                            animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
-                        )
-                    ) {
+                Box {
+                    if (state.visualEffectsEnabled) {
+                        AnimatedVisibility(
+                            visible = true,
+                            enter = fadeIn(tween(300)) + scaleIn(
+                                initialScale = 0.92f,
+                                animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
+                            )
+                        ) {
+                            cardContent()
+                        }
+                    } else {
                         cardContent()
                     }
-                } else {
-                    cardContent()
+                    MangaContextMenu(
+                        expanded = state.contextMenuMangaId == manga.id,
+                        mangaId = manga.id,
+                        onEvent = onEvent,
+                    )
                 }
             }
         }
@@ -455,6 +488,54 @@ private fun LibraryListRow(
         if (unreadCount > 0) {
             UnreadBadge(count = unreadCount)
         }
+    }
+}
+
+@Composable
+private fun MangaContextMenu(
+    expanded: Boolean,
+    mangaId: Long,
+    onEvent: (LibraryEvent) -> Unit,
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = { onEvent(LibraryEvent.DismissContextMenu) },
+    ) {
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.library_context_menu_open)) },
+            leadingIcon = {
+                Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null)
+            },
+            onClick = {
+                onEvent(LibraryEvent.DismissContextMenu)
+                onEvent(LibraryEvent.OnMangaClick(mangaId))
+            },
+        )
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.library_context_menu_resume)) },
+            leadingIcon = { Icon(Icons.Default.PlayArrow, contentDescription = null) },
+            onClick = { onEvent(LibraryEvent.ResumeFromContextMenu(mangaId)) },
+        )
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.library_context_menu_mark_read)) },
+            leadingIcon = { Icon(Icons.Default.CheckCircle, contentDescription = null) },
+            onClick = { onEvent(LibraryEvent.MarkMangaAsReadFromMenu(mangaId)) },
+        )
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.library_context_menu_share)) },
+            leadingIcon = { Icon(Icons.Default.Share, contentDescription = null) },
+            onClick = { onEvent(LibraryEvent.ShareMangaFromMenu(mangaId)) },
+        )
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.library_context_menu_migrate)) },
+            leadingIcon = { Icon(Icons.Default.SwapHoriz, contentDescription = null) },
+            onClick = { onEvent(LibraryEvent.MigrateMangaFromMenu(mangaId)) },
+        )
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.library_context_menu_select)) },
+            leadingIcon = { Icon(Icons.Default.TouchApp, contentDescription = null) },
+            onClick = { onEvent(LibraryEvent.SelectMangaFromMenu(mangaId)) },
+        )
     }
 }
 

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -94,6 +94,8 @@ data class LibraryState(
     val savedViews: List<SavedLibraryView> = emptyList(),
     val showSaveViewDialog: Boolean = false,
     val saveViewName: String = "",
+    // L2/L3: long-press context menu — holds the id of the manga whose popup is open
+    val contextMenuMangaId: Long? = null,
 )
 
 data class LibraryMangaItem(
@@ -190,6 +192,14 @@ sealed class LibraryEvent {
     data class DeleteSavedView(val id: String) : LibraryEvent()
     // EH favorites sync (#1024)
     data object SyncEhFavorites : LibraryEvent()
+    // L2/L3: long-press context menu
+    data class ShowContextMenu(val mangaId: Long) : LibraryEvent()
+    data object DismissContextMenu : LibraryEvent()
+    data class ResumeFromContextMenu(val mangaId: Long) : LibraryEvent()
+    data class MarkMangaAsReadFromMenu(val mangaId: Long) : LibraryEvent()
+    data class ShareMangaFromMenu(val mangaId: Long) : LibraryEvent()
+    data class MigrateMangaFromMenu(val mangaId: Long) : LibraryEvent()
+    data class SelectMangaFromMenu(val mangaId: Long) : LibraryEvent()
 }
 
 sealed class LibraryEffect {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -60,7 +60,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -102,6 +104,7 @@ fun LibraryScreen(
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+    val haptic = LocalHapticFeedback.current
     var showMenu by remember { mutableStateOf(false) }
     var pendingBulkAction: LibraryEvent? by remember { mutableStateOf(null) }
 
@@ -165,6 +168,7 @@ fun LibraryScreen(
             },
             confirmButton = {
                 TextButton(onClick = {
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                     viewModel.onEvent(action)
                     pendingBulkAction = null
                 }) {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -150,6 +150,15 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.ShowSaveViewDialog, is LibraryEvent.HideSaveViewDialog,
             is LibraryEvent.UpdateSaveViewName, is LibraryEvent.ConfirmSaveView,
             is LibraryEvent.ApplySavedView, is LibraryEvent.DeleteSavedView -> handleSavedViewEvent(event)
+            is LibraryEvent.ShowContextMenu, is LibraryEvent.DismissContextMenu,
+            is LibraryEvent.ResumeFromContextMenu, is LibraryEvent.MarkMangaAsReadFromMenu,
+            is LibraryEvent.ShareMangaFromMenu, is LibraryEvent.MigrateMangaFromMenu,
+            is LibraryEvent.SelectMangaFromMenu -> handleContextMenuEvent(event)
+        }
+    }
+
+    private fun handleContextMenuEvent(event: LibraryEvent) {
+        when (event) {
             is LibraryEvent.ShowContextMenu ->
                 _state.update { it.copy(contextMenuMangaId = event.mangaId) }
             is LibraryEvent.DismissContextMenu ->
@@ -162,6 +171,7 @@ class LibraryViewModel @Inject constructor(
                 selection.toggle(event.mangaId)
                 _state.update { it.copy(contextMenuMangaId = null) }
             }
+            else -> Unit
         }
     }
 
@@ -674,8 +684,10 @@ class LibraryViewModel @Inject constructor(
     private fun removeSelectedFromLibrary() {
         val ids = selection.snapshotAndClear()
         if (ids.isEmpty()) return
+        val count = ids.size
         viewModelScope.launch {
             ids.forEach { mangaId -> toggleFavoriteManga(mangaId) }
+            _effect.send(LibraryEffect.ShowSnackbar(R.string.library_removed_count, listOf(count)))
         }
     }
 

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -150,6 +150,18 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.ShowSaveViewDialog, is LibraryEvent.HideSaveViewDialog,
             is LibraryEvent.UpdateSaveViewName, is LibraryEvent.ConfirmSaveView,
             is LibraryEvent.ApplySavedView, is LibraryEvent.DeleteSavedView -> handleSavedViewEvent(event)
+            is LibraryEvent.ShowContextMenu ->
+                _state.update { it.copy(contextMenuMangaId = event.mangaId) }
+            is LibraryEvent.DismissContextMenu ->
+                _state.update { it.copy(contextMenuMangaId = null) }
+            is LibraryEvent.ResumeFromContextMenu -> resumeFromContextMenu(event.mangaId)
+            is LibraryEvent.MarkMangaAsReadFromMenu -> markMangaAsReadFromMenu(event.mangaId)
+            is LibraryEvent.ShareMangaFromMenu -> shareMangaFromMenu(event.mangaId)
+            is LibraryEvent.MigrateMangaFromMenu -> migrateMangaFromMenu(event.mangaId)
+            is LibraryEvent.SelectMangaFromMenu -> {
+                selection.toggle(event.mangaId)
+                _state.update { it.copy(contextMenuMangaId = null) }
+            }
         }
     }
 
@@ -598,7 +610,7 @@ class LibraryViewModel @Inject constructor(
     }
 
     private fun onMangaLongClick(mangaId: Long) {
-        selection.toggle(mangaId)
+        _state.update { it.copy(contextMenuMangaId = mangaId) }
     }
 
     private fun onSearchQueryChange(query: String) {
@@ -721,6 +733,49 @@ class LibraryViewModel @Inject constructor(
         val mangaId = _state.value.selectedManga.singleOrNull() ?: return
         selection.clear()
         viewModelScope.launch { _effect.send(LibraryEffect.NavigateToManga(mangaId)) }
+    }
+
+    private fun resumeFromContextMenu(mangaId: Long) {
+        _state.update { it.copy(contextMenuMangaId = null) }
+        val continueItem = _state.value.continueReadingItems.find { it.mangaId == mangaId }
+        viewModelScope.launch {
+            if (continueItem != null) {
+                _effect.send(LibraryEffect.NavigateToReader(continueItem.mangaId, continueItem.chapterId))
+            } else {
+                _effect.send(LibraryEffect.NavigateToManga(mangaId))
+            }
+        }
+    }
+
+    private fun markMangaAsReadFromMenu(mangaId: Long) {
+        _state.update { it.copy(contextMenuMangaId = null) }
+        viewModelScope.launch {
+            try {
+                val chapters = chapterRepository.getChaptersByMangaIdSync(mangaId)
+                val ids = chapters.map { it.id }
+                if (ids.isNotEmpty()) {
+                    chapterRepository.updateChapterProgress(ids, read = true, lastPageRead = 0)
+                }
+            } catch (_: Exception) {}
+        }
+    }
+
+    private fun shareMangaFromMenu(mangaId: Long) {
+        _state.update { it.copy(contextMenuMangaId = null) }
+        viewModelScope.launch {
+            val manga = mangaRepository.getMangaById(mangaId) ?: return@launch
+            val url = manga.url.takeIf {
+                it.startsWith("http://") || it.startsWith("https://")
+            } ?: ""
+            _effect.send(LibraryEffect.ShareManga(title = manga.title, url = url))
+        }
+    }
+
+    private fun migrateMangaFromMenu(mangaId: Long) {
+        _state.update { it.copy(contextMenuMangaId = null) }
+        viewModelScope.launch {
+            _effect.send(LibraryEffect.NavigateToMigration(listOf(mangaId)))
+        }
     }
 
     private fun toggleFavorite(mangaId: Long) {

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -283,6 +283,8 @@
     <string name="library_eh_sync_nothing_new">Library is already up to date</string>
     <string name="library_eh_sync_not_configured">No E-Hentai session found. Sign in via Browse first.</string>
     <string name="library_eh_sync_failed">EH sync failed. Check your session and try again.</string>
+    <!-- Bulk delete feedback (L8) -->
+    <string name="library_removed_count">Removed %1$d manga from library</string>
     <!-- Long-press context menu (L2/L3) -->
     <string name="library_context_menu_open">Open</string>
     <string name="library_context_menu_resume">Resume reading</string>

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -283,4 +283,11 @@
     <string name="library_eh_sync_nothing_new">Library is already up to date</string>
     <string name="library_eh_sync_not_configured">No E-Hentai session found. Sign in via Browse first.</string>
     <string name="library_eh_sync_failed">EH sync failed. Check your session and try again.</string>
+    <!-- Long-press context menu (L2/L3) -->
+    <string name="library_context_menu_open">Open</string>
+    <string name="library_context_menu_resume">Resume reading</string>
+    <string name="library_context_menu_mark_read">Mark as read</string>
+    <string name="library_context_menu_share">Share</string>
+    <string name="library_context_menu_migrate">Migrate</string>
+    <string name="library_context_menu_select">Select</string>
 </resources>

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderMvi.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderMvi.kt
@@ -189,6 +189,10 @@ data class ReaderState(
     // --- Actions ---
     /** Show actions menu on long tap */
     val showActionsOnLongTap: Boolean = true,
+    /** Whether the page long-press context menu (save/share/cover) is visible. */
+    val isPageContextMenuVisible: Boolean = false,
+    /** URL of the page that triggered the long-press context menu. */
+    val contextMenuPageUrl: String? = null,
     /** Save pages to separate folders by manga title */
     val savePagesToSeparateFolders: Boolean = false,
     /** Show thumbnail strip at bottom of reader */
@@ -608,6 +612,18 @@ sealed interface ReaderEvent {
     /** Apply a saved reader preset (mode, scale, background colour, etc.). */
     data class ApplyPreset(val preset: app.otakureader.core.preferences.ReaderPreset) : ActionEvent
 
+    /** User long-pressed a page image; opens the context menu for that page. */
+    data class OnPageLongPress(val pageUrl: String) : ActionEvent
+
+    /** Dismiss the page long-press context menu without taking any action. */
+    data object DismissPageContextMenu : ActionEvent
+
+    /** Save the context-menu page image to the device gallery. */
+    data object SavePageImage : ActionEvent
+
+    /** Set the context-menu page image as the manga cover. */
+    data object SetPageAsCover : ActionEvent
+
     // ──────────────────────────────────────────────────────────────────────────
     // Constants
     // ──────────────────────────────────────────────────────────────────────────
@@ -682,4 +698,6 @@ sealed interface ReaderEffect {
         @androidx.annotation.StringRes val messageResId: Int? = null
     ) : ReaderEffect
     data class NavigateToChapter(val chapterId: Long) : ReaderEffect
+    /** Trigger the system share sheet for a page image URL. */
+    data class SharePage(val pageUrl: String) : ReaderEffect
 }

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -1,10 +1,12 @@
 package app.otakureader.feature.reader
 
 import android.app.Activity
+import android.content.Intent
 import android.view.WindowManager
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,8 +15,18 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -126,6 +138,15 @@ fun ReaderScreen(
                 is ReaderEffect.NavigateToChapter -> {
                     // Handle chapter navigation
                     snackbarHostState.showSnackbar(context.getString(R.string.reader_navigating_to_chapter))
+                }
+                is ReaderEffect.SharePage -> {
+                    scope.launch {
+                        val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                            type = "text/plain"
+                            putExtra(Intent.EXTRA_TEXT, effect.pageUrl)
+                        }
+                        context.startActivity(Intent.createChooser(shareIntent, null))
+                    }
                 }
             }
         }
@@ -265,6 +286,9 @@ fun ReaderScreen(
                     },
                     onZoomChange = { zoom ->
                         viewModel.onEvent(ReaderEvent.OnZoomChange(zoom))
+                    },
+                    onLongPress = { pageUrl ->
+                        viewModel.onEvent(ReaderEvent.OnPageLongPress(pageUrl))
                     }
                 )
             }
@@ -467,6 +491,16 @@ fun ReaderScreen(
             },
             onDismiss = { viewModel.onEvent(ReaderEvent.ToggleChapterListOverlay) },
         )
+
+        // Page long-press context menu
+        if (state.isPageContextMenuVisible) {
+            PageContextMenuBottomSheet(
+                onSaveImage = { viewModel.onEvent(ReaderEvent.SavePageImage) },
+                onSetAsCover = { viewModel.onEvent(ReaderEvent.SetPageAsCover) },
+                onShare = { viewModel.onEvent(ReaderEvent.SharePage) },
+                onDismiss = { viewModel.onEvent(ReaderEvent.DismissPageContextMenu) },
+            )
+        }
     }
 }
 
@@ -477,7 +511,8 @@ private fun ReaderContent(
     onPanelChange: (Int) -> Unit,
     onTap: (Offset) -> Unit,
     onDoubleTap: (Offset) -> Unit,
-    onZoomChange: (Float) -> Unit
+    onZoomChange: (Float) -> Unit,
+    onLongPress: ((String) -> Unit)? = null,
 ) {
     // Use the per-manga background color if set, otherwise default to black
     val backgroundColor = if (state.readerBackgroundColor != null) {
@@ -511,6 +546,7 @@ private fun ReaderContent(
                     onTap = onTap,
                     onDoubleTap = onDoubleTap,
                     onZoomChange = onZoomChange,
+                    onLongPress = if (state.showActionsOnLongTap) onLongPress else null,
                     rotation = state.pageRotation.degrees,
                     cropBordersEnabled = state.cropBordersEnabled,
                     imageQuality = state.imageQuality,
@@ -525,6 +561,7 @@ private fun ReaderContent(
                     currentPage = state.currentPage,
                     onPageChange = onPageChange,
                     onTap = onTap,
+                    onLongPress = if (state.showActionsOnLongTap) onLongPress else null,
                     isRtl = state.readingDirection == app.otakureader.domain.model.ReadingDirection.RTL,
                     rotation = state.pageRotation.degrees,
                     cropBordersEnabled = state.cropBordersEnabled,
@@ -540,6 +577,7 @@ private fun ReaderContent(
                     currentPage = state.currentPage,
                     onPageChange = onPageChange,
                     onTap = onTap,
+                    onLongPress = if (state.showActionsOnLongTap) onLongPress else null,
                     rotation = state.pageRotation.degrees,
                     cropBordersEnabled = state.cropBordersEnabled,
                     imageQuality = state.imageQuality,
@@ -558,6 +596,7 @@ private fun ReaderContent(
                     onPageChange = onPageChange,
                     onPanelChange = onPanelChange,
                     onTap = onTap,
+                    onLongPress = if (state.showActionsOnLongTap) onLongPress else null,
                     rotation = state.pageRotation.degrees,
                     cropBordersEnabled = state.cropBordersEnabled,
                     imageQuality = state.imageQuality,
@@ -587,4 +626,39 @@ private fun ReaderContent(
     }
 }
 
-
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PageContextMenuBottomSheet(
+    onSaveImage: () -> Unit,
+    onSetAsCover: () -> Unit,
+    onShare: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp),
+        ) {
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.reader_page_menu_save_image)) },
+                leadingContent = { Icon(Icons.Default.Download, contentDescription = null) },
+                modifier = Modifier.clickable(onClick = onSaveImage)
+            )
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.reader_page_menu_set_as_cover)) },
+                leadingContent = { Icon(Icons.Default.Image, contentDescription = null) },
+                modifier = Modifier.clickable(onClick = onSetAsCover)
+            )
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.reader_page_menu_share)) },
+                leadingContent = { Icon(Icons.Default.Share, contentDescription = null) },
+                modifier = Modifier.clickable(onClick = onShare)
+            )
+        }
+    }
+}

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -1,6 +1,10 @@
 package app.otakureader.feature.reader
 
+import android.content.ContentValues
+import android.content.Context
+import android.os.Build
 import android.os.SystemClock
+import android.provider.MediaStore
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -32,7 +36,13 @@ import app.otakureader.feature.reader.viewmodel.delegate.ReaderDownloadAheadDele
 import app.otakureader.feature.reader.viewmodel.delegate.ReaderHistoryDelegate
 import app.otakureader.feature.reader.viewmodel.delegate.ReaderPrefetchDelegate
 import app.otakureader.feature.reader.viewmodel.delegate.ReaderSettingsLoaderDelegate
+import app.otakureader.feature.reader.R
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.toBitmap
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -79,6 +89,7 @@ import javax.inject.Inject
 @HiltViewModel
 @Suppress("LargeClass")
 class ReaderViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val mangaRepository: MangaRepository,
     private val chapterRepository: ChapterRepository,
     private val pageBookmarkRepository: PageBookmarkRepository,
@@ -559,6 +570,14 @@ class ReaderViewModel @Inject constructor(
                 readerPreferences.applyPreset(event.preset)
                 loadSettings()
             }
+            is ReaderEvent.OnPageLongPress -> _state.update {
+                it.copy(isPageContextMenuVisible = true, contextMenuPageUrl = event.pageUrl)
+            }
+            ReaderEvent.DismissPageContextMenu -> _state.update {
+                it.copy(isPageContextMenuVisible = false, contextMenuPageUrl = null)
+            }
+            ReaderEvent.SavePageImage -> savePageImage()
+            ReaderEvent.SetPageAsCover -> setPageAsCover()
         }
     }
 
@@ -686,8 +705,80 @@ class ReaderViewModel @Inject constructor(
      * Multiple rapid page changes will only trigger one save after the delay period.
      */
     private fun sharePage() {
+        val pageUrl = _state.value.contextMenuPageUrl ?: return
+        _state.update { it.copy(isPageContextMenuVisible = false, contextMenuPageUrl = null) }
         viewModelScope.launch {
-            _effect.send(ReaderEffect.ShowSnackbar("Share page coming soon"))
+            _effect.send(ReaderEffect.SharePage(pageUrl))
+        }
+    }
+
+    private fun savePageImage() {
+        val pageUrl = _state.value.contextMenuPageUrl ?: return
+        _state.update { it.copy(isPageContextMenuVisible = false, contextMenuPageUrl = null) }
+        viewModelScope.launch {
+            try {
+                val result = context.imageLoader.execute(
+                    ImageRequest.Builder(context).data(pageUrl).build()
+                )
+                val bitmap = (result as? SuccessResult)?.image?.toBitmap() ?: run {
+                    _effect.send(ReaderEffect.ShowSnackbar(messageResId = R.string.reader_page_save_failed))
+                    return@launch
+                }
+                val fileName = "otaku_reader_${System.currentTimeMillis()}.jpg"
+                val values = ContentValues().apply {
+                    put(MediaStore.Images.Media.DISPLAY_NAME, fileName)
+                    put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/OtakuReader")
+                        put(MediaStore.Images.Media.IS_PENDING, 1)
+                    }
+                }
+                val resolver = context.contentResolver
+                val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+                if (uri == null) {
+                    _effect.send(ReaderEffect.ShowSnackbar(messageResId = R.string.reader_page_save_failed))
+                    return@launch
+                }
+                resolver.openOutputStream(uri)?.use { out ->
+                    bitmap.compress(android.graphics.Bitmap.CompressFormat.JPEG, 95, out)
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    values.clear()
+                    values.put(MediaStore.Images.Media.IS_PENDING, 0)
+                    resolver.update(uri, values, null, null)
+                }
+                _effect.send(ReaderEffect.ShowSnackbar(messageResId = R.string.reader_page_saved))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                _effect.send(ReaderEffect.ShowSnackbar(messageResId = R.string.reader_page_save_failed))
+            }
+        }
+    }
+
+    private fun setPageAsCover() {
+        val pageUrl = _state.value.contextMenuPageUrl ?: return
+        _state.update { it.copy(isPageContextMenuVisible = false, contextMenuPageUrl = null) }
+        viewModelScope.launch {
+            try {
+                val result = context.imageLoader.execute(
+                    ImageRequest.Builder(context).data(pageUrl).build()
+                )
+                val bitmap = (result as? SuccessResult)?.image?.toBitmap() ?: run {
+                    _effect.send(ReaderEffect.ShowSnackbar(messageResId = R.string.reader_page_cover_failed))
+                    return@launch
+                }
+                val tempFile = java.io.File(context.cacheDir, "cover_${System.currentTimeMillis()}.jpg")
+                tempFile.outputStream().use { out ->
+                    bitmap.compress(android.graphics.Bitmap.CompressFormat.JPEG, 95, out)
+                }
+                mangaRepository.setCustomCover(mangaId, android.net.Uri.fromFile(tempFile).toString())
+                _effect.send(ReaderEffect.ShowSnackbar(messageResId = R.string.reader_page_cover_set))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                _effect.send(ReaderEffect.ShowSnackbar(messageResId = R.string.reader_page_cover_failed))
+            }
         }
     }
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/components/PanelNavigationView.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/components/PanelNavigationView.kt
@@ -48,6 +48,7 @@ fun PanelNavigationView(
     totalPanels: Int,
     onPanelChange: (Int) -> Unit,
     onTap: (Offset) -> Unit,
+    onLongPress: ((String) -> Unit)? = null,
     rotation: Float = 0f,
     cropBordersEnabled: Boolean = false,
     dataSaverEnabled: Boolean = false,
@@ -121,6 +122,7 @@ fun PanelNavigationView(
                     onTap(offset)
                 }
             },
+            onLongPress = onLongPress,
             modifier = Modifier
                 .fillMaxSize()
                 .graphicsLayer {

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/components/ZoomableImage.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/components/ZoomableImage.kt
@@ -81,6 +81,7 @@ fun ZoomableImage(
     dataSaverEnabled: Boolean = false,
     onDoubleTap: ((Offset) -> Unit)? = null,
     onTap: ((Offset) -> Unit)? = null,
+    onLongPress: ((String) -> Unit)? = null,
     onZoomChange: ((Float) -> Unit)? = null,
     onImageSizeKnown: ((width: Int, height: Int) -> Unit)? = null,
     decoderFactory: Decoder.Factory? = null,
@@ -148,6 +149,10 @@ fun ZoomableImage(
             }
             .pointerInput(imageUrl, minScale, maxScale, doubleTapScale) {
                 detectTapGestures(
+                    onLongPress = { _ ->
+                        val url = imageUrl
+                        if (url != null) onLongPress?.invoke(url)
+                    },
                     onDoubleTap = { offset ->
                         scope.launch {
                             val targetScale = if (zoomState.scale >= doubleTapScale * 0.9f) {

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/modes/DualPageReader.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/modes/DualPageReader.kt
@@ -79,6 +79,7 @@ fun DualPageReader(
     currentPage: Int,
     onPageChange: (Int) -> Unit,
     onTap: (androidx.compose.ui.geometry.Offset) -> Unit,
+    onLongPress: ((String) -> Unit)? = null,
     isRtl: Boolean = false,
     rotation: Float = 0f,
     cropBordersEnabled: Boolean = false,
@@ -145,6 +146,7 @@ fun DualPageReader(
                         imageQuality = imageQuality,
                         dataSaverEnabled = dataSaverEnabled,
                         onTap = onTap,
+                        onLongPress = onLongPress,
                         onImageSizeKnown = { w, h ->
                             if (w > 0 && h > 0) {
                                 detectedSpreads[page.index] = w.toFloat() / h > SPREAD_ASPECT_RATIO_THRESHOLD
@@ -176,6 +178,7 @@ fun DualPageReader(
                                 imageQuality = imageQuality,
                                 dataSaverEnabled = dataSaverEnabled,
                                 onTap = onTap,
+                                onLongPress = onLongPress,
                                 onImageSizeKnown = { w, h ->
                                     if (w > 0 && h > 0) {
                                         detectedSpreads[leftPage.index] = w.toFloat() / h > SPREAD_ASPECT_RATIO_THRESHOLD
@@ -205,6 +208,7 @@ fun DualPageReader(
                                 imageQuality = imageQuality,
                                 dataSaverEnabled = dataSaverEnabled,
                                 onTap = onTap,
+                                onLongPress = onLongPress,
                                 onImageSizeKnown = { w, h ->
                                     if (w > 0 && h > 0) {
                                         detectedSpreads[rightPage.index] = w.toFloat() / h > SPREAD_ASPECT_RATIO_THRESHOLD

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/modes/SinglePageReader.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/modes/SinglePageReader.kt
@@ -33,6 +33,7 @@ fun SinglePageReader(
     onTap: (androidx.compose.ui.geometry.Offset) -> Unit,
     onDoubleTap: (androidx.compose.ui.geometry.Offset) -> Unit,
     onZoomChange: (Float) -> Unit,
+    onLongPress: ((String) -> Unit)? = null,
     rotation: Float = 0f,
     cropBordersEnabled: Boolean = false,
     imageQuality: ImageQuality = ImageQuality.ORIGINAL,
@@ -88,6 +89,7 @@ fun SinglePageReader(
                 dataSaverEnabled = dataSaverEnabled,
                 onTap = onTap,
                 onDoubleTap = onDoubleTap,
+                onLongPress = onLongPress,
                 onZoomChange = onZoomChange,
                 modifier = Modifier.fillMaxSize()
             )

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/modes/SmartPanelsReader.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/modes/SmartPanelsReader.kt
@@ -35,6 +35,7 @@ fun SmartPanelsReader(
     onPageChange: (Int) -> Unit,
     onPanelChange: (Int) -> Unit,
     onTap: (androidx.compose.ui.geometry.Offset) -> Unit,
+    onLongPress: ((String) -> Unit)? = null,
     rotation: Float = 0f,
     cropBordersEnabled: Boolean = false,
     imageQuality: ImageQuality = ImageQuality.ORIGINAL,
@@ -85,6 +86,7 @@ fun SmartPanelsReader(
                     currentPanel = if (pageIndex == currentPage) currentPanel else 0,
                     onPanelChange = onPanelChange,
                     onTap = onTap,
+                    onLongPress = onLongPress,
                     rotation = rotation,
                     cropBordersEnabled = cropBordersEnabled,
                     imageQuality = imageQuality,
@@ -102,6 +104,7 @@ fun SmartPanelsReader(
                     imageQuality = imageQuality,
                     dataSaverEnabled = dataSaverEnabled,
                     onTap = onTap,
+                    onLongPress = onLongPress,
                     modifier = Modifier.fillMaxSize()
                 )
             }
@@ -116,6 +119,7 @@ private fun SmartPanelView(
     currentPanel: Int,
     onPanelChange: (Int) -> Unit,
     onTap: (androidx.compose.ui.geometry.Offset) -> Unit,
+    onLongPress: ((String) -> Unit)? = null,
     rotation: Float = 0f,
     cropBordersEnabled: Boolean = false,
     imageQuality: ImageQuality = ImageQuality.ORIGINAL,
@@ -134,6 +138,7 @@ private fun SmartPanelView(
             cropBordersEnabled = cropBordersEnabled,
             dataSaverEnabled = dataSaverEnabled,
             onTap = onTap,
+            onLongPress = onLongPress,
             modifier = modifier
         )
         return
@@ -149,6 +154,7 @@ private fun SmartPanelView(
         totalPanels = panels.size,
         onPanelChange = onPanelChange,
         onTap = onTap,
+        onLongPress = onLongPress,
         rotation = rotation,
         cropBordersEnabled = cropBordersEnabled,
         dataSaverEnabled = dataSaverEnabled,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/modes/WebtoonReader.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/modes/WebtoonReader.kt
@@ -42,6 +42,7 @@ fun WebtoonReader(
     currentPage: Int,
     onPageChange: (Int) -> Unit,
     onTap: (androidx.compose.ui.geometry.Offset) -> Unit,
+    onLongPress: ((String) -> Unit)? = null,
     rotation: Float = 0f,
     cropBordersEnabled: Boolean = false,
     imageQuality: ImageQuality = ImageQuality.ORIGINAL,
@@ -143,6 +144,7 @@ fun WebtoonReader(
                     imageQuality = imageQuality,
                     dataSaverEnabled = dataSaverEnabled,
                     onTap = onTap,
+                    onLongPress = onLongPress,
                     decoderFactory = webtoonDecoderFactory,
                     minScale = if (disableZoomOut) 1f else 0.5f,
                     modifier = Modifier.fillMaxWidth()

--- a/feature/reader/src/main/res/values/strings.xml
+++ b/feature/reader/src/main/res/values/strings.xml
@@ -183,4 +183,14 @@
     <string name="reader_page_load_failed">Page failed to load</string>
     <string name="reader_chapter_bookmarked">Bookmarked</string>
     <string name="reader_chapter_read">Read</string>
+
+    <!-- Page long-press context menu -->
+    <string name="reader_page_menu_save_image">Save image</string>
+    <string name="reader_page_menu_set_as_cover">Set as cover</string>
+    <string name="reader_page_menu_share">Share page</string>
+    <string name="reader_page_menu_title">Page options</string>
+    <string name="reader_page_saved">Image saved to gallery</string>
+    <string name="reader_page_save_failed">Failed to save image</string>
+    <string name="reader_page_cover_set">Cover updated</string>
+    <string name="reader_page_cover_failed">Failed to set cover</string>
 </resources>

--- a/feature/reader/src/test/java/app/otakureader/feature/reader/ReaderViewModelTest.kt
+++ b/feature/reader/src/test/java/app/otakureader/feature/reader/ReaderViewModelTest.kt
@@ -221,6 +221,7 @@ class ReaderViewModelTest {
             imageLoader = imageLoader,
         )
         return ReaderViewModel(
+            context = context,
             mangaRepository = mangaRepository,
             chapterRepository = chapterRepository,
             pageBookmarkRepository = pageBookmarkRepository,

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesMvi.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesMvi.kt
@@ -48,6 +48,10 @@ data class UpdatesState(
     val lastRunSummary: UpdateRunSummary? = null,
     /** Active/queued downloads keyed by chapterId, for per-row progress indicators. */
     val activeDownloads: Map<Long, DownloadItem> = emptyMap(),
+    /** Start of the active date filter (epoch-ms, inclusive), or null if no filter set. */
+    val dateFilterStart: Long? = null,
+    /** End of the active date filter (epoch-ms, inclusive), or null if no filter set. */
+    val dateFilterEnd: Long? = null,
 ) : UiState
 
 sealed interface UpdatesEvent : UiEvent {
@@ -73,6 +77,10 @@ sealed interface UpdatesEvent : UiEvent {
     data object StartLibraryUpdate : UpdatesEvent
     /** Revert a swipe-to-mark-read action. */
     data class UnmarkChapterAsRead(val chapterId: Long) : UpdatesEvent
+    /** Apply a date range filter. Pass null for either bound to leave it open-ended. */
+    data class SetDateFilter(val start: Long?, val end: Long?) : UpdatesEvent
+    /** Remove the active date range filter and show all update entries. */
+    data object ClearDateFilter : UpdatesEvent
 }
 
 sealed interface UpdatesEffect : UiEffect {

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesMvi.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesMvi.kt
@@ -3,6 +3,7 @@ package app.otakureader.feature.updates
 import app.otakureader.core.common.mvi.UiEffect
 import app.otakureader.core.common.mvi.UiEvent
 import app.otakureader.core.common.mvi.UiState
+import app.otakureader.domain.model.DownloadItem
 import app.otakureader.domain.model.MangaUpdate
 import app.otakureader.domain.model.UpdateRunSummary
 
@@ -45,6 +46,8 @@ data class UpdatesState(
     val showPendingUpdates: Boolean = false,
     /** Diagnostics card: summary of the last completed library update run (#1041). */
     val lastRunSummary: UpdateRunSummary? = null,
+    /** Active/queued downloads keyed by chapterId, for per-row progress indicators. */
+    val activeDownloads: Map<Long, DownloadItem> = emptyMap(),
 ) : UiState
 
 sealed interface UpdatesEvent : UiEvent {

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesMvi.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesMvi.kt
@@ -30,6 +30,7 @@ data class PendingUpdateManga(
 
 data class UpdatesState(
     val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
     val updates: List<MangaUpdate> = emptyList(),
     val error: String? = null,
     /** Selected chapter IDs for bulk operations. */
@@ -67,9 +68,13 @@ sealed interface UpdatesEvent : UiEvent {
     data object ShowPendingUpdates : UpdatesEvent
     data object HidePendingUpdates : UpdatesEvent
     data object StartLibraryUpdate : UpdatesEvent
+    /** Revert a swipe-to-mark-read action. */
+    data class UnmarkChapterAsRead(val chapterId: Long) : UpdatesEvent
 }
 
 sealed interface UpdatesEffect : UiEffect {
     data class NavigateToReader(val mangaId: Long, val chapterId: Long) : UpdatesEffect
     data class ShowSnackbar(val message: String) : UpdatesEffect
+    /** Snackbar with an Undo action after swipe-to-mark-read. Awaited inline by the screen. */
+    data class ShowUndoSnackbar(val message: String, val chapterId: Long) : UpdatesEffect
 }

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
@@ -3,6 +3,7 @@ package app.otakureader.feature.updates
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -68,6 +69,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.otakureader.domain.model.DownloadItem
+import app.otakureader.domain.model.DownloadStatus
 import app.otakureader.domain.model.MangaUpdate
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
@@ -244,6 +247,7 @@ fun UpdatesScreen(
                 else -> UpdatesList(
                     updates = state.updates,
                     selectedItems = state.selectedItems,
+                    activeDownloads = state.activeDownloads,
                     lastRunSummary = state.lastRunSummary,
                     onChapterClick = { update ->
                         viewModel.onEvent(
@@ -330,6 +334,7 @@ private fun bucketLabel(bucket: UpdateDateBucket): String = when (bucket) {
 private fun UpdatesList(
     updates: List<MangaUpdate>,
     selectedItems: Set<Long>,
+    activeDownloads: Map<Long, DownloadItem>,
     lastRunSummary: app.otakureader.domain.model.UpdateRunSummary?,
     onChapterClick: (MangaUpdate) -> Unit,
     onChapterLongClick: (MangaUpdate) -> Unit,
@@ -401,6 +406,7 @@ private fun UpdatesList(
                         UpdateItem(
                             update = item.update,
                             isSelected = selectedItems.contains(item.update.chapter.id),
+                            activeDownload = activeDownloads[item.update.chapter.id],
                             onClick = { onChapterClick(item.update) },
                             onLongClick = { onChapterLongClick(item.update) },
                             onDownloadClick = { onDownloadClick(item.update) }
@@ -430,6 +436,7 @@ private fun UpdatesDateHeader(label: String, modifier: Modifier = Modifier) {
 private fun UpdateItem(
     update: MangaUpdate,
     isSelected: Boolean,
+    activeDownload: DownloadItem?,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
     onDownloadClick: () -> Unit,
@@ -499,13 +506,29 @@ private fun UpdateItem(
                     modifier = Modifier.widthIn(max = 72.dp)
                 )
             }
-            // Per-item download button
-            IconButton(onClick = onDownloadClick) {
-                Icon(
-                    imageVector = Icons.Default.Download,
-                    contentDescription = stringResource(R.string.updates_download_chapter),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+            // Per-item download button / progress indicator
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.size(48.dp)
+            ) {
+                when (activeDownload?.status) {
+                    DownloadStatus.DOWNLOADING -> CircularProgressIndicator(
+                        progress = { (activeDownload.progress / 100f).coerceIn(0f, 1f) },
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.dp,
+                    )
+                    DownloadStatus.QUEUED, DownloadStatus.PAUSED -> CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.dp,
+                    )
+                    else -> IconButton(onClick = onDownloadClick) {
+                        Icon(
+                            imageVector = Icons.Default.Download,
+                            contentDescription = stringResource(R.string.updates_download_chapter),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
             }
         }
     }

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
@@ -46,10 +46,14 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.AlertDialog
 import androidx.compose.foundation.layout.height
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -57,6 +61,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import kotlinx.coroutines.launch
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -85,14 +90,30 @@ fun UpdatesScreen(
     viewModel: UpdatesViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val snackbarHostState = androidx.compose.material3.SnackbarHostState()
+    val snackbarHostState = remember { androidx.compose.material3.SnackbarHostState() }
+    val scope = rememberCoroutineScope()
     val haptic = LocalHapticFeedback.current
+    val context = LocalContext.current
 
     LaunchedEffect(viewModel.effect) {
         viewModel.effect.collectLatest { effect ->
             when (effect) {
                 is UpdatesEffect.NavigateToReader -> onMangaClick(effect.mangaId)
-                is UpdatesEffect.ShowSnackbar -> snackbarHostState.showSnackbar(effect.message)
+                is UpdatesEffect.ShowSnackbar -> scope.launch {
+                    snackbarHostState.showSnackbar(effect.message)
+                }
+                // Inline await — collectLatest cancels this if another swipe fires, which is
+                // correct since the chapter is already marked read at that point.
+                is UpdatesEffect.ShowUndoSnackbar -> {
+                    val result = snackbarHostState.showSnackbar(
+                        message = effect.message,
+                        actionLabel = context.getString(R.string.updates_undo_action),
+                        duration = SnackbarDuration.Short,
+                    )
+                    if (result == SnackbarResult.ActionPerformed) {
+                        viewModel.onEvent(UpdatesEvent.UnmarkChapterAsRead(effect.chapterId))
+                    }
+                }
             }
         }
     }
@@ -172,80 +193,82 @@ fun UpdatesScreen(
             }
         }
     ) { paddingValues ->
-        when {
-            state.isLoading -> Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator()
-            }
-
-            state.error != null -> Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = state.error ?: stringResource(R.string.updates_unknown_error),
-                    color = MaterialTheme.colorScheme.error
-                )
-            }
-
-            state.updates.isEmpty() -> Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.padding(horizontal = 32.dp)
+        PullToRefreshBox(
+            isRefreshing = state.isRefreshing,
+            onRefresh = { viewModel.onEvent(UpdatesEvent.StartLibraryUpdate) },
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+        ) {
+            when {
+                state.isLoading -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.NewReleases,
-                        contentDescription = null,
-                        modifier = Modifier.size(64.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
+                    CircularProgressIndicator()
+                }
+
+                state.error != null -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
                     Text(
-                        text = stringResource(R.string.updates_empty),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        text = state.error ?: stringResource(R.string.updates_unknown_error),
+                        color = MaterialTheme.colorScheme.error
                     )
                 }
-            }
 
-            else -> UpdatesList(
-                updates = state.updates,
-                selectedItems = state.selectedItems,
-                lastRunSummary = state.lastRunSummary,
-                onChapterClick = { update ->
-                    viewModel.onEvent(
-                        UpdatesEvent.OnChapterClick(
-                            mangaId = update.manga.id,
-                            chapterId = update.chapter.id
+                state.updates.isEmpty() -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.padding(horizontal = 32.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.NewReleases,
+                            contentDescription = null,
+                            modifier = Modifier.size(64.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
-                    )
-                },
-                onChapterLongClick = { update ->
-                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                    viewModel.onEvent(UpdatesEvent.OnChapterLongClick(update.chapter.id))
-                },
-                onDownloadClick = { update ->
-                    viewModel.onEvent(
-                        UpdatesEvent.OnDownloadChapter(
-                            mangaId = update.manga.id,
-                            chapterId = update.chapter.id
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = stringResource(R.string.updates_empty),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
-                    )
-                },
-                onMarkAsRead = { chapterId -> viewModel.onEvent(UpdatesEvent.MarkChapterAsRead(chapterId)) },
-                modifier = Modifier.padding(paddingValues)
-            )
+                    }
+                }
+
+                else -> UpdatesList(
+                    updates = state.updates,
+                    selectedItems = state.selectedItems,
+                    lastRunSummary = state.lastRunSummary,
+                    onChapterClick = { update ->
+                        viewModel.onEvent(
+                            UpdatesEvent.OnChapterClick(
+                                mangaId = update.manga.id,
+                                chapterId = update.chapter.id
+                            )
+                        )
+                    },
+                    onChapterLongClick = { update ->
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        viewModel.onEvent(UpdatesEvent.OnChapterLongClick(update.chapter.id))
+                    },
+                    onDownloadClick = { update ->
+                        viewModel.onEvent(
+                            UpdatesEvent.OnDownloadChapter(
+                                mangaId = update.manga.id,
+                                chapterId = update.chapter.id
+                            )
+                        )
+                    },
+                    onMarkAsRead = { chapterId -> viewModel.onEvent(UpdatesEvent.MarkChapterAsRead(chapterId)) },
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
         }
 
         // Update Error Dialog

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
@@ -102,9 +102,9 @@ fun UpdatesScreen(
                 is UpdatesEffect.ShowSnackbar -> scope.launch {
                     snackbarHostState.showSnackbar(effect.message)
                 }
-                // Inline await — collectLatest cancels this if another swipe fires, which is
-                // correct since the chapter is already marked read at that point.
-                is UpdatesEffect.ShowUndoSnackbar -> {
+                // Launch independently so collectLatest cancelling on the next swipe
+                // does not cut this snackbar short; each mark-as-read is independently undoable.
+                is UpdatesEffect.ShowUndoSnackbar -> scope.launch {
                     val result = snackbarHostState.showSnackbar(
                         message = effect.message,
                         actionLabel = context.getString(R.string.updates_undo_action),

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
@@ -27,9 +27,12 @@ import androidx.compose.material.icons.filled.NewReleases
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.SelectAll
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Card
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -196,82 +199,138 @@ fun UpdatesScreen(
             }
         }
     ) { paddingValues ->
-        PullToRefreshBox(
-            isRefreshing = state.isRefreshing,
-            onRefresh = { viewModel.onEvent(UpdatesEvent.StartLibraryUpdate) },
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues),
+                .padding(paddingValues)
         ) {
-            when {
-                state.isLoading -> Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
+            if (state.selectedItems.isEmpty()) {
+                val now = System.currentTimeMillis()
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier
+                        .horizontalScroll(rememberScrollState())
+                        .padding(horizontal = 16.dp, vertical = 4.dp)
                 ) {
-                    CircularProgressIndicator()
-                }
-
-                state.error != null -> Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = state.error ?: stringResource(R.string.updates_unknown_error),
-                        color = MaterialTheme.colorScheme.error
+                    FilterChip(
+                        selected = state.dateFilterStart == now - 7L * 24 * 60 * 60 * 1000 &&
+                            state.dateFilterEnd == null,
+                        onClick = {
+                            if (state.dateFilterStart == now - 7L * 24 * 60 * 60 * 1000 &&
+                                state.dateFilterEnd == null
+                            ) {
+                                viewModel.onEvent(UpdatesEvent.ClearDateFilter)
+                            } else {
+                                viewModel.onEvent(
+                                    UpdatesEvent.SetDateFilter(now - 7L * 24 * 60 * 60 * 1000, null)
+                                )
+                            }
+                        },
+                        label = { Text(stringResource(R.string.updates_filter_last_7_days)) },
+                    )
+                    FilterChip(
+                        selected = state.dateFilterStart == now - 30L * 24 * 60 * 60 * 1000 &&
+                            state.dateFilterEnd == null,
+                        onClick = {
+                            if (state.dateFilterStart == now - 30L * 24 * 60 * 60 * 1000 &&
+                                state.dateFilterEnd == null
+                            ) {
+                                viewModel.onEvent(UpdatesEvent.ClearDateFilter)
+                            } else {
+                                viewModel.onEvent(
+                                    UpdatesEvent.SetDateFilter(now - 30L * 24 * 60 * 60 * 1000, null)
+                                )
+                            }
+                        },
+                        label = { Text(stringResource(R.string.updates_filter_last_30_days)) },
                     )
                 }
+            }
 
-                state.updates.isEmpty() -> Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        modifier = Modifier.padding(horizontal = 32.dp)
+            val filteredUpdates = remember(state.updates, state.dateFilterStart, state.dateFilterEnd) {
+                var result = state.updates
+                state.dateFilterStart?.let { start -> result = result.filter { it.chapter.dateFetch >= start } }
+                state.dateFilterEnd?.let { end -> result = result.filter { it.chapter.dateFetch <= end } }
+                result
+            }
+
+            PullToRefreshBox(
+                isRefreshing = state.isRefreshing,
+                onRefresh = { viewModel.onEvent(UpdatesEvent.StartLibraryUpdate) },
+                modifier = Modifier.weight(1f),
+            ) {
+                when {
+                    state.isLoading -> Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
                     ) {
-                        Icon(
-                            imageVector = Icons.Default.NewReleases,
-                            contentDescription = null,
-                            modifier = Modifier.size(64.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Spacer(modifier = Modifier.height(16.dp))
+                        CircularProgressIndicator()
+                    }
+
+                    state.error != null -> Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
                         Text(
-                            text = stringResource(R.string.updates_empty),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            text = state.error ?: stringResource(R.string.updates_unknown_error),
+                            color = MaterialTheme.colorScheme.error
                         )
                     }
-                }
 
-                else -> UpdatesList(
-                    updates = state.updates,
-                    selectedItems = state.selectedItems,
-                    activeDownloads = state.activeDownloads,
-                    lastRunSummary = state.lastRunSummary,
-                    onChapterClick = { update ->
-                        viewModel.onEvent(
-                            UpdatesEvent.OnChapterClick(
-                                mangaId = update.manga.id,
-                                chapterId = update.chapter.id
+                    filteredUpdates.isEmpty() -> Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            modifier = Modifier.padding(horizontal = 32.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.NewReleases,
+                                contentDescription = null,
+                                modifier = Modifier.size(64.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
                             )
-                        )
-                    },
-                    onChapterLongClick = { update ->
-                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        viewModel.onEvent(UpdatesEvent.OnChapterLongClick(update.chapter.id))
-                    },
-                    onDownloadClick = { update ->
-                        viewModel.onEvent(
-                            UpdatesEvent.OnDownloadChapter(
-                                mangaId = update.manga.id,
-                                chapterId = update.chapter.id
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Text(
+                                text = stringResource(R.string.updates_empty),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
-                        )
-                    },
-                    onMarkAsRead = { chapterId -> viewModel.onEvent(UpdatesEvent.MarkChapterAsRead(chapterId)) },
-                    modifier = Modifier.fillMaxSize()
-                )
+                        }
+                    }
+
+                    else -> UpdatesList(
+                        updates = filteredUpdates,
+                        selectedItems = state.selectedItems,
+                        activeDownloads = state.activeDownloads,
+                        lastRunSummary = state.lastRunSummary,
+                        onChapterClick = { update ->
+                            viewModel.onEvent(
+                                UpdatesEvent.OnChapterClick(
+                                    mangaId = update.manga.id,
+                                    chapterId = update.chapter.id
+                                )
+                            )
+                        },
+                        onChapterLongClick = { update ->
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            viewModel.onEvent(UpdatesEvent.OnChapterLongClick(update.chapter.id))
+                        },
+                        onDownloadClick = { update ->
+                            viewModel.onEvent(
+                                UpdatesEvent.OnDownloadChapter(
+                                    mangaId = update.manga.id,
+                                    chapterId = update.chapter.id
+                                )
+                            )
+                        },
+                        onMarkAsRead = { chapterId ->
+                            viewModel.onEvent(UpdatesEvent.MarkChapterAsRead(chapterId))
+                        },
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
             }
         }
 

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 
 @HiltViewModel
 class UpdatesViewModel @Inject constructor(
@@ -42,7 +43,7 @@ class UpdatesViewModel @Inject constructor(
     private val _state = MutableStateFlow(UpdatesState())
     val state: StateFlow<UpdatesState> = _state.asStateFlow()
 
-    private val _effect = Channel<UpdatesEffect>()
+    private val _effect = Channel<UpdatesEffect>(Channel.BUFFERED)
     val effect = _effect.receiveAsFlow()
 
     init {
@@ -62,6 +63,7 @@ class UpdatesViewModel @Inject constructor(
             UpdatesEvent.DownloadSelected -> downloadSelected()
             UpdatesEvent.MarkSelectedAsRead -> markSelectedAsRead()
             is UpdatesEvent.MarkChapterAsRead -> markSingleChapterAsRead(event.chapterId)
+            is UpdatesEvent.UnmarkChapterAsRead -> unmarkChapterAsRead(event.chapterId)
 
             // Update Error Screen events
             UpdatesEvent.ShowUpdateErrors -> _state.update { it.copy(showUpdateErrors = true) }
@@ -194,10 +196,28 @@ class UpdatesViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 chapterRepository.updateChapterProgress(setOf(chapterId), read = true, lastPageRead = 0)
+                _effect.send(
+                    UpdatesEffect.ShowUndoSnackbar(
+                        message = context.getString(R.string.updates_marked_as_read_single),
+                        chapterId = chapterId,
+                    )
+                )
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Exception) {
                 _effect.send(UpdatesEffect.ShowSnackbar(context.getString(R.string.updates_mark_as_read_failed)))
+            }
+        }
+    }
+
+    private fun unmarkChapterAsRead(chapterId: Long) {
+        viewModelScope.launch {
+            try {
+                chapterRepository.updateChapterProgress(setOf(chapterId), read = false, lastPageRead = 0)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                _effect.send(UpdatesEffect.ShowSnackbar(context.getString(R.string.updates_unmark_as_read_failed)))
             }
         }
     }
@@ -254,12 +274,14 @@ class UpdatesViewModel @Inject constructor(
         }
     }
 
-    /** Start a manual library update. */
+    /** Start a manual library update; shows a brief pull-to-refresh indicator. */
     private fun startLibraryUpdate() {
+        _state.update { it.copy(isRefreshing = true, showPendingUpdates = false) }
         viewModelScope.launch {
             libraryUpdateScheduler.enqueueNow()
-            _state.update { it.copy(showPendingUpdates = false) }
             _effect.send(UpdatesEffect.ShowSnackbar(context.getString(R.string.updates_library_update_started)))
+            delay(1_500L)
+            _state.update { it.copy(isRefreshing = false) }
         }
     }
 }

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
@@ -65,21 +65,6 @@ class UpdatesViewModel @Inject constructor(
             UpdatesEvent.MarkSelectedAsRead -> markSelectedAsRead()
             is UpdatesEvent.MarkChapterAsRead -> markSingleChapterAsRead(event.chapterId)
             is UpdatesEvent.UnmarkChapterAsRead -> unmarkChapterAsRead(event.chapterId)
-
-            // Update Error Screen events
-            UpdatesEvent.ShowUpdateErrors -> _state.update { it.copy(showUpdateErrors = true) }
-            UpdatesEvent.HideUpdateErrors -> _state.update { it.copy(showUpdateErrors = false) }
-            is UpdatesEvent.ClearUpdateError -> _state.update { state ->
-                state.copy(updateErrors = state.updateErrors.filter { it.mangaId != event.mangaId })
-            }
-            UpdatesEvent.ClearAllUpdateErrors -> _state.update { it.copy(updateErrors = emptyList()) }
-
-            // To-Be-Updated Screen events
-            UpdatesEvent.ShowPendingUpdates -> {
-                _state.update { it.copy(showPendingUpdates = true) }
-                loadPendingUpdates()
-            }
-            UpdatesEvent.HidePendingUpdates -> _state.update { it.copy(showPendingUpdates = false) }
             UpdatesEvent.StartLibraryUpdate -> startLibraryUpdate()
             is UpdatesEvent.SetDateFilter -> _state.update {
                 it.copy(dateFilterStart = event.start, dateFilterEnd = event.end)
@@ -87,6 +72,29 @@ class UpdatesViewModel @Inject constructor(
             UpdatesEvent.ClearDateFilter -> _state.update {
                 it.copy(dateFilterStart = null, dateFilterEnd = null)
             }
+            UpdatesEvent.ShowUpdateErrors,
+            UpdatesEvent.HideUpdateErrors,
+            UpdatesEvent.ClearAllUpdateErrors,
+            UpdatesEvent.ShowPendingUpdates,
+            UpdatesEvent.HidePendingUpdates -> handleOverlayEvent(event)
+            is UpdatesEvent.ClearUpdateError -> handleOverlayEvent(event)
+        }
+    }
+
+    private fun handleOverlayEvent(event: UpdatesEvent) {
+        when (event) {
+            UpdatesEvent.ShowUpdateErrors -> _state.update { it.copy(showUpdateErrors = true) }
+            UpdatesEvent.HideUpdateErrors -> _state.update { it.copy(showUpdateErrors = false) }
+            is UpdatesEvent.ClearUpdateError -> _state.update { state ->
+                state.copy(updateErrors = state.updateErrors.filter { it.mangaId != event.mangaId })
+            }
+            UpdatesEvent.ClearAllUpdateErrors -> _state.update { it.copy(updateErrors = emptyList()) }
+            UpdatesEvent.ShowPendingUpdates -> {
+                _state.update { it.copy(showPendingUpdates = true) }
+                loadPendingUpdates()
+            }
+            UpdatesEvent.HidePendingUpdates -> _state.update { it.copy(showPendingUpdates = false) }
+            else -> Unit
         }
     }
 

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
@@ -50,6 +50,7 @@ class UpdatesViewModel @Inject constructor(
         loadUpdates()
         loadLastRunSummary()
         markUpdatesViewed()
+        observeActiveDownloads()
     }
 
     fun onEvent(event: UpdatesEvent) {
@@ -241,6 +242,16 @@ class UpdatesViewModel @Inject constructor(
                 _state.update { it.copy(lastRunSummary = summary) }
             }
             .catch { /* diagnostics failure should not affect the main updates list */ }
+            .launchIn(viewModelScope)
+    }
+
+    /** Observe the download queue and surface active/queued items for per-row progress UI. */
+    private fun observeActiveDownloads() {
+        downloadRepository.observeDownloads()
+            .onEach { items ->
+                _state.update { it.copy(activeDownloads = items.filter { d -> d.isActive }.associateBy { d -> d.chapterId }) }
+            }
+            .catch { /* download progress failure should not affect the main updates list */ }
             .launchIn(viewModelScope)
     }
 

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
@@ -276,12 +276,20 @@ class UpdatesViewModel @Inject constructor(
 
     /** Start a manual library update; shows a brief pull-to-refresh indicator. */
     private fun startLibraryUpdate() {
+        if (_state.value.isRefreshing) return
         _state.update { it.copy(isRefreshing = true, showPendingUpdates = false) }
         viewModelScope.launch {
-            libraryUpdateScheduler.enqueueNow()
-            _effect.send(UpdatesEffect.ShowSnackbar(context.getString(R.string.updates_library_update_started)))
-            delay(1_500L)
-            _state.update { it.copy(isRefreshing = false) }
+            try {
+                libraryUpdateScheduler.enqueueNow()
+                _effect.send(UpdatesEffect.ShowSnackbar(context.getString(R.string.updates_library_update_started)))
+                delay(REFRESH_INDICATOR_DURATION_MS)
+            } finally {
+                _state.update { it.copy(isRefreshing = false) }
+            }
         }
+    }
+
+    companion object {
+        const val REFRESH_INDICATOR_DURATION_MS = 1_500L
     }
 }

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
@@ -81,6 +81,12 @@ class UpdatesViewModel @Inject constructor(
             }
             UpdatesEvent.HidePendingUpdates -> _state.update { it.copy(showPendingUpdates = false) }
             UpdatesEvent.StartLibraryUpdate -> startLibraryUpdate()
+            is UpdatesEvent.SetDateFilter -> _state.update {
+                it.copy(dateFilterStart = event.start, dateFilterEnd = event.end)
+            }
+            UpdatesEvent.ClearDateFilter -> _state.update {
+                it.copy(dateFilterStart = null, dateFilterEnd = null)
+            }
         }
     }
 

--- a/feature/updates/src/main/res/values/strings.xml
+++ b/feature/updates/src/main/res/values/strings.xml
@@ -89,4 +89,8 @@
     <string name="updates_date_this_month">This month</string>
     <string name="updates_date_older">Older</string>
     <string name="updates_unknown_error">Something went wrong while loading updates</string>
+    <!-- Swipe-to-mark-read undo -->
+    <string name="updates_marked_as_read_single">Marked as read</string>
+    <string name="updates_unmark_as_read_failed">Failed to undo</string>
+    <string name="updates_undo_action">Undo</string>
 </resources>

--- a/feature/updates/src/main/res/values/strings.xml
+++ b/feature/updates/src/main/res/values/strings.xml
@@ -89,6 +89,9 @@
     <string name="updates_date_this_month">This month</string>
     <string name="updates_date_older">Older</string>
     <string name="updates_unknown_error">Something went wrong while loading updates</string>
+    <!-- Date filter chips (U1) -->
+    <string name="updates_filter_last_7_days">Last 7 days</string>
+    <string name="updates_filter_last_30_days">Last 30 days</string>
     <!-- Swipe-to-mark-read undo -->
     <string name="updates_marked_as_read_single">Marked as read</string>
     <string name="updates_unmark_as_read_failed">Failed to undo</string>

--- a/feature/updates/src/test/java/app/otakureader/feature/updates/UpdatesViewModelTest.kt
+++ b/feature/updates/src/test/java/app/otakureader/feature/updates/UpdatesViewModelTest.kt
@@ -222,4 +222,36 @@ class UpdatesViewModelTest {
         assertFalse(viewModel.state.value.isRefreshing)
         coVerify(exactly = 1) { libraryUpdateScheduler.enqueueNow() }
     }
+
+    @Test
+    fun onEvent_SetDateFilter_updatesDateFilterState() = runTest {
+        every { getRecentUpdatesUseCase() } returns flowOf(emptyList())
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val start = 1_000_000L
+        val end = 2_000_000L
+        viewModel.onEvent(UpdatesEvent.SetDateFilter(start = start, end = end))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(start, viewModel.state.value.dateFilterStart)
+        assertEquals(end, viewModel.state.value.dateFilterEnd)
+    }
+
+    @Test
+    fun onEvent_ClearDateFilter_removesDateFilterState() = runTest {
+        every { getRecentUpdatesUseCase() } returns flowOf(emptyList())
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(UpdatesEvent.SetDateFilter(start = 1_000_000L, end = 2_000_000L))
+        testDispatcher.scheduler.advanceUntilIdle()
+        viewModel.onEvent(UpdatesEvent.ClearDateFilter)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(viewModel.state.value.dateFilterStart)
+        assertNull(viewModel.state.value.dateFilterEnd)
+    }
 }

--- a/feature/updates/src/test/java/app/otakureader/feature/updates/UpdatesViewModelTest.kt
+++ b/feature/updates/src/test/java/app/otakureader/feature/updates/UpdatesViewModelTest.kt
@@ -206,4 +206,20 @@ class UpdatesViewModelTest {
 
         coVerify(exactly = 1) { generalPreferences.setLastUpdatesViewedAt(any()) }
     }
+
+    @Test
+    fun onEvent_StartLibraryUpdate_clearsIsRefreshingAfterDelay() = runTest {
+        every { getRecentUpdatesUseCase() } returns flowOf(emptyList())
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertFalse(viewModel.state.value.isRefreshing)
+
+        // Trigger the library update; advance through the full delay in one step
+        viewModel.onEvent(UpdatesEvent.StartLibraryUpdate)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(viewModel.state.value.isRefreshing)
+        coVerify(exactly = 1) { libraryUpdateScheduler.enqueueNow() }
+    }
 }


### PR DESCRIPTION
## Summary

Continues the screen-by-screen Komikku-parity "Invisible 20%" audit. This PR covers Phase B (polish gaps) and Phase C (remaining quick-win items).

### History — Phase B
| ID | Gap | Fix |
|----|-----|-----|
| **H3** | Swipe-delete had no undo | Deletion is now **buffered** — item disappears immediately (filtered by `pendingDeleteIds: Set`) and a snackbar with **Undo** appears. The ViewModel owns the 4 s auto-commit timer (`delay(UNDO_TIMEOUT_MS)` inside a `Job`); undo cancels the job + restores. Screen exits with pending delete → `onCleared()` commits it. |
| **H7** | Selection mode had no "Mark as read" | Added **CheckCircle** icon button in selection TopAppBar → `MarkSelectedAsRead` event → `chapterRepository.updateChapterProgress(selected, read=true)`. |

### Updates — Phase B
| ID | Gap | Fix |
|----|-----|-----|
| **X3** | No pull-to-refresh on Updates | Wrapped content in **`PullToRefreshBox`**; pulling fires `StartLibraryUpdate` which sets `isRefreshing = true`. Guarded against double-trigger; `try/finally` ensures `isRefreshing = false` always clears. |
| **U3** | Swipe-to-mark-read had no undo | After marking read, emits `ShowUndoSnackbar`. Undo fires `updateChapterProgress(read=false)`. |

### Updates — Phase C
| ID | Gap | Fix |
|----|-----|-----|
| **U1** | No date-range filter chips | Added **"Last 7 days"** and **"Last 30 days"** `FilterChip` row in a horizontal scroll above the updates list. Chips toggle `dateFilterStart`/`dateFilterEnd` in state; list is filtered client-side via `remember(state.updates, state.dateFilterStart, state.dateFilterEnd)`. Tap active chip to clear. |

### History — Phase C
| ID | Gap | Fix |
|----|-----|-----|
| **X3** | No pull-to-refresh on History | Wrapped History content in `PullToRefreshBox`; pulling fires `RefreshHistory` event → `isPullRefreshing = true` → 1 s delay → `isPullRefreshing = false`. |

### Details — Localization fix
| ID | Gap | Fix |
|----|-----|-----|
| **L13** | "Manga"/"Manhwa" content-type chip labels hardcoded | Moved to `details_content_type_manga` / `details_content_type_manhwa` in `strings.xml`. |

### New unit tests
- `HistoryViewModelTest`: `onEvent_SetDateFilter_updatesDateFilterState`, `onEvent_ClearDateFilter_removesDateFilterState`, `onEvent_RefreshHistory_setsPullRefreshingThenClearsIt`
- `UpdatesViewModelTest`: `onEvent_SetDateFilter_updatesDateFilterState`, `onEvent_ClearDateFilter_removesDateFilterState`

### Bug fixes / review fixes
- `UpdatesViewModel._effect` was a `RENDEZVOUS` channel (capacity 0); changed to `Channel.BUFFERED`.
- Both screens' `ShowUndoSnackbar` handlers moved to `scope.launch {}` so `collectLatest` cancellation on a new swipe cannot cut the snackbar interaction short.
- `HistoryViewModel` now uses `Set` for pending-delete IDs (supports concurrent swipes without flicker or stale state).
- `HistoryMvi`: removed `pendingDeleteChapterId` from `HistoryState`; removed `ConfirmRemoveFromHistory`; `UndoRemoveFromHistory` is now a `data class` carrying `chapterId`.

## Verification

- `./gradlew :feature:history:compileDebugKotlin` ✅
- `./gradlew :feature:updates:compileDebugKotlin` ✅
- `./gradlew :feature:history:testDebugUnitTest` ✅
- `./gradlew :feature:updates:testDebugUnitTest` ✅
- `./gradlew detekt` ✅

https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Undo** option when removing chapters from **History**.
  * Added **Undo** for “swipe-to-mark-read” in **Updates**.
  * Added **pull-to-refresh** to the **Library updates** screen.
  * Added a **page long-press context menu** in the Reader (share, save image, set as custom cover).
  * Added **bulk mark-as-read** for selected chapters in History.
  * Added **date range filtering** in History (presets + custom range).
* **UI Improvements**
  * Added **long-press haptics** and a **per-manga context menu** in the library.
* **Localization**
  * Updated content type chip labels with localized strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->