### PR TITLE
Komikku parity — Browse/Extensions: fix installed sources missing + match layout

### DIFF
--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -347,6 +347,9 @@ fun OtakuReaderNavHost(
             },
             onNavigateToGlobalSearch = { query ->
                 navController.navigate(Route.Search(query = query))
+            },
+            onNavigateToSourceSearch = { sourceId, query ->
+                navController.navigate(Route.SourceListing(sourceId, query))
             }
         )
 

--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -5,8 +5,6 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.Intent
 import android.os.Build
-import android.provider.Settings
-import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import app.otakureader.core.extension.data.remote.ExtensionRemoteDataSource
 import app.otakureader.core.extension.domain.model.Extension
@@ -126,19 +124,18 @@ class ExtensionInstaller(
             // universal trust gate inside ExtensionLoader can be satisfied without a separate
             // user confirmation step. The repository-backed extension rides along so a
             // fallback-created DB row keeps provenance (#1019) plus apkUrl/iconUrl metadata.
-            val result = install(
+            // Private-installer model (matches Komikku's default): install() copies the APK into
+            // the app's private extensions dir, loads/validates it, trusts repo-sourced signatures,
+            // and persists the DB row. That is fully self-sufficient — the source becomes loadable
+            // immediately and the caller's refreshSources() picks it up. We deliberately do NOT
+            // also launch the system package installer here: doing so popped a second, confusing
+            // "install this app?" dialog (and an unknown-sources settings redirect) on top of an
+            // already-successful silent install.
+            install(
                 downloadFile,
                 trustedHash = extension.signatureHash,
                 repoMetadata = extension,
             )
-
-            result.onSuccess { installed ->
-                installed.apkPath?.let { path ->
-                    maybeLaunchSystemInstaller(File(path))
-                }
-            }
-
-            result
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -624,41 +621,6 @@ class ExtensionInstaller(
         _installationState.value = InstallationState.Idle
     }
 
-    /**
-     * Optionally trigger the system package installer so extensions are registered
-     * as shared packages. Falls back to internal loading if the permission is not
-     * granted; opens the settings screen to request it.
-     */
-    private fun maybeLaunchSystemInstaller(apkFile: File) {
-        // Make the file read-only so the system installer accepts it.
-        apkFile.setReadOnly()
-
-        // C-4: Request unknown-sources permission if not already granted.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
-            !context.packageManager.canRequestPackageInstalls()
-        ) {
-            val settingsIntent = Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
-                data = "package:${context.packageName}".toUri()
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }
-            context.startActivity(settingsIntent)
-            // Note: The user must manually return and retry the install after granting.
-            return
-        }
-
-        val uri = FileProvider.getUriForFile(
-            context,
-            "${context.packageName}.fileprovider",
-            apkFile,
-        )
-        val installIntent = Intent(Intent.ACTION_VIEW).apply {
-            setDataAndType(uri, "application/vnd.android.package-archive")
-            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-
-        context.startActivity(installIntent)
-    }
-    
     private fun computeHash(bytes: ByteArray): String {
         val digest = MessageDigest.getInstance("SHA-256")
         val hash = digest.digest(bytes)

--- a/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
+++ b/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
@@ -71,7 +71,7 @@ sealed interface Route {
      * @param sourceId Installed extension source ID (string identifier).
      */
     @Serializable
-    data class SourceListing(val sourceId: String) : Route
+    data class SourceListing(val sourceId: String, val initialQuery: String = "") : Route
 
     /**
      * Extension catalog — browse/install available extensions.

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
@@ -83,8 +83,14 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
 
     // --- Browse ---
 
-    /** Whether to show NSFW (18+) sources and extensions in the Browse screen. */
-    val showNsfwContent: Flow<Boolean> = dataStore.data.map { it[Keys.SHOW_NSFW_CONTENT] ?: false }
+    /**
+     * Whether to show NSFW (18+) sources and extensions in the Browse screen.
+     *
+     * Defaults to true to match Mihon/Komikku (showNsfwSource defaults to true). A false default
+     * silently hid freshly installed NSFW sources from the Sources screen — the user installs an
+     * 18+ extension and it never appears, which reads as a broken install.
+     */
+    val showNsfwContent: Flow<Boolean> = dataStore.data.map { it[Keys.SHOW_NSFW_CONTENT] ?: true }
     suspend fun setShowNsfwContent(value: Boolean) = dataStore.edit { it[Keys.SHOW_NSFW_CONTENT] = value }
 
     /** Language codes (e.g. "en", "ja") the user wants to see in Browse. Default: all English sources. */

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/LibraryPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/LibraryPreferences.kt
@@ -67,8 +67,13 @@ class LibraryPreferences(private val dataStore: DataStore<Preferences>) {
 
     // --- NSFW Filter ---
 
-    /** Whether to show NSFW content in the library. false = hide NSFW categories. */
-    val showNsfwContent: Flow<Boolean> = dataStore.data.map { it[Keys.SHOW_NSFW_CONTENT] ?: false }
+    /**
+     * Whether to show NSFW content in the library. false = hide NSFW categories.
+     *
+     * Defaults to true to match Mihon/Komikku and to stay consistent with
+     * [GeneralPreferences.showNsfwContent], which reads the same SHOW_NSFW_CONTENT key.
+     */
+    val showNsfwContent: Flow<Boolean> = dataStore.data.map { it[Keys.SHOW_NSFW_CONTENT] ?: true }
     suspend fun setShowNsfwContent(value: Boolean) = dataStore.edit { it[Keys.SHOW_NSFW_CONTENT] = value }
 
     /** Whether to show hidden categories in the library. */

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/LibraryPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/LibraryPreferences.kt
@@ -71,7 +71,9 @@ class LibraryPreferences(private val dataStore: DataStore<Preferences>) {
      * Whether to show NSFW content in the library. false = hide NSFW categories.
      *
      * Defaults to true to match Mihon/Komikku and to stay consistent with
-     * [GeneralPreferences.showNsfwContent], which reads the same SHOW_NSFW_CONTENT key.
+     * [GeneralPreferences.showNsfwContent]. Note these are independent keys
+     * ("library_show_nsfw_content" here vs "show_nsfw_content" there): this one gates library
+     * content visibility, while the General one gates source/extension/search visibility.
      */
     val showNsfwContent: Flow<Boolean> = dataStore.data.map { it[Keys.SHOW_NSFW_CONTENT] ?: true }
     suspend fun setShowNsfwContent(value: Boolean) = dataStore.edit { it[Keys.SHOW_NSFW_CONTENT] = value }

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/NavOrderPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/NavOrderPreferences.kt
@@ -10,8 +10,9 @@ import kotlinx.coroutines.flow.map
 /** Identifiers for the five main bottom-navigation tabs. */
 enum class NavTab { LIBRARY, UPDATES, BROWSE, HISTORY, MORE }
 
+// Matches Mihon/Komikku's default bottom-nav order: Library, Updates, History, Browse, More.
 private val DEFAULT_ORDER = listOf(
-    NavTab.LIBRARY, NavTab.UPDATES, NavTab.BROWSE, NavTab.HISTORY, NavTab.MORE
+    NavTab.LIBRARY, NavTab.UPDATES, NavTab.HISTORY, NavTab.BROWSE, NavTab.MORE
 )
 
 /**

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/NavOrderPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/NavOrderPreferences.kt
@@ -10,11 +10,6 @@ import kotlinx.coroutines.flow.map
 /** Identifiers for the five main bottom-navigation tabs. */
 enum class NavTab { LIBRARY, UPDATES, BROWSE, HISTORY, MORE }
 
-// Matches Mihon/Komikku's default bottom-nav order: Library, Updates, History, Browse, More.
-private val DEFAULT_ORDER = listOf(
-    NavTab.LIBRARY, NavTab.UPDATES, NavTab.HISTORY, NavTab.BROWSE, NavTab.MORE
-)
-
 /**
  * Lightweight projection of a tab's persisted state: its position in the list and whether
  * the user has toggled it on or off. Kept in core so the ViewModel can convert to and from
@@ -71,5 +66,16 @@ class NavOrderPreferences(private val dataStore: DataStore<Preferences>) {
 
     private object Keys {
         val TAB_ORDER = stringPreferencesKey("nav_tab_order")
+    }
+
+    companion object {
+        /**
+         * Default bottom-nav order, matching Mihon/Komikku: Library, Updates, History, Browse, More.
+         * Used both for the first-run fallback and for the "Reset" action so they stay in sync —
+         * do not derive the reset order from [NavTab.entries], whose declaration order differs.
+         */
+        val DEFAULT_ORDER: List<NavTab> = listOf(
+            NavTab.LIBRARY, NavTab.UPDATES, NavTab.HISTORY, NavTab.BROWSE, NavTab.MORE,
+        )
     }
 }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -671,8 +671,12 @@ private fun SourceListContent(
 
     val pinnedSources = allSources.filter { it.id.toSourceId() in state.pinnedSourceIds }
     val unpinnedSources = allSources.filter { it.id.toSourceId() !in state.pinnedSourceIds }
+    // Group unpinned sources by their assigned source category when one is set, otherwise by
+    // language — matching Komikku's SourcesScreen, which shows language headers (English, Multi, …)
+    // for uncategorized sources rather than a single flat list.
     val grouped: Map<String, List<MangaSource>> = unpinnedSources.groupBy { src ->
-        state.sourceCategoryMap[src.id.toSourceId()] ?: ""
+        state.sourceCategoryMap[src.id.toSourceId()]?.takeIf { it.isNotBlank() }
+            ?: src.lang.uppercase()
     }
     val categoryOrder = grouped.keys.sortedWith(compareBy { if (it.isBlank()) "" else it })
 

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -105,6 +105,7 @@ import app.otakureader.sourceapi.SourceManga
 import app.otakureader.sourceapi.isActive
 import app.otakureader.sourceapi.toSourceId
 import coil3.compose.AsyncImage
+import java.util.Locale
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
@@ -467,7 +468,7 @@ private fun LanguageFilterDialog(
                                 Spacer(Modifier.size(LANGUAGE_DIALOG_ICON_SIZE))
                             }
                             Spacer(Modifier.width(LANGUAGE_DIALOG_ICON_TEXT_SPACING))
-                            Text(lang.uppercase(), style = MaterialTheme.typography.bodyMedium)
+                            Text(lang.uppercase(Locale.ROOT), style = MaterialTheme.typography.bodyMedium)
                         }
                     }
                 }
@@ -676,7 +677,7 @@ private fun SourceListContent(
     // for uncategorized sources rather than a single flat list.
     val grouped: Map<String, List<MangaSource>> = unpinnedSources.groupBy { src ->
         state.sourceCategoryMap[src.id.toSourceId()]?.takeIf { it.isNotBlank() }
-            ?: src.lang.uppercase()
+            ?: src.lang.uppercase(Locale.ROOT)
     }
     val categoryOrder = grouped.keys.sortedWith(compareBy { if (it.isBlank()) "" else it })
 
@@ -956,7 +957,7 @@ private fun LanguageBadge(lang: String, modifier: Modifier = Modifier) {
         containerColor = MaterialTheme.colorScheme.secondaryContainer,
         contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
     ) {
-        Text(lang.uppercase(), style = MaterialTheme.typography.labelSmall)
+        Text(lang.uppercase(Locale.ROOT), style = MaterialTheme.typography.labelSmall)
     }
 }
 

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
@@ -498,7 +498,9 @@ private fun ExtensionRow(
                         when (extension.status) {
                             InstallStatus.AVAILABLE, InstallStatus.ERROR ->
                                 onEvent(ExtensionsEvent.InstallExtension(extension))
-                            else -> onViewDetails()
+                            // No-op while a transient operation is in flight.
+                            InstallStatus.INSTALLING, InstallStatus.UPDATING, InstallStatus.UNINSTALLING -> Unit
+                            InstallStatus.INSTALLED, InstallStatus.HAS_UPDATE -> onViewDetails()
                         }
                     },
                     onLongClick = { if (isInstalledKind) menuExpanded = true },
@@ -596,17 +598,18 @@ private fun ExtensionMetadataLine(
     extension: Extension,
     modifier: Modifier = Modifier,
 ) {
+    val separator = stringResource(R.string.extension_meta_separator)
     val parts = buildList {
         if (extension.lang.isNotBlank()) add(extension.lang.uppercase())
-        if (extension.versionName.isNotBlank()) add("v${extension.versionName}")
-        repoOwner(extension.repoUrl)?.let { add("@$it") }
+        if (extension.versionName.isNotBlank()) add(stringResource(R.string.extension_meta_version, extension.versionName))
+        repoOwner(extension.repoUrl)?.let { add(stringResource(R.string.extension_meta_repo, it)) }
     }
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            text = parts.joinToString(SEPARATOR),
+            text = parts.joinToString(separator),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
@@ -615,7 +618,7 @@ private fun ExtensionMetadataLine(
         )
         if (extension.isNsfw) {
             Text(
-                text = SEPARATOR,
+                text = separator,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -703,8 +706,6 @@ private fun UnverifiedInstallDialog(
     )
 }
 
-private const val SEPARATOR = " • "
-
 /**
  * Best-effort extraction of the repository owner from an extension's repo URL, e.g.
  * `https://raw.githubusercontent.com/keiyoushi/extensions/repo` → `keiyoushi`. Falls back to the
@@ -717,9 +718,11 @@ private fun repoOwner(repoUrl: String?): String? {
         .split("/")
         .filter { it.isNotBlank() }
     val host = segments.firstOrNull() ?: return null
-    return if (host.contains("githubusercontent") || host.contains("github")) {
-        segments.getOrNull(1) ?: host
-    } else {
-        host
+    return when {
+        // GitHub Pages: the owner is the subdomain, e.g. keiyoushi.github.io/extensions
+        host.endsWith(".github.io", ignoreCase = true) -> host.substringBefore(".github.io")
+        // raw.githubusercontent.com/<owner>/<repo>/... or github.com/<owner>/<repo>
+        host.contains("githubusercontent") || host.contains("github") -> segments.getOrNull(1) ?: host
+        else -> host
     }
 }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
@@ -1,8 +1,8 @@
 @file:Suppress("MaxLineLength")
 package app.otakureader.feature.browse
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -18,40 +18,30 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Sort
 import androidx.compose.material.icons.filled.Update
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SuggestionChip
-import androidx.compose.material3.SuggestionChipDefaults
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -65,7 +55,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -79,6 +68,16 @@ import app.otakureader.feature.browse.R
 import coil3.compose.AsyncImage
 import kotlinx.coroutines.launch
 
+/**
+ * Extensions browser — restructured to match Mihon/Komikku's single sectioned list.
+ *
+ * Komikku shows one scrolling list with section headers (Updates pending → Installed →
+ * Available, grouped by language) and compact rows. Per the parity work, the old inline
+ * search bar, NSFW/sort row, repository manager and security banner, and Installed/Available/
+ * Updates sub-tabs were removed: repository management lives on its own screen (reachable from a
+ * section-header action), and enable/disable + uninstall are reached by long-pressing a row
+ * (matching Komikku's onLongClickItem affordance).
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ExtensionsBottomSheet(
@@ -127,8 +126,8 @@ fun ExtensionsBottomSheet(
 }
 
 /**
- * Scaffold-free body used both by [ExtensionsContent] (inside the bottom sheet Scaffold) and
- * by [ExtensionsTabBody] (embedded directly in Browse's Extensions tab).
+ * Scaffold-free body used both by [ExtensionsContent] (inside the bottom sheet / full-screen
+ * Scaffold) and by [ExtensionsTabBody] (embedded directly in Browse's Extensions tab).
  */
 @Composable
 private fun ExtensionsBody(
@@ -138,139 +137,124 @@ private fun ExtensionsBody(
     onNavigateToExtensionDetail: (packageName: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val selectedTab = state.selectedTab
-    val tabs = listOf(
-        stringResource(R.string.extensions_tab_installed),
-        stringResource(R.string.extensions_tab_available),
-        stringResource(R.string.extensions_tab_updates),
-    )
+    val allEmpty = state.installedExtensions.isEmpty() &&
+        state.availableExtensions.isEmpty() &&
+        state.extensionsWithUpdates.isEmpty()
 
-    Column(modifier = modifier) {
-        // Search bar
-        TextField(
-            value = state.searchQuery,
-            onValueChange = { onEvent(ExtensionsEvent.OnSearchQueryChange(it)) },
-            placeholder = { Text(stringResource(R.string.extensions_search_placeholder)) },
-            leadingIcon = { Icon(Icons.Default.Search, contentDescription = stringResource(R.string.extensions_search_cd)) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp)
+    when {
+        state.isLoading && allEmpty -> LoadingScreen(modifier = modifier)
+        state.error != null && allEmpty -> ErrorScreen(
+            message = state.error,
+            onRetry = { onEvent(ExtensionsEvent.Refresh) },
+            modifier = modifier,
         )
-
-        // Filter & Sort controls
-        FilterAndSortRow(
-            showNsfw = state.showNsfw,
-            sortMode = state.sortMode,
-            onToggleNsfw = { onEvent(ExtensionsEvent.ToggleNsfw(it)) },
-            onSetSortMode = { onEvent(ExtensionsEvent.SetSortMode(it)) }
+        allEmpty -> EmptyExtensionsView(
+            onManageRepositories = onNavigateToRepositories,
+            modifier = modifier,
         )
-
-        // Update All button (only in Updates tab, visible whenever updates exist)
-        if (selectedTab == 2 && state.updateCount > 0) {
-            UpdateAllButton(
-                updateCount = state.updateCount,
-                isUpdating = state.isUpdatingAll,
-                onUpdateAll = { onEvent(ExtensionsEvent.UpdateAllExtensions) }
-            )
-        }
-
-        RepositoryManager(
-            repositories = state.repositories,
-            onAdd = { onEvent(ExtensionsEvent.AddRepository(it)) },
-            onRemove = { onEvent(ExtensionsEvent.RemoveRepository(it)) },
-            onOpenFullManager = onNavigateToRepositories,
+        else -> ExtensionsList(
+            state = state,
+            onEvent = onEvent,
+            onNavigateToRepositories = onNavigateToRepositories,
+            onNavigateToExtensionDetail = onNavigateToExtensionDetail,
+            modifier = modifier,
         )
+    }
 
-        // Tabs
-        TabRow(selectedTabIndex = selectedTab) {
-            tabs.forEachIndexed { index, title ->
-                Tab(
-                    selected = selectedTab == index,
-                    onClick = { onEvent(ExtensionsEvent.SelectTab(index)) },
-                    text = {
-                        when (index) {
-                            2 -> if (state.updateCount > 0) {
-                                Row(verticalAlignment = Alignment.CenterVertically) {
-                                    Text(title)
-                                    Spacer(modifier = Modifier.width(4.dp))
-                                    Surface(
-                                        shape = CircleShape,
-                                        color = MaterialTheme.colorScheme.error
-                                    ) {
-                                        Text(
-                                            text = state.updateCount.toString(),
-                                            style = MaterialTheme.typography.labelSmall,
-                                            color = MaterialTheme.colorScheme.onError,
-                                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
-                                        )
-                                    }
-                                }
-                            } else Text(title)
-                            else -> Text(title)
-                        }
-                    }
+    // Unverified install confirmation dialog (sideloaded APKs with no repo-provided hash).
+    if (state.showUnverifiedInstallDialog) {
+        UnverifiedInstallDialog(
+            extension = state.pendingUnverifiedExtension,
+            onDismiss = { onEvent(ExtensionsEvent.DismissUnverifiedDialog) },
+            onConfirm = { onEvent(ExtensionsEvent.ConfirmUnverifiedInstall) }
+        )
+    }
+}
+
+@Composable
+private fun ExtensionsList(
+    state: ExtensionsState,
+    onEvent: (ExtensionsEvent) -> Unit,
+    onNavigateToRepositories: () -> Unit,
+    onNavigateToExtensionDetail: (packageName: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Place the "manage repositories" header action on the Installed section when present,
+    // otherwise on the first Available-language section, so repos are always reachable.
+    val repoActionOnInstalled = state.installedExtensions.isNotEmpty()
+    val availableByLang = state.availableExtensions.groupBy { it.lang }.toSortedMap(compareBy { it })
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(vertical = 4.dp),
+    ) {
+        // ── Updates pending ──────────────────────────────────────────────────────────
+        if (state.extensionsWithUpdates.isNotEmpty()) {
+            item(key = "hdr_updates") {
+                ExtensionSectionHeader(
+                    title = stringResource(R.string.extensions_tab_updates),
+                    actionText = stringResource(R.string.extensions_update_all),
+                    onAction = { onEvent(ExtensionsEvent.UpdateAllExtensions) },
+                )
+            }
+            items(state.extensionsWithUpdates, key = { "upd_${it.id}" }) { extension ->
+                ExtensionRow(
+                    extension = extension,
+                    signerMismatch = extension.pkgName in state.signerMismatchedPackages,
+                    blockedReason = state.blockedPackages[extension.pkgName],
+                    onEvent = onEvent,
+                    onViewDetails = { onNavigateToExtensionDetail(extension.pkgName) },
                 )
             }
         }
 
-        when (selectedTab) {
-            0 -> ExtensionsList(
-                extensions = state.installedExtensions,
-                isLoading = state.isLoading,
-                error = state.error,
-                signerMismatchedPackages = state.signerMismatchedPackages,
-                blockedPackages = state.blockedPackages,
-                onInstall = { /* Already installed */ },
-                onUninstall = { onEvent(ExtensionsEvent.UninstallExtension(it)) },
-                onUpdate = { onEvent(ExtensionsEvent.UpdateExtension(it)) },
-                onToggleEnabled = { ext, enabled ->
-                    onEvent(ExtensionsEvent.ToggleExtensionEnabled(ext, enabled))
-                },
-                onRefresh = { onEvent(ExtensionsEvent.Refresh) },
-                onViewDetails = { onNavigateToExtensionDetail(it.pkgName) }
-            )
-            1 -> Column {
-                if (state.hasUnverifiedExtensions) {
-                    TrustBanner(visible = true)
-                }
-                ExtensionsList(
-                    extensions = state.availableExtensions,
-                    isLoading = state.isLoading,
-                    error = state.error,
-                    signerMismatchedPackages = emptySet(),
-                    blockedPackages = state.blockedPackages,
-                    onInstall = { onEvent(ExtensionsEvent.InstallExtension(it)) },
-                    onUninstall = { /* Not installed */ },
-                    onUpdate = { /* No update */ },
-                    onToggleEnabled = { _, _ -> },
-                    onRefresh = { onEvent(ExtensionsEvent.Refresh) },
-                    onViewDetails = { onNavigateToExtensionDetail(it.pkgName) }
+        // ── Installed ────────────────────────────────────────────────────────────────
+        if (state.installedExtensions.isNotEmpty()) {
+            item(key = "hdr_installed") {
+                ExtensionSectionHeader(
+                    title = stringResource(R.string.extensions_tab_installed),
+                    actionText = stringResource(R.string.extensions_manage_repositories),
+                    onAction = onNavigateToRepositories,
                 )
             }
-            2 -> ExtensionsList(
-                extensions = state.extensionsWithUpdates,
-                isLoading = state.isLoading,
-                error = state.error,
-                signerMismatchedPackages = state.signerMismatchedPackages,
-                blockedPackages = state.blockedPackages,
-                onInstall = { /* Already installed */ },
-                onUninstall = { onEvent(ExtensionsEvent.UninstallExtension(it)) },
-                onUpdate = { onEvent(ExtensionsEvent.UpdateExtension(it)) },
-                onToggleEnabled = { ext, enabled ->
-                    onEvent(ExtensionsEvent.ToggleExtensionEnabled(ext, enabled))
-                },
-                onRefresh = { onEvent(ExtensionsEvent.Refresh) },
-                onViewDetails = { onNavigateToExtensionDetail(it.pkgName) }
-            )
+            items(state.installedExtensions, key = { "ins_${it.id}" }) { extension ->
+                ExtensionRow(
+                    extension = extension,
+                    signerMismatch = extension.pkgName in state.signerMismatchedPackages,
+                    blockedReason = state.blockedPackages[extension.pkgName],
+                    onEvent = onEvent,
+                    onViewDetails = { onNavigateToExtensionDetail(extension.pkgName) },
+                )
+            }
         }
 
-        // Unverified install confirmation dialog
-        if (state.showUnverifiedInstallDialog) {
-            UnverifiedInstallDialog(
-                extension = state.pendingUnverifiedExtension,
-                onDismiss = { onEvent(ExtensionsEvent.DismissUnverifiedDialog) },
-                onConfirm = { onEvent(ExtensionsEvent.ConfirmUnverifiedInstall) }
-            )
+        // ── Available, grouped by language ───────────────────────────────────────────
+        availableByLang.entries.forEachIndexed { index, (lang, extensions) ->
+            val showRepoAction = !repoActionOnInstalled && index == 0
+            item(key = "hdr_avail_$lang") {
+                ExtensionSectionHeader(
+                    title = if (lang.isBlank()) {
+                        stringResource(R.string.extensions_tab_available)
+                    } else {
+                        lang.uppercase()
+                    },
+                    actionText = if (showRepoAction) {
+                        stringResource(R.string.extensions_manage_repositories)
+                    } else {
+                        null
+                    },
+                    onAction = onNavigateToRepositories,
+                )
+            }
+            items(extensions, key = { "avl_${it.id}" }) { extension ->
+                ExtensionRow(
+                    extension = extension,
+                    signerMismatch = false,
+                    blockedReason = state.blockedPackages[extension.pkgName],
+                    onEvent = onEvent,
+                    onViewDetails = { onNavigateToExtensionDetail(extension.pkgName) },
+                )
+            }
         }
     }
 }
@@ -288,6 +272,7 @@ private fun ExtensionsContent(
 ) {
     Scaffold(
         topBar = {
+            var overflowExpanded by remember { mutableStateOf(false) }
             TopAppBar(
                 title = { Text(stringResource(R.string.extensions_sheet_title)) },
                 navigationIcon = {
@@ -299,8 +284,50 @@ private fun ExtensionsContent(
                     IconButton(onClick = { onEvent(ExtensionsEvent.Refresh) }) {
                         Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.extensions_refresh))
                     }
-                    IconButton(onClick = onNavigateToSettings) {
-                        Icon(Icons.Default.Settings, contentDescription = stringResource(R.string.extensions_settings))
+                    Box {
+                        IconButton(onClick = { overflowExpanded = true }) {
+                            Icon(Icons.Default.Settings, contentDescription = stringResource(R.string.extensions_settings))
+                        }
+                        DropdownMenu(
+                            expanded = overflowExpanded,
+                            onDismissRequest = { overflowExpanded = false },
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.extensions_manage_repositories)) },
+                                onClick = {
+                                    overflowExpanded = false
+                                    onNavigateToRepositories()
+                                },
+                            )
+                            DropdownMenuItem(
+                                text = {
+                                    Text(
+                                        if (state.showNsfw) {
+                                            stringResource(R.string.browse_hide_nsfw)
+                                        } else {
+                                            stringResource(R.string.browse_show_nsfw)
+                                        },
+                                    )
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        if (state.showNsfw) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                                        contentDescription = null,
+                                    )
+                                },
+                                onClick = {
+                                    onEvent(ExtensionsEvent.ToggleNsfw(!state.showNsfw))
+                                    overflowExpanded = false
+                                },
+                            )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.extensions_settings)) },
+                                onClick = {
+                                    overflowExpanded = false
+                                    onNavigateToSettings()
+                                },
+                            )
+                        }
                     }
                 }
             )
@@ -320,14 +347,8 @@ private fun ExtensionsContent(
 }
 
 /**
- * Full-screen Extensions destination that replaces the old ModalBottomSheet approach.
- *
- * This composable is registered as [Route.ExtensionCatalog] in the nav graph. It renders
- * [ExtensionsContent] (which already contains a Scaffold and TopAppBar) without any
- * bottom-sheet chrome, so navigating to it produces a regular slide-in screen rather than
- * a slide-up overlay. This matches the Mihon/Komikku UX described in issue #1117.
- *
- * The [onNavigateBack] callback is wired to the TopAppBar close button via [onClose].
+ * Full-screen Extensions destination ([Route.ExtensionCatalog] in the nav graph). Renders
+ * [ExtensionsContent] (Scaffold + TopAppBar) as a regular slide-in screen (issue #1117).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -363,7 +384,7 @@ fun ExtensionsScreen(
 
 /**
  * Scaffold-free Extensions content for embedding in Browse's Extensions tab.
- * Manages its own [ExtensionsViewModel] and snackbar; no TopAppBar.
+ * Manages its own [ExtensionsViewModel] and snackbar; no TopAppBar (Browse provides it).
  */
 @Composable
 internal fun ExtensionsTabBody(
@@ -400,533 +421,248 @@ internal fun ExtensionsTabBody(
 }
 
 @Composable
-private fun ExtensionsList(
-    extensions: List<Extension>,
-    isLoading: Boolean,
-    error: String?,
-    signerMismatchedPackages: Set<String>,
-    blockedPackages: Map<String, String> = emptyMap(),
-    onInstall: (Extension) -> Unit,
-    onUninstall: (Extension) -> Unit,
-    onUpdate: (Extension) -> Unit,
-    onToggleEnabled: (Extension, Boolean) -> Unit,
-    onRefresh: () -> Unit,
-    onViewDetails: (Extension) -> Unit = {},
-    modifier: Modifier = Modifier
+private fun ExtensionSectionHeader(
+    title: String,
+    actionText: String?,
+    onAction: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    when {
-        isLoading -> LoadingScreen(modifier = modifier)
-        error != null -> ErrorScreen(
-            message = error,
-            onRetry = onRefresh,
-            modifier = modifier
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 8.dp, top = 12.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.weight(1f),
         )
-        extensions.isEmpty() -> EmptyExtensionsView(modifier = modifier)
-        else -> LazyColumn(
-            modifier = modifier.fillMaxSize(),
-            contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            items(extensions, key = { it.id }) { extension ->
-                ExtensionItem(
-                    extension = extension,
-                    signerMismatch = extension.pkgName in signerMismatchedPackages,
-                    blockedReason = blockedPackages[extension.pkgName],
-                    onInstall = { onInstall(extension) },
-                    onUninstall = { onUninstall(extension) },
-                    onUpdate = { onUpdate(extension) },
-                    onToggleEnabled = { enabled -> onToggleEnabled(extension, enabled) },
-                    onViewDetails = { onViewDetails(extension) }
-                )
+        if (actionText != null) {
+            TextButton(onClick = onAction) {
+                Text(actionText)
             }
         }
     }
 }
 
 @Composable
-private fun EmptyExtensionsView(modifier: Modifier = Modifier) {
+private fun EmptyExtensionsView(
+    onManageRepositories: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Box(
         modifier = modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        Text(
-            text = "No extensions found",
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
-}
-
-@Composable
-private fun ExtensionItem(
-    extension: Extension,
-    signerMismatch: Boolean,
-    blockedReason: String? = null,
-    onInstall: () -> Unit,
-    onUninstall: () -> Unit,
-    onUpdate: () -> Unit,
-    onToggleEnabled: (Boolean) -> Unit,
-    onViewDetails: () -> Unit = {},
-    modifier: Modifier = Modifier
-) {
-    Card(
-        modifier = modifier.fillMaxWidth()
-    ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // Extension icon
-                AsyncImage(
-                    model = extension.iconUrl,
-                    contentDescription = extension.name,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier
-                        .size(48.dp)
-                        .clip(CircleShape)
-                )
-
-                Spacer(modifier = Modifier.width(16.dp))
-
-                Column(modifier = Modifier.weight(1f)) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            text = extension.name,
-                            style = MaterialTheme.typography.titleMedium,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f, fill = false),
-                        )
-                        // Signer mismatch warning: shown when the signing cert changed since
-                        // first install. Surfaced here so the user can decide whether to keep
-                        // the extension. Full details are logged at WARN level.
-                        if (signerMismatch) {
-                            Spacer(modifier = Modifier.width(4.dp))
-                            Icon(
-                                imageVector = Icons.Default.Warning,
-                                contentDescription = stringResource(R.string.extension_signer_mismatch_warning),
-                                tint = MaterialTheme.colorScheme.error,
-                                modifier = Modifier.size(16.dp),
-                            )
-                        }
-                    }
-                    Text(
-                        text = "v${extension.versionName} • ${extension.lang.uppercase()}",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    if (extension.sources.isNotEmpty()) {
-                        Text(
-                            text = "${extension.sources.size} source(s)",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    if (signerMismatch) {
-                        Text(
-                            text = stringResource(R.string.extension_signer_mismatch_warning),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.error,
-                        )
-                    }
-                    if (blockedReason != null) {
-                        Text(
-                            text = stringResource(R.string.extension_blocked_warning, blockedReason),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.error,
-                        )
-                    }
-                    Text(
-                    text = if (extension.signatureHash != null) "Trusted" else "Unverified",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = if (extension.signatureHash != null) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    }
-                )
-                // Capability badges: shown only when the flag is true so the row is invisible
-                // for most extensions and adds zero visual noise.
-                ExtensionCapabilityBadges(extension = extension)
-            }
-
-            // Action buttons based on status
-            when (extension.status) {
-                InstallStatus.INSTALLED -> {
-                    Column(horizontalAlignment = Alignment.End) {
-                        Switch(
-                            checked = extension.isEnabled,
-                            onCheckedChange = onToggleEnabled
-                        )
-                        IconButton(onClick = onUninstall) {
-                            Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.extensions_uninstall))
-                        }
-                    }
-                }
-                InstallStatus.HAS_UPDATE -> {
-                    Column(horizontalAlignment = Alignment.End) {
-                        Switch(
-                            checked = extension.isEnabled,
-                            onCheckedChange = onToggleEnabled
-                        )
-                        IconButton(onClick = onUpdate) {
-                            Icon(
-                                Icons.Default.Update,
-                                contentDescription = stringResource(R.string.extensions_update),
-                                tint = MaterialTheme.colorScheme.primary
-                            )
-                        }
-                    }
-                }
-                InstallStatus.AVAILABLE -> {
-                    IconButton(onClick = onInstall) {
-                        Icon(
-                            Icons.Default.Download,
-                            contentDescription = stringResource(R.string.extensions_install),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                }
-                InstallStatus.INSTALLING, InstallStatus.UPDATING -> {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(24.dp),
-                        strokeWidth = 2.dp
-                    )
-                }
-                else -> {
-                    // Error or other states - show install button
-                    IconButton(onClick = onInstall) {
-                        Icon(Icons.Default.Download, contentDescription = stringResource(R.string.extensions_install))
-                    }
-                }
-            }
-            }
-
-            // Details link — always visible at the bottom of the card
-            TextButton(
-                onClick = onViewDetails,
-                modifier = Modifier
-                    .align(Alignment.End)
-                    .padding(end = 8.dp, bottom = 4.dp)
-            ) {
-                Text(stringResource(R.string.extension_detail_view_details))
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = stringResource(R.string.browse_no_sources_title),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            TextButton(onClick = onManageRepositories) {
+                Text(stringResource(R.string.extensions_manage_repositories))
             }
         }
     }
 }
 
 /**
- * Displays glanceable capability badges for an extension.
- *
- * - Amber "CF" chip: extension requires Cloudflare bypass (any of its sources has hasCloudflare).
- * - Blue "README" chip: extension has README documentation in its repository.
- * - Green "CHANGELOG" chip: extension has a changelog in its repository.
- *
- * The Row is only shown when at least one badge is visible; otherwise it collapses to nothing,
- * so extensions without any of these flags incur zero layout cost.
+ * Compact extension row matching Komikku's [ExtensionItem]: icon, name, a single metadata line
+ * (language · version · @repo · NSFW), and a trailing action (install / update / settings /
+ * progress). Long-press opens enable-disable / uninstall / details for installed extensions.
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun ExtensionCapabilityBadges(
+private fun ExtensionRow(
     extension: Extension,
-    modifier: Modifier = Modifier
+    signerMismatch: Boolean,
+    blockedReason: String?,
+    onEvent: (ExtensionsEvent) -> Unit,
+    onViewDetails: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    val hasAny = extension.hasCloudflare || extension.hasReadme || extension.hasChangelog
-    if (!hasAny) return
+    var menuExpanded by remember { mutableStateOf(false) }
+    val isInstalledKind = extension.status == InstallStatus.INSTALLED ||
+        extension.status == InstallStatus.HAS_UPDATE
 
-    Row(
-        modifier = modifier.padding(top = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        if (extension.hasCloudflare) {
-            SuggestionChip(
-                onClick = {},
-                label = {
-                    Text(
-                        text = stringResource(R.string.extension_has_cloudflare),
-                        style = MaterialTheme.typography.labelSmall
-                    )
-                },
-                colors = SuggestionChipDefaults.suggestionChipColors(
-                    containerColor = MaterialTheme.colorScheme.errorContainer,
-                    labelColor = MaterialTheme.colorScheme.onErrorContainer
-                )
-            )
-        }
-        if (extension.hasReadme) {
-            SuggestionChip(
-                onClick = {},
-                label = {
-                    Text(
-                        text = stringResource(R.string.extension_has_readme),
-                        style = MaterialTheme.typography.labelSmall
-                    )
-                },
-                colors = SuggestionChipDefaults.suggestionChipColors(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    labelColor = MaterialTheme.colorScheme.onSecondaryContainer
-                )
-            )
-        }
-        if (extension.hasChangelog) {
-            SuggestionChip(
-                onClick = {},
-                label = {
-                    Text(
-                        text = stringResource(R.string.extension_has_changelog),
-                        style = MaterialTheme.typography.labelSmall
-                    )
-                },
-                colors = SuggestionChipDefaults.suggestionChipColors(
-                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                    labelColor = MaterialTheme.colorScheme.onTertiaryContainer
-                )
-            )
-        }
-    }
-}
-
-@Composable
-private fun FilterAndSortRow(
-    showNsfw: Boolean,
-    sortMode: SortMode,
-    onToggleNsfw: (Boolean) -> Unit,
-    onSetSortMode: (SortMode) -> Unit
-) {
-    var showSortMenu by remember { mutableStateOf(false) }
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        // NSFW Toggle
+    Box {
         Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.clickable { onToggleNsfw(!showNsfw) }
-        ) {
-            Icon(
-                imageVector = Icons.Default.Warning,
-                contentDescription = stringResource(R.string.extensions_icon_cd),
-                tint = if (showNsfw) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(18.dp)
-            )
-            Spacer(modifier = Modifier.width(4.dp))
-            Text(
-                text = stringResource(R.string.extensions_nsfw_label),
-                style = MaterialTheme.typography.labelMedium,
-                color = if (showNsfw) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Switch(
-                checked = showNsfw,
-                onCheckedChange = onToggleNsfw,
-                modifier = Modifier.padding(start = 4.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.weight(1f))
-
-        // Sort dropdown
-        Box {
-            TextButton(onClick = { showSortMenu = true }) {
-                Icon(
-                    imageVector = Icons.Default.Sort,
-                    contentDescription = stringResource(R.string.extensions_language_cd),
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(modifier = Modifier.width(4.dp))
-                Text(
-                    text = when (sortMode) {
-                        SortMode.NAME -> stringResource(R.string.extensions_sort_name)
-                        SortMode.RECENTLY_ADDED -> stringResource(R.string.extensions_sort_recently_added)
-                        SortMode.LANGUAGE -> stringResource(R.string.extensions_sort_language)
-                    }
-                )
-            }
-
-            DropdownMenu(
-                expanded = showSortMenu,
-                onDismissRequest = { showSortMenu = false }
-            ) {
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.extensions_sort_name)) },
-                    onClick = {
-                        onSetSortMode(SortMode.NAME)
-                        showSortMenu = false
-                    },
-                    leadingIcon = {
-                        if (sortMode == SortMode.NAME) {
-                            Icon(Icons.Default.Check, contentDescription = stringResource(R.string.extensions_installed_cd))
-                        }
-                    }
-                )
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.extensions_sort_recently_added)) },
-                    onClick = {
-                        onSetSortMode(SortMode.RECENTLY_ADDED)
-                        showSortMenu = false
-                    },
-                    leadingIcon = {
-                        if (sortMode == SortMode.RECENTLY_ADDED) {
-                            Icon(Icons.Default.Check, contentDescription = stringResource(R.string.extensions_installed_cd))
-                        }
-                    }
-                )
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.extensions_sort_language)) },
-                    onClick = {
-                        onSetSortMode(SortMode.LANGUAGE)
-                        showSortMenu = false
-                    },
-                    leadingIcon = {
-                        if (sortMode == SortMode.LANGUAGE) {
-                            Icon(Icons.Default.Check, contentDescription = stringResource(R.string.extensions_installed_cd))
-                        }
-                    }
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun UpdateAllButton(
-    updateCount: Int,
-    isUpdating: Boolean,
-    onUpdateAll: () -> Unit
-) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
-            .clickable(enabled = !isUpdating) { onUpdateAll() }
-    ) {
-        Row(
-            modifier = Modifier
+            modifier = modifier
                 .fillMaxWidth()
-                .padding(16.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+                .combinedClickable(
+                    onClick = {
+                        when (extension.status) {
+                            InstallStatus.AVAILABLE, InstallStatus.ERROR ->
+                                onEvent(ExtensionsEvent.InstallExtension(extension))
+                            else -> onViewDetails()
+                        }
+                    },
+                    onLongClick = { if (isInstalledKind) menuExpanded = true },
+                )
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                if (isUpdating) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(20.dp),
-                        strokeWidth = 2.dp
+            AsyncImage(
+                model = extension.iconUrl,
+                contentDescription = extension.name,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape),
+            )
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = extension.name,
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false),
                     )
-                } else {
-                    Icon(
-                        imageVector = Icons.Default.Update,
-                        contentDescription = stringResource(R.string.extensions_language_flag_cd),
-                        tint = MaterialTheme.colorScheme.primary
-                    )
+                    if (signerMismatch) {
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Icon(
+                            imageVector = Icons.Default.Warning,
+                            contentDescription = stringResource(R.string.extension_signer_mismatch_warning),
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(14.dp),
+                        )
+                    }
                 }
-                Spacer(modifier = Modifier.width(12.dp))
-                Column {
+                ExtensionMetadataLine(extension = extension)
+                if (blockedReason != null) {
                     Text(
-                        text = if (isUpdating) {
-                            stringResource(R.string.extensions_updating_all)
-                        } else {
-                            stringResource(R.string.extensions_update_all)
-                        },
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    Text(
-                        text = pluralStringResource(R.plurals.extensions_updates_available, updateCount, updateCount),
+                        text = stringResource(R.string.extension_blocked_warning, blockedReason),
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.error,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
                 }
             }
 
-            if (!isUpdating) {
-                Surface(
-                    shape = CircleShape,
-                    color = MaterialTheme.colorScheme.primary
-                ) {
+            ExtensionRowAction(
+                status = extension.status,
+                onInstall = { onEvent(ExtensionsEvent.InstallExtension(extension)) },
+                onUpdate = { onEvent(ExtensionsEvent.UpdateExtension(extension)) },
+                onSettings = onViewDetails,
+            )
+        }
+
+        DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+            DropdownMenuItem(
+                text = {
                     Text(
-                        text = updateCount.toString(),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                        if (extension.isEnabled) {
+                            stringResource(R.string.extensions_disable)
+                        } else {
+                            stringResource(R.string.extensions_enable)
+                        },
                     )
-                }
-            }
+                },
+                onClick = {
+                    menuExpanded = false
+                    onEvent(ExtensionsEvent.ToggleExtensionEnabled(extension, !extension.isEnabled))
+                },
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.extension_detail_view_details)) },
+                onClick = {
+                    menuExpanded = false
+                    onViewDetails()
+                },
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.extensions_uninstall)) },
+                leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                onClick = {
+                    menuExpanded = false
+                    onEvent(ExtensionsEvent.UninstallExtension(extension))
+                },
+            )
         }
     }
 }
 
 @Composable
-private fun RepositoryManager(
-    repositories: List<String>,
-    onAdd: (String) -> Unit,
-    onRemove: (String) -> Unit,
-    onOpenFullManager: () -> Unit = {},
+private fun ExtensionMetadataLine(
+    extension: Extension,
+    modifier: Modifier = Modifier,
 ) {
-    var repoInput by remember { mutableStateOf("") }
-
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+    val parts = buildList {
+        if (extension.lang.isNotBlank()) add(extension.lang.uppercase())
+        if (extension.versionName.isNotBlank()) add("v${extension.versionName}")
+        repoOwner(extension.repoUrl)?.let { add("@$it") }
+    }
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(text = stringResource(R.string.extensions_repositories_title), style = MaterialTheme.typography.titleMedium)
-
-        repositories.forEach { repo ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Text(
-                    text = repo,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
-                )
-                IconButton(onClick = { onRemove(repo) }) {
-                    Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.extensions_remove_repo))
-                }
-            }
-        }
-
-        OutlinedTextField(
-            value = repoInput,
-            onValueChange = { repoInput = it },
-            placeholder = { Text(stringResource(R.string.extensions_repo_url_placeholder)) },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true
+        Text(
+            text = parts.joinToString(SEPARATOR),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f, fill = false),
         )
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            TextButton(onClick = onOpenFullManager) {
-                Text(stringResource(R.string.extensions_manage_repositories))
-            }
-            TextButton(
-                onClick = {
-                    onAdd(repoInput)
-                    repoInput = ""
-                },
-                enabled = repoInput.isNotBlank()
-            ) {
-                Text(stringResource(R.string.extensions_add_repository))
-            }
+        if (extension.isNsfw) {
+            Text(
+                text = SEPARATOR,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = stringResource(R.string.browse_source_nsfw_badge),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+            )
         }
-
-        HorizontalDivider()
     }
 }
 
+@Composable
+private fun ExtensionRowAction(
+    status: InstallStatus,
+    onInstall: () -> Unit,
+    onUpdate: () -> Unit,
+    onSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        when (status) {
+            InstallStatus.INSTALLED -> IconButton(onClick = onSettings) {
+                Icon(Icons.Default.Settings, contentDescription = stringResource(R.string.extensions_settings))
+            }
+            InstallStatus.HAS_UPDATE -> IconButton(onClick = onUpdate) {
+                Icon(
+                    Icons.Default.Update,
+                    contentDescription = stringResource(R.string.extensions_update),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+            InstallStatus.AVAILABLE, InstallStatus.ERROR -> IconButton(onClick = onInstall) {
+                Icon(
+                    Icons.Default.Download,
+                    contentDescription = stringResource(R.string.extensions_install),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+            InstallStatus.INSTALLING, InstallStatus.UPDATING, InstallStatus.UNINSTALLING ->
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    strokeWidth = 2.dp,
+                )
+        }
+    }
+}
 
 @Composable
 private fun UnverifiedInstallDialog(
@@ -935,7 +671,7 @@ private fun UnverifiedInstallDialog(
     onConfirm: () -> Unit,
 ) {
     if (extension == null) return
-    androidx.compose.material3.AlertDialog(
+    AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.extension_unverified_title)) },
         text = {
@@ -952,7 +688,7 @@ private fun UnverifiedInstallDialog(
         confirmButton = {
             TextButton(
                 onClick = onConfirm,
-                colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
+                colors = ButtonDefaults.textButtonColors(
                     contentColor = MaterialTheme.colorScheme.error
                 )
             ) {
@@ -967,39 +703,23 @@ private fun UnverifiedInstallDialog(
     )
 }
 
-@Composable
-private fun TrustBanner(
-    visible: Boolean,
-    modifier: Modifier = Modifier
-) {
-    if (!visible) return
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.errorContainer
-        )
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            Icon(
-                imageVector = Icons.Default.Warning,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.error,
-                modifier = Modifier.size(24.dp)
-            )
-            Text(
-                text = stringResource(R.string.extension_repo_warning),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onErrorContainer,
-                modifier = Modifier.weight(1f)
-            )
-        }
+private const val SEPARATOR = " • "
+
+/**
+ * Best-effort extraction of the repository owner from an extension's repo URL, e.g.
+ * `https://raw.githubusercontent.com/keiyoushi/extensions/repo` → `keiyoushi`. Falls back to the
+ * host when the path has no owner segment. Returns null when no URL is known.
+ */
+private fun repoOwner(repoUrl: String?): String? {
+    if (repoUrl.isNullOrBlank()) return null
+    val segments = repoUrl
+        .substringAfter("://", repoUrl)
+        .split("/")
+        .filter { it.isNotBlank() }
+    val host = segments.firstOrNull() ?: return null
+    return if (host.contains("githubusercontent") || host.contains("github")) {
+        segments.getOrNull(1) ?: host
+    } else {
+        host
     }
 }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Update
@@ -66,6 +67,7 @@ import app.otakureader.core.ui.component.ErrorScreen
 import app.otakureader.core.ui.component.LoadingScreen
 import app.otakureader.feature.browse.R
 import coil3.compose.AsyncImage
+import java.util.Locale
 import kotlinx.coroutines.launch
 
 /**
@@ -193,8 +195,15 @@ private fun ExtensionsList(
             item(key = "hdr_updates") {
                 ExtensionSectionHeader(
                     title = stringResource(R.string.extensions_tab_updates),
-                    actionText = stringResource(R.string.extensions_update_all),
+                    actionText = stringResource(
+                        if (state.isUpdatingAll) {
+                            R.string.extensions_updating_all
+                        } else {
+                            R.string.extensions_update_all
+                        },
+                    ),
                     onAction = { onEvent(ExtensionsEvent.UpdateAllExtensions) },
+                    actionEnabled = !state.isUpdatingAll,
                 )
             }
             items(state.extensionsWithUpdates, key = { "upd_${it.id}" }) { extension ->
@@ -236,7 +245,7 @@ private fun ExtensionsList(
                     title = if (lang.isBlank()) {
                         stringResource(R.string.extensions_tab_available)
                     } else {
-                        lang.uppercase()
+                        lang.uppercase(Locale.ROOT)
                     },
                     actionText = if (showRepoAction) {
                         stringResource(R.string.extensions_manage_repositories)
@@ -286,7 +295,7 @@ private fun ExtensionsContent(
                     }
                     Box {
                         IconButton(onClick = { overflowExpanded = true }) {
-                            Icon(Icons.Default.Settings, contentDescription = stringResource(R.string.extensions_settings))
+                            Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.browse_more_options))
                         }
                         DropdownMenu(
                             expanded = overflowExpanded,
@@ -426,6 +435,7 @@ private fun ExtensionSectionHeader(
     actionText: String?,
     onAction: () -> Unit,
     modifier: Modifier = Modifier,
+    actionEnabled: Boolean = true,
 ) {
     Row(
         modifier = modifier
@@ -440,7 +450,7 @@ private fun ExtensionSectionHeader(
             modifier = Modifier.weight(1f),
         )
         if (actionText != null) {
-            TextButton(onClick = onAction) {
+            TextButton(onClick = onAction, enabled = actionEnabled) {
                 Text(actionText)
             }
         }
@@ -600,7 +610,7 @@ private fun ExtensionMetadataLine(
 ) {
     val separator = stringResource(R.string.extension_meta_separator)
     val parts = buildList {
-        if (extension.lang.isNotBlank()) add(extension.lang.uppercase())
+        if (extension.lang.isNotBlank()) add(extension.lang.uppercase(Locale.ROOT))
         if (extension.versionName.isNotBlank()) add(stringResource(R.string.extension_meta_version, extension.versionName))
         repoOwner(extension.repoUrl)?.let { add(stringResource(R.string.extension_meta_repo, it)) }
     }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaScreen.kt
@@ -57,12 +57,13 @@ fun SourceMangaScreen(
     sourceId: String,
     onMangaClick: (mangaUrl: String, mangaTitle: String) -> Unit,
     onNavigateBack: () -> Unit,
+    initialQuery: String = "",
     viewModel: SourceMangaViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
-    LaunchedEffect(sourceId) {
-        viewModel.setSourceId(sourceId)
+    LaunchedEffect(sourceId, initialQuery) {
+        viewModel.setSourceId(sourceId, initialQuery)
     }
 
     LaunchedEffect(viewModel.effect) {

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaViewModel.kt
@@ -66,26 +66,31 @@ class SourceMangaViewModel @Inject constructor(
     val effect = _effect.receiveAsFlow()
 
     fun setSourceId(sourceId: String, initialQuery: String = "") {
-        if (_state.value.sourceId != sourceId) {
-            viewModelScope.launch {
-                val sourceName = sourceRepository.getSource(sourceId)?.name ?: sourceId
-                val hasQuery = initialQuery.isNotBlank()
-                _state.update {
-                    it.copy(
-                        sourceId = sourceId,
-                        sourceName = sourceName,
-                        manga = emptyList(),
-                        currentPage = 1,
-                        hasNextPage = false,
-                        isSearchMode = hasQuery,
-                        searchQuery = initialQuery,
-                        error = null,
-                    )
-                }
-                // When opened with a tag/genre query (from a manga's detail page), search the
-                // source for it immediately; otherwise show the popular listing.
-                if (hasQuery) performSearch() else loadManga(sourceId, page = 1)
+        val hasQuery = initialQuery.isNotBlank()
+        val current = _state.value
+        // Re-initialize when either the source OR the requested query changes, so navigating
+        // to the same source with a different tag/genre query re-runs the search.
+        val sameRequest = current.sourceId == sourceId &&
+            current.searchQuery == initialQuery &&
+            current.isSearchMode == hasQuery
+        if (sameRequest) return
+        viewModelScope.launch {
+            val sourceName = sourceRepository.getSource(sourceId)?.name ?: sourceId
+            _state.update {
+                it.copy(
+                    sourceId = sourceId,
+                    sourceName = sourceName,
+                    manga = emptyList(),
+                    currentPage = 1,
+                    hasNextPage = false,
+                    isSearchMode = hasQuery,
+                    searchQuery = initialQuery,
+                    error = null,
+                )
             }
+            // When opened with a tag/genre query (from a manga's detail page), search the
+            // source for it immediately; otherwise show the popular listing.
+            if (hasQuery) performSearch() else loadManga(sourceId, page = 1)
         }
     }
 

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaViewModel.kt
@@ -65,10 +65,11 @@ class SourceMangaViewModel @Inject constructor(
     private val _effect = Channel<SourceMangaEffect>()
     val effect = _effect.receiveAsFlow()
 
-    fun setSourceId(sourceId: String) {
+    fun setSourceId(sourceId: String, initialQuery: String = "") {
         if (_state.value.sourceId != sourceId) {
             viewModelScope.launch {
                 val sourceName = sourceRepository.getSource(sourceId)?.name ?: sourceId
+                val hasQuery = initialQuery.isNotBlank()
                 _state.update {
                     it.copy(
                         sourceId = sourceId,
@@ -76,12 +77,14 @@ class SourceMangaViewModel @Inject constructor(
                         manga = emptyList(),
                         currentPage = 1,
                         hasNextPage = false,
-                        isSearchMode = false,
-                        searchQuery = "",
+                        isSearchMode = hasQuery,
+                        searchQuery = initialQuery,
                         error = null,
                     )
                 }
-                loadManga(sourceId, page = 1)
+                // When opened with a tag/genre query (from a manga's detail page), search the
+                // source for it immediately; otherwise show the popular listing.
+                if (hasQuery) performSearch() else loadManga(sourceId, page = 1)
             }
         }
     }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/extension/ExtensionDetailScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/extension/ExtensionDetailScreen.kt
@@ -67,6 +67,7 @@ import app.otakureader.core.ui.component.ErrorScreen
 import app.otakureader.core.ui.component.LoadingScreen
 import app.otakureader.feature.browse.R
 import coil3.compose.AsyncImage
+import java.util.Locale
 
 // ─── Nav-graph extension ─────────────────────────────────────────────────────
 
@@ -348,7 +349,7 @@ private fun CapabilityBadges(extension: Extension, modifier: Modifier = Modifier
             CapabilityChip(label = "Changelog")
         }
         // Show language badge
-        CapabilityChip(label = extension.lang.uppercase())
+        CapabilityChip(label = extension.lang.uppercase(Locale.ROOT))
     }
 }
 
@@ -412,7 +413,7 @@ private fun SourcesList(extension: Extension, modifier: Modifier = Modifier) {
                                 style = MaterialTheme.typography.bodyMedium,
                             )
                             Text(
-                                text = source.lang.uppercase(),
+                                text = source.lang.uppercase(Locale.ROOT),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
@@ -59,7 +59,8 @@ fun NavGraphBuilder.sourceDetailScreen(
             onMangaClick = { mangaUrl, mangaTitle ->
                 onMangaClick(route.sourceId.toString(), mangaUrl, mangaTitle)
             },
-            onNavigateBack = onNavigateBack
+            onNavigateBack = onNavigateBack,
+            initialQuery = route.initialQuery,
         )
     }
 }

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -57,6 +57,8 @@
     <string name="extensions_uninstall">Uninstall</string>
     <string name="extensions_update">Update</string>
     <string name="extensions_install">Install</string>
+    <string name="extensions_enable">Enable</string>
+    <string name="extensions_disable">Disable</string>
     <string name="extensions_remove_repo">Remove repository</string>
 
     <!-- Accessibility: GlobalSearchScreen -->

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -59,6 +59,9 @@
     <string name="extensions_install">Install</string>
     <string name="extensions_enable">Enable</string>
     <string name="extensions_disable">Disable</string>
+    <string name="extension_meta_version">v%1$s</string>
+    <string name="extension_meta_repo">@%1$s</string>
+    <string name="extension_meta_separator">" • "</string>
     <string name="extensions_remove_repo">Remove repository</string>
 
     <!-- Accessibility: GlobalSearchScreen -->

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
@@ -255,6 +255,12 @@ object DetailsContract {
         /** [imageUri] is a content:// URI string returned by the system image picker. */
         data class SetCustomCover(val imageUri: String) : Event
         data object RemoveCustomCover : Event
+
+        /** Genre/tag chip short-press: search this tag within the manga's own source. */
+        data class GenreClick(val genre: String) : Event
+
+        /** Genre/tag chip long-press: search this tag across all sources (global search). */
+        data class GenreLongClick(val genre: String) : Event
     }
 
     /**
@@ -268,6 +274,8 @@ object DetailsContract {
         data class NavigateToTracking(val mangaId: Long, val mangaTitle: String) : Effect
         data class OpenInBrowser(val url: String) : Effect
         data class NavigateToGlobalSearch(val query: String) : Effect
+        /** Search [query] within a single source's browse listing (tag short-press). */
+        data class NavigateToSourceSearch(val sourceId: String, val query: String) : Effect
         data class OpenDownloadFolder(val sourceName: String, val mangaTitle: String) : Effect
     }
 }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -100,6 +100,11 @@ private const val CHAPTER_PANE_WEIGHT = 0.45f
 // Controls how far the user must scroll before the TopAppBar reaches full opacity.
 private const val HERO_TOP_BAR_FADE_RANGE = 600f
 
+// Genre/tag chip layout tokens.
+private val GENRE_CHIP_SPACING = 8.dp
+private val GENRE_CHIP_PADDING_HORIZONTAL = 12.dp
+private val GENRE_CHIP_PADDING_VERTICAL = 6.dp
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DetailsScreen(
@@ -883,8 +888,8 @@ private fun MangaGenreChips(
     if (genres.isEmpty()) return
     FlowRow(
         modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(GENRE_CHIP_SPACING),
+        verticalArrangement = Arrangement.spacedBy(GENRE_CHIP_SPACING),
     ) {
         genres.forEach { genre ->
             GenreChip(
@@ -913,7 +918,10 @@ private fun GenreChip(
         Text(
             text = text,
             style = MaterialTheme.typography.labelMedium,
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            modifier = Modifier.padding(
+                horizontal = GENRE_CHIP_PADDING_HORIZONTAL,
+                vertical = GENRE_CHIP_PADDING_VERTICAL,
+            ),
         )
     }
 }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -5,9 +5,13 @@ import android.content.Intent
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -49,6 +53,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
@@ -103,6 +108,7 @@ fun DetailsScreen(
     onNavigateToReader: (mangaId: Long, chapterId: Long) -> Unit,
     onNavigateToTracking: (mangaId: Long, mangaTitle: String) -> Unit = { _, _ -> },
     onNavigateToGlobalSearch: (query: String) -> Unit = {},
+    onNavigateToSourceSearch: (sourceId: String, query: String) -> Unit = { _, _ -> },
     viewModel: DetailsViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -155,6 +161,9 @@ fun DetailsScreen(
                 }
                 is DetailsContract.Effect.NavigateToGlobalSearch -> {
                     onNavigateToGlobalSearch(effect.query)
+                }
+                is DetailsContract.Effect.NavigateToSourceSearch -> {
+                    onNavigateToSourceSearch(effect.sourceId, effect.query)
                 }
                 is DetailsContract.Effect.OpenDownloadFolder -> {
                     val externalFilesDir = context.getExternalFilesDir(null)
@@ -623,6 +632,17 @@ private fun LazyListScope.detailsInfoTabItems(
         )
     }
 
+    if (manga.genre.isNotEmpty()) {
+        item {
+            MangaGenreChips(
+                genres = manga.genre,
+                onGenreClick = { onEvent(DetailsContract.Event.GenreClick(it)) },
+                onGenreLongClick = { onEvent(DetailsContract.Event.GenreLongClick(it)) },
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+        }
+    }
+
     item {
         MangaNotes(
             notes = manga.notes,
@@ -846,6 +866,56 @@ private fun NoteEditorDialog(
             TextButton(onClick = onDismiss) { Text(stringResource(R.string.notes_editor_cancel)) }
         }
     )
+}
+
+/**
+ * Genre/tag chips shown under the description. Matches Mihon/Komikku: short-press searches the
+ * tag within the manga's source, long-press searches it across all sources (global search).
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun MangaGenreChips(
+    genres: List<String>,
+    onGenreClick: (String) -> Unit,
+    onGenreLongClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (genres.isEmpty()) return
+    FlowRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        genres.forEach { genre ->
+            GenreChip(
+                text = genre,
+                onClick = { onGenreClick(genre) },
+                onLongClick = { onGenreLongClick(genre) },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun GenreChip(
+    text: String,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        shape = MaterialTheme.shapes.small,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier.combinedClickable(onClick = onClick, onLongClick = onLongClick),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+        )
+    }
 }
 
 @Composable

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -172,6 +172,9 @@ class DetailsViewModel @Inject constructor(
             is DetailsContract.Event.ResetMangaInfo -> resetMangaInfo()
             is DetailsContract.Event.SetCustomCover -> setCustomCover(event.imageUri)
             is DetailsContract.Event.RemoveCustomCover -> removeCustomCover()
+
+            is DetailsContract.Event.GenreClick -> searchGenreInSource(event.genre)
+            is DetailsContract.Event.GenreLongClick -> searchGenreGlobally(event.genre)
         }
     }
 
@@ -184,6 +187,26 @@ class DetailsViewModel @Inject constructor(
                     mangaTitle = manga.title
                 )
             )
+        }
+    }
+
+    /** Tag short-press: browse the manga's own source filtered by [genre] (Mihon/Komikku). */
+    private fun searchGenreInSource(genre: String) {
+        viewModelScope.launch {
+            val manga = _state.value.manga ?: return@launch
+            _effect.send(
+                DetailsContract.Effect.NavigateToSourceSearch(
+                    sourceId = manga.sourceId.toString(),
+                    query = genre,
+                )
+            )
+        }
+    }
+
+    /** Tag long-press: search [genre] across all sources (global search). */
+    private fun searchGenreGlobally(genre: String) {
+        viewModelScope.launch {
+            _effect.send(DetailsContract.Effect.NavigateToGlobalSearch(query = genre))
         }
     }
 

--- a/feature/details/src/main/java/app/otakureader/feature/details/navigation/DetailsNavigation.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/navigation/DetailsNavigation.kt
@@ -11,6 +11,7 @@ fun NavGraphBuilder.detailsScreen(
     onNavigateToReader: (mangaId: Long, chapterId: Long) -> Unit,
     onNavigateToTracking: (mangaId: Long, mangaTitle: String) -> Unit = { _, _ -> },
     onNavigateToGlobalSearch: (query: String) -> Unit = {},
+    onNavigateToSourceSearch: (sourceId: String, query: String) -> Unit = { _, _ -> },
 ) {
     composable<Route.MangaDetails> { backStackEntry ->
         val route = backStackEntry.toRoute<Route.MangaDetails>()
@@ -19,7 +20,8 @@ fun NavGraphBuilder.detailsScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToReader = onNavigateToReader,
             onNavigateToTracking = onNavigateToTracking,
-            onNavigateToGlobalSearch = onNavigateToGlobalSearch
+            onNavigateToGlobalSearch = onNavigateToGlobalSearch,
+            onNavigateToSourceSearch = onNavigateToSourceSearch,
         )
     }
 }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/navorder/NavOrderViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/navorder/NavOrderViewModel.kt
@@ -2,7 +2,6 @@ package app.otakureader.feature.settings.navorder
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import app.otakureader.core.preferences.NavTab
 import app.otakureader.core.preferences.NavOrderPreferences
 import app.otakureader.core.preferences.NavTabPreferenceEntry
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -76,8 +75,9 @@ class NavOrderViewModel @Inject constructor(
     }
 
     private fun reset() {
-        // Restore default order with all tabs visible.
-        persist(NavTab.entries.map { NavTabEntry(it, isVisible = true) })
+        // Restore the same default order used on first run (NOT NavTab.entries, whose enum
+        // declaration order differs), with all tabs visible.
+        persist(NavOrderPreferences.DEFAULT_ORDER.map { NavTabEntry(it, isVisible = true) })
     }
 
     private fun persist(order: List<NavTabEntry>) {


### PR DESCRIPTION
## **User description**
## Komikku 1:1 parity — first slice: Browse → Extensions / Sources

This is the first slice of the ongoing effort to make Otaku Reader **look and function exactly like Mihon/Komikku**. It targets the area called out directly: installing an extension and it never appearing in Sources, plus the Extensions screen not looking right.

### Functional fixes
- **Installed NSFW sources no longer vanish from Sources.** `showNsfwContent` now defaults to **true** (in both `GeneralPreferences` and `LibraryPreferences`, which share the `show_nsfw_content` key), matching Mihon/Komikku's `showNsfwSource` default of `true`. With the old `false` default, installing an 18+ source (most extensions are 18+) silently filtered it out of the Sources list — reading as a broken install. ⚠️ *This shows NSFW sources/content by default, matching Komikku.*
- **Clean single-path install.** `ExtensionInstaller` no longer launches the system package installer after a successful silent private (`.ext`) install — that popped a confusing second "install this app?" dialog / unknown-sources redirect on top of an install that already made the source loadable.

### Visual parity — Extensions tab
Rewrote the overloaded Extensions tab (inline search bar + NSFW/sort row + repository manager + red security banner + Installed/Available/Updates sub-tabs) into Komikku's layout:
- One **sectioned list**: *Updates pending* (with Update-all) → *Installed* → *Available* grouped by language.
- **Compact rows**: icon, name, one metadata line (`language • version • @repo • NSFW`), trailing action (install / update / settings / progress).
- Repository management moved off the tab (section-header action + full-screen overflow).
- Enable/disable + uninstall moved to a **row long-press menu** (matches Komikku's `onLongClickItem`).

### Bottom navigation
Default tab order changed to **Library · Updates · History · Browse · More** to match Mihon/Komikku (was `… Browse · History …`).

### Verification note
This environment has **no Android SDK**, so the app could not be built or run locally — CI is the compile/test gate for this PR. Changes were made carefully by inspection: all referenced string resources and model fields were verified to exist, and the ViewModels/tests were left unchanged. Please confirm the green build before merge.

### Known follow-ups (next sessions)
- Wire extension **search** into the Browse top bar (the inline search field was removed to match Komikku; search plumbing still exists in the ViewModel).
- Continue down the parity backlog: Library, Manga detail, Reader, Updates/History/Downloads, Settings, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_


___

## **CodeAnt-AI Description**
**Fix installed NSFW sources from disappearing and match Komikku’s browse/extensions layout**

### What Changed
- Newly installed 18+ sources now stay visible in Sources by default, so an extension install no longer looks broken.
- Installing a private extension no longer opens the system app installer afterward, avoiding the extra install prompt and unknown-sources redirect.
- The Extensions screen now uses a single sectioned list with Updates, Installed, and Available groups instead of tabs, and available sources are grouped by language.
- Installed extensions now use a long-press menu for enable/disable, details, and uninstall, and the top menu now includes repository management and NSFW visibility.
- The bottom navigation now follows Library, Updates, History, Browse, More.

### Impact
`✅ Fewer “installed but missing” source reports`
`✅ Fewer confusing install prompts`
`✅ Faster access to installed and updated extensions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added source-level search with deep-linkable initial queries for manga listings.
  * Enhanced manga details with genre/tag chips (tap to filter the manga’s source, long-press to filter global results).
  * Redesigned Extensions interface with sectioned lists, unified controls, and per-item actions (tap/long-press).

* **Bug Fixes**
  * Improved uncategorized source grouping and language display casing for consistency.
  * Fixed default navigation tab order fallback.

* **Settings**
  * NSFW content visibility now defaults to enabled for new/missing preference values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->