### PR TITLE
Komikku parity — Library: category tabs only (drop redundant chip row)

### DIFF
--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryCategoryFilter.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryCategoryFilter.kt
@@ -12,41 +12,6 @@ import androidx.compose.ui.unit.dp
 import app.otakureader.core.ui.components.OtakuChip
 
 @Composable
-internal fun CategoryFilterChips(
-    categories: List<CategoryItem>,
-    selectedCategory: Long?,
-    onCategorySelected: (Long?) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    LazyRow(
-        contentPadding = PaddingValues(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = modifier.fillMaxWidth()
-    ) {
-        // "All" chip
-        item {
-            OtakuChip(
-                label = stringResource(R.string.library_category_all),
-                selected = selectedCategory == null,
-                onClick = { onCategorySelected(null) },
-            )
-        }
-
-        // Category chips
-        items(
-            items = categories,
-            key = { it.id }
-        ) { category ->
-            OtakuChip(
-                label = "${category.name} (${category.count})",
-                selected = selectedCategory == category.id,
-                onClick = { onCategorySelected(category.id) },
-            )
-        }
-    }
-}
-
-@Composable
 internal fun ReadingListFilterChips(
     readingLists: List<ReadingListFilterItem>,
     selectedListId: Long?,

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -227,8 +227,7 @@ internal fun MangaGrid(
             }
         }
 
-        // Category selector as Mihon/Komikku-style swipeable tabs. (A redundant duplicate chip
-        // row used to render directly above this; it was removed so categories show as tabs only.)
+        // Category selector — Mihon/Komikku-style swipeable tabs.
         CategoryTabRow(
             categories = state.categories,
             selectedCategory = state.selectedCategory,

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -227,13 +227,8 @@ internal fun MangaGrid(
             }
         }
 
-        CategoryFilterChips(
-            categories = state.categories,
-            selectedCategory = state.selectedCategory,
-            onCategorySelected = { onEvent(LibraryEvent.OnCategorySelected(it)) },
-            modifier = Modifier.padding(vertical = 4.dp)
-        )
-
+        // Category selector as Mihon/Komikku-style swipeable tabs. (A redundant duplicate chip
+        // row used to render directly above this; it was removed so categories show as tabs only.)
         CategoryTabRow(
             categories = state.categories,
             selectedCategory = state.selectedCategory,


### PR DESCRIPTION
## **User description**
## What & why

The Library was rendering **two** category selectors stacked on top of each other:
1. `CategoryFilterChips` — a `LazyRow` of chips ("All", "Category (count)")
2. `CategoryTabRow` — a Mihon/Komikku-style `ScrollableTabRow` of category tabs

Both drove the same `OnCategorySelected` event, so this was duplicate, cluttered UI that doesn't match Komikku (which uses **category tabs**, not chips).

## Changes

- Removed the redundant `CategoryFilterChips(...)` render from `LibraryMangaGrid`, keeping the Komikku-style `CategoryTabRow`.
- Removed the now-unused `CategoryFilterChips` composable from `LibraryCategoryFilter.kt` (kept `ReadingListFilterChips`, which is still used).

No state/VM changes — the category-filter wiring (`OnCategorySelected` → `selectedCategory` → `categoryFilterMangaIds` → grid filter) is untouched; this just removes the duplicate UI.

## Verification

No Android SDK in the container — relies on CI (Detekt, Ktlint, Unit Tests, Assemble, Screenshot Tests). Verified by inspection: `CategoryFilterChips` had exactly one call site (now removed) and no test/preview references; all remaining imports in `LibraryCategoryFilter.kt` are still used by `ReadingListFilterChips`.

Part of the ongoing Komikku 1:1 parity effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_


___

## **CodeAnt-AI Description**
**Library category selection now shows tabs only**

### What Changed
- Removed the duplicate category chip row from the Library screen, so users now see only the category tabs
- Kept category selection behavior the same when switching between all categories and individual categories
- Removed the unused chip-row component after it was no longer needed

### Impact
`✅ Less clutter in the Library`
`✅ Clearer category browsing`
`✅ More consistent Komikku-style category navigation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
