### PR TITLE
Komikku parity — Library: add Comfortable grid display mode

### DIFF
--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
@@ -154,6 +154,26 @@ private fun DisplayTab(
             )
         }
 
+        // Display mode picker (grid / comfortable / list) — matches Mihon/Komikku.
+        Text(
+            text = stringResource(R.string.display_mode_label),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            LibraryDisplayMode.entries.forEach { mode ->
+                FilterChip(
+                    selected = state.displayMode == mode,
+                    onClick = { onEvent(LibraryEvent.SetDisplayMode(mode)) },
+                    label = { Text(mode.label()) },
+                )
+            }
+        }
+
         // Show title on cover
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -340,6 +360,13 @@ private fun GroupTab(
             )
         }
     }
+}
+
+@Composable
+private fun LibraryDisplayMode.label(): String = when (this) {
+    LibraryDisplayMode.GRID -> stringResource(R.string.display_mode_grid)
+    LibraryDisplayMode.COMFORTABLE_GRID -> stringResource(R.string.display_mode_comfortable)
+    LibraryDisplayMode.LIST -> stringResource(R.string.display_mode_list)
 }
 
 @Composable

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
@@ -166,7 +166,14 @@ private fun DisplayTab(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            LibraryDisplayMode.entries.forEach { mode ->
+            // Explicit display order (Grid → Comfortable → List), independent of the enum's
+            // declaration/ordinal order, which keeps COMFORTABLE_GRID appended for stable
+            // persisted ordinals.
+            listOf(
+                LibraryDisplayMode.GRID,
+                LibraryDisplayMode.COMFORTABLE_GRID,
+                LibraryDisplayMode.LIST,
+            ).forEach { mode ->
                 FilterChip(
                     selected = state.displayMode == mode,
                     onClick = { onEvent(LibraryEvent.SetDisplayMode(mode)) },

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
@@ -90,6 +90,7 @@ internal fun LibraryBottomSheet(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun DisplayTab(
     state: LibraryState,
@@ -160,10 +161,10 @@ private fun DisplayTab(
             style = MaterialTheme.typography.labelLarge,
             color = MaterialTheme.colorScheme.primary,
         )
-        Row(
+        FlowRow(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             LibraryDisplayMode.entries.forEach { mode ->
                 FilterChip(

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
@@ -90,6 +90,9 @@ internal fun LibraryBottomSheet(
     }
 }
 
+/** Spacing between the display-mode chips in the library display settings. */
+private val DISPLAY_MODE_CHIP_SPACING = 8.dp
+
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun DisplayTab(
@@ -163,8 +166,8 @@ private fun DisplayTab(
         )
         FlowRow(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(DISPLAY_MODE_CHIP_SPACING),
+            verticalArrangement = Arrangement.spacedBy(DISPLAY_MODE_CHIP_SPACING),
         ) {
             // Explicit display order (Grid → Comfortable → List), independent of the enum's
             // declaration/ordinal order, which keeps COMFORTABLE_GRID appended for stable

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -101,6 +101,9 @@ internal fun isManhwa(manga: LibraryMangaItem): Boolean {
 /** Max title lines for the caption shown below covers in comfortable grid mode. */
 private const val COMFORTABLE_TITLE_MAX_LINES = 2
 
+/** Padding around the title caption shown below covers in comfortable grid mode. */
+private val COMFORTABLE_TITLE_PADDING = 4.dp
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun MangaGrid(
@@ -521,7 +524,11 @@ private fun LibraryMangaPageContent(
                                 overflow = TextOverflow.Ellipsis,
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(top = 4.dp, start = 4.dp, end = 4.dp),
+                                    .padding(
+                                        top = COMFORTABLE_TITLE_PADDING,
+                                        start = COMFORTABLE_TITLE_PADDING,
+                                        end = COMFORTABLE_TITLE_PADDING,
+                                    ),
                             )
                         }
                     } else {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.scaleIn
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -96,6 +97,9 @@ internal fun isManhwa(manga: LibraryMangaItem): Boolean {
     return src.contains("manhwa") || src.contains("webtoon") ||
         src.contains("korean") || src.contains("toon") || src.contains("naver")
 }
+
+/** Max title lines for the caption shown below covers in comfortable grid mode. */
+private const val COMFORTABLE_TITLE_MAX_LINES = 2
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -499,12 +503,21 @@ private fun LibraryMangaPageContent(
                 }
                 val cardContent: @Composable () -> Unit = {
                     if (comfortable) {
-                        Column {
+                        // Whole item (cover + caption + padding) is tappable. Null indication
+                        // avoids a second ripple layering over the card's own ripple.
+                        Column(
+                            modifier = Modifier.combinedClickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                                onClick = { onMangaTap(manga) },
+                                onLongClick = { onMangaLongClick(manga.id) },
+                            ),
+                        ) {
                             card()
                             Text(
                                 text = manga.title,
                                 style = MaterialTheme.typography.bodySmall,
-                                maxLines = 2,
+                                maxLines = COMFORTABLE_TITLE_MAX_LINES,
                                 overflow = TextOverflow.Ellipsis,
                                 modifier = Modifier
                                     .fillMaxWidth()

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -347,7 +347,7 @@ private fun LibraryMangaPageContent(
                 }
             }
         }
-    } else if (state.isStaggeredGrid) {
+    } else if (state.isStaggeredGrid && state.displayMode != LibraryDisplayMode.COMFORTABLE_GRID) {
         LazyVerticalStaggeredGrid(
             columns = StaggeredGridCells.Adaptive(130.dp),
             contentPadding = PaddingValues(8.dp),
@@ -457,7 +457,10 @@ private fun LibraryMangaPageContent(
                 } else null
                 val downloadCount = state.downloadCountByManga[manga.id] ?: 0
                 val continueReading = manga.lastRead != null && manga.unreadCount > 0
-                val cardContent: @Composable () -> Unit = {
+                // Comfortable grid (#Komikku parity): cover with the title shown as a caption
+                // below it rather than overlaid on the cover.
+                val comfortable = state.displayMode == LibraryDisplayMode.COMFORTABLE_GRID
+                val card: @Composable () -> Unit = {
                     MangaCard(
                         title = manga.title,
                         coverUrl = manga.thumbnailUrl,
@@ -467,7 +470,7 @@ private fun LibraryMangaPageContent(
                         readProgress = readProgress,
                         continueReading = continueReading,
                         isNew = manga.unreadCount > 0,
-                        showTitle = state.showTitle,
+                        showTitle = if (comfortable) false else state.showTitle,
                         badge = when {
                             state.showBadges && manga.unreadCount > 0 &&
                                 state.showDownloadBadge && downloadCount > 0 -> {
@@ -493,6 +496,24 @@ private fun LibraryMangaPageContent(
                         },
                         modifier = Modifier.fillMaxWidth()
                     )
+                }
+                val cardContent: @Composable () -> Unit = {
+                    if (comfortable) {
+                        Column {
+                            card()
+                            Text(
+                                text = manga.title,
+                                style = MaterialTheme.typography.bodySmall,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 4.dp, start = 4.dp, end = 4.dp),
+                            )
+                        }
+                    } else {
+                        card()
+                    }
                 }
                 Box {
                     if (state.visualEffectsEnabled) {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -36,14 +36,18 @@ enum class LibraryBottomSheetTab {
  * Top-level layout for the library grid.
  *
  * - [GRID]: cover-centric grid (the [LibraryState.isStaggeredGrid] flag further selects
- *   uniform vs. waterfall columns).
+ *   uniform vs. waterfall columns; [LibraryState.showTitle] toggles compact vs. cover-only).
+ * - [COMFORTABLE_GRID]: like the grid, but the title is a caption *below* each cover instead
+ *   of overlaid — matches Mihon/Komikku's "Comfortable grid".
  * - [LIST]: compact single-column rows with a small cover thumbnail, title, and badges.
  *
- * Persisted as an ordinal via `LibraryPreferences.libraryDisplayMode`.
+ * Persisted as an ordinal via `LibraryPreferences.libraryDisplayMode`. New values must be
+ * appended (never reordered) so existing persisted ordinals keep resolving correctly.
  */
 enum class LibraryDisplayMode {
     GRID,
     LIST,
+    COMFORTABLE_GRID,
 }
 
 data class LibraryState(

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -199,6 +199,10 @@
     <string name="display_show_download_badge">Show download badge</string>
     <string name="display_show_title">Show title on cover</string>
     <string name="display_staggered_grid">Staggered grid</string>
+    <string name="display_mode_label">Display mode</string>
+    <string name="display_mode_grid">Grid</string>
+    <string name="display_mode_comfortable">Comfortable</string>
+    <string name="display_mode_list">List</string>
     <string name="group_category_label">Category</string>
     <string name="group_by_category">Group by category</string>
     <!-- Filter sheet -->


### PR DESCRIPTION
## **User description**
## Komikku parity — Library display modes

Next slice of the Mihon/Komikku parity work (follows #1139).

Mihon/Komikku's library offers a **Comfortable grid** mode where each cover shows its title as a **caption below** the cover instead of overlaid on it. Otaku previously only had `GRID` (title-on-cover, with a `showTitle` cover-only toggle) and `LIST` — the comfortable layout was missing, and there was no display-mode picker (only a binary grid↔list top-bar toggle).

### Changes (all in `feature/library` + the enum)
- `LibraryDisplayMode` gains **`COMFORTABLE_GRID`** (appended, so persisted ordinals stay stable; persistence + read-back already resolve it via the ordinal).
- `LibraryMangaGrid` renders comfortable mode as `MangaCard(showTitle = false)` with a title caption below it, and takes precedence over the staggered layout.
- `LibraryBottomSheet` gains a **Grid / Comfortable / List** display-mode picker in the display settings (the top-bar button still toggles grid↔list); adds a `LibraryDisplayMode.label()`.
- New `display_mode_*` string resources.

No shared `core/ui` `MangaCard` change was needed — the caption is composed in the library grid.

### Verification note
No Android SDK in this environment, so this was verified by inspection (imports, exhaustive `when` checks, no other `LibraryDisplayMode` references affected); CI is the compile/test gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_


___

## **CodeAnt-AI Description**
**Add a comfortable library grid view with a display mode picker**

### What Changed
- Added a new library display mode that shows manga titles below each cover instead of on top of the cover
- Added a display mode picker so users can switch between Grid, Comfortable, and List views from the library settings
- Comfortable grid now takes priority over the staggered grid layout, so the title-below-cover layout is kept in that mode

### Impact
`✅ Clearer manga titles in grid view`
`✅ Easier switching between library layouts`
`✅ Closer parity with Mihon/Komikku library display`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Comfortable Grid** display mode for the library, featuring larger titles beneath cover images for improved readability.
  * Introduced a **display mode picker** in the library bottom sheet to switch between **Grid**, **Comfortable Grid**, and **List** views.  
* **Bug Fixes**
  * Improved interaction handling for comfortable-grid items to ensure consistent tap and long-press behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->