### PR TITLE
feat(parity): close 7 Komikku functional parity gaps (GAPs 1, 2, 4, 6, 8, 9, 12)

### DIFF
--- a/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
@@ -87,6 +87,15 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
     val showNsfwContent: Flow<Boolean> = dataStore.data.map { it[Keys.SHOW_NSFW_CONTENT] ?: false }
     suspend fun setShowNsfwContent(value: Boolean) = dataStore.edit { it[Keys.SHOW_NSFW_CONTENT] = value }
 
+    /** Language codes (e.g. "en", "ja") the user wants to see in Browse. Default: all English sources. */
+    val enabledSourceLanguages: Flow<Set<String>> = dataStore.data.map {
+        it[Keys.ENABLED_SOURCE_LANGUAGES] ?: setOf("en")
+    }
+    suspend fun setEnabledSourceLanguages(languages: Set<String>) = dataStore.edit {
+        if (languages.isEmpty()) it.remove(Keys.ENABLED_SOURCE_LANGUAGES)
+        else it[Keys.ENABLED_SOURCE_LANGUAGES] = languages
+    }
+
     // --- Discord Rich Presence ---
 
     /** Whether Discord Rich Presence is enabled. Default: off (opt-in). */
@@ -492,6 +501,7 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
         val SOURCE_CATEGORY_MAP = stringPreferencesKey("source_category_map")
         val SAVED_SOURCE_SEARCHES_JSON = stringPreferencesKey("saved_source_searches_json")
         val EXTENSION_FIRST_SEEN_HASHES = stringPreferencesKey("extension_first_seen_hashes")
