### PR TITLE
Komikku parity — Library: update progress banner

### DIFF
--- a/data/src/main/java/app/otakureader/data/worker/LibraryUpdateScheduler.kt
+++ b/data/src/main/java/app/otakureader/data/worker/LibraryUpdateScheduler.kt
@@ -1,8 +1,12 @@
 package app.otakureader.data.worker
 
 import android.content.Context
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
 import app.otakureader.domain.scheduler.LibraryUpdateScheduler as LibraryUpdateSchedulerInterface
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -29,4 +33,9 @@ class LibraryUpdateScheduler @Inject constructor(
     override fun enqueueNow() {
         LibraryUpdateWorker.enqueue(context)
     }
+
+    override fun isUpdating(): Flow<Boolean> =
+        WorkManager.getInstance(context)
+            .getWorkInfosForUniqueWorkFlow(LibraryUpdateWorker.WORK_NAME)
+            .map { infos -> infos.any { it.state == WorkInfo.State.RUNNING } }
 }

--- a/data/src/main/java/app/otakureader/data/worker/LibraryUpdateScheduler.kt
+++ b/data/src/main/java/app/otakureader/data/worker/LibraryUpdateScheduler.kt
@@ -6,7 +6,7 @@ import androidx.work.WorkManager
 import app.otakureader.domain.scheduler.LibraryUpdateScheduler as LibraryUpdateSchedulerInterface
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -34,8 +34,20 @@ class LibraryUpdateScheduler @Inject constructor(
         LibraryUpdateWorker.enqueue(context)
     }
 
-    override fun isUpdating(): Flow<Boolean> =
-        WorkManager.getInstance(context)
-            .getWorkInfosForUniqueWorkFlow(LibraryUpdateWorker.WORK_NAME)
-            .map { infos -> infos.any { it.state == WorkInfo.State.RUNNING } }
+    /**
+     * Emits `true` whenever a library update is running — whether it was triggered manually
+     * (the one-off [LibraryUpdateWorker.WORK_NAME]) or by the periodic scheduler
+     * ([LibraryUpdateWorker.PERIODIC_WORK_NAME]). We combine both unique-work flows so the
+     * progress banner shows for either trigger, matching Mihon/Komikku.
+     */
+    override fun isUpdating(): Flow<Boolean> {
+        val workManager = WorkManager.getInstance(context)
+        return combine(
+            workManager.getWorkInfosForUniqueWorkFlow(LibraryUpdateWorker.WORK_NAME),
+            workManager.getWorkInfosForUniqueWorkFlow(LibraryUpdateWorker.PERIODIC_WORK_NAME),
+        ) { oneOff, periodic ->
+            oneOff.any { it.state == WorkInfo.State.RUNNING } ||
+                periodic.any { it.state == WorkInfo.State.RUNNING }
+        }
+    }
 }

--- a/domain/src/main/java/app/otakureader/domain/scheduler/LibraryUpdateScheduler.kt
+++ b/domain/src/main/java/app/otakureader/domain/scheduler/LibraryUpdateScheduler.kt
@@ -1,7 +1,15 @@
 package app.otakureader.domain.scheduler
 
