### PR TITLE
Komikku parity — Manga detail: chapter-selection bottom action menu

### DIFF
--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
@@ -199,6 +199,7 @@ object DetailsContract {
         data object SaveChapterNote : Event
         data object ClearChapterSelection : Event
         data object SelectAllChapters : Event
+        data object InvertChapterSelection : Event
         data object DownloadSelectedChapters : Event
         data object DownloadAllChapters : Event
         data object DownloadUnreadChapters : Event

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -5,7 +5,11 @@ import android.content.Intent
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -26,17 +30,21 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.FlipToBack
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.QueryStats
-import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.RemoveDone
 import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.AlertDialog
@@ -72,6 +80,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -104,6 +113,9 @@ private const val HERO_TOP_BAR_FADE_RANGE = 600f
 private val GENRE_CHIP_SPACING = 8.dp
 private val GENRE_CHIP_PADDING_HORIZONTAL = 12.dp
 private val GENRE_CHIP_PADDING_VERTICAL = 6.dp
+
+// Corner radius for the ripple on each chapter selection bottom-bar action.
+private val CHAPTER_ACTION_CORNER = 8.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -225,10 +237,7 @@ fun DetailsScreen(
                     selectedCount = state.selectedChapters.size,
                     onClearSelection = { viewModel.onEvent(DetailsContract.Event.ClearChapterSelection) },
                     onSelectAll = { viewModel.onEvent(DetailsContract.Event.SelectAllChapters) },
-                    onMarkRead = { viewModel.onEvent(DetailsContract.Event.MarkSelectedAsRead) },
-                    onMarkUnread = { viewModel.onEvent(DetailsContract.Event.MarkSelectedAsUnread) },
-                    onDownload = { viewModel.onEvent(DetailsContract.Event.DownloadSelectedChapters) },
-                    onDelete = { viewModel.onEvent(DetailsContract.Event.DeleteSelectedChapters) },
+                    onInvertSelection = { viewModel.onEvent(DetailsContract.Event.InvertChapterSelection) },
                 )
             } else {
             TopAppBar(
@@ -376,6 +385,21 @@ fun DetailsScreen(
             )
             }
         },
