### PR TITLE
Komikku parity — Manga detail: clean header (drop animated title / glow buttons)

### DIFF
--- a/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
@@ -67,6 +67,10 @@ private const val HEADER_TITLE_MAX_LINES = 3
 private const val HEADER_SUBTITLE_MAX_LINES = 1
 private const val HEADER_SUBTITLE_ALPHA = 0.8f
 private val HEADER_ACTION_ICON_SIZE = 18.dp
+private val HEADER_SUBTITLE_TOP_SPACING = 6.dp
+private val HEADER_STATUS_TOP_SPACING = 4.dp
+private val HEADER_ACTION_TOP_SPACING = 10.dp
+private val HEADER_ACTION_CONTENT_SPACING = 8.dp
 
 @Composable
 internal fun MangaHeader(
@@ -242,7 +246,7 @@ internal fun MangaHeader(
                         // Only insert the leading gap when at least one subtitle is present, so a
                         // manga with no author/artist doesn't get a double-spacer gap below the title.
                         if (author != null || artist != null) {
-                            Spacer(modifier = Modifier.height(6.dp))
+                            Spacer(modifier = Modifier.height(HEADER_SUBTITLE_TOP_SPACING))
                             author?.let {
                                 Text(
                                     text = it,
@@ -263,7 +267,7 @@ internal fun MangaHeader(
                             }
                         }
 
-                        Spacer(modifier = Modifier.height(4.dp))
+                        Spacer(modifier = Modifier.height(HEADER_STATUS_TOP_SPACING))
 
                         Text(
                             text = stringResource(manga.status.displayTextResId()),
@@ -271,7 +275,7 @@ internal fun MangaHeader(
                             color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
                         )
 
-                        Spacer(modifier = Modifier.height(10.dp))
+                        Spacer(modifier = Modifier.height(HEADER_ACTION_TOP_SPACING))
 
                         FilledTonalButton(onClick = onToggleFavorite) {
                             Icon(
@@ -279,7 +283,7 @@ internal fun MangaHeader(
                                 contentDescription = null,
                                 modifier = Modifier.size(HEADER_ACTION_ICON_SIZE),
                             )
-                            Spacer(Modifier.width(8.dp))
+                            Spacer(Modifier.width(HEADER_ACTION_CONTENT_SPACING))
                             Text(
                                 text = if (isFavorite) {
                                     stringResource(R.string.details_remove_from_library)

--- a/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
@@ -22,19 +22,15 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AspectRatio
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.FilledIconToggleButton
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -53,13 +49,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.otakureader.core.ui.background.CoverSplashBackground
-import app.otakureader.core.ui.components.GlitchText
-import app.otakureader.core.ui.components.GlowButton
-import app.otakureader.core.ui.components.InkButton
-import app.otakureader.core.ui.components.TypewriterText
-import app.otakureader.core.ui.theme.ContentType
 import app.otakureader.core.ui.theme.LocalOtakuColors
-import app.otakureader.core.ui.theme.manhwaAccent
 import app.otakureader.feature.details.R
 import coil3.compose.AsyncImage
 
@@ -72,6 +62,11 @@ private const val HERO_BG_PARALLAX_FACTOR = 0.4f
 private const val HERO_FG_PARALLAX_FACTOR = 0.15f
 private const val HERO_BG_SCALE = 1.15f
 
+// Header info-block tokens.
+private const val HEADER_TITLE_MAX_LINES = 3
+private const val HEADER_SUBTITLE_ALPHA = 0.8f
+private val HEADER_ACTION_ICON_SIZE = 18.dp
+
 @Composable
 internal fun MangaHeader(
     manga: app.otakureader.domain.model.Manga,
@@ -83,24 +78,6 @@ internal fun MangaHeader(
     modifier: Modifier = Modifier
 ) {
     val otaku = LocalOtakuColors.current
-
-    // Detect content type from sourceId string representation
-    val sourceIdStr = remember(manga.sourceId) { manga.sourceId.toString() }
-    val autoDetectedContentType = remember(sourceIdStr) {
-        val src = sourceIdStr.lowercase()
-        if (src.contains("manhwa") || src.contains("webtoon") ||
-            src.contains("korean") || src.contains("toon")
-        ) {
-            ContentType.MANHWA
-        } else {
-            ContentType.MANGA
-        }
-    }
-    // Local override toggle — survives recomposition, resets when manga changes
-    var isOverriddenManhwa by rememberSaveable(manga.id) {
-        mutableStateOf(autoDetectedContentType == ContentType.MANHWA)
-    }
-    val contentType = if (isOverriddenManhwa) ContentType.MANHWA else ContentType.MANGA
 
     // Bloom enter animation — fades the hero in on first composition.
     // The Animatable is remembered so Compose reads its `value` as observable state,
@@ -243,94 +220,67 @@ internal fun MangaHeader(
                         }
                     }
 
-                    // Title, author, action buttons
+                    // Clean Mihon/Komikku-style info block: plain bold title, author, artist,
+                    // status, and an add-to-library button. No animated title, content-type
+                    // toggle, or glow buttons (those Otaku-exclusive flourishes diverged from
+                    // Komikku's look and were dropped per the parity pass).
                     Column(modifier = Modifier.weight(1f)) {
-                        // Animated title: TypewriterText for manga, GlitchText for manhwa
-                        val titleStyle = MaterialTheme.typography.headlineSmall.copy(
+                        Text(
+                            text = manga.title,
+                            style = MaterialTheme.typography.headlineSmall,
                             fontWeight = FontWeight.Bold,
                             color = Color.White,
+                            maxLines = HEADER_TITLE_MAX_LINES,
+                            overflow = TextOverflow.Ellipsis,
                         )
-                        if (contentType == ContentType.MANGA) {
-                            TypewriterText(
-                                text = manga.title,
-                                style = titleStyle,
-                                speedMs = 40L
+
+                        Spacer(modifier = Modifier.height(6.dp))
+
+                        manga.author?.takeIf { it.isNotBlank() }?.let { author ->
+                            Text(
+                                text = author,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
                             )
-                        } else {
-                            GlitchText(
-                                text = manga.title,
-                                style = titleStyle
+                        }
+                        // Show the artist only when it differs from the author (Komikku behaviour).
+                        manga.artist?.takeIf { it.isNotBlank() && it != manga.author }?.let { artist ->
+                            Text(
+                                text = artist,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
                             )
                         }
 
                         Spacer(modifier = Modifier.height(4.dp))
-                        manga.author?.let { author ->
-                            Text(
-                                text = author,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = Color.White.copy(alpha = 0.8f),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
 
-                        Spacer(modifier = Modifier.height(6.dp))
-
-                        // ContentType toggle chip
-                        AssistChip(
-                            onClick = { isOverriddenManhwa = !isOverriddenManhwa },
-                            label = {
-                                Text(
-                                    if (contentType == ContentType.MANGA) {
-                                        stringResource(R.string.details_content_type_manga)
-                                    } else {
-                                        stringResource(R.string.details_content_type_manhwa)
-                                    },
-                                    style = MaterialTheme.typography.labelSmall
-                                )
-                            }
+                        Text(
+                            text = stringResource(manga.status.displayTextResId()),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
                         )
 
-                        Spacer(modifier = Modifier.height(8.dp))
+                        Spacer(modifier = Modifier.height(10.dp))
 
-                        // Read button — styled by content type
-                        if (contentType == ContentType.MANGA) {
-                            InkButton(onClick = onToggleFavorite) {
-                                Icon(
-                                    imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(16.dp)
-                                )
-                                Spacer(Modifier.width(4.dp))
-                                Text(
-                                    text = if (isFavorite)
-                                        stringResource(R.string.details_remove_from_library)
-                                    else
-                                        stringResource(R.string.details_add_to_library),
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = Color.White
-                                )
-                            }
-                        } else {
-                            GlowButton(
-                                onClick = onToggleFavorite,
-                                glowColor = ContentType.MANHWA.manhwaAccent()
-                            ) {
-                                Icon(
-                                    imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(16.dp)
-                                )
-                                Spacer(Modifier.width(4.dp))
-                                Text(
-                                    text = if (isFavorite)
-                                        stringResource(R.string.details_remove_from_library)
-                                    else
-                                        stringResource(R.string.details_add_to_library),
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = Color.White
-                                )
-                            }
+                        FilledTonalButton(onClick = onToggleFavorite) {
+                            Icon(
+                                imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                                contentDescription = null,
+                                modifier = Modifier.size(HEADER_ACTION_ICON_SIZE),
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                text = if (isFavorite) {
+                                    stringResource(R.string.details_remove_from_library)
+                                } else {
+                                    stringResource(R.string.details_add_to_library)
+                                },
+                                style = MaterialTheme.typography.labelLarge,
+                            )
                         }
                     }
                 }

--- a/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
@@ -64,6 +64,7 @@ private const val HERO_BG_SCALE = 1.15f
 
 // Header info-block tokens.
 private const val HEADER_TITLE_MAX_LINES = 3
+private const val HEADER_SUBTITLE_MAX_LINES = 1
 private const val HEADER_SUBTITLE_ALPHA = 0.8f
 private val HEADER_ACTION_ICON_SIZE = 18.dp
 
@@ -234,26 +235,32 @@ internal fun MangaHeader(
                             overflow = TextOverflow.Ellipsis,
                         )
 
-                        Spacer(modifier = Modifier.height(6.dp))
-
-                        manga.author?.takeIf { it.isNotBlank() }?.let { author ->
-                            Text(
-                                text = author,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        }
+                        val author = manga.author?.takeIf { it.isNotBlank() }
                         // Show the artist only when it differs from the author (Komikku behaviour).
-                        manga.artist?.takeIf { it.isNotBlank() && it != manga.author }?.let { artist ->
-                            Text(
-                                text = artist,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
+                        val artist = manga.artist?.takeIf { it.isNotBlank() && it != manga.author }
+
+                        // Only insert the leading gap when at least one subtitle is present, so a
+                        // manga with no author/artist doesn't get a double-spacer gap below the title.
+                        if (author != null || artist != null) {
+                            Spacer(modifier = Modifier.height(6.dp))
+                            author?.let {
+                                Text(
+                                    text = it,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
+                                    maxLines = HEADER_SUBTITLE_MAX_LINES,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                            artist?.let {
+                                Text(
+                                    text = it,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
+                                    maxLines = HEADER_SUBTITLE_MAX_LINES,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
                         }
 
                         Spacer(modifier = Modifier.height(4.dp))


### PR DESCRIPTION
## **User description**
## What & why

This addresses the divergence you pointed at with the screenshots — the manga **detail header** not looking like Komikku. Otaku's header used an Otaku-exclusive "hero": a **typewriter/glitch animated title**, a **manga/manhwa content-type toggle chip**, and **ink/glow Read buttons**. Mihon/Komikku's `MangaInfoHeader` is plain and clean. Per your "dump the old UI stuff" go-ahead, the foreground info block is replaced with Komikku's look.

## Changes (all in `MangaHeader.kt`, signature unchanged so nothing else breaks)

- **Title**: plain bold `headlineSmall` (up to 3 lines), no animation.
- **Author / artist**: plain subtitles; artist shown only when it differs from the author (matches Komikku).
- **Status**: plain status text.
- **Library action**: a standard Material `FilledTonalButton` (Add to library / Remove from library) instead of the ink/glow buttons.
- **Removed**: the content-type detection + override toggle chip and the `TypewriterText` / `GlitchText` / `InkButton` / `GlowButton` / `ContentType` / `manhwaAccent` usages and imports.
- **Kept**: the blurred-cover backdrop + subtle parallax (already close to Komikku) and the panorama-cover mode, unchanged.

## Verification

No Android SDK in the container — relies on CI (Detekt, Ktlint, Unit Tests, Assemble, Screenshot Tests). Verified by inspection: the `MangaHeader(...)` signature is unchanged so `DetailsContent` callers are unaffected; all removed symbols/imports were grep-confirmed to have no remaining references; `status.displayTextResId()` is already used by the panorama branch.

Part of the ongoing Komikku 1:1 parity effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_


___

## **CodeAnt-AI Description**
**Make the manga detail header match Komikku’s clean layout**

### What Changed
- Replaced the animated, glow-heavy header with a plain title, author, artist, and status display.
- The add-to-library action now uses a standard button with a simple favorite icon and text.
- Removed the manga/manhwa toggle chip and the content-specific styling from the header.
- Kept the blurred cover backdrop, parallax motion, and panorama cover view unchanged.

### Impact
`✅ Cleaner manga detail pages`
`✅ Less distracting header on first view`
`✅ More consistent library actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined manga detail header design with a simpler, cleaner static layout replacing previous animated visual elements.

* **Refactor**
  * Removed content-type-specific display behaviors for more consistent presentation.
  * Streamlined header information display including title, author, and artist details.
  * Simplified favorite button styling and interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->