### PR TITLE
Komikku parity — History: invert selection in selection mode

### DIFF
--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryMvi.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryMvi.kt
@@ -24,6 +24,7 @@ sealed interface HistoryEvent : UiEvent {
     data object ClearHistory : HistoryEvent
     data object ClearSelection : HistoryEvent
     data object SelectAll : HistoryEvent
+    data object InvertSelection : HistoryEvent
     data class OnSearchQueryChange(val query: String) : HistoryEvent
     data class RemoveFromHistory(val chapterId: Long) : HistoryEvent
     /** Cancel the pending swipe-delete; carries chapterId so the ViewModel knows which timer to cancel. */

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.FlipToBack
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.SelectAll
@@ -174,6 +175,12 @@ fun HistoryScreen(
                 },
                 actions = {
                     if (state.selectedItems.isNotEmpty()) {
+                        IconButton(onClick = { viewModel.onEvent(HistoryEvent.SelectAll) }) {
+                            Icon(Icons.Default.SelectAll, contentDescription = stringResource(R.string.history_select_all))
+                        }
+                        IconButton(onClick = { viewModel.onEvent(HistoryEvent.InvertSelection) }) {
+                            Icon(Icons.Default.FlipToBack, contentDescription = stringResource(R.string.history_invert_selection))
+                        }
                         IconButton(onClick = { viewModel.onEvent(HistoryEvent.MarkSelectedAsRead) }) {
                             Icon(Icons.Default.CheckCircle, contentDescription = stringResource(R.string.history_mark_read))
                         }

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryViewModel.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryViewModel.kt
@@ -79,6 +79,7 @@ class HistoryViewModel @Inject constructor(
             is HistoryEvent.ClearHistory -> clearHistory()
             is HistoryEvent.ClearSelection -> clearSelection()
             is HistoryEvent.SelectAll -> selectAll()
+            is HistoryEvent.InvertSelection -> invertSelection()
             is HistoryEvent.OnSearchQueryChange -> {
                 searchQuery.value = event.query
                 _state.update { it.copy(searchQuery = event.query) }
@@ -134,6 +135,18 @@ class HistoryViewModel @Inject constructor(
         _state.update { state ->
             val allIds = state.history.map { it.chapter.id }.toSet()
             state.copy(selectedItems = allIds)
+        }
+    }
+
+    /**
+     * Selects every visible history entry not currently selected and deselects the rest
+     * (Mihon/Komikku parity). [HistoryState.history] is already the filtered/searched list, so
+     * inverting against it never touches entries hidden by an active search or date filter.
+     */
+    private fun invertSelection() {
+        _state.update { state ->
+            val allIds = state.history.map { it.chapter.id }.toSet()
+            state.copy(selectedItems = allIds - state.selectedItems)
         }
     }
 

--- a/feature/history/src/main/res/values/strings.xml
+++ b/feature/history/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="history_back">Back</string>
     <string name="history_delete_selected">Delete selected</string>
     <string name="history_select_all">Select all</string>
+    <string name="history_invert_selection">Invert selection</string>
     <string name="history_clear_all">Clear all</string>
     <!-- Clear-all confirmation -->
     <string name="history_clear_all_confirm_title">Clear history?</string>

--- a/feature/history/src/test/java/app/otakureader/feature/history/HistoryViewModelTest.kt
+++ b/feature/history/src/test/java/app/otakureader/feature/history/HistoryViewModelTest.kt
@@ -183,6 +183,34 @@ class HistoryViewModelTest {
     }
 
     @Test
+    fun onEvent_InvertSelection_selectsComplementOfCurrentSelection() = runTest {
+        every { getHistoryUseCase() } returns flowOf(sampleHistory)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Select item 1, then invert: items 2 and 3 should now be selected, 1 deselected.
+        viewModel.onEvent(HistoryEvent.OnChapterLongClick(1L))
+        assertEquals(setOf(1L), viewModel.state.value.selectedItems)
+
+        viewModel.onEvent(HistoryEvent.InvertSelection)
+
+        assertEquals(setOf(2L, 3L), viewModel.state.value.selectedItems)
+    }
+
+    @Test
+    fun onEvent_InvertSelection_withNoSelection_selectsAll() = runTest {
+        every { getHistoryUseCase() } returns flowOf(sampleHistory)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(HistoryEvent.InvertSelection)
+
+        assertEquals(setOf(1L, 2L, 3L), viewModel.state.value.selectedItems)
+    }
+
+    @Test
     fun onEvent_OnChapterClick_withNoSelection_emitsNavigateEffect() = runTest {
         every { getHistoryUseCase() } returns flowOf(sampleHistory)
 


### PR DESCRIPTION
## What & why

Brings the History selection toolbar in line with Mihon/Komikku. While selecting, History only offered **Mark as read** and **Delete** — Mihon's selection toolbar also has **Select all** and **Invert selection**. (Otaku did have a Select-all button, but only when *not* in selection mode.)

## Changes

- **`InvertSelection`** event + `invertSelection()` handler — selects every visible history entry not currently selected and deselects the rest. `HistoryState.history` is already the filtered/searched list (the VM applies search + date filter before exposing it), so the inversion is inherently safe — it can never touch entries hidden by an active search or date filter.
- **Surface Select-all in selection mode** as well, alongside Invert, Mark-read, and Delete — matching Mihon's selection toolbar layout.
- New `history_invert_selection` string; reuses the existing `FlipToBack` / `SelectAll` icons.

This keeps the selection UX consistent with the parity work already landed in Manga detail (#1143) and Updates (#1145).

## Verification

No Android SDK in the container — relies on CI (Detekt, Ktlint, Unit Tests, Assemble, Screenshot Tests). Verified by inspection: mirrors the existing `selectAll`; `history.onEvent` gains one `when` arm (well under the Detekt complexity threshold); strings/icons added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_