### PR TITLE
Komikku parity — Library: add Resume FAB

### DIFF
--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.automirrored.filled.DriveFileMove
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.VisibilityOff
@@ -39,6 +40,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -474,7 +476,23 @@ fun LibraryScreen(
                 )
             }
         },
-        snackbarHost = { SnackbarHost(snackbarHostState) }
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            // Resume FAB (Mihon/Komikku): continues the most recently read chapter. Shown only
+            // when there is something to resume and not while selecting or searching.
+            val resume = state.continueReadingItems.firstOrNull()
+            if (resume != null && state.selectedManga.isEmpty() && !state.showSearchBar) {
+                ExtendedFloatingActionButton(
+                    text = { Text(stringResource(R.string.library_resume)) },
+                    icon = { Icon(Icons.Default.PlayArrow, contentDescription = null) },
+                    onClick = {
+                        viewModel.onEvent(
+                            LibraryEvent.ContinueReadingClick(resume.mangaId, resume.chapterId)
+                        )
+                    },
+                )
+            }
+        },
     ) { padding ->
         LibraryContent(
             state = state,

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -1,5 +1,10 @@
 package app.otakureader.feature.library
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -479,18 +484,26 @@ fun LibraryScreen(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
             // Resume FAB (Mihon/Komikku): continues the most recently read chapter. Shown only
-            // when there is something to resume and not while selecting or searching.
+            // when there is something to resume and not while selecting or searching, and it
+            // animates in/out rather than popping when those modes change.
             val resume = state.continueReadingItems.firstOrNull()
-            if (resume != null && state.selectedManga.isEmpty() && !state.showSearchBar) {
-                ExtendedFloatingActionButton(
-                    text = { Text(stringResource(R.string.library_resume)) },
-                    icon = { Icon(Icons.Default.PlayArrow, contentDescription = null) },
-                    onClick = {
-                        viewModel.onEvent(
-                            LibraryEvent.ContinueReadingClick(resume.mangaId, resume.chapterId)
-                        )
-                    },
-                )
+            val showFab = resume != null && state.selectedManga.isEmpty() && !state.showSearchBar
+            AnimatedVisibility(
+                visible = showFab,
+                enter = fadeIn() + scaleIn(),
+                exit = fadeOut() + scaleOut(),
+            ) {
+                if (resume != null) {
+                    ExtendedFloatingActionButton(
+                        text = { Text(stringResource(R.string.library_resume)) },
+                        icon = { Icon(Icons.Default.PlayArrow, contentDescription = null) },
+                        onClick = {
+                            viewModel.onEvent(
+                                LibraryEvent.ContinueReadingClick(resume.mangaId, resume.chapterId)
+                            )
+                        },
+                    )
+                }
             }
         },
     ) { padding ->

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="library_toggle_incognito">Toggle incognito mode</string>
     <string name="library_view_mode_grid">Switch to grid view</string>
     <string name="library_view_mode_list">Switch to list view</string>
+    <string name="library_resume">Resume</string>
     <!-- Content-type filter tabs -->
     <string name="library_content_tab_all">All</string>
     <string name="library_content_tab_manga">Manga</string>


### PR DESCRIPTION
## **User description**
## Komikku parity — Library: Resume FAB

Adds Mihon/Komikku's library **"Resume" floating action button**.

- An `ExtendedFloatingActionButton` (PlayArrow + "Resume") shown at the bottom of the library.
- Appears only when there's a recently-read chapter to continue, and is hidden during multi-select and search (matching Mihon, which hides Resume in those modes).
- Tapping resumes the most recent continue-reading entry via the existing `ContinueReadingClick → NavigateToReader` flow — no new navigation plumbing.

This is additive: the existing Continue-Reading carousel stays as an Otaku extra.

(Note: the parity brief mentioned a long-press "reposition" gesture, but real Mihon/Komikku has no such behavior on this FAB, so it's intentionally omitted.)

### Verification
No Android SDK locally, so verified by inspection (imports, state fields, event wiring); CI is the compile/test gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_


___

## **CodeAnt-AI Description**
**Add a Resume button to the Library screen**

### What Changed
- A new floating “Resume” button appears in the Library when there is a recently read chapter to continue.
- The button stays hidden while selecting items or searching, so it does not get in the way of those actions.
- Tapping Resume opens the most recent continue-reading chapter.
- Added the label text used by the new button.

### Impact
`✅ Faster return to the last chapter`
`✅ Fewer taps to continue reading`
`✅ Cleaner library screen while searching or selecting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