+        bottomBar = {
+            val selectedChapters = remember(state.chapters, state.selectedChapters) {
+                state.chapters.filter { it.id in state.selectedChapters }
+            }
+            ChapterSelectionBottomBar(
+                selectedChapters = selectedChapters,
+                onMarkRead = { viewModel.onEvent(DetailsContract.Event.MarkSelectedAsRead) },
+                onMarkUnread = { viewModel.onEvent(DetailsContract.Event.MarkSelectedAsUnread) },
+                onMarkPreviousAsRead = { chapterId ->
+                    viewModel.onEvent(DetailsContract.Event.MarkPreviousAsRead(chapterId))
+                },
+                onDownload = { viewModel.onEvent(DetailsContract.Event.DownloadSelectedChapters) },
+                onDelete = { viewModel.onEvent(DetailsContract.Event.DeleteSelectedChapters) },
+            )
+        },
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { paddingValues ->
         when {
@@ -398,8 +422,10 @@ fun DetailsScreen(
 }
 
 /**
- * Contextual app bar shown while one or more chapters are selected. Surfaces the batch
- * actions that the ViewModel already handles (select-all, mark read/unread, download, delete).
+ * Contextual app bar shown while one or more chapters are selected. Matching Mihon/Komikku's
+ * `MangaToolbar` selection mode, this only carries the count plus select-all / invert-selection;
+ * the actual batch operations (mark read/unread, download, delete) live in the animated
+ * [ChapterSelectionBottomBar] at the bottom of the screen.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -407,10 +433,7 @@ private fun ChapterSelectionTopBar(
     selectedCount: Int,
     onClearSelection: () -> Unit,
     onSelectAll: () -> Unit,
-    onMarkRead: () -> Unit,
-    onMarkUnread: () -> Unit,
-    onDownload: () -> Unit,
-    onDelete: () -> Unit,
+    onInvertSelection: () -> Unit,
 ) {
     TopAppBar(
         title = { Text(stringResource(R.string.details_selected_count, selectedCount)) },
@@ -423,23 +446,119 @@ private fun ChapterSelectionTopBar(
             IconButton(onClick = onSelectAll) {
                 Icon(Icons.Default.SelectAll, contentDescription = stringResource(R.string.details_select_all))
             }
-            IconButton(onClick = onMarkRead) {
-                Icon(Icons.Default.CheckCircle, contentDescription = stringResource(R.string.details_mark_as_read))
-            }
-            IconButton(onClick = onMarkUnread) {
-                Icon(
-                    Icons.Default.RadioButtonUnchecked,
-                    contentDescription = stringResource(R.string.details_mark_as_unread),
-                )
-            }
-            IconButton(onClick = onDownload) {
-                Icon(Icons.Default.Download, contentDescription = stringResource(R.string.details_download_selected))
-            }
-            IconButton(onClick = onDelete) {
-                Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.details_delete_selected))
+            IconButton(onClick = onInvertSelection) {
+                Icon(Icons.Default.FlipToBack, contentDescription = stringResource(R.string.details_invert_selection))
             }
         },
     )
+}
+
+/**
+ * Komikku-style chapter selection action menu. Slides up from the bottom while chapters are
+ * selected and only surfaces the actions that make sense for the current selection — mirroring
+ * Mihon/Komikku's `MangaBottomActionMenu`:
+ *  - Mark as read: shown when any selected chapter is unread.
+ *  - Mark as unread: shown when any selected chapter is read (or partially read).
+ *  - Mark previous as read: shown only when exactly one chapter is selected.
+ *  - Download: shown when any selected chapter is not yet downloaded.
+ *  - Delete: shown when any selected chapter is downloaded.
+ */
+@Composable
+private fun ChapterSelectionBottomBar(
+    selectedChapters: List<DetailsContract.ChapterItem>,
+    onMarkRead: () -> Unit,
+    onMarkUnread: () -> Unit,
+    onMarkPreviousAsRead: (Long) -> Unit,
+    onDownload: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    AnimatedVisibility(
+        visible = selectedChapters.isNotEmpty(),
+        enter = expandVertically(expandFrom = Alignment.Bottom),
+        exit = shrinkVertically(shrinkTowards = Alignment.Bottom),
+    ) {
+        val showMarkRead = selectedChapters.any { !it.read }
+        val showMarkUnread = selectedChapters.any { it.read || it.lastPageRead > 0 }
+        val showMarkPrevious = selectedChapters.size == 1
+        val showDownload = selectedChapters.any { it.downloadStatus != DetailsContract.DownloadStatus.DOWNLOADED }
+        val showDelete = selectedChapters.any { it.downloadStatus == DetailsContract.DownloadStatus.DOWNLOADED }
+
+        Surface(
+            shape = MaterialTheme.shapes.large.copy(
+                bottomEnd = androidx.compose.foundation.shape.ZeroCornerSize,
+                bottomStart = androidx.compose.foundation.shape.ZeroCornerSize,
+            ),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .navigationBarsPadding()
+                    .padding(horizontal = 8.dp, vertical = 12.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+            ) {
+                if (showMarkRead) {
+                    ChapterSelectionAction(
+                        icon = Icons.Default.DoneAll,
+                        label = stringResource(R.string.details_mark_as_read),
+                        onClick = onMarkRead,
+                    )
+                }
+                if (showMarkUnread) {
+                    ChapterSelectionAction(
+                        icon = Icons.Default.RemoveDone,
+                        label = stringResource(R.string.details_mark_as_unread),
+                        onClick = onMarkUnread,
+                    )
+                }
+                if (showMarkPrevious) {
+                    ChapterSelectionAction(
+                        icon = Icons.Default.Done,
+                        label = stringResource(R.string.details_mark_previous_as_read),
+                        onClick = { onMarkPreviousAsRead(selectedChapters.first().id) },
+                    )
+                }
+                if (showDownload) {
+                    ChapterSelectionAction(
+                        icon = Icons.Default.Download,
+                        label = stringResource(R.string.details_download_selected),
+                        onClick = onDownload,
+                    )
+                }
+                if (showDelete) {
+                    ChapterSelectionAction(
+                        icon = Icons.Default.Delete,
+                        label = stringResource(R.string.details_delete_selected),
+                        onClick = onDelete,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChapterSelectionAction(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .clip(RoundedCornerShape(CHAPTER_ACTION_CORNER))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Icon(imageVector = icon, contentDescription = null)
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
 }
 
 @Composable

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -117,6 +117,13 @@ private val GENRE_CHIP_PADDING_VERTICAL = 6.dp
 // Corner radius for the ripple on each chapter selection bottom-bar action.
 private val CHAPTER_ACTION_CORNER = 8.dp
 
+// "Mark previous as read" only applies to a single anchor chapter, so the action is shown
+// only when exactly this many chapters are selected (Komikku parity).
+private const val SINGLE_CHAPTER_SELECTION = 1
+
+// Action labels in the selection bottom bar are kept to a single line so the row stays compact.
+private const val CHAPTER_ACTION_LABEL_MAX_LINES = 1
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DetailsScreen(
@@ -386,8 +393,8 @@ fun DetailsScreen(
             }
         },
         bottomBar = {
-            val selectedChapters = remember(state.chapters, state.selectedChapters) {
-                state.chapters.filter { it.id in state.selectedChapters }
+            val selectedChapters = remember(state.sortedChapters, state.selectedChapters) {
+                state.sortedChapters.filter { it.id in state.selectedChapters }
             }
             ChapterSelectionBottomBar(
                 selectedChapters = selectedChapters,
@@ -471,15 +478,17 @@ private fun ChapterSelectionBottomBar(
     onMarkPreviousAsRead: (Long) -> Unit,
     onDownload: () -> Unit,
     onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(
         visible = selectedChapters.isNotEmpty(),
         enter = expandVertically(expandFrom = Alignment.Bottom),
         exit = shrinkVertically(shrinkTowards = Alignment.Bottom),
+        modifier = modifier,
     ) {
         val showMarkRead = selectedChapters.any { !it.read }
         val showMarkUnread = selectedChapters.any { it.read || it.lastPageRead > 0 }
-        val showMarkPrevious = selectedChapters.size == 1
+        val showMarkPrevious = selectedChapters.size == SINGLE_CHAPTER_SELECTION
         val showDownload = selectedChapters.any { it.downloadStatus != DetailsContract.DownloadStatus.DOWNLOADED }
         val showDelete = selectedChapters.any { it.downloadStatus == DetailsContract.DownloadStatus.DOWNLOADED }
 
@@ -512,10 +521,11 @@ private fun ChapterSelectionBottomBar(
                     )
                 }
                 if (showMarkPrevious) {
+                    val previousAnchorId = selectedChapters.first().id
                     ChapterSelectionAction(
                         icon = Icons.Default.Done,
                         label = stringResource(R.string.details_mark_previous_as_read),
-                        onClick = { onMarkPreviousAsRead(selectedChapters.first().id) },
+                        onClick = { onMarkPreviousAsRead(previousAnchorId) },
                     )
                 }
                 if (showDownload) {
@@ -555,7 +565,7 @@ private fun ChapterSelectionAction(
         Text(
             text = label,
             style = MaterialTheme.typography.labelSmall,
-            maxLines = 1,
+            maxLines = CHAPTER_ACTION_LABEL_MAX_LINES,
             overflow = TextOverflow.Ellipsis,
         )
     }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -236,12 +236,20 @@ fun DetailsScreen(
         enabled = state.manga?.mangaThemeOverride ?: state.autoThemeEnabled
     )
 
+    // Single source of truth for both selection bars: the selected chapters that are actually
+    // visible in the current (filtered/sorted) list. Deriving the top bar count and the bottom
+    // action menu from the same list keeps them in sync even if some selected IDs become stale
+    // after a list refresh or are hidden by a filter.
+    val selectedVisibleChapters = remember(state.sortedChapters, state.selectedChapters) {
+        state.sortedChapters.filter { it.id in state.selectedChapters }
+    }
+
     MangaDynamicTheme(colorScheme = dynamicScheme) {
         Scaffold(
             topBar = {
-            if (state.selectedChapters.isNotEmpty()) {
+            if (selectedVisibleChapters.isNotEmpty()) {
                 ChapterSelectionTopBar(
-                    selectedCount = state.selectedChapters.size,
+                    selectedCount = selectedVisibleChapters.size,
                     onClearSelection = { viewModel.onEvent(DetailsContract.Event.ClearChapterSelection) },
                     onSelectAll = { viewModel.onEvent(DetailsContract.Event.SelectAllChapters) },
                     onInvertSelection = { viewModel.onEvent(DetailsContract.Event.InvertChapterSelection) },
@@ -393,11 +401,8 @@ fun DetailsScreen(
             }
         },
         bottomBar = {
-            val selectedChapters = remember(state.sortedChapters, state.selectedChapters) {
-                state.sortedChapters.filter { it.id in state.selectedChapters }
-            }
             ChapterSelectionBottomBar(
-                selectedChapters = selectedChapters,
+                selectedChapters = selectedVisibleChapters,
                 onMarkRead = { viewModel.onEvent(DetailsContract.Event.MarkSelectedAsRead) },
                 onMarkUnread = { viewModel.onEvent(DetailsContract.Event.MarkSelectedAsUnread) },
                 onMarkPreviousAsRead = { chapterId ->

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -769,6 +769,9 @@ class DetailsViewModel @Inject constructor(
                     }
                 }
                 _effect.send(DetailsContract.Effect.ShowSnackbar("Marked previous chapters as read"))
+                // Exit selection mode like the other batch actions. Harmless no-op when invoked
+                // from the per-chapter context menu (no selection is active there).
+                clearChapterSelection()
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -130,6 +130,7 @@ class DetailsViewModel @Inject constructor(
             is DetailsContract.Event.SaveChapterNote -> saveChapterNote()
             is DetailsContract.Event.ClearChapterSelection -> clearChapterSelection()
             is DetailsContract.Event.SelectAllChapters -> selectAllChapters()
+            is DetailsContract.Event.InvertChapterSelection -> invertChapterSelection()
             is DetailsContract.Event.DownloadSelectedChapters -> downloadSelectedChapters()
             is DetailsContract.Event.DeleteSelectedChapters -> deleteSelectedChapters()
             is DetailsContract.Event.MarkSelectedAsRead -> markSelectedAsRead()
@@ -500,6 +501,14 @@ class DetailsViewModel @Inject constructor(
         _state.update { state ->
             val allIds = state.chapters.map { it.id }.toSet()
             state.copy(selectedChapters = allIds)
+        }
+    }
+
+    /** Selects every chapter not currently selected and deselects the rest (Komikku parity). */
+    private fun invertChapterSelection() {
+        _state.update { state ->
+            val allIds = state.chapters.map { it.id }.toSet()
+            state.copy(selectedChapters = allIds - state.selectedChapters)
         }
     }
 

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -499,16 +499,23 @@ class DetailsViewModel @Inject constructor(
 
     private fun selectAllChapters() {
         _state.update { state ->
-            val allIds = state.chapters.map { it.id }.toSet()
-            state.copy(selectedChapters = allIds)
+            // Only the currently visible (filtered/searched) chapters — matches Mihon/Komikku,
+            // so an active filter never selects chapters the user can't see.
+            val visibleIds = state.sortedChapters.map { it.id }.toSet()
+            state.copy(selectedChapters = state.selectedChapters + visibleIds)
         }
     }
 
-    /** Selects every chapter not currently selected and deselects the rest (Komikku parity). */
+    /**
+     * Selects every visible chapter not currently selected and deselects the visible ones that
+     * are (Komikku parity). Restricted to [State.sortedChapters] so a filter/search can't flip
+     * the selection state of hidden chapters.
+     */
     private fun invertChapterSelection() {
         _state.update { state ->
-            val allIds = state.chapters.map { it.id }.toSet()
-            state.copy(selectedChapters = allIds - state.selectedChapters)
+            val visibleIds = state.sortedChapters.map { it.id }.toSet()
+            val keptHidden = state.selectedChapters - visibleIds
+            state.copy(selectedChapters = keptHidden + (visibleIds - state.selectedChapters))
         }
     }
 

--- a/feature/details/src/main/res/values/strings.xml
+++ b/feature/details/src/main/res/values/strings.xml
@@ -111,6 +111,8 @@
     <string name="details_mark_as_unread">Mark as unread</string>
     <string name="details_delete_selected">Delete selected</string>
     <string name="details_select_all">Select all</string>
+    <string name="details_invert_selection">Invert selection</string>
+    <string name="details_mark_previous_as_read">Mark previous as read</string>
     <string name="details_sort_chapters">Sort chapters</string>
 
     <!-- Chapter context menu actions -->


### PR DESCRIPTION
## **User description**
## What & why

Brings the manga detail screen's **chapter selection UX** in line with Mihon/Komikku.

Previously Otaku surfaced the batch actions (mark read/unread, download, delete) as icons crammed into the contextual **top app bar**. Komikku instead keeps only the *count + select-all/invert* in the top bar and presents the operations in an **animated bottom action menu** (`MangaBottomActionMenu`) that slides up while chapters are selected — and it only shows the actions that make sense for the current selection.

## Changes

- **Top selection bar** (`ChapterSelectionTopBar`) trimmed to: clear, selected count, **select all**, and a new **invert selection**.
- New **`InvertChapterSelection`** event + `invertChapterSelection()` ViewModel handler (selects the complement of the current selection).
- New **`ChapterSelectionBottomBar`** mirroring `MangaBottomActionMenu`, with each action shown conditionally:
  - **Mark as read** — when any selected chapter is unread
  - **Mark as unread** — when any selected chapter is read / partially read
  - **Mark previous as read** — only when exactly one chapter is selected
  - **Download** — when any selected chapter isn't downloaded
  - **Delete** — when any selected chapter is downloaded
- All actions reuse existing, already-wired ViewModel handlers — no backend changes.

Part of the ongoing Komikku 1:1 parity effort (follows the Library work in #1140–#1142).

## Verification

No Android SDK in the container, so this relies on CI (Detekt, Ktlint, Unit Tests, Assemble, Screenshot Tests). Verified by inspection: unused top-bar icon imports removed, conditional logic guarantees the bar is never empty (a chapter is always either read or unread), `ChapterItem` qualified correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_


___

## **CodeAnt-AI Description**
**Bring chapter selection actions to a bottom menu**

### What Changed
- Chapter selection now keeps only clear, select all, and invert selection in the top bar.
- Batch actions for selected chapters now appear in a bottom menu that slides up while chapters are selected.
- The bottom menu shows only the actions that fit the current selection, including mark as read, mark as unread, mark previous as read, download, and delete.
- Invert selection is now available from the chapter selection bar, and “mark previous as read” is shown when exactly one chapter is selected.

### Impact
`✅ Easier chapter bulk actions`
`✅ Less crowded selection controls`
`✅ Fewer taps to change chapter selection`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