+import kotlinx.coroutines.flow.Flow
+
 interface LibraryUpdateScheduler {
     fun schedule(intervalHours: Int, wifiOnly: Boolean)
     fun cancel()
     fun enqueueNow()
+
+    /**
+     * Emits true while a one-off library update is running, so the UI can show a progress
+     * banner (matching Mihon/Komikku). Backed by the WorkManager unique-work state.
+     */
+    fun isUpdating(): Flow<Boolean>
 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -53,6 +53,8 @@ enum class LibraryDisplayMode {
 data class LibraryState(
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
+    /** True while a background library update (the WorkManager job) is running. */
+    val isLibraryUpdating: Boolean = false,
     val mangaList: List<LibraryMangaItem> = emptyList(),
     val selectedManga: Set<Long> = emptySet(),
     val searchQuery: String = "",

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
@@ -514,6 +515,24 @@ fun LibraryScreen(
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
+/**
+ * Thin progress banner shown at the top of the library while a background library update is
+ * running, matching Mihon/Komikku's update indicator. Driven by [LibraryState.isLibraryUpdating].
+ */
+@Composable
+private fun LibraryUpdatingBanner(modifier: Modifier = Modifier) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.library_updating),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+        )
+        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+    }
+}
+
+@Composable
 private fun LibraryContent(
     state: LibraryState,
     onEvent: (LibraryEvent) -> Unit,
@@ -532,6 +551,10 @@ private fun LibraryContent(
     Column(modifier = modifier.fillMaxSize()) {
         if (state.incognitoMode) {
             IncognitoBanner()
+        }
+
+        if (state.isLibraryUpdating) {
+            LibraryUpdatingBanner()
         }
 
         if (state.showSearchBar) {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -513,8 +513,6 @@ fun LibraryScreen(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
-@Composable
 /**
  * Thin progress banner shown at the top of the library while a background library update is
  * running, matching Mihon/Komikku's update indicator. Driven by [LibraryState.isLibraryUpdating].

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -500,6 +500,9 @@ class LibraryViewModel @Inject constructor(
         generalPreferences.visualEffectsEnabled
             .onEach { enabled -> _state.update { it.copy(visualEffectsEnabled = enabled) } }
             .launchIn(viewModelScope)
+        libraryUpdateScheduler.isUpdating()
+            .onEach { updating -> _state.update { it.copy(isLibraryUpdating = updating) } }
+            .launchIn(viewModelScope)
         libraryPreferences.groupByCategory
             .onEach { groupByCategory -> _state.update { it.copy(groupByCategory = groupByCategory) } }
             .launchIn(viewModelScope)

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="library_toggle_incognito">Toggle incognito mode</string>
     <string name="library_view_mode_grid">Switch to grid view</string>
     <string name="library_view_mode_list">Switch to list view</string>
+    <string name="library_updating">Updating library…</string>
     <!-- Content-type filter tabs -->
     <string name="library_content_tab_all">All</string>
     <string name="library_content_tab_manga">Manga</string>


### PR DESCRIPTION
## **User description**
## Komikku parity — Library: update progress banner

Matches Mihon/Komikku, which show an update indicator while a library refresh is running. Otaku enqueued the update worker but surfaced no progress.

### Changes (domain → data → VM → UI)
- `LibraryUpdateScheduler.isUpdating(): Flow<Boolean>` (domain interface; pure-Kotlin Flow).
- Data impl observes the WorkManager **unique-work** state for the one-off update job (`getWorkInfosForUniqueWorkFlow(WORK_NAME)` → any `RUNNING`).
- `LibraryViewModel` collects it into a new `LibraryState.isLibraryUpdating` flag.
- `LibraryScreen` renders a thin **"Updating library…"** `LinearProgressIndicator` banner at the top of the content while updating.

The VM test uses a relaxed mock of the scheduler, so the new flow method auto-stubs; no test changes needed.

### Branch note
This is branched from `main` (not the audit branch) because PR #1141 (Resume FAB) still occupies that branch; keeping this PR's diff isolated.

### Verification
No Android SDK locally — verified by inspection (interface/impl consistency, single implementer confirmed, WorkManager 2.11.2 has the Flow API); CI is the compile/test gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_


___

## **CodeAnt-AI Description**
**Show a progress banner while the library is updating**

### What Changed
- The Library screen now shows an “Updating library…” banner with a progress bar while a background library refresh is running.
- The app now watches the update job state so the banner appears and disappears automatically during library refreshes.
- The banner text is added to the library screen strings for display in the app.

### Impact
`✅ Clearer library refresh status`
`✅ Fewer "did my update start?" moments`
`✅ More obvious background update activity`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
