### PR TITLE
perf(more): eliminate duplicate history scan in MoreViewModel (#1120)

### DIFF
--- a/data/src/main/java/app/otakureader/data/repository/StatisticsRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/StatisticsRepositoryImpl.kt
@@ -91,7 +91,8 @@ class StatisticsRepositoryImpl @Inject constructor(
             dailyGoal = dailyGoal,
             dailyProgress = todayCount,
             weeklyGoal = weeklyGoal,
-            weeklyProgress = weekCount
+            weeklyProgress = weekCount,
+            currentStreak = currentStreak,
         )
     }
     

--- a/data/src/main/java/app/otakureader/data/repository/StatisticsRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/StatisticsRepositoryImpl.kt
@@ -85,8 +85,7 @@ class StatisticsRepositoryImpl @Inject constructor(
             .sorted()
         
         val currentStreak = calculateCurrentStreak(readingDays, today)
-        val bestStreak = calculateBestStreak(readingDays)
-        
+
         ReadingGoal(
             dailyGoal = dailyGoal,
             dailyProgress = todayCount,

--- a/domain/src/main/java/app/otakureader/domain/model/ReadingGoal.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/ReadingGoal.kt
@@ -2,11 +2,12 @@ package app.otakureader.domain.model
 
 import androidx.compose.runtime.Immutable
 
-/** Progress toward daily and weekly reading goals. */
+/** Progress toward daily and weekly reading goals, including current streak. */
 @Immutable
 data class ReadingGoal(
     val dailyGoal: Int = 0,
     val dailyProgress: Int = 0,
     val weeklyGoal: Int = 0,
-    val weeklyProgress: Int = 0
+    val weeklyProgress: Int = 0,
+    val currentStreak: Int = 0,
 )

--- a/feature/more/src/main/java/app/otakureader/feature/more/MoreViewModel.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/MoreViewModel.kt
@@ -3,13 +3,13 @@ package app.otakureader.feature.more
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.otakureader.core.preferences.ReadingGoalPreferences
-import app.otakureader.domain.usecase.GetReadingStatsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import app.otakureader.domain.repository.StatisticsRepository
 import javax.inject.Inject
@@ -22,7 +22,6 @@ data class MoreState(
 
 @HiltViewModel
 class MoreViewModel @Inject constructor(
-    private val getReadingStatsUseCase: GetReadingStatsUseCase,
     private val statisticsRepository: StatisticsRepository,
     private val readingGoalPreferences: ReadingGoalPreferences,
 ) : ViewModel() {
@@ -32,34 +31,31 @@ class MoreViewModel @Inject constructor(
     }
 
     /**
-     * Combines:
-     *  - [GetReadingStatsUseCase] → provides [currentStreak] (all-time, no date filter)
-     *  - [ReadingGoalPreferences.dailyChapterGoal] → user's configured daily target
-     *  - [StatisticsRepository.getReadingGoalProgress] → today's actual progress
+     * Single readingHistoryDao.observeHistory() subscription for the More screen.
      *
-     * Why flatMapLatest here?  When the user changes their daily goal in Settings, the
-     * goal preference emits a new value.  flatMapLatest cancels the previous inner
-     * combine (which was fetching progress against the old goal) and immediately starts
-     * a new one with the updated goal — so the widget always reflects the live setting
-     * without any stale data.
+     * Previously, GetReadingStatsUseCase and getReadingGoalProgress() each subscribed to the
+     * history DAO independently, causing two full history scans per update. Now that ReadingGoal
+     * includes currentStreak (computed in the same scan as dailyProgress/weeklyProgress),
+     * GetReadingStatsUseCase is no longer needed here.
+     *
+     * flatMapLatest: when the user changes their daily/weekly goal in Settings, the inner flow
+     * is cancelled and restarted with the updated goals so the widget stays in sync.
      */
     val state: StateFlow<MoreState> =
         combine(
             readingGoalPreferences.dailyChapterGoal,
             readingGoalPreferences.weeklyChapterGoal,
         ) { daily, weekly -> Pair(daily, weekly) }
-            .distinctUntilChanged()  // prevent inner flow restarts from unrelated DataStore edits
+            .distinctUntilChanged()
             .flatMapLatest { (dailyGoal, weeklyGoal) ->
-                combine(
-                    getReadingStatsUseCase(),
-                    statisticsRepository.getReadingGoalProgress(dailyGoal, weeklyGoal),
-                ) { stats, goalProgress ->
-                    MoreState(
-                        currentStreak = stats.currentStreak,
-                        todayChaptersRead = goalProgress.dailyProgress,
-                        dailyGoal = goalProgress.dailyGoal,
-                    )
-                }
+                statisticsRepository.getReadingGoalProgress(dailyGoal, weeklyGoal)
+            }
+            .map { goalProgress ->
+                MoreState(
+                    currentStreak = goalProgress.currentStreak,
+                    todayChaptersRead = goalProgress.dailyProgress,
+                    dailyGoal = goalProgress.dailyGoal,
+                )
             }
             .stateIn(
                 scope = viewModelScope,

--- a/feature/more/src/main/java/app/otakureader/feature/more/MoreViewModel.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/MoreViewModel.kt
@@ -45,7 +45,8 @@ class MoreViewModel @Inject constructor(
         combine(
             readingGoalPreferences.dailyChapterGoal,
             readingGoalPreferences.weeklyChapterGoal,
-        ) { daily, weekly -> Pair(daily, weekly) }
+            ::Pair,
+        )
             .distinctUntilChanged()
             .flatMapLatest { (dailyGoal, weeklyGoal) ->
                 statisticsRepository.getReadingGoalProgress(dailyGoal, weeklyGoal)


### PR DESCRIPTION
## **User description**
## Summary

- `getReadingGoalProgress()` in `StatisticsRepositoryImpl` already computed `currentStreak` internally but threw it away, so `MoreViewModel` had to separately subscribe to `GetReadingStatsUseCase` (which calls `readingHistoryDao.observeHistory()`) just to get that one field — two full history scans per update while the More screen is visible
- Added `currentStreak: Int = 0` to the `ReadingGoal` domain DTO and populated it from the value already computed in the same map block in `StatisticsRepositoryImpl.getReadingGoalProgress()`
- Removed `GetReadingStatsUseCase` from `MoreViewModel`'s constructor; collapsed the inner `combine(getReadingStatsUseCase(), statisticsRepository.getReadingGoalProgress(...))` to a single `statisticsRepository.getReadingGoalProgress(...).map { ... }` — one DAO subscription instead of two

## Files changed

| File | Change |
|------|--------|
| `domain/.../ReadingGoal.kt` | Add `currentStreak: Int = 0` field |
| `data/.../StatisticsRepositoryImpl.kt` | Populate `currentStreak` in `ReadingGoal(...)` constructor |
| `feature/more/.../MoreViewModel.kt` | Remove `GetReadingStatsUseCase` injection; single-flow state derivation |

## Test plan

- [ ] Build passes: `./gradlew :feature:more:assembleDebug :app:assembleDebug`
- [ ] More screen renders streak and goal progress correctly
- [ ] Changing daily/weekly goal in Settings updates the More screen widget immediately
- [ ] No regressions in Statistics screen (uses `ReadingGoal` via separate call path)

Closes #1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Show reading streak and goal progress with one history scan**

### What Changed
- The More screen now gets the reading streak from the same progress update it already uses, instead of loading reading stats separately
- Reading goal progress now includes the current streak directly, so the More screen still shows streak, today’s chapters read, and daily goal
- Changing daily or weekly goals in Settings still refreshes the More screen immediately

### Impact
`✅ Faster More screen updates`
`✅ Fewer duplicate history scans`
`✅ Lower background work while the More screen is open`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