+        val ENABLED_SOURCE_LANGUAGES = stringSetPreferencesKey("enabled_source_languages")
     }
 
     companion object {

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
@@ -92,8 +92,7 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
         it[Keys.ENABLED_SOURCE_LANGUAGES] ?: setOf("en")
     }
     suspend fun setEnabledSourceLanguages(languages: Set<String>) = dataStore.edit {
-        if (languages.isEmpty()) it.remove(Keys.ENABLED_SOURCE_LANGUAGES)
-        else it[Keys.ENABLED_SOURCE_LANGUAGES] = languages
+        it[Keys.ENABLED_SOURCE_LANGUAGES] = languages
     }
 
     // --- Discord Rich Presence ---

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/LibraryPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/LibraryPreferences.kt
@@ -31,11 +31,15 @@ class LibraryPreferences(private val dataStore: DataStore<Preferences>) {
     val isStaggeredGrid: Flow<Boolean> = dataStore.data.map { it[Keys.IS_STAGGERED_GRID] ?: false }
     suspend fun setStaggeredGrid(value: Boolean) = dataStore.edit { it[Keys.IS_STAGGERED_GRID] = value }
 
-    // --- Badges ---
+    // --- Badges & Title ---
 
     /** Whether to show unread-count badges on library covers. */
     val showBadges: Flow<Boolean> = dataStore.data.map { it[Keys.SHOW_BADGES] ?: true }
     suspend fun setShowBadges(value: Boolean) = dataStore.edit { it[Keys.SHOW_BADGES] = value }
+
+    /** Whether to show the manga title overlaid on cover art in the library grid. */
+    val showTitle: Flow<Boolean> = dataStore.data.map { it[Keys.SHOW_TITLE] ?: true }
+    suspend fun setShowTitle(value: Boolean) = dataStore.edit { it[Keys.SHOW_TITLE] = value }
 
     /** Whether to show downloaded-chapter count badges on library covers. */
     val showDownloadBadge: Flow<Boolean> = dataStore.data.map { it[Keys.SHOW_DOWNLOAD_BADGE] ?: true }
@@ -171,6 +175,7 @@ class LibraryPreferences(private val dataStore: DataStore<Preferences>) {
         val IS_STAGGERED_GRID = booleanPreferencesKey("is_staggered_grid")
         val SHOW_BADGES = booleanPreferencesKey("library_show_badges")
         val SHOW_DOWNLOAD_BADGE = booleanPreferencesKey("show_download_badge")
+        val SHOW_TITLE = booleanPreferencesKey("library_show_title")
         val LIBRARY_SORT_MODE = intPreferencesKey("library_sort_mode")
         val LIBRARY_DISPLAY_MODE = intPreferencesKey("library_display_mode")
         val LIBRARY_FILTER_MODE = intPreferencesKey("library_filter_mode")

--- a/core/ui/src/main/java/app/otakureader/core/ui/components/MangaCard.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/components/MangaCard.kt
@@ -58,6 +58,13 @@ import app.otakureader.core.ui.modifiers.bottomGradientScrim
  * @param isNew When true, shows a "NEW" badge in the top-left corner
  * @param sourceIcon Optional composable for a small source favicon watermark (bottom-right corner)
  */
+private object MangaCardDefaults {
+    const val SCRIM_HEIGHT_PERCENT = 0.45f
+    const val SCRIM_START_ALPHA = 0.0f
+    const val SCRIM_END_ALPHA = 0.85f
+    const val TITLE_MAX_LINES = 2
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun MangaCard(
@@ -127,9 +134,9 @@ fun MangaCard(
                         .fillMaxWidth()
                         .aspectRatio(2f / 3f)
                         .bottomGradientScrim(
-                            heightPercent = 0.45f,
-                            startAlpha = 0.0f,
-                            endAlpha = 0.85f
+                            heightPercent = MangaCardDefaults.SCRIM_HEIGHT_PERCENT,
+                            startAlpha = MangaCardDefaults.SCRIM_START_ALPHA,
+                            endAlpha = MangaCardDefaults.SCRIM_END_ALPHA
                         )
                 )
 
@@ -138,7 +145,7 @@ fun MangaCard(
                     text = title,
                     style = MaterialTheme.typography.bodySmall,
                     color = Color.White,
-                    maxLines = 2,
+                    maxLines = MangaCardDefaults.TITLE_MAX_LINES,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier
                         .align(Alignment.BottomStart)

--- a/core/ui/src/main/java/app/otakureader/core/ui/components/MangaCard.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/components/MangaCard.kt
@@ -74,6 +74,7 @@ fun MangaCard(
     continueReading: Boolean = false,
     isNew: Boolean = false,
     sourceIcon: @Composable (() -> Unit)? = null,
+    showTitle: Boolean = true,
 ) {
     val context = LocalContext.current
 
@@ -119,30 +120,32 @@ fun MangaCard(
                     )
             )
 
-            // Gradient scrim for title readability
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(2f / 3f)
-                    .bottomGradientScrim(
-                        heightPercent = 0.45f,
-                        startAlpha = 0.0f,
-                        endAlpha = 0.85f
-                    )
-            )
+            if (showTitle) {
+                // Gradient scrim for title readability
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(2f / 3f)
+                        .bottomGradientScrim(
+                            heightPercent = 0.45f,
+                            startAlpha = 0.0f,
+                            endAlpha = 0.85f
+                        )
+                )
 
-            // Title overlaid at bottom
-            Text(
-                text = title,
-                style = MaterialTheme.typography.bodySmall,
-                color = Color.White,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .padding(start = 8.dp, end = 8.dp, bottom = if (readProgress != null) 10.dp else 8.dp)
-                    .fillMaxWidth(),
-            )
+                // Title overlaid at bottom
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.White,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(start = 8.dp, end = 8.dp, bottom = if (readProgress != null) 10.dp else 8.dp)
+                        .fillMaxWidth(),
+                )
+            }
 
             // Unread / custom badge
             badge?.let {

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseMvi.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseMvi.kt
@@ -66,6 +66,12 @@ data class BrowseState(
     val saveSearchName: String = "",
     /** Mirrors [app.otakureader.core.preferences.GeneralPreferences.showNsfwContent] for display in the overflow menu. */
     val showNsfw: Boolean = false,
+    /** Language codes the user has enabled for Browse source filtering (e.g. "en", "ja"). */
+    val enabledLanguages: Set<String> = setOf("en"),
+    /** Whether the language filter dialog is open. */
+    val showLanguageDialog: Boolean = false,
+    /** All distinct language codes present across installed sources (computed in ViewModel). */
+    val availableLanguages: List<String> = emptyList(),
 ) : UiState
 
 sealed interface BrowseEvent : UiEvent {
@@ -135,6 +141,13 @@ sealed interface BrowseEvent : UiEvent {
 
     /** Toggles the global NSFW content preference from the Browse overflow menu. */
     data object ToggleNsfwFilter : BrowseEvent
+
+    /** Opens the language filter dialog. */
+    data object ShowLanguageDialog : BrowseEvent
+    /** Dismisses the language filter dialog without saving. */
+    data object DismissLanguageDialog : BrowseEvent
+    /** Persists the selected language set and re-filters the source list. */
+    data class SetEnabledLanguages(val languages: Set<String>) : BrowseEvent
 }
 
 sealed interface BrowseEffect : UiEffect {

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -425,7 +425,7 @@ private fun LanguageFilterDialog(
     onConfirm: (Set<String>) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var selected by remember(enabledLanguages) { mutableStateOf(enabledLanguages.toMutableSet()) }
+    var selected by remember(enabledLanguages) { mutableStateOf(enabledLanguages) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -441,9 +441,7 @@ private fun LanguageFilterDialog(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable {
-                                    selected = selected.toMutableSet().also {
-                                        if (checked) it.remove(lang) else it.add(lang)
-                                    }
+                                    selected = if (checked) selected - lang else selected + lang
                                 }
                                 .padding(vertical = 4.dp),
                             verticalAlignment = Alignment.CenterVertically,
@@ -466,7 +464,7 @@ private fun LanguageFilterDialog(
             }
         },
         confirmButton = {
-            TextButton(onClick = { onConfirm(selected.toSet()) }) {
+            TextButton(onClick = { onConfirm(selected) }) {
                 Text(stringResource(android.R.string.ok))
             }
         },

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -79,6 +80,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
@@ -418,6 +420,10 @@ fun BrowseScreen(
 // Language filter dialog — multi-select chips for source language filtering
 // ────────────────────────────────────────────────────────────────────────────────
 
+private val LANGUAGE_DIALOG_ROW_VERTICAL_PADDING = 4.dp
+private val LANGUAGE_DIALOG_ICON_SIZE = 20.dp
+private val LANGUAGE_DIALOG_ICON_TEXT_SPACING = 12.dp
+
 @Composable
 private fun LanguageFilterDialog(
     availableLanguages: List<String>,
@@ -440,10 +446,14 @@ private fun LanguageFilterDialog(
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clickable {
-                                    selected = if (checked) selected - lang else selected + lang
-                                }
-                                .padding(vertical = 4.dp),
+                                .toggleable(
+                                    value = checked,
+                                    role = Role.Checkbox,
+                                    onValueChange = {
+                                        selected = if (checked) selected - lang else selected + lang
+                                    },
+                                )
+                                .padding(vertical = LANGUAGE_DIALOG_ROW_VERTICAL_PADDING),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             if (checked) {
@@ -451,12 +461,12 @@ private fun LanguageFilterDialog(
                                     Icons.Default.Done,
                                     contentDescription = null,
                                     tint = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier.size(20.dp),
+                                    modifier = Modifier.size(LANGUAGE_DIALOG_ICON_SIZE),
                                 )
                             } else {
-                                Spacer(Modifier.size(20.dp))
+                                Spacer(Modifier.size(LANGUAGE_DIALOG_ICON_SIZE))
                             }
-                            Spacer(Modifier.width(12.dp))
+                            Spacer(Modifier.width(LANGUAGE_DIALOG_ICON_TEXT_SPACING))
                             Text(lang.uppercase(), style = MaterialTheme.typography.bodyMedium)
                         }
                     }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.ClearAll
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.LibraryAdd
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PushPin
@@ -185,6 +187,14 @@ fun BrowseScreen(
                         }
                         IconButton(onClick = onGlobalSearchClick) {
                             Icon(Icons.Default.Search, contentDescription = stringResource(R.string.browse_search))
+                        }
+                        if (state.selectedTab == BrowseTab.SOURCES) {
+                            IconButton(onClick = { viewModel.onEvent(BrowseEvent.ShowLanguageDialog) }) {
+                                Icon(
+                                    Icons.Default.FilterList,
+                                    contentDescription = stringResource(R.string.browse_language_filter)
+                                )
+                            }
                         }
                         if (state.selectedTab == BrowseTab.SOURCES || state.selectedTab == BrowseTab.EXTENSIONS) {
                             Box {
@@ -366,6 +376,16 @@ fun BrowseScreen(
         )
     }
 
+    // Language filter dialog
+    if (state.showLanguageDialog) {
+        LanguageFilterDialog(
+            availableLanguages = state.availableLanguages,
+            enabledLanguages = state.enabledLanguages,
+            onConfirm = { selected -> viewModel.onEvent(BrowseEvent.SetEnabledLanguages(selected)) },
+            onDismiss = { viewModel.onEvent(BrowseEvent.DismissLanguageDialog) },
+        )
+    }
+
     // Save search dialog
     if (state.showSaveSearchDialog) {
         AlertDialog(
@@ -392,6 +412,70 @@ fun BrowseScreen(
             },
         )
     }
+}
+
+// ────────────────────────────────────────────────────────────────────────────────
+// Language filter dialog — multi-select chips for source language filtering
+// ────────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun LanguageFilterDialog(
+    availableLanguages: List<String>,
+    enabledLanguages: Set<String>,
+    onConfirm: (Set<String>) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var selected by remember(enabledLanguages) { mutableStateOf(enabledLanguages.toMutableSet()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.browse_language_filter)) },
+        text = {
+            Column {
+                if (availableLanguages.isEmpty()) {
+                    Text(stringResource(R.string.browse_no_languages))
+                } else {
+                    availableLanguages.forEach { lang ->
+                        val checked = lang in selected
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    selected = selected.toMutableSet().also {
+                                        if (checked) it.remove(lang) else it.add(lang)
+                                    }
+                                }
+                                .padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            if (checked) {
+                                Icon(
+                                    Icons.Default.Done,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.size(20.dp),
+                                )
+                            } else {
+                                Spacer(Modifier.size(20.dp))
+                            }
+                            Spacer(Modifier.width(12.dp))
+                            Text(lang.uppercase(), style = MaterialTheme.typography.bodyMedium)
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(selected.toSet()) }) {
+                Text(stringResource(android.R.string.ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        },
+    )
 }
 
 // ────────────────────────────────────────────────────────────────────────────────

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
@@ -74,17 +74,31 @@ class BrowseViewModel @Inject constructor(
     private val nsfwToggleMutex = Mutex()
 
     init {
-        // Collect sources and filter by NSFW preference; also mirror showNsfw into state
-        // so the Browse overflow menu can display the current toggle state.
+        // Collect sources and filter by NSFW preference and enabled languages.
+        // Also mirrors showNsfw + enabledLanguages into state for the Browse UI.
         viewModelScope.launch {
             combine(
                 getSourcesUseCase(),
-                generalPreferences.showNsfwContent
-            ) { sources, showNsfw ->
-                Pair(if (showNsfw) sources else sources.filter { !it.isNsfw }, showNsfw)
-            }.collect { (filteredSources, showNsfw) ->
+                generalPreferences.showNsfwContent,
+                generalPreferences.enabledSourceLanguages,
+            ) { sources, showNsfw, enabledLangs ->
+                val nsfwFiltered = if (showNsfw) sources else sources.filter { !it.isNsfw }
+                // availableLanguages = all langs from NSFW-filtered set (before language filter)
+                val availableLangs = nsfwFiltered.map { it.lang }.distinct().sorted()
+                val langFiltered = if (enabledLangs.isEmpty()) nsfwFiltered
+                    else nsfwFiltered.filter { it.lang in enabledLangs }
+                Triple(langFiltered to availableLangs, showNsfw, enabledLangs)
+            }.collect { (sourcesAndLangs, showNsfw, enabledLangs) ->
+                val (filteredSources, availableLangs) = sourcesAndLangs
                 _sources.value = filteredSources
-                _state.update { it.copy(sources = filteredSources, showNsfw = showNsfw) }
+                _state.update {
+                    it.copy(
+                        sources = filteredSources,
+                        showNsfw = showNsfw,
+                        enabledLanguages = enabledLangs,
+                        availableLanguages = availableLangs,
+                    )
+                }
             }
         }
         observeSavedSearches()
@@ -246,6 +260,14 @@ class BrowseViewModel @Inject constructor(
                     nsfwToggleMutex.withLock {
                         generalPreferences.setShowNsfwContent(!state.value.showNsfw)
                     }
+                }
+            }
+            is BrowseEvent.ShowLanguageDialog -> _state.update { it.copy(showLanguageDialog = true) }
+            is BrowseEvent.DismissLanguageDialog -> _state.update { it.copy(showLanguageDialog = false) }
+            is BrowseEvent.SetEnabledLanguages -> {
+                viewModelScope.launch {
+                    generalPreferences.setEnabledSourceLanguages(event.languages)
+                    _state.update { it.copy(showLanguageDialog = false) }
                 }
             }
         }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
@@ -22,6 +22,7 @@ import app.otakureader.sourceapi.SourceManga
 import app.otakureader.sourceapi.toSourceId
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -30,6 +31,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -88,7 +90,7 @@ class BrowseViewModel @Inject constructor(
                 val langFiltered = if (enabledLangs.isEmpty()) nsfwFiltered
                     else nsfwFiltered.filter { it.lang in enabledLangs }
                 Triple(langFiltered to availableLangs, showNsfw, enabledLangs)
-            }.collect { (sourcesAndLangs, showNsfw, enabledLangs) ->
+            }.flowOn(Dispatchers.Default).collect { (sourcesAndLangs, showNsfw, enabledLangs) ->
                 val (filteredSources, availableLangs) = sourcesAndLangs
                 _sources.value = filteredSources
                 _state.update {

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -154,6 +154,9 @@
     <string name="browse_add_to_library">Add to Library</string>
     <string name="browse_exit_selection">Exit selection</string>
     <string name="browse_clear_selection">Clear selection</string>
+    <!-- Browse language filter (GAP 12) -->
+    <string name="browse_language_filter">Filter languages</string>
+    <string name="browse_no_languages">No languages detected</string>
     <!-- Browse overflow menu: NSFW quick filter (#1117) -->
     <string name="browse_show_nsfw">Show NSFW (18+)</string>
     <string name="browse_hide_nsfw">Hide NSFW (18+)</string>

--- a/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
+++ b/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
@@ -80,6 +80,7 @@ class BrowseViewModelTest {
         // Default stubs — applied before ViewModel creation
         every { sourceRepository.getSources() } returns flowOf(emptyList())
         every { generalPreferences.showNsfwContent } returns flowOf(false)
+        every { generalPreferences.enabledSourceLanguages } returns flowOf(emptySet())
         every { generalPreferences.browseSearchHistory } returns flowOf(emptyList())
         coEvery { generalPreferences.addBrowseSearchHistory(any()) } returns mockk(relaxed = true)
         coEvery { generalPreferences.getBrowseFilterState(any()) } returns null

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
@@ -154,6 +154,19 @@ private fun DisplayTab(
             )
         }
 
+        // Show title on cover
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(stringResource(R.string.display_show_title))
+            Switch(
+                checked = state.showTitle,
+                onCheckedChange = { enabled -> onEvent(LibraryEvent.SetShowTitle(enabled)) },
+            )
+        }
+
         // Staggered grid
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -336,6 +349,8 @@ private fun LibrarySortMode.label(): String = when (this) {
     LibrarySortMode.DATE_ADDED -> stringResource(R.string.sort_date_added)
     LibrarySortMode.UNREAD_COUNT -> stringResource(R.string.sort_unread_count)
     LibrarySortMode.SOURCE -> stringResource(R.string.sort_source)
+    LibrarySortMode.LAST_UPDATED -> stringResource(R.string.sort_last_updated)
+    LibrarySortMode.TOTAL_CHAPTERS -> stringResource(R.string.sort_total_chapters)
 }
 
 @Composable

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
@@ -56,6 +56,8 @@ internal fun applySort(items: List<LibraryMangaItem>, sortMode: LibrarySortMode,
         LibrarySortMode.DATE_ADDED -> items.sortedByDescending { it.dateAdded }
         LibrarySortMode.UNREAD_COUNT -> items.sortedByDescending { it.unreadCount }
         LibrarySortMode.SOURCE -> items.sortedBy { it.sourceId }
+        LibrarySortMode.LAST_UPDATED -> items.sortedByDescending { it.lastUpdate }
+        LibrarySortMode.TOTAL_CHAPTERS -> items.sortedByDescending { it.totalChapterCount }
     }
     return if (ascending) sorted else sorted.reversed()
 }
@@ -78,6 +80,7 @@ internal fun Manga.toLibraryItem(
     dateAdded = dateAdded,
     status = status,
     totalChapterCount = totalChapters,
+    lastUpdate = lastUpdate,
     userCompleted = userCompleted,
     userDropped = userDropped,
     genres = genre,

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -162,7 +162,9 @@ internal fun MangaGrid(
         onEvent(LibraryEvent.OnCategorySelected(id))
     }
     // Chip / tab tap → scroll pager to matching page
+    // Guard against fighting an in-progress user swipe gesture
     LaunchedEffect(state.selectedCategory) {
+        if (pagerState.isScrollInProgress) return@LaunchedEffect
         val target = categoryPages.indexOf(state.selectedCategory).coerceAtLeast(0)
         if (pagerState.currentPage != target) {
             pagerState.animateScrollToPage(target)

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items as columnItems
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -38,6 +40,7 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -144,21 +147,40 @@ internal fun MangaGrid(
         }
     }
 
-    // Header items shared by both grid variants
-    val headerContent: @Composable () -> Unit = {
-        // Greeting header
+    // GAP 1: page 0 = "All" (null), pages 1..n = each category id
+    val categoryPages: List<Long?> = remember(state.categories) {
+        listOf(null) + state.categories.map { it.id }
+    }
+    val pagerState = rememberPagerState(
+        initialPage = categoryPages.indexOf(state.selectedCategory).coerceAtLeast(0),
+        pageCount = { categoryPages.size },
+    )
+
+    // Swipe → update selected category in ViewModel
+    LaunchedEffect(pagerState.currentPage) {
+        val id = categoryPages.getOrNull(pagerState.currentPage)
+        onEvent(LibraryEvent.OnCategorySelected(id))
+    }
+    // Chip / tab tap → scroll pager to matching page
+    LaunchedEffect(state.selectedCategory) {
+        val target = categoryPages.indexOf(state.selectedCategory).coerceAtLeast(0)
+        if (pagerState.currentPage != target) {
+            pagerState.animateScrollToPage(target)
+        }
+    }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        // Fixed header: greeting, goal banner, continue reading, category controls
         LibraryGreetingHeader(
             mangaCount = state.mangaList.size,
             unreadCount = state.mangaList.sumOf { it.unreadCount },
             userName = state.displayName,
         )
 
-        // Daily reading goal banner
         if (state.readingGoal.dailyGoal > 0) {
             DailyGoalBanner(readingGoal = state.readingGoal)
         }
 
-        // Continue Reading section
         if (state.continueReadingItems.isNotEmpty()) {
             ContinueReadingSection(
                 items = state.continueReadingItems,
@@ -176,7 +198,6 @@ internal fun MangaGrid(
             )
         }
 
-        // "Categories" section header
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -211,7 +232,6 @@ internal fun MangaGrid(
             modifier = Modifier.padding(vertical = 4.dp)
         )
 
-        // Reading list filter chips
         if (state.readingLists.isNotEmpty()) {
             ReadingListFilterChips(
                 readingLists = state.readingLists,
@@ -221,7 +241,7 @@ internal fun MangaGrid(
             )
         }
 
-        // Content-type filter tabs
+        // Content-type filter tabs (All / Manga / Manhwa)
         TabRow(
             selectedTabIndex = selectedContentFilter,
             containerColor = Color.Transparent,
@@ -255,7 +275,6 @@ internal fun MangaGrid(
             }
         }
 
-        // "All Titles" section header
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -269,15 +288,40 @@ internal fun MangaGrid(
                 modifier = Modifier.weight(1f),
             )
         }
-    }
 
+        // Swipeable pager — each page shows the active category's manga list.
+        // Content is extracted to a separate composable to prevent ColumnScope from leaking
+        // into AnimatedVisibility resolution (Kotlin 2.x context receiver change).
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxSize(),
+        ) { _ ->
+            LibraryMangaPageContent(
+                state = state,
+                adaptiveColumns = adaptiveColumns,
+                displayedManga = displayedManga,
+                onMangaTap = onMangaTap,
+                onMangaLongClick = onMangaLongClick,
+                onEvent = onEvent,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LibraryMangaPageContent(
+    state: LibraryState,
+    adaptiveColumns: Int,
+    displayedManga: List<LibraryMangaItem>,
+    onMangaTap: (LibraryMangaItem) -> Unit,
+    onMangaLongClick: (Long) -> Unit,
+    onEvent: (LibraryEvent) -> Unit,
+) {
     if (state.displayMode == LibraryDisplayMode.LIST) {
         LazyColumn(
             contentPadding = PaddingValues(vertical = 8.dp),
-            modifier = modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize(),
         ) {
-            item(contentType = "header_section") { headerContent() }
-
             columnItems(
                 items = displayedManga,
                 key = { it.id },
@@ -301,21 +345,14 @@ internal fun MangaGrid(
                 }
             }
         }
-        return
-    }
-
-    if (state.isStaggeredGrid) {
+    } else if (state.isStaggeredGrid) {
         LazyVerticalStaggeredGrid(
             columns = StaggeredGridCells.Adaptive(130.dp),
             contentPadding = PaddingValues(8.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalItemSpacing = 8.dp,
-            modifier = modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize(),
         ) {
-            item(span = StaggeredGridItemSpan.FullLine) {
-                Column { headerContent() }
-            }
-
             staggeredItems(
                 items = displayedManga,
                 key = { it.id },
@@ -348,6 +385,7 @@ internal fun MangaGrid(
                             readProgress = readProgress,
                             continueReading = continueReading,
                             isNew = manga.unreadCount > 0,
+                            showTitle = state.showTitle,
                             badge = when {
                                 state.showBadges && manga.unreadCount > 0 &&
                                     state.showDownloadBadge && downloadCount > 0 -> {
@@ -403,15 +441,8 @@ internal fun MangaGrid(
             contentPadding = PaddingValues(8.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize(),
         ) {
-            item(
-                span = { GridItemSpan(maxLineSpan) },
-                contentType = "header_section"
-            ) {
-                Column { headerContent() }
-            }
-
             gridItems(
                 items = displayedManga,
                 key = { it.id },
@@ -434,6 +465,7 @@ internal fun MangaGrid(
                         readProgress = readProgress,
                         continueReading = continueReading,
                         isNew = manga.unreadCount > 0,
+                        showTitle = state.showTitle,
                         badge = when {
                             state.showBadges && manga.unreadCount > 0 &&
                                 state.showDownloadBadge && downloadCount > 0 -> {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -10,7 +10,9 @@ enum class LibrarySortMode {
     LAST_READ,
     DATE_ADDED,
     UNREAD_COUNT,
-    SOURCE
+    SOURCE,
+    LAST_UPDATED,
+    TOTAL_CHAPTERS
 }
 
 enum class LibraryFilterMode {
@@ -58,6 +60,7 @@ data class LibraryState(
     val gridSize: Int = 3,
     val showBadges: Boolean = true,
     val showDownloadBadge: Boolean = true,
+    val showTitle: Boolean = true,
     val downloadCountByManga: Map<Long, Int> = emptyMap(),
     val isStaggeredGrid: Boolean = false,
     val displayMode: LibraryDisplayMode = LibraryDisplayMode.GRID,
@@ -97,6 +100,9 @@ data class LibraryState(
     // L2/L3: long-press context menu — holds the id of the manga whose popup is open
     val contextMenuMangaId: Long? = null,
     val displayName: String = "",
+    // Move to category bulk action (GAP 2)
+    val showMoveToCategoryDialog: Boolean = false,
+    val moveToCategoryMangaIds: Set<Long> = emptySet(),
 )
 
 data class LibraryMangaItem(
@@ -114,6 +120,7 @@ data class LibraryMangaItem(
     val dateAdded: Long = 0L,
     val status: MangaStatus = MangaStatus.UNKNOWN,
     val totalChapterCount: Int = 0,
+    val lastUpdate: Long = 0L,
     val userCompleted: Boolean = false,
     val userDropped: Boolean = false,
     val genres: List<String> = emptyList(),
@@ -175,6 +182,7 @@ sealed class LibraryEvent {
     data class SetGridSize(val size: Int) : LibraryEvent()
     data class SetShowBadges(val enabled: Boolean) : LibraryEvent()
     data class SetShowDownloadBadge(val enabled: Boolean) : LibraryEvent()
+    data class SetShowTitle(val show: Boolean) : LibraryEvent()
     data class SetStaggeredGrid(val enabled: Boolean) : LibraryEvent()
     data class SetDisplayMode(val mode: LibraryDisplayMode) : LibraryEvent()
     data object ToggleFilterSheet : LibraryEvent()
@@ -202,6 +210,10 @@ sealed class LibraryEvent {
     data class MigrateMangaFromMenu(val mangaId: Long) : LibraryEvent()
     data class SelectMangaFromMenu(val mangaId: Long) : LibraryEvent()
     data class UndoLibraryDelete(val mangaIds: Set<Long>) : LibraryEvent()
+    // Move to category bulk action (GAP 2)
+    data object OpenMoveToCategoryDialog : LibraryEvent()
+    data object DismissMoveToCategoryDialog : LibraryEvent()
+    data class MoveToCategory(val mangaIds: Set<Long>, val categoryId: Long) : LibraryEvent()
 }
 
 sealed class LibraryEffect {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -229,7 +229,10 @@ fun LibraryScreen(
                         }
                         if (state.categories.isNotEmpty()) {
                             IconButton(onClick = { viewModel.onEvent(LibraryEvent.OpenMoveToCategoryDialog) }) {
-                                Icon(Icons.AutoMirrored.Filled.DriveFileMove, contentDescription = stringResource(R.string.library_move_to_category))
+                                Icon(
+                                    Icons.AutoMirrored.Filled.DriveFileMove,
+                                    contentDescription = stringResource(R.string.library_move_to_category),
+                                )
                             }
                         }
                         IconButton(onClick = { pendingBulkAction = LibraryEvent.RemoveSelectedFromLibrary }) {
@@ -499,7 +502,6 @@ fun LibraryScreen(
     if (state.showMoveToCategoryDialog) {
         MoveToCategoryDialog(
             categories = state.categories,
-            mangaIds = state.moveToCategoryMangaIds,
             onConfirm = { categoryId ->
                 viewModel.onEvent(LibraryEvent.MoveToCategory(state.moveToCategoryMangaIds, categoryId))
             },
@@ -810,7 +812,6 @@ private fun SaveViewDialog(
 @Composable
 private fun MoveToCategoryDialog(
     categories: List<CategoryItem>,
-    mangaIds: Set<Long>,
     onConfirm: (Long) -> Unit,
     onDismiss: () -> Unit,
 ) {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.automirrored.filled.DriveFileMove
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.MoreVert
@@ -27,9 +28,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -223,6 +226,11 @@ fun LibraryScreen(
                         }
                         IconButton(onClick = { viewModel.onEvent(LibraryEvent.DownloadSelected) }) {
                             Icon(Icons.Default.Download, contentDescription = stringResource(R.string.library_download_selected))
+                        }
+                        if (state.categories.isNotEmpty()) {
+                            IconButton(onClick = { viewModel.onEvent(LibraryEvent.OpenMoveToCategoryDialog) }) {
+                                Icon(Icons.AutoMirrored.Filled.DriveFileMove, contentDescription = stringResource(R.string.library_move_to_category))
+                            }
                         }
                         IconButton(onClick = { pendingBulkAction = LibraryEvent.RemoveSelectedFromLibrary }) {
                             Icon(Icons.Default.DeleteForever, contentDescription = stringResource(R.string.library_remove_selected))
@@ -485,6 +493,17 @@ fun LibraryScreen(
             onNameChange = { viewModel.onEvent(LibraryEvent.UpdateSaveViewName(it)) },
             onConfirm = { viewModel.onEvent(LibraryEvent.ConfirmSaveView) },
             onDismiss = { viewModel.onEvent(LibraryEvent.HideSaveViewDialog) },
+        )
+    }
+
+    if (state.showMoveToCategoryDialog) {
+        MoveToCategoryDialog(
+            categories = state.categories,
+            mangaIds = state.moveToCategoryMangaIds,
+            onConfirm = { categoryId ->
+                viewModel.onEvent(LibraryEvent.MoveToCategory(state.moveToCategoryMangaIds, categoryId))
+            },
+            onDismiss = { viewModel.onEvent(LibraryEvent.DismissMoveToCategoryDialog) },
         )
     }
 }
@@ -778,6 +797,59 @@ private fun SaveViewDialog(
                 enabled = name.isNotBlank(),
             ) {
                 Text(stringResource(R.string.library_save_view_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun MoveToCategoryDialog(
+    categories: List<CategoryItem>,
+    mangaIds: Set<Long>,
+    onConfirm: (Long) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var selectedCategoryId by remember { mutableStateOf<Long?>(null) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.library_move_to_category)) },
+        text = {
+            Column {
+                categories.forEach { category ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .selectable(
+                                selected = selectedCategoryId == category.id,
+                                onClick = { selectedCategoryId = category.id },
+                            )
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = selectedCategoryId == category.id,
+                            onClick = { selectedCategoryId = category.id },
+                        )
+                        Text(
+                            text = category.name,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.padding(start = 8.dp),
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { selectedCategoryId?.let { onConfirm(it) } },
+                enabled = selectedCategoryId != null,
+            ) {
+                Text(stringResource(android.R.string.ok))
             }
         },
         dismissButton = {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -25,6 +25,8 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.filled.Tune
@@ -820,8 +822,8 @@ private fun MoveToCategoryDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.library_move_to_category)) },
         text = {
-            Column {
-                categories.forEach { category ->
+            LazyColumn(modifier = Modifier.heightIn(max = 320.dp)) {
+                items(categories, key = { it.id }) { category ->
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -269,8 +269,10 @@ class LibraryViewModel @Inject constructor(
 
     private fun moveMangaToCategory(mangaIds: Set<Long>, categoryId: Long) {
         viewModelScope.launch {
-            mangaIds.forEach { mangaId ->
-                runCatching { categoryRepository.addMangaToCategory(mangaId, categoryId) }
+            coroutineScope {
+                mangaIds.map { mangaId ->
+                    async { runCatching { categoryRepository.addMangaToCategory(mangaId, categoryId) } }
+                }.awaitAll()
             }
             _state.update { it.copy(showMoveToCategoryDialog = false, moveToCategoryMangaIds = emptySet()) }
             selection.clear()

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -6,6 +6,7 @@ import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.core.preferences.LibraryPreferences
 import app.otakureader.core.preferences.ReadingGoalPreferences
 import app.otakureader.core.ui.selection.SelectionManager
+import app.otakureader.domain.repository.CategoryRepository
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.MangaRepository
@@ -66,6 +67,7 @@ class LibraryViewModel @Inject constructor(
     private val downloadRepository: DownloadRepository,
     private val settingsRepository: ReaderSettingsRepository,
     private val trackRepository: TrackRepository,
+    private val categoryRepository: CategoryRepository,
     private val getCategories: GetCategoriesUseCase,
     private val getContinueReading: GetContinueReadingUseCase,
     private val readingGoalPreferences: ReadingGoalPreferences,
@@ -134,6 +136,7 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.SetGroupByCategory -> viewModelScope.launch { libraryPreferences.setGroupByCategory(event.enabled) }
             is LibraryEvent.SetGridSize, is LibraryEvent.SetShowBadges,
             is LibraryEvent.SetShowDownloadBadge, is LibraryEvent.SetStaggeredGrid,
+            is LibraryEvent.SetShowTitle,
             is LibraryEvent.SetDisplayMode -> handleDisplayEvent(event)
             is LibraryEvent.ToggleIncognito -> toggleIncognitoMode()
             is LibraryEvent.DismissRecommendation -> dismissRecommendation(event.mangaId)
@@ -143,7 +146,9 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.MarkSelectedAsUnread, is LibraryEvent.RemoveSelectedFromLibrary,
             is LibraryEvent.DownloadSelected, is LibraryEvent.MarkSelectedAsCompleted,
             is LibraryEvent.MarkSelectedAsDropped, is LibraryEvent.ShareSelectedManga,
-            is LibraryEvent.ViewSelectedManga, is LibraryEvent.UndoLibraryDelete -> handleActionEvent(event)
+            is LibraryEvent.ViewSelectedManga, is LibraryEvent.UndoLibraryDelete,
+            is LibraryEvent.OpenMoveToCategoryDialog, is LibraryEvent.DismissMoveToCategoryDialog,
+            is LibraryEvent.MoveToCategory -> handleActionEvent(event)
             is LibraryEvent.UpdateLibrary, is LibraryEvent.UpdateCategory,
             is LibraryEvent.OpenRandomEntry, is LibraryEvent.ReindexDownloads,
             is LibraryEvent.SyncEhFavorites,
@@ -183,6 +188,8 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.SetShowBadges -> viewModelScope.launch { libraryPreferences.setShowBadges(event.enabled) }
             is LibraryEvent.SetShowDownloadBadge ->
                 viewModelScope.launch { libraryPreferences.setShowDownloadBadge(event.enabled) }
+            is LibraryEvent.SetShowTitle ->
+                viewModelScope.launch { libraryPreferences.setShowTitle(event.show) }
             is LibraryEvent.SetStaggeredGrid ->
                 viewModelScope.launch { libraryPreferences.setStaggeredGrid(event.enabled) }
             is LibraryEvent.SetDisplayMode ->
@@ -249,7 +256,26 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.ShareSelectedManga -> shareSelectedManga()
             is LibraryEvent.ViewSelectedManga -> viewSelectedManga()
             is LibraryEvent.UndoLibraryDelete -> undoLibraryDelete(event.mangaIds)
+            is LibraryEvent.OpenMoveToCategoryDialog -> _state.update {
+                it.copy(showMoveToCategoryDialog = true, moveToCategoryMangaIds = it.selectedManga)
+            }
+            is LibraryEvent.DismissMoveToCategoryDialog -> _state.update {
+                it.copy(showMoveToCategoryDialog = false, moveToCategoryMangaIds = emptySet())
+            }
+            is LibraryEvent.MoveToCategory -> moveMangaToCategory(event.mangaIds, event.categoryId)
             else -> Unit
+        }
+    }
+
+    private fun moveMangaToCategory(mangaIds: Set<Long>, categoryId: Long) {
+        viewModelScope.launch {
+            mangaIds.forEach { mangaId ->
+                runCatching { categoryRepository.addMangaToCategory(mangaId, categoryId) }
+            }
+            _state.update { it.copy(showMoveToCategoryDialog = false, moveToCategoryMangaIds = emptySet()) }
+            selection.clear()
+            _state.update { it.copy(selectedManga = emptySet()) }
+            _effect.send(LibraryEffect.ShowSnackbar(R.string.library_moved_to_category))
         }
     }
 
@@ -430,6 +456,9 @@ class LibraryViewModel @Inject constructor(
             .launchIn(viewModelScope)
         libraryPreferences.showDownloadBadge
             .onEach { show -> _state.update { it.copy(showDownloadBadge = show) } }
+            .launchIn(viewModelScope)
+        libraryPreferences.showTitle
+            .onEach { show -> _state.update { it.copy(showTitle = show) } }
             .launchIn(viewModelScope)
         libraryPreferences.librarySortMode
             .onEach { sortModeInt ->

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -269,15 +269,20 @@ class LibraryViewModel @Inject constructor(
 
     private fun moveMangaToCategory(mangaIds: Set<Long>, categoryId: Long) {
         viewModelScope.launch {
-            coroutineScope {
+            val results = coroutineScope {
                 mangaIds.map { mangaId ->
                     async { runCatching { categoryRepository.addMangaToCategory(mangaId, categoryId) } }
                 }.awaitAll()
             }
+            val allSucceeded = results.all { it.isSuccess }
             _state.update { it.copy(showMoveToCategoryDialog = false, moveToCategoryMangaIds = emptySet()) }
-            selection.clear()
-            _state.update { it.copy(selectedManga = emptySet()) }
-            _effect.send(LibraryEffect.ShowSnackbar(R.string.library_moved_to_category))
+            if (allSucceeded) {
+                selection.clear()
+                _state.update { it.copy(selectedManga = emptySet()) }
+                _effect.send(LibraryEffect.ShowSnackbar(R.string.library_moved_to_category))
+            } else {
+                _effect.send(LibraryEffect.ShowSnackbar(R.string.library_move_to_category_error))
+            }
         }
     }
 

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -103,6 +103,8 @@
     <string name="library_mark_selected_read">Mark as read</string>
     <string name="library_mark_selected_unread">Mark as unread</string>
     <string name="library_download_selected">Download selected</string>
+    <string name="library_move_to_category">Move to category</string>
+    <string name="library_moved_to_category">Moved to category</string>
     <string name="library_remove_selected">Remove from library</string>
     <string name="library_more_actions">More actions</string>
     <string name="library_select_all">Select all</string>
@@ -165,6 +167,7 @@
     <string name="display_grid_size_value">%1$d columns</string>
     <string name="display_show_badges">Show unread badges</string>
     <string name="display_show_download_badge">Show download badge</string>
+    <string name="display_show_title">Show title on cover</string>
     <string name="display_staggered_grid">Staggered grid</string>
     <string name="group_category_label">Category</string>
     <string name="group_by_category">Group by category</string>
@@ -181,6 +184,8 @@
     <string name="sort_date_added">Date added</string>
     <string name="sort_unread_count">Unread count</string>
     <string name="sort_source">Source</string>
+    <string name="sort_last_updated">Last updated</string>
+    <string name="sort_total_chapters">Total chapters</string>
     <string name="filter_all">All</string>
     <string name="filter_downloaded">Downloaded</string>
     <string name="filter_unread">Unread</string>

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -105,6 +105,7 @@
     <string name="library_download_selected">Download selected</string>
     <string name="library_move_to_category">Move to category</string>
     <string name="library_moved_to_category">Moved to category</string>
+    <string name="library_move_to_category_error">Some items could not be moved</string>
     <string name="library_remove_selected">Remove from library</string>
     <string name="library_more_actions">More actions</string>
     <string name="library_select_all">Select all</string>

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -10,6 +10,7 @@ import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.model.ReadingList
 import app.otakureader.domain.model.ReadingListMangaItem
 import app.otakureader.domain.model.DownloadItem
+import app.otakureader.domain.repository.CategoryRepository
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.MangaRepository
@@ -67,6 +68,7 @@ class LibraryViewModelTest {
     private lateinit var downloadRepository: DownloadRepository
     private lateinit var settingsRepository: ReaderSettingsRepository
     private lateinit var trackRepository: TrackRepository
+    private val categoryRepository: CategoryRepository = mockk(relaxed = true)
     private lateinit var getCategories: GetCategoriesUseCase
     private lateinit var getContinueReading: GetContinueReadingUseCase
     private lateinit var readingGoalPreferences: ReadingGoalPreferences
@@ -109,6 +111,7 @@ class LibraryViewModelTest {
             every { groupByCategory } returns flowOf(false)
             every { savedViewsJson } returns flowOf("[]")
             coEvery { setSavedViewsJson(any()) } just Awaits
+            every { showTitle } returns flowOf(true)
         }
         generalPreferences = mockk {
             every { showNsfwContent } returns flowOf(true)
@@ -168,6 +171,7 @@ class LibraryViewModelTest {
             downloadRepository,
             settingsRepository,
             trackRepository,
+            categoryRepository,
             getCategories,
             getContinueReading,
             readingGoalPreferences,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderMvi.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderMvi.kt
@@ -191,6 +191,9 @@ data class ReaderState(
     val showActionsOnLongTap: Boolean = true,
     /** Whether the page long-press context menu (save/share/cover) is visible. */
     val isPageContextMenuVisible: Boolean = false,
+
+    /** True when the currently-open chapter is already downloaded to device storage. */
+    val isCurrentChapterDownloaded: Boolean = false,
     /** URL of the page that triggered the long-press context menu. */
     val contextMenuPageUrl: String? = null,
     /** Save pages to separate folders by manga title */
@@ -623,6 +626,9 @@ sealed interface ReaderEvent {
 
     /** Set the context-menu page image as the manga cover. */
     data object SetPageAsCover : ActionEvent
+
+    /** Enqueue the currently-open chapter for download. */
+    data object DownloadCurrentChapter : ActionEvent
 
     // ──────────────────────────────────────────────────────────────────────────
     // Constants

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -110,6 +110,7 @@ import kotlinx.coroutines.launch
  */
 
 private const val VOLUME_HOLD_SKIP_PAGES = 5
+private const val DIRECTION_INDICATOR_DURATION_MS = 2_000L
 
 @Composable
 @Suppress("UnusedParameter")
@@ -190,7 +191,7 @@ fun ReaderScreen(
     // Reading direction indicator — brief arrow overlay on direction change
     LaunchedEffect(state.readingDirection) {
         showDirectionIndicator = true
-        delay(2_000)
+        delay(DIRECTION_INDICATOR_DURATION_MS)
         showDirectionIndicator = false
     }
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -8,6 +8,9 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,10 +18,17 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
@@ -121,6 +131,7 @@ fun ReaderScreen(
     var showZoomIndicator by remember { mutableStateOf(false) }
     var showBrightnessSlider by remember { mutableStateOf(false) }
     var showChapterFilterSheet by remember { mutableStateOf(false) }
+    var showDirectionIndicator by remember { mutableStateOf(false) }
     
     // Handle effects
     LaunchedEffect(Unit) {
@@ -176,6 +187,13 @@ fun ReaderScreen(
         }
     }
     
+    // Reading direction indicator — brief arrow overlay on direction change
+    LaunchedEffect(state.readingDirection) {
+        showDirectionIndicator = true
+        delay(2_000)
+        showDirectionIndicator = false
+    }
+
     // Handle zoom indicator visibility
     LaunchedEffect(state.zoomLevel) {
         if (state.zoomLevel != 1f) {
@@ -317,6 +335,8 @@ fun ReaderScreen(
             visualEffectsEnabled = state.visualEffectsEnabled,
             onDismiss = onNavigateBack,
             onSettingsClick = { viewModel.onEvent(ReaderEvent.ToggleMenu) },
+            onDownloadChapter = { viewModel.onEvent(ReaderEvent.DownloadCurrentChapter) },
+            isCurrentChapterDownloaded = state.isCurrentChapterDownloaded,
             onPrevChapter = { viewModel.onEvent(ReaderEvent.PrevChapter) },
             onNextChapter = { viewModel.onEvent(ReaderEvent.NextChapter) },
             onPageSliderChange = { fraction ->
@@ -455,6 +475,15 @@ fun ReaderScreen(
                 modifier = Modifier
             )
         }
+
+        // Reading direction indicator — bottom-start, fades after 2 s
+        ReadingDirectionIndicator(
+            readingDirection = state.readingDirection,
+            isVisible = showDirectionIndicator && !state.isMenuVisible,
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(start = 16.dp, bottom = 80.dp)
+        )
 
         // Snackbar host
         SnackbarHost(
@@ -622,6 +651,39 @@ private fun ReaderContent(
                     ColorFilterMode.NONE -> Unit
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun ReadingDirectionIndicator(
+    readingDirection: app.otakureader.domain.model.ReadingDirection,
+    isVisible: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = isVisible,
+        enter = fadeIn(),
+        exit = fadeOut(),
+        modifier = modifier,
+    ) {
+        val (icon, label) = when (readingDirection) {
+            app.otakureader.domain.model.ReadingDirection.LTR ->
+                Icons.AutoMirrored.Filled.ArrowForward to stringResource(R.string.reader_direction_ltr)
+            app.otakureader.domain.model.ReadingDirection.RTL ->
+                Icons.AutoMirrored.Filled.ArrowBack to stringResource(R.string.reader_direction_rtl)
+            app.otakureader.domain.model.ReadingDirection.VERTICAL ->
+                Icons.Default.ArrowDownward to stringResource(R.string.reader_direction_vertical)
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .background(Color.Black.copy(alpha = 0.7f), RoundedCornerShape(8.dp))
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+        ) {
+            Icon(icon, contentDescription = null, tint = Color.White, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(6.dp))
+            Text(label, color = Color.White, style = MaterialTheme.typography.labelMedium)
         }
     }
 }

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -111,6 +111,13 @@ import kotlinx.coroutines.launch
 
 private const val VOLUME_HOLD_SKIP_PAGES = 5
 private const val DIRECTION_INDICATOR_DURATION_MS = 2_000L
+private val DIRECTION_INDICATOR_BOTTOM_PADDING = 80.dp
+private val DIRECTION_INDICATOR_CORNER_RADIUS = 8.dp
+private val DIRECTION_INDICATOR_HORIZONTAL_PADDING = 12.dp
+private val DIRECTION_INDICATOR_VERTICAL_PADDING = 8.dp
+private val DIRECTION_INDICATOR_ICON_SIZE = 18.dp
+private val DIRECTION_INDICATOR_ICON_SPACING = 6.dp
+private const val DIRECTION_INDICATOR_SCRIM_ALPHA = 0.7f
 
 @Composable
 @Suppress("UnusedParameter")
@@ -483,7 +490,7 @@ fun ReaderScreen(
             isVisible = showDirectionIndicator && !state.isMenuVisible,
             modifier = Modifier
                 .align(Alignment.BottomStart)
-                .padding(start = 16.dp, bottom = 80.dp)
+                .padding(start = 16.dp, bottom = DIRECTION_INDICATOR_BOTTOM_PADDING)
         )
 
         // Snackbar host
@@ -679,11 +686,17 @@ private fun ReadingDirectionIndicator(
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
-                .background(Color.Black.copy(alpha = 0.7f), RoundedCornerShape(8.dp))
-                .padding(horizontal = 12.dp, vertical = 8.dp)
+                .background(
+                    Color.Black.copy(alpha = DIRECTION_INDICATOR_SCRIM_ALPHA),
+                    RoundedCornerShape(DIRECTION_INDICATOR_CORNER_RADIUS),
+                )
+                .padding(
+                    horizontal = DIRECTION_INDICATOR_HORIZONTAL_PADDING,
+                    vertical = DIRECTION_INDICATOR_VERTICAL_PADDING,
+                )
         ) {
-            Icon(icon, contentDescription = null, tint = Color.White, modifier = Modifier.size(18.dp))
-            Spacer(Modifier.width(6.dp))
+            Icon(icon, contentDescription = null, tint = Color.White, modifier = Modifier.size(DIRECTION_INDICATOR_ICON_SIZE))
+            Spacer(Modifier.width(DIRECTION_INDICATOR_ICON_SPACING))
             Text(label, color = Color.White, style = MaterialTheme.typography.labelMedium)
         }
     }

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -368,6 +368,12 @@ class ReaderViewModel @Inject constructor(
                         )
                     }
 
+                    // Update download badge so the overlay can show/hide the download button.
+                    val isDownloaded = runCatching {
+                        downloadAheadDelegate.isChapterDownloaded(result.manga, result.chapter)
+                    }.getOrDefault(false)
+                    _state.update { it.copy(isCurrentChapterDownloaded = isDownloaded) }
+
                     // Record history now that the chapter is confirmed to exist.
                     historyDelegate.recordOpen(
                         scope = viewModelScope,
@@ -578,6 +584,16 @@ class ReaderViewModel @Inject constructor(
             }
             ReaderEvent.SavePageImage -> savePageImage()
             ReaderEvent.SetPageAsCover -> setPageAsCover()
+            ReaderEvent.DownloadCurrentChapter -> downloadCurrentChapter()
+        }
+    }
+
+    private fun downloadCurrentChapter() {
+        val manga = currentManga ?: return
+        val chapter = currentChapter ?: return
+        downloadAheadDelegate.enqueueCurrentChapter(viewModelScope, manga, chapter)
+        viewModelScope.launch {
+            _effect.send(ReaderEffect.ShowSnackbar(messageResId = R.string.reader_chapter_download_queued))
         }
     }
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -369,9 +369,14 @@ class ReaderViewModel @Inject constructor(
                     }
 
                     // Update download badge so the overlay can show/hide the download button.
-                    val isDownloaded = runCatching {
+                    val isDownloaded = try {
                         downloadAheadDelegate.isChapterDownloaded(result.manga, result.chapter)
-                    }.getOrDefault(false)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Exception) {
+                        false
+                    }
+                    if (chapterId != _state.value.currentChapterId) return@launch
                     _state.update { it.copy(isCurrentChapterDownloaded = isDownloaded) }
 
                     // Record history now that the chapter is confirmed to exist.
@@ -592,7 +597,13 @@ class ReaderViewModel @Inject constructor(
         val manga = currentManga ?: return
         val chapter = currentChapter ?: return
         viewModelScope.launch {
-            val enqueued = downloadAheadDelegate.enqueueCurrentChapter(manga, chapter)
+            val enqueued = try {
+                downloadAheadDelegate.enqueueCurrentChapter(manga, chapter)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                false
+            }
             if (enqueued) {
                 _effect.send(ReaderEffect.ShowSnackbar(messageResId = R.string.reader_chapter_download_queued))
             }

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -318,10 +318,6 @@ class ReaderViewModel @Inject constructor(
         }
     }
 
-    /**
-     * Load chapter pages and initialize reader state.
-     */
-    @Suppress("LongMethod")
     private fun loadChapter() {
         loadChapterJob?.cancel()
         // Capture the target ID now so the coroutine can guard against stale writes.
@@ -333,9 +329,7 @@ class ReaderViewModel @Inject constructor(
             when (val result = chapterLoaderDelegate.load(mangaId, targetChapterId)) {
                 is ReaderChapterLoaderDelegate.Result.NotFound -> {
                     if (targetChapterId != chapterId) return@launch
-                    _state.update {
-                        it.copy(isLoading = false, error = result.message)
-                    }
+                    _state.update { it.copy(isLoading = false, error = result.message) }
                 }
                 is ReaderChapterLoaderDelegate.Result.Failure -> {
                     if (targetChapterId != chapterId) return@launch
@@ -346,75 +340,75 @@ class ReaderViewModel @Inject constructor(
                         )
                     }
                 }
-                is ReaderChapterLoaderDelegate.Result.Success -> {
-                    // Discard the result if the user navigated to a different chapter while
-                    // this load was in flight — prevents stale pages overwriting the new chapter.
-                    if (targetChapterId != chapterId) return@launch
-                    currentManga = result.manga
-                    currentChapter = result.chapter
-                    observeContentType(result.manga)
-
-                    val pages = result.pages
-                    val initialPage = result.chapter.lastPageRead
-                        .coerceIn(0, (pages.size - 1).coerceAtLeast(0))
-
-                    _state.update { current ->
-                        current.copy(
-                            pages = pages,
-                            currentPage = initialPage,
-                            isLoading = false,
-                            chapterTitle = result.chapter.name,
-                            readerBackgroundColor = result.manga.readerBackgroundColor,
-                        )
-                    }
-
-                    // Update download badge so the overlay can show/hide the download button.
-                    val isDownloaded = try {
-                        downloadAheadDelegate.isChapterDownloaded(result.manga, result.chapter)
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (_: Exception) {
-                        false
-                    }
-                    if (chapterId != _state.value.currentChapterId) return@launch
-                    _state.update { it.copy(isCurrentChapterDownloaded = isDownloaded) }
-
-                    // Record history now that the chapter is confirmed to exist.
-                    historyDelegate.recordOpen(
-                        scope = viewModelScope,
-                        chapterId = chapterId,
-                        sessionReadAt = sessionReadAt,
-                        fallbackIncognito = _state.value.incognitoMode,
-                    )
-                    // Reset page-change timestamp so first recorded page duration
-                    // does not include chapter load time.
-                    lastPageChangeMs = SystemClock.elapsedRealtime()
-
-                    // Update Discord Rich Presence with reading info.
-                    discordDelegate.updatePresence(
-                        result.manga.title,
-                        result.chapter.name,
-                        pages.size,
-                    )
-
-                    // Start preloading adjacent pages.
-                    if (pages.isNotEmpty()) {
-                        prefetchDelegate.preloadPages(
-                            scope = viewModelScope,
-                            pages = pages,
-                            currentPage = initialPage,
-                            mangaId = mangaId,
-                            chapterId = chapterId,
-                            currentManga = currentManga,
-                        )
-                    }
-
-                    // Start panel detection when in Smart Panels mode.
-                    if (_state.value.mode == ReaderMode.SMART_PANELS && pages.isNotEmpty()) {
-                        // Panel detection is handled by SmartPanelsReader composable.
-                    }
-                }
+                is ReaderChapterLoaderDelegate.Result.Success ->
+                    handleChapterLoadSuccess(result, targetChapterId)
             }
+        }
+    }
+
+    private suspend fun handleChapterLoadSuccess(
+        result: ReaderChapterLoaderDelegate.Result.Success,
+        targetChapterId: Long,
+    ) {
+        // Discard the result if the user navigated to a different chapter while
+        // this load was in flight — prevents stale pages overwriting the new chapter.
+        if (targetChapterId != chapterId) return
+        currentManga = result.manga
+        currentChapter = result.chapter
+        observeContentType(result.manga)
+
+        val pages = result.pages
+        val initialPage = result.chapter.lastPageRead
+            .coerceIn(0, (pages.size - 1).coerceAtLeast(0))
+
+        _state.update { current ->
+            current.copy(
+                pages = pages,
+                currentPage = initialPage,
+                isLoading = false,
+                chapterTitle = result.chapter.name,
+                readerBackgroundColor = result.manga.readerBackgroundColor,
+            )
+        }
+
+        // Update download badge so the overlay can show/hide the download button.
+        val isDownloaded = try {
+            downloadAheadDelegate.isChapterDownloaded(result.manga, result.chapter)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            false
+        }
+        if (chapterId != _state.value.currentChapterId) return
+        _state.update { it.copy(isCurrentChapterDownloaded = isDownloaded) }
+
+        // Record history now that the chapter is confirmed to exist.
+        historyDelegate.recordOpen(
+            scope = viewModelScope,
+            chapterId = chapterId,
+            sessionReadAt = sessionReadAt,
+            fallbackIncognito = _state.value.incognitoMode,
+        )
+        // Reset page-change timestamp so first recorded page duration
+        // does not include chapter load time.
+        lastPageChangeMs = SystemClock.elapsedRealtime()
+
+        // Update Discord Rich Presence with reading info.
+        discordDelegate.updatePresence(
+            result.manga.title,
+            result.chapter.name,
+            pages.size,
+        )
+
+        if (pages.isNotEmpty()) {
+            prefetchDelegate.preloadPages(
+                scope = viewModelScope,
+                pages = pages,
+                currentPage = initialPage,
+                mangaId = mangaId,
+                chapterId = chapterId,
+                currentManga = currentManga,
+            )
         }
     }
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -591,9 +591,11 @@ class ReaderViewModel @Inject constructor(
     private fun downloadCurrentChapter() {
         val manga = currentManga ?: return
         val chapter = currentChapter ?: return
-        downloadAheadDelegate.enqueueCurrentChapter(viewModelScope, manga, chapter)
         viewModelScope.launch {
-            _effect.send(ReaderEffect.ShowSnackbar(messageResId = R.string.reader_chapter_download_queued))
+            val enqueued = downloadAheadDelegate.enqueueCurrentChapter(manga, chapter)
+            if (enqueued) {
+                _effect.send(ReaderEffect.ShowSnackbar(messageResId = R.string.reader_chapter_download_queued))
+            }
         }
     }
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderContentOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderContentOverlay.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.NavigateNext
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.LinearScale
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.ViewModule
@@ -80,6 +81,8 @@ import app.otakureader.feature.reader.R
  *                             Material 3 controls are used (respects user preference).
  * @param onDismiss     Called when the back arrow is tapped — typically navigates back.
  * @param onSettingsClick Called when the settings icon is tapped.
+ * @param onDownloadChapter Called when the download icon is tapped; null hides the button.
+ * @param isCurrentChapterDownloaded When true, the download button is hidden.
  * @param onPrevChapter Called when "Prev chapter" is tapped.
  * @param onNextChapter Called when "Next chapter" is tapped.
  * @param onPageSliderChange Called with a 0–1 normalized value as the user scrubs the slider.
@@ -96,6 +99,8 @@ fun ReaderContentOverlay(
     visualEffectsEnabled: Boolean,
     onDismiss: () -> Unit,
     onSettingsClick: () -> Unit,
+    onDownloadChapter: (() -> Unit)? = null,
+    isCurrentChapterDownloaded: Boolean = false,
     onPrevChapter: () -> Unit,
     onNextChapter: () -> Unit,
     onPageSliderChange: (Float) -> Unit,
@@ -117,6 +122,8 @@ fun ReaderContentOverlay(
                 visualEffectsEnabled = visualEffectsEnabled,
                 onDismiss = onDismiss,
                 onSettingsClick = onSettingsClick,
+                onDownloadChapter = onDownloadChapter,
+                isCurrentChapterDownloaded = isCurrentChapterDownloaded,
                 onPrevChapter = onPrevChapter,
                 onNextChapter = onNextChapter,
                 onPageSliderChange = onPageSliderChange,
@@ -131,6 +138,8 @@ fun ReaderContentOverlay(
                 visualEffectsEnabled = visualEffectsEnabled,
                 onDismiss = onDismiss,
                 onSettingsClick = onSettingsClick,
+                onDownloadChapter = onDownloadChapter,
+                isCurrentChapterDownloaded = isCurrentChapterDownloaded,
                 onPrevChapter = onPrevChapter,
                 onNextChapter = onNextChapter,
                 onPageSliderChange = onPageSliderChange,
@@ -153,6 +162,8 @@ private fun MangaReaderOverlayContent(
     visualEffectsEnabled: Boolean,
     onDismiss: () -> Unit,
     onSettingsClick: () -> Unit,
+    onDownloadChapter: (() -> Unit)? = null,
+    isCurrentChapterDownloaded: Boolean = false,
     onPrevChapter: () -> Unit,
     onNextChapter: () -> Unit,
     onPageSliderChange: (Float) -> Unit,
@@ -192,6 +203,15 @@ private fun MangaReaderOverlayContent(
                     style = MaterialTheme.typography.bodySmall,
                     color = LocalOtakuColors.current.unselectedPageIndicator
                 )
+            }
+            if (onDownloadChapter != null && !isCurrentChapterDownloaded) {
+                IconButton(onClick = onDownloadChapter) {
+                    Icon(
+                        Icons.Default.Download,
+                        contentDescription = stringResource(R.string.reader_download_chapter),
+                        tint = LocalOtakuColors.current.unselectedPageIndicator
+                    )
+                }
             }
             IconButton(onClick = onSettingsClick) {
                 Icon(
@@ -326,6 +346,8 @@ private fun ManhwaReaderOverlayContent(
     visualEffectsEnabled: Boolean,
     onDismiss: () -> Unit,
     onSettingsClick: () -> Unit,
+    onDownloadChapter: (() -> Unit)? = null,
+    isCurrentChapterDownloaded: Boolean = false,
     onPrevChapter: () -> Unit,
     onNextChapter: () -> Unit,
     onPageSliderChange: (Float) -> Unit,
@@ -382,6 +404,15 @@ private fun ManhwaReaderOverlayContent(
                     style = MaterialTheme.typography.bodySmall,
                     color = LocalOtakuColors.current.unselectedPageIndicator
                 )
+            }
+            if (onDownloadChapter != null && !isCurrentChapterDownloaded) {
+                IconButton(onClick = onDownloadChapter) {
+                    Icon(
+                        Icons.Default.Download,
+                        contentDescription = stringResource(R.string.reader_download_chapter),
+                        tint = accentColor
+                    )
+                }
             }
             IconButton(onClick = onSettingsClick) {
                 Icon(

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDownloadAheadDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDownloadAheadDelegate.kt
@@ -31,8 +31,7 @@ class ReaderDownloadAheadDelegate @Inject constructor(
         val existingDownloads = downloadRepository.observeDownloads().first()
         if (existingDownloads.any { it.chapterId == chapter.id }) return false
         if (downloadRepository.isChapterDownloaded(sourceName, manga.title, chapter.name)) return false
-        tryEnqueueChapter(manga, chapter, sourceName, existingDownloads)
-        return true
+        return tryEnqueueChapter(manga, chapter, sourceName, existingDownloads)
     }
 
     suspend fun isChapterDownloaded(manga: Manga, chapter: Chapter): Boolean =
@@ -77,9 +76,9 @@ class ReaderDownloadAheadDelegate @Inject constructor(
         chapter: Chapter,
         sourceName: String,
         existingDownloads: List<DownloadItem>,
-    ) {
-        if (existingDownloads.any { it.chapterId == chapter.id }) return
-        if (downloadRepository.isChapterDownloaded(sourceName, manga.title, chapter.name)) return
+    ): Boolean {
+        if (existingDownloads.any { it.chapterId == chapter.id }) return false
+        if (downloadRepository.isChapterDownloaded(sourceName, manga.title, chapter.name)) return false
 
         val sourceChapter = SourceChapter(
             url = chapter.url,
@@ -99,7 +98,7 @@ class ReaderDownloadAheadDelegate @Inject constructor(
         val pageUrls = pageListResult.getOrNull()
             ?.mapNotNull { page -> page.effectiveUrl() }
             .orEmpty()
-        if (pageUrls.isEmpty()) return
+        if (pageUrls.isEmpty()) return false
 
         downloadRepository.enqueueChapter(
             mangaId = manga.id,
@@ -109,6 +108,7 @@ class ReaderDownloadAheadDelegate @Inject constructor(
             chapterTitle = chapter.name,
             pageUrls = pageUrls,
         )
+        return true
     }
 
     private fun isOnWifi(): Boolean {

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDownloadAheadDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDownloadAheadDelegate.kt
@@ -26,6 +26,21 @@ class ReaderDownloadAheadDelegate @Inject constructor(
     private val chapterRepository: ChapterRepository,
     private val mangaRepository: MangaRepository,
 ) {
+    fun enqueueCurrentChapter(
+        scope: CoroutineScope,
+        manga: Manga,
+        chapter: Chapter,
+    ) {
+        scope.launch {
+            val sourceName = manga.sourceId.toString()
+            val existingDownloads = downloadRepository.observeDownloads().first()
+            tryEnqueueChapter(manga, chapter, sourceName, existingDownloads)
+        }
+    }
+
+    suspend fun isChapterDownloaded(manga: Manga, chapter: Chapter): Boolean =
+        downloadRepository.isChapterDownloaded(manga.sourceId.toString(), manga.title, chapter.name)
+
     fun maybeDownloadNextChapter(
         scope: CoroutineScope,
         currentPage: Int,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDownloadAheadDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDownloadAheadDelegate.kt
@@ -26,16 +26,13 @@ class ReaderDownloadAheadDelegate @Inject constructor(
     private val chapterRepository: ChapterRepository,
     private val mangaRepository: MangaRepository,
 ) {
-    fun enqueueCurrentChapter(
-        scope: CoroutineScope,
-        manga: Manga,
-        chapter: Chapter,
-    ) {
-        scope.launch {
-            val sourceName = manga.sourceId.toString()
-            val existingDownloads = downloadRepository.observeDownloads().first()
-            tryEnqueueChapter(manga, chapter, sourceName, existingDownloads)
-        }
+    suspend fun enqueueCurrentChapter(manga: Manga, chapter: Chapter): Boolean {
+        val sourceName = manga.sourceId.toString()
+        val existingDownloads = downloadRepository.observeDownloads().first()
+        if (existingDownloads.any { it.chapterId == chapter.id }) return false
+        if (downloadRepository.isChapterDownloaded(sourceName, manga.title, chapter.name)) return false
+        tryEnqueueChapter(manga, chapter, sourceName, existingDownloads)
+        return true
     }
 
     suspend fun isChapterDownloaded(manga: Manga, chapter: Chapter): Boolean =

--- a/feature/reader/src/main/res/values/strings.xml
+++ b/feature/reader/src/main/res/values/strings.xml
@@ -188,6 +188,10 @@
     <string name="reader_chapter_bookmarked">Bookmarked</string>
     <string name="reader_chapter_read">Read</string>
 
+    <!-- Download current chapter (GAP 9) -->
+    <string name="reader_download_chapter">Download chapter</string>
+    <string name="reader_chapter_download_queued">Chapter download queued</string>
+
     <!-- Page long-press context menu -->
     <string name="reader_page_menu_save_image">Save image</string>
     <string name="reader_page_menu_set_as_cover">Set as cover</string>


### PR DESCRIPTION
## **User description**
## Summary

Implements 7 of the 12 planned Komikku/Mihon functional parity gaps. All changes build cleanly; no new Hilt bindings were broken.

- **GAP 1 — Library category swipe navigation**: Replaced the static grid layout with a `HorizontalPager` so users can swipe left/right to change the active category. Bidirectional sync: chip/tab tap → `animateScrollToPage`; swipe → `OnCategorySelected` event. Grid content extracted to `LibraryMangaPageContent` to avoid `ColumnScope.AnimatedVisibility` ambiguity in Kotlin 2.x.
- **GAP 2 — Move to Category bulk action**: Folder-move icon added to the selection TopBar (visible only when categories exist). Tapping opens a `RadioButton` dialog listing all categories. Confirm dispatches `MoveToCategory(mangaIds, categoryId)` → `CategoryRepository.addMangaToCategory` per manga, clears selection, shows snackbar.
- **GAP 4 — Library sort modes**: Added `LAST_UPDATED` (by `manga.lastUpdate` desc) and `TOTAL_CHAPTERS` (by `manga.totalChapters` desc) to `LibrarySortMode`, sort logic, bottom sheet picker, and strings.
- **GAP 6 — Show title on cover toggle**: Added `SwitchPreferenceRow` for `showTitle` in the Display Options section of `LibraryBottomSheet`. Was in state/grid but had no UI control.
- **GAP 8 — Reading direction indicator**: `AnimatedVisibility` overlay in the reader bottom-start corner shows an arrow icon + label ("Left to Right" / "Right to Left" / "Vertical") for 2 s when the reader opens or the direction changes. No new ViewModel state — fully local composable state.
- **GAP 9 — Download current chapter button**: `Download` icon added to the reader top bar. Hidden when `state.isCurrentChapterDownloaded`. Dispatches `DownloadCurrentChapter` → `ReaderDownloadAheadDelegate.enqueueCurrentChapter()` → snackbar confirmation.
- **GAP 12 — Browse source language filter**: `FilterList` icon in Browse Sources top bar opens a multi-select dialog of all installed source languages. Persisted via `GeneralPreferences.enabledSourceLanguages` (DataStore `stringSetPreferencesKey`). Source list filtered reactively via a `combine()` in `BrowseViewModel`.

## Test plan

- [ ] Library → swipe left/right → categories change, chip scrolls to match
- [ ] Library → chip tap → pager scrolls to matching page
- [ ] Library → long-press manga → folder icon visible → pick category → manga in new category, selection cleared
- [ ] Library → folder icon hidden when no categories exist
- [ ] Library → sort picker shows "Last updated" and "Total chapters" options
- [ ] Library → Display Options sheet shows "Show title on cover" switch
- [ ] Browse → Languages button → multi-select dialog → source list filters by selected languages
- [ ] Reader → open chapter → direction arrow fades after 2 s
- [ ] Reader → change reading direction in settings → arrow re-appears
- [ ] Reader → Download button visible for undownloaded chapter, hidden for downloaded
- [ ] Reader → tap Download → chapter download queued snackbar

🤖 Generated with Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01DbR89ujj7kZoaSRypSfgUS)_


___

## **CodeAnt-AI Description**
**Close several Komikku parity gaps across library, browse, and reader screens**

### What Changed
- Library browsing now supports swipeable category pages, with tab taps and swipes staying in sync.
- The library selection bar now includes Move to category, and selected manga can be moved in one step with a category picker dialog.
- Library covers can now sort by last updated or total chapters, and the Display settings now include a toggle to show or hide titles on covers.
- Reader screens now show a brief reading-direction indicator when a chapter opens or direction changes, and the current chapter can be downloaded from the top bar unless it is already downloaded.
- Browse Sources now includes a language filter dialog so users can hide sources in languages they do not want to see.

### Impact
`✅ Faster library category switching`
`✅ Fewer steps to reorganize selected manga`
`✅ Cleaner library and browse views`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Language filtering for manga sources in Browse tab
  * "Show title on cover" display toggle in library
  * New sorting options: "Last updated" and "Total chapters"
  * Bulk move selected manga to categories
  * Reading direction change visual indicator in reader
  * Download current chapter button in reader

<!-- end of auto-generated comment: release notes by coderabbit.ai -->