### PR TITLE
Komikku parity — Reader: real previous/next chapter navigation

### DIFF
--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -110,6 +110,8 @@ import kotlinx.coroutines.launch
  */
 
 private const val VOLUME_HOLD_SKIP_PAGES = 5
+// Index of the first chapter in reading order; used to gate the previous/next-chapter buttons.
+private const val FIRST_CHAPTER_INDEX = 0
 private const val DIRECTION_INDICATOR_DURATION_MS = 2_000L
 private val DIRECTION_INDICATOR_BOTTOM_PADDING = 80.dp
 private val DIRECTION_INDICATOR_CORNER_RADIUS = 8.dp
@@ -461,11 +463,12 @@ fun ReaderScreen(
         // Page slider — shown when the menu is visible so users can quickly scrub pages, flanked
         // by previous/next-chapter buttons (Komikku's ChapterNavigator). Adjacent-chapter
         // availability is derived from the manga's chapter list in reading order.
-        val orderedChapterIds = remember(chapters) {
-            chapters.sortedBy { it.chapterNumber }.map { it.id }
-        }
-        val currentChapterIndex = remember(orderedChapterIds, state.currentChapterId) {
-            orderedChapterIds.indexOf(state.currentChapterId)
+        val (hasPreviousChapter, hasNextChapter) = remember(chapters, state.currentChapterId) {
+            val ordered = chapters.sortedBy { it.chapterNumber }
+            val currentIndex = ordered.indexOfFirst { it.id == state.currentChapterId }
+            val hasPrev = currentIndex > FIRST_CHAPTER_INDEX
+            val hasNext = currentIndex >= FIRST_CHAPTER_INDEX && currentIndex < ordered.lastIndex
+            hasPrev to hasNext
         }
         PageSlider(
             currentPage = state.currentPage,
@@ -473,8 +476,8 @@ fun ReaderScreen(
             onPageSeek = { viewModel.onEvent(ReaderEvent.OnPageChange(it)) },
             onPreviousChapter = { viewModel.onEvent(ReaderEvent.PrevChapter) },
             onNextChapter = { viewModel.onEvent(ReaderEvent.NextChapter) },
-            hasPreviousChapter = currentChapterIndex > 0,
-            hasNextChapter = currentChapterIndex >= 0 && currentChapterIndex < orderedChapterIds.lastIndex,
+            hasPreviousChapter = hasPreviousChapter,
+            hasNextChapter = hasNextChapter,
             readingDirection = state.readingDirection,
             isVisible = state.isMenuVisible && state.pages.isNotEmpty(),
             modifier = Modifier.align(Alignment.BottomCenter)

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -458,11 +458,23 @@ fun ReaderScreen(
             modifier = Modifier.align(Alignment.CenterStart)
         )
 
-        // Page slider — shown when the menu is visible so users can quickly scrub pages
+        // Page slider — shown when the menu is visible so users can quickly scrub pages, flanked
+        // by previous/next-chapter buttons (Komikku's ChapterNavigator). Adjacent-chapter
+        // availability is derived from the manga's chapter list in reading order.
+        val orderedChapterIds = remember(chapters) {
+            chapters.sortedBy { it.chapterNumber }.map { it.id }
+        }
+        val currentChapterIndex = remember(orderedChapterIds, state.currentChapterId) {
+            orderedChapterIds.indexOf(state.currentChapterId)
+        }
         PageSlider(
             currentPage = state.currentPage,
             totalPages = state.totalPages,
             onPageSeek = { viewModel.onEvent(ReaderEvent.OnPageChange(it)) },
+            onPreviousChapter = { viewModel.onEvent(ReaderEvent.PrevChapter) },
+            onNextChapter = { viewModel.onEvent(ReaderEvent.NextChapter) },
+            hasPreviousChapter = currentChapterIndex > 0,
+            hasNextChapter = currentChapterIndex >= 0 && currentChapterIndex < orderedChapterIds.lastIndex,
             readingDirection = state.readingDirection,
             isVisible = state.isMenuVisible && state.pages.isNotEmpty(),
             modifier = Modifier.align(Alignment.BottomCenter)

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -827,20 +827,39 @@ class ReaderViewModel @Inject constructor(
         }
     }
 
-    private fun navigatePreviousChapter() {
-        viewModelScope.launch {
-            _effect.send(ReaderEffect.NavigateBack)
-        }
-    }
+    private fun navigatePreviousChapter() = navigateToAdjacentChapter(forward = false)
 
-    private fun navigateNextChapter() {
-        viewModelScope.launch {
-            _effect.send(
-                ReaderEffect.ShowSnackbar(
-                    messageResId = app.otakureader.feature.reader.R.string.reader_end_of_chapters
+    private fun navigateNextChapter() = navigateToAdjacentChapter(forward = true)
+
+    /**
+     * Loads the chapter immediately before or after the current one, in reading order
+     * (ascending chapter number). Previously both directions were stubbed — "next" only showed
+     * an end-of-chapters toast and "previous" simply exited the reader — so chapter-to-chapter
+     * navigation never worked. Reuses the same [loadChapterById] path the chapter-list overlay
+     * uses, and falls back to a boundary snackbar when there is no adjacent chapter.
+     */
+    private fun navigateToAdjacentChapter(forward: Boolean) {
+        val ordered = chapters.value.sortedBy { it.chapterNumber }
+        if (ordered.isEmpty()) return
+        val currentIndex = ordered.indexOfFirst { it.id == _state.value.currentChapterId }
+        if (currentIndex < 0) return
+
+        val target = ordered.getOrNull(if (forward) currentIndex + 1 else currentIndex - 1)
+        if (target == null) {
+            viewModelScope.launch {
+                _effect.send(
+                    ReaderEffect.ShowSnackbar(
+                        messageResId = if (forward) {
+                            R.string.reader_end_of_chapters
+                        } else {
+                            R.string.reader_no_previous_chapter
+                        }
+                    )
                 )
-            )
+            }
+            return
         }
+        loadChapterById(target.id)
     }
 
     /**

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -840,11 +840,16 @@ class ReaderViewModel @Inject constructor(
      */
     private fun navigateToAdjacentChapter(forward: Boolean) {
         val ordered = chapters.value.sortedBy { it.chapterNumber }
-        if (ordered.isEmpty()) return
         val currentIndex = ordered.indexOfFirst { it.id == _state.value.currentChapterId }
-        if (currentIndex < 0) return
-
-        val target = ordered.getOrNull(if (forward) currentIndex + 1 else currentIndex - 1)
+        // Resolve the target only when the current chapter is found; an unresolved current
+        // chapter (empty/not-yet-loaded list) is treated the same as hitting a boundary so the
+        // control always gives feedback instead of becoming a silent no-op — this matters for the
+        // end-of-chapter overlay's "Next" button, which isn't gated by the slider's enabled state.
+        val target = if (currentIndex >= 0) {
+            ordered.getOrNull(if (forward) currentIndex + 1 else currentIndex - 1)
+        } else {
+            null
+        }
         if (target == null) {
             viewModelScope.launch {
                 _effect.send(

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/PageSlider.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/PageSlider.kt
@@ -37,6 +37,8 @@ import app.otakureader.feature.reader.R
 private val NAV_ROW_PADDING_HORIZONTAL = 8.dp
 private val NAV_ROW_PADDING_VERTICAL = 8.dp
 private val NAV_ROW_ITEM_SPACING = 4.dp
+private const val SLIDER_SURFACE_ALPHA = 0.95f
+private val SLIDER_SURFACE_ELEVATION = 8.dp
 
 /**
  * Draggable page slider (seekbar) for the reader.
@@ -85,8 +87,8 @@ fun PageSlider(
         // bar from flashing empty while the menu animates away.
         if (totalPages > 0) {
             Surface(
-                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f),
-                tonalElevation = 8.dp
+                color = MaterialTheme.colorScheme.surface.copy(alpha = SLIDER_SURFACE_ALPHA),
+                tonalElevation = SLIDER_SURFACE_ELEVATION
             ) {
                 val isRtl = readingDirection == ReadingDirection.RTL
                 // Under RTL the on-screen left/right buttons swap which chapter they load, so the

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/PageSlider.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/PageSlider.kt
@@ -33,6 +33,11 @@ import androidx.compose.ui.unit.dp
 import app.otakureader.domain.model.ReadingDirection
 import app.otakureader.feature.reader.R
 
+// Layout tokens for the chapter-navigator row (slider flanked by prev/next-chapter buttons).
+private val NAV_ROW_PADDING_HORIZONTAL = 8.dp
+private val NAV_ROW_PADDING_VERTICAL = 8.dp
+private val NAV_ROW_ITEM_SPACING = 4.dp
+
 /**
  * Draggable page slider (seekbar) for the reader.
  *
@@ -75,48 +80,53 @@ fun PageSlider(
         exit = slideOutVertically { it } + fadeOut(),
         modifier = modifier
     ) {
-        Surface(
-            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f),
-            tonalElevation = 8.dp
-        ) {
-            // Guard against totalPages == 0 (can occur during AnimatedVisibility exit transition).
-            if (totalPages <= 0) return@Surface
-
-            val isRtl = readingDirection == ReadingDirection.RTL
-            // Under RTL the on-screen left/right buttons swap which chapter they load, so the
-            // physical layout still reads skip-previous | slider | skip-next.
-            val leftEnabled = if (isRtl) hasNextChapter else hasPreviousChapter
-            val leftClick = if (isRtl) onNextChapter else onPreviousChapter
-            val leftDesc = stringResource(
-                if (isRtl) R.string.reader_next_chapter else R.string.reader_previous_chapter
-            )
-            val rightEnabled = if (isRtl) hasPreviousChapter else hasNextChapter
-            val rightClick = if (isRtl) onPreviousChapter else onNextChapter
-            val rightDesc = stringResource(
-                if (isRtl) R.string.reader_previous_chapter else R.string.reader_next_chapter
-            )
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 8.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
+        // Guard against totalPages == 0 (can occur during the AnimatedVisibility exit transition).
+        // Wrapping the Surface — rather than returning from its content lambda — keeps the elevated
+        // bar from flashing empty while the menu animates away.
+        if (totalPages > 0) {
+            Surface(
+                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f),
+                tonalElevation = 8.dp
             ) {
-                FilledIconButton(onClick = leftClick, enabled = leftEnabled) {
-                    Icon(imageVector = Icons.Outlined.SkipPrevious, contentDescription = leftDesc)
-                }
-
-                PageSeekColumn(
-                    currentPage = currentPage,
-                    totalPages = totalPages,
-                    onPageSeek = onPageSeek,
-                    readingDirection = readingDirection,
-                    modifier = Modifier.weight(1f),
+                val isRtl = readingDirection == ReadingDirection.RTL
+                // Under RTL the on-screen left/right buttons swap which chapter they load, so the
+                // physical layout still reads skip-previous | slider | skip-next.
+                val leftEnabled = if (isRtl) hasNextChapter else hasPreviousChapter
+                val leftClick = if (isRtl) onNextChapter else onPreviousChapter
+                val leftDesc = stringResource(
+                    if (isRtl) R.string.reader_next_chapter else R.string.reader_previous_chapter
+                )
+                val rightEnabled = if (isRtl) hasPreviousChapter else hasNextChapter
+                val rightClick = if (isRtl) onPreviousChapter else onNextChapter
+                val rightDesc = stringResource(
+                    if (isRtl) R.string.reader_previous_chapter else R.string.reader_next_chapter
                 )
 
-                FilledIconButton(onClick = rightClick, enabled = rightEnabled) {
-                    Icon(imageVector = Icons.Outlined.SkipNext, contentDescription = rightDesc)
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            horizontal = NAV_ROW_PADDING_HORIZONTAL,
+                            vertical = NAV_ROW_PADDING_VERTICAL,
+                        ),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(NAV_ROW_ITEM_SPACING),
+                ) {
+                    FilledIconButton(onClick = leftClick, enabled = leftEnabled) {
+                        Icon(imageVector = Icons.Outlined.SkipPrevious, contentDescription = leftDesc)
+                    }
+
+                    PageSeekColumn(
+                        currentPage = currentPage,
+                        totalPages = totalPages,
+                        onPageSeek = onPageSeek,
+                        readingDirection = readingDirection,
+                        modifier = Modifier.weight(1f),
+                    )
+
+                    FilledIconButton(onClick = rightClick, enabled = rightEnabled) {
+                        Icon(imageVector = Icons.Outlined.SkipNext, contentDescription = rightDesc)
+                    }
                 }
             }
         }

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/PageSlider.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/PageSlider.kt
@@ -10,6 +10,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.SkipNext
+import androidx.compose.material.icons.outlined.SkipPrevious
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
@@ -23,10 +28,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.otakureader.domain.model.ReadingDirection
-import app.otakureader.feature.reader.PageRotation
-import app.otakureader.feature.reader.TapZone
+import app.otakureader.feature.reader.R
 
 /**
  * Draggable page slider (seekbar) for the reader.
@@ -35,9 +40,18 @@ import app.otakureader.feature.reader.TapZone
  * For RTL reading direction the slider is horizontally mirrored so that dragging
  * right moves to earlier pages, matching the manga reading flow.
  *
+ * Mirrors Mihon/Komikku's `ChapterNavigator`: the page seekbar is flanked by previous- and
+ * next-chapter buttons. For RTL the two buttons swap which chapter they load (the left button
+ * always carries the "skip previous" glyph but moves to the next chapter under RTL), matching
+ * the mirrored slider.
+ *
  * @param currentPage   0-based index of the currently displayed page.
  * @param totalPages    Total number of pages in the chapter.
  * @param onPageSeek    Callback invoked with a 0-based page index while the user drags.
+ * @param onPreviousChapter Loads the chapter before the current one (reading order).
+ * @param onNextChapter Loads the chapter after the current one (reading order).
+ * @param hasPreviousChapter Whether a previous chapter exists (disables the button otherwise).
+ * @param hasNextChapter Whether a next chapter exists (disables the button otherwise).
  * @param readingDirection Current reading direction; RTL reverses the slider visually.
  * @param isVisible     Controls the animated visibility of the slider.
  * @param modifier      Optional [Modifier] for the outer container.
@@ -47,6 +61,10 @@ fun PageSlider(
     currentPage: Int,
     totalPages: Int,
     onPageSeek: (Int) -> Unit,
+    onPreviousChapter: () -> Unit,
+    onNextChapter: () -> Unit,
+    hasPreviousChapter: Boolean,
+    hasNextChapter: Boolean,
     readingDirection: ReadingDirection = ReadingDirection.LTR,
     isVisible: Boolean = true,
     modifier: Modifier = Modifier
@@ -61,14 +79,63 @@ fun PageSlider(
             color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f),
             tonalElevation = 8.dp
         ) {
-            Column(
+            // Guard against totalPages == 0 (can occur during AnimatedVisibility exit transition).
+            if (totalPages <= 0) return@Surface
+
+            val isRtl = readingDirection == ReadingDirection.RTL
+            // Under RTL the on-screen left/right buttons swap which chapter they load, so the
+            // physical layout still reads skip-previous | slider | skip-next.
+            val leftEnabled = if (isRtl) hasNextChapter else hasPreviousChapter
+            val leftClick = if (isRtl) onNextChapter else onPreviousChapter
+            val leftDesc = stringResource(
+                if (isRtl) R.string.reader_next_chapter else R.string.reader_previous_chapter
+            )
+            val rightEnabled = if (isRtl) hasPreviousChapter else hasNextChapter
+            val rightClick = if (isRtl) onPreviousChapter else onNextChapter
+            val rightDesc = stringResource(
+                if (isRtl) R.string.reader_previous_chapter else R.string.reader_next_chapter
+            )
+
+            Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .padding(horizontal = 8.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                // Guard against totalPages == 0 (can occur during AnimatedVisibility exit transition).
-                if (totalPages <= 0) return@Column
+                FilledIconButton(onClick = leftClick, enabled = leftEnabled) {
+                    Icon(imageVector = Icons.Outlined.SkipPrevious, contentDescription = leftDesc)
+                }
 
+                PageSeekColumn(
+                    currentPage = currentPage,
+                    totalPages = totalPages,
+                    onPageSeek = onPageSeek,
+                    readingDirection = readingDirection,
+                    modifier = Modifier.weight(1f),
+                )
+
+                FilledIconButton(onClick = rightClick, enabled = rightEnabled) {
+                    Icon(imageVector = Icons.Outlined.SkipNext, contentDescription = rightDesc)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The page label row plus the draggable seekbar. Extracted so [PageSlider] can flank it with the
+ * previous/next-chapter buttons.
+ */
+@Composable
+private fun PageSeekColumn(
+    currentPage: Int,
+    totalPages: Int,
+    onPageSeek: (Int) -> Unit,
+    readingDirection: ReadingDirection,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
                 // Page label row: e.g. "5 / 120"
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -131,7 +198,5 @@ fun PageSlider(
                     steps = if (totalPages > 2) totalPages - 2 else 0,
                     modifier = sliderModifier
                 )
-            }
-        }
     }
 }

--- a/feature/reader/src/main/res/values/strings.xml
+++ b/feature/reader/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <!-- Reader screen -->
     <string name="reader_navigating_to_chapter">Navigating to chapter…</string>
     <string name="reader_end_of_chapters">End of available chapters</string>
+    <string name="reader_no_previous_chapter">No previous chapter</string>
 
     <!-- Brightness slider -->
     <string name="reader_brightness_decrease">Decrease brightness</string>


### PR DESCRIPTION
## **User description**
## What & why

Fixes a genuinely broken core flow and brings the reader's bottom bar in line with Mihon/Komikku's `ChapterNavigator`.

**The bug:** chapter-to-chapter navigation in the reader was stubbed.
- `navigateNextChapter()` only sent an "End of available chapters" snackbar — it never loaded the next chapter.
- `navigatePreviousChapter()` just exited the reader (`NavigateBack`).

So a reader could never move between chapters from the menu (only by backing out to the detail screen). This also violated the repo's **"Never Stub Live UI"** rule.

## Changes

- **Real navigation** (`ReaderViewModel`): new `navigateToAdjacentChapter(forward)` loads the chapter immediately before/after the current one in reading order (ascending `chapterNumber`), reusing the same `loadChapterById` path the chapter-list overlay already uses. Falls back to a boundary snackbar (`reader_end_of_chapters` / new `reader_no_previous_chapter`) when there's no adjacent chapter. `navigateNextChapter()`/`navigatePreviousChapter()` now delegate to it.
- **ChapterNavigator UI** (`PageSlider`): the page seekbar is now flanked by previous/next-chapter `FilledIconButton`s, matching Komikku. Buttons disable at the first/last chapter; under RTL they swap which chapter they load so the physical layout stays *skip-previous | slider | skip-next*. The label-row + seekbar were extracted into a private `PageSeekColumn`.
- `ReaderScreen` derives adjacent-chapter availability from the manga's chapter list (ordered by `chapterNumber`) and wires the `PrevChapter`/`NextChapter` events (both already existed in the MVI contract).

## Verification

No Android SDK in the container — relies on CI (Detekt, Ktlint, Unit Tests, Assemble, Screenshot Tests). Verified by inspection: `LoadChapter`/`loadChapterById` is the proven navigation path; `PrevChapter`/`NextChapter` events already existed and were already wired to the (previously stubbed) handlers; the only real `PageSlider` caller is `ReaderScreen` (the test file's `TestPageSlider` is a self-contained reimplementation, unaffected).

Part of the ongoing Komikku 1:1 parity effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_


___

## **CodeAnt-AI Description**
**Add chapter-to-chapter navigation to the reader**

### What Changed
- The reader’s page bar now includes previous and next chapter buttons, so users can move between chapters without leaving the reading screen.
- The buttons are disabled at the start and end of a chapter list, and show a clear message when no earlier or later chapter is available.
- In right-to-left reading, the buttons keep the same on-screen layout while switching which chapter each button opens.

### Impact
`✅ Faster chapter switching`
`✅ Fewer exits back to the manga details screen`
`✅ Clearer end-of-list feedback`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added previous/next chapter navigation buttons to the reader interface for easier chapter transitions
  * Chapter navigation buttons intelligently enable or disable based on your position in the manga
  * Added informative messages when attempting to navigate beyond the first or last chapter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->