### PR TITLE
Reader: screen-orientation lock + manga-title in top bar (R1)

### DIFF
--- a/data/src/main/java/app/otakureader/data/repository/ReaderSettingsRepository.kt
+++ b/data/src/main/java/app/otakureader/data/repository/ReaderSettingsRepository.kt
@@ -14,6 +14,7 @@ import app.otakureader.domain.model.ColorFilterMode
 import app.otakureader.domain.repository.ReaderSettingsRepository as ReaderSettingsRepositoryInterface
 import app.otakureader.domain.model.ImageQuality
 import app.otakureader.domain.model.ReaderMode
+import app.otakureader.domain.model.ReaderOrientation
 import app.otakureader.domain.model.ReadingDirection
 import app.otakureader.domain.model.TapZoneConfig
 import kotlinx.coroutines.CoroutineScope
@@ -73,7 +74,17 @@ class ReaderSettingsRepository @Inject constructor(
     override suspend fun setReaderMode(mode: ReaderMode) {
         safeEdit { it[Keys.READER_MODE] = mode.ordinal }
     }
-    
+
+    // ==================== Orientation ====================
+
+    override val readerOrientation: Flow<ReaderOrientation> = dataStore.data.map { prefs ->
+        ReaderOrientation.fromOrdinal(prefs[Keys.READER_ORIENTATION])
+    }
+
+    override suspend fun setReaderOrientation(orientation: ReaderOrientation) {
+        safeEdit { it[Keys.READER_ORIENTATION] = orientation.ordinal }
+    }
+
     // ==================== Brightness ====================
     
     override val brightness: Flow<Float> = dataStore.data.map { prefs ->
@@ -588,6 +599,7 @@ class ReaderSettingsRepository @Inject constructor(
 
     private object Keys {
         val READER_MODE = intPreferencesKey("reader_mode_setting")
+        val READER_ORIENTATION = intPreferencesKey("reader_orientation")
         val BRIGHTNESS = floatPreferencesKey("reader_brightness")
         val ZOOM_LEVEL = floatPreferencesKey("reader_zoom_level")
         val DOUBLE_TAP_ZOOM = booleanPreferencesKey("reader_double_tap_zoom")

--- a/domain/src/main/java/app/otakureader/domain/model/ReaderOrientation.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/ReaderOrientation.kt
@@ -1,0 +1,38 @@
+package app.otakureader.domain.model
+
+/**
+ * Screen-orientation lock applied while the reader is open, mirroring Mihon/Komikku's
+ * orientation options.
+ *
+ * Pure-domain enum: it carries no Android types. The feature layer maps each entry to the
+ * corresponding `ActivityInfo.SCREEN_ORIENTATION_*` value when applying it to the activity.
+ * Persisted by [ordinal], so entries must only be appended, never reordered.
+ */
+enum class ReaderOrientation {
+    /** Follow the system / user default (no explicit lock). */
+    DEFAULT,
+
+    /** Free rotation regardless of the system auto-rotate setting. */
+    FREE,
+
+    /** Sensor portrait (allows 180° flip). */
+    PORTRAIT,
+
+    /** Sensor landscape (allows left/right). */
+    LANDSCAPE,
+
+    /** Locked to a single portrait orientation. */
+    LOCKED_PORTRAIT,
+
+    /** Locked to a single landscape orientation. */
+    LOCKED_LANDSCAPE,
+
+    /** Reverse (upside-down) portrait. */
+    REVERSE_PORTRAIT,
+    ;
+
+    companion object {
+        /** Resolve a persisted ordinal back to an entry, falling back to [DEFAULT]. */
+        fun fromOrdinal(ordinal: Int?): ReaderOrientation = entries.getOrNull(ordinal ?: -1) ?: DEFAULT
+    }
+}

--- a/domain/src/main/java/app/otakureader/domain/model/ReaderOrientation.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/ReaderOrientation.kt
@@ -32,7 +32,11 @@ enum class ReaderOrientation {
     ;
 
     companion object {
+        /** Sentinel ordinal that never matches an entry, so a null/absent preference resolves to [DEFAULT]. */
+        private const val INVALID_ORDINAL = -1
+
         /** Resolve a persisted ordinal back to an entry, falling back to [DEFAULT]. */
-        fun fromOrdinal(ordinal: Int?): ReaderOrientation = entries.getOrNull(ordinal ?: -1) ?: DEFAULT
+        fun fromOrdinal(ordinal: Int?): ReaderOrientation =
+            entries.getOrNull(ordinal ?: INVALID_ORDINAL) ?: DEFAULT
     }
 }

--- a/domain/src/main/java/app/otakureader/domain/repository/ReaderSettingsRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/ReaderSettingsRepository.kt
@@ -3,6 +3,7 @@ package app.otakureader.domain.repository
 import app.otakureader.domain.model.ColorFilterMode
 import app.otakureader.domain.model.ImageQuality
 import app.otakureader.domain.model.ReaderMode
+import app.otakureader.domain.model.ReaderOrientation
 import app.otakureader.domain.model.ReadingDirection
 import app.otakureader.domain.model.TapZoneConfig
 import kotlinx.coroutines.flow.Flow
@@ -12,6 +13,7 @@ interface ReaderSettingsRepository {
     val writeFailureEvents: Flow<Unit>
 
     val readerMode: Flow<ReaderMode>
+    val readerOrientation: Flow<ReaderOrientation>
     val readingDirection: Flow<ReadingDirection>
     val brightness: Flow<Float>
     val keepScreenOn: Flow<Boolean>
@@ -67,6 +69,7 @@ interface ReaderSettingsRepository {
     val secureScreen: Flow<Boolean>
 
     suspend fun setReaderMode(mode: ReaderMode)
+    suspend fun setReaderOrientation(orientation: ReaderOrientation)
     suspend fun setBrightness(brightness: Float)
     suspend fun setReadingDirection(direction: ReadingDirection)
     suspend fun setKeepScreenOn(enabled: Boolean)

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderMvi.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderMvi.kt
@@ -3,6 +3,7 @@ package app.otakureader.feature.reader
 import app.otakureader.domain.model.ColorFilterMode
 import app.otakureader.domain.model.ImageQuality
 import app.otakureader.domain.model.ReaderMode
+import app.otakureader.domain.model.ReaderOrientation
 import app.otakureader.domain.model.ReadingDirection
 import app.otakureader.feature.reader.model.ReaderPage
 import app.otakureader.domain.model.TapZoneConfig
@@ -37,6 +38,9 @@ data class ReaderState(
 
     /** Current reader display mode */
     val mode: ReaderMode = ReaderMode.SINGLE_PAGE,
+
+    /** Screen-orientation lock applied while the reader is open */
+    val readerOrientation: ReaderOrientation = ReaderOrientation.DEFAULT,
 
     /** Current zoom level (1.0 = 100%, 2.0 = 200%, etc.) */
     val zoomLevel: Float = 1f,
@@ -94,6 +98,9 @@ data class ReaderState(
 
     /** Show page number indicator */
     val showPageNumber: Boolean = true,
+
+    /** Manga/series title shown as the reader top-bar title */
+    val mangaTitle: String = "",
 
     /** Current chapter title */
     val chapterTitle: String = "",
@@ -443,6 +450,9 @@ sealed interface ReaderEvent {
 
     /** Change the reader display mode (single, dual, webtoon, smart panels). */
     data class OnModeChange(val mode: ReaderMode) : DisplayControl
+
+    /** Change the screen-orientation lock applied while reading. */
+    data class OnOrientationChange(val orientation: ReaderOrientation) : DisplayControl
 
     /** Change reading direction (LTR/RTL/Vertical). */
     data class OnDirectionChange(val direction: ReadingDirection) : DisplayControl

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -2,6 +2,7 @@ package app.otakureader.feature.reader
 
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.view.WindowManager
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Canvas
@@ -69,6 +70,7 @@ import app.otakureader.core.ui.component.LoadingScreen
 import app.otakureader.feature.reader.R
 import app.otakureader.domain.model.ColorFilterMode
 import app.otakureader.domain.model.ReaderMode
+import app.otakureader.domain.model.ReaderOrientation
 import app.otakureader.feature.reader.modes.DualPageReader
 import app.otakureader.feature.reader.modes.SinglePageReader
 import app.otakureader.feature.reader.modes.SmartPanelsReader
@@ -119,6 +121,17 @@ private val DIRECTION_INDICATOR_VERTICAL_PADDING = 8.dp
 private val DIRECTION_INDICATOR_ICON_SIZE = 18.dp
 private val DIRECTION_INDICATOR_ICON_SPACING = 6.dp
 private const val DIRECTION_INDICATOR_SCRIM_ALPHA = 0.7f
+
+/** Maps a domain [ReaderOrientation] to the matching Android `ActivityInfo` orientation flag. */
+private fun ReaderOrientation.toActivityInfo(): Int = when (this) {
+    ReaderOrientation.DEFAULT -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+    ReaderOrientation.FREE -> ActivityInfo.SCREEN_ORIENTATION_FULL_USER
+    ReaderOrientation.PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+    ReaderOrientation.LANDSCAPE -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+    ReaderOrientation.LOCKED_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    ReaderOrientation.LOCKED_LANDSCAPE -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+    ReaderOrientation.REVERSE_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
+}
 
 @Composable
 @Suppress("UnusedParameter")
@@ -193,6 +206,15 @@ fun ReaderScreen(
         }
         onDispose {
             activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+
+    // Apply the reader's screen-orientation lock; restore the system default on exit.
+    DisposableEffect(state.readerOrientation) {
+        val activity = context as? Activity
+        activity?.requestedOrientation = state.readerOrientation.toActivityInfo()
+        onDispose {
+            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
         }
     }
     
@@ -337,7 +359,7 @@ fun ReaderScreen(
         // live in the bottom bar (PageSlider) and thumbnails in PageThumbnailStrip, so this
         // overlay deliberately carries only the top bar to avoid duplicating those controls.
         ReaderContentOverlay(
-            title = state.chapterTitle,
+            title = state.mangaTitle,
             chapterTitle = state.chapterTitle,
             isVisible = state.isMenuVisible && !state.isGalleryOpen && !state.isLoading,
             onDismiss = onNavigateBack,
@@ -507,12 +529,14 @@ fun ReaderScreen(
             isVisible = state.isSettingsOverlayVisible,
             currentMode = state.mode,
             readingDirection = state.readingDirection,
+            orientation = state.readerOrientation,
             brightness = state.brightness,
             colorFilterMode = state.colorFilterMode,
             cropBordersEnabled = state.cropBordersEnabled,
             incognitoMode = state.incognitoMode,
             onModeChange = { viewModel.onEvent(ReaderEvent.OnModeChange(it)) },
             onDirectionChange = { viewModel.onEvent(ReaderEvent.OnDirectionChange(it)) },
+            onOrientationChange = { viewModel.onEvent(ReaderEvent.OnOrientationChange(it)) },
             onBrightnessChange = { viewModel.onEvent(ReaderEvent.OnBrightnessChange(it)) },
             onColorFilterChange = { viewModel.onEvent(ReaderEvent.SetColorFilterMode(it)) },
             onToggleCropBorders = { viewModel.onEvent(ReaderEvent.ToggleSetting(ReaderSetting.CROP_BORDERS)) },

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -209,12 +209,16 @@ fun ReaderScreen(
         }
     }
 
-    // Apply the reader's screen-orientation lock; restore the system default on exit.
-    DisposableEffect(state.readerOrientation) {
-        val activity = context as? Activity
-        activity?.requestedOrientation = state.readerOrientation.toActivityInfo()
+    // Apply the reader's screen-orientation lock whenever it changes, and restore the system
+    // default only when leaving the reader. Splitting application (LaunchedEffect) from
+    // restoration (DisposableEffect) avoids a brief reset-to-default flicker on each change.
+    val readerActivity = context as? Activity
+    LaunchedEffect(readerActivity, state.readerOrientation) {
+        readerActivity?.requestedOrientation = state.readerOrientation.toActivityInfo()
+    }
+    DisposableEffect(readerActivity) {
         onDispose {
-            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+            readerActivity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
         }
     }
     

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -366,6 +366,7 @@ class ReaderViewModel @Inject constructor(
                 pages = pages,
                 currentPage = initialPage,
                 isLoading = false,
+                mangaTitle = result.manga.title,
                 chapterTitle = result.chapter.name,
                 readerBackgroundColor = result.manga.readerBackgroundColor,
             )
@@ -506,6 +507,7 @@ class ReaderViewModel @Inject constructor(
     private fun handleDisplay(event: ReaderEvent.DisplayControl) {
         when (event) {
             is ReaderEvent.OnModeChange -> displayDelegate.changeReaderMode(event.mode)
+            is ReaderEvent.OnOrientationChange -> displayDelegate.changeOrientation(event.orientation)
             is ReaderEvent.OnDirectionChange -> displayDelegate.updateReadingDirection(event.direction)
             ReaderEvent.RotateCW -> displayDelegate.cyclePageRotation()
             ReaderEvent.ResetRotation -> displayDelegate.resetRotation()

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -20,6 +20,7 @@ import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.model.PageBookmark
 import app.otakureader.domain.model.ColorFilterMode
 import app.otakureader.domain.model.ReaderMode
+import app.otakureader.domain.model.ReaderOrientation
 import app.otakureader.feature.reader.model.ReaderPage
 import app.otakureader.domain.model.ReadingDirection
 import app.otakureader.domain.model.ReaderComment
@@ -271,12 +272,21 @@ class ReaderViewModel @Inject constructor(
             val manga = mangaRepository.getMangaById(mangaId)
             currentManga = manga
             val settingsState = settingsLoaderDelegate.load(_state.value, manga)
+            // Read orientation here rather than in ReaderSettingsLoaderDelegate.load(): that
+            // method's coroutineScope lambda is already near the JVM 64KB method-size limit, so
+            // adding another async read there overflows it ("Method too large").
+            val orientation = try {
+                settingsRepository.readerOrientation.first()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                ReaderOrientation.DEFAULT
+            }
             // Merge only settings fields into current state to avoid overwriting
             // pages/chapter data loaded concurrently by loadChapter().
             _state.update { current ->
                 current.copy(
                     mode = settingsState.mode,
-                    readerOrientation = settingsState.readerOrientation,
+                    readerOrientation = orientation,
                     brightness = settingsState.brightness,
                     keepScreenOn = settingsState.keepScreenOn,
                     showPageNumber = settingsState.showPageNumber,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -277,8 +277,9 @@ class ReaderViewModel @Inject constructor(
             // adding another async read there overflows it ("Method too large").
             val orientation = try {
                 settingsRepository.readerOrientation.first()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                if (e is CancellationException) throw e
                 ReaderOrientation.DEFAULT
             }
             // Merge only settings fields into current state to avoid overwriting

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -276,6 +276,7 @@ class ReaderViewModel @Inject constructor(
             _state.update { current ->
                 current.copy(
                     mode = settingsState.mode,
+                    readerOrientation = settingsState.readerOrientation,
                     brightness = settingsState.brightness,
                     keepScreenOn = settingsState.keepScreenOn,
                     showPageNumber = settingsState.showPageNumber,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderSettingsOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderSettingsOverlay.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.otakureader.domain.model.ColorFilterMode
 import app.otakureader.domain.model.ReaderMode
+import app.otakureader.domain.model.ReaderOrientation
 import app.otakureader.domain.model.ReadingDirection
 import app.otakureader.feature.reader.R
 
@@ -44,12 +45,14 @@ fun ReaderSettingsOverlay(
     isVisible: Boolean,
     currentMode: ReaderMode,
     readingDirection: ReadingDirection,
+    orientation: ReaderOrientation,
     brightness: Float,
     colorFilterMode: ColorFilterMode,
     cropBordersEnabled: Boolean,
     incognitoMode: Boolean,
     onModeChange: (ReaderMode) -> Unit,
     onDirectionChange: (ReadingDirection) -> Unit,
+    onOrientationChange: (ReaderOrientation) -> Unit,
     onBrightnessChange: (Float) -> Unit,
     onColorFilterChange: (ColorFilterMode) -> Unit,
     onToggleCropBorders: () -> Unit,
@@ -100,6 +103,26 @@ fun ReaderSettingsOverlay(
                         selected = readingDirection == direction,
                         onClick = { onDirectionChange(direction) },
                         label = { Text(direction.toLabel()) },
+                        modifier = Modifier.padding(end = 6.dp),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Orientation lock
+            Text(
+                text = stringResource(R.string.reader_orientation_title),
+                style = androidx.compose.material3.MaterialTheme.typography.labelMedium,
+            )
+            FlowRow(modifier = Modifier.fillMaxWidth()) {
+                ReaderOrientation.entries.forEach { entry ->
+                    FilterChip(
+                        selected = orientation == entry,
+                        onClick = { onOrientationChange(entry) },
+                        label = { Text(entry.toLabel()) },
                         modifier = Modifier.padding(end = 6.dp),
                     )
                 }
@@ -198,6 +221,17 @@ private fun ReadingDirection.toLabel(): String = when (this) {
     ReadingDirection.LTR -> stringResource(R.string.reader_direction_ltr)
     ReadingDirection.RTL -> stringResource(R.string.reader_direction_rtl)
     ReadingDirection.VERTICAL -> stringResource(R.string.reader_direction_vertical)
+}
+
+@Composable
+private fun ReaderOrientation.toLabel(): String = when (this) {
+    ReaderOrientation.DEFAULT -> stringResource(R.string.reader_orientation_default)
+    ReaderOrientation.FREE -> stringResource(R.string.reader_orientation_free)
+    ReaderOrientation.PORTRAIT -> stringResource(R.string.reader_orientation_portrait)
+    ReaderOrientation.LANDSCAPE -> stringResource(R.string.reader_orientation_landscape)
+    ReaderOrientation.LOCKED_PORTRAIT -> stringResource(R.string.reader_orientation_locked_portrait)
+    ReaderOrientation.LOCKED_LANDSCAPE -> stringResource(R.string.reader_orientation_locked_landscape)
+    ReaderOrientation.REVERSE_PORTRAIT -> stringResource(R.string.reader_orientation_reverse_portrait)
 }
 
 @Composable

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDisplayDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDisplayDelegate.kt
@@ -3,6 +3,7 @@ package app.otakureader.feature.reader.viewmodel.delegate
 import app.otakureader.domain.model.ColorFilterMode
 import app.otakureader.domain.model.ImageQuality
 import app.otakureader.domain.model.ReaderMode
+import app.otakureader.domain.model.ReaderOrientation
 import app.otakureader.domain.model.ReadingDirection
 import app.otakureader.feature.reader.PageRotation
 import app.otakureader.feature.reader.ReaderSetting
@@ -57,6 +58,11 @@ class ReaderDisplayDelegate @Inject constructor(
     fun updateReadingDirection(direction: ReadingDirection) {
         update { it.copy(readingDirection = direction) }
         launchSave { setReadingDirection(direction) }
+    }
+
+    fun changeOrientation(orientation: ReaderOrientation) {
+        update { it.copy(readerOrientation = orientation) }
+        launchSave { setReaderOrientation(orientation) }
     }
 
     fun cyclePageRotation() {

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderSettingsLoaderDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderSettingsLoaderDelegate.kt
@@ -5,7 +5,6 @@ import app.otakureader.domain.model.PrefetchStrategy
 import app.otakureader.domain.model.ColorFilterMode
 import app.otakureader.domain.model.ImageQuality
 import app.otakureader.domain.model.ReaderMode
-import app.otakureader.domain.model.ReaderOrientation
 import app.otakureader.domain.model.ReadingDirection
 import app.otakureader.domain.model.VolumeKeyBehavior
 import app.otakureader.domain.repository.ReaderSettingsRepository
@@ -46,12 +45,6 @@ class ReaderSettingsLoaderDelegate @Inject constructor(
         val keepScreenOnD = async { settingsRepository.keepScreenOn.first() }
         val showPageNumberD = async { settingsRepository.showPageNumber.first() }
         val directionD = async { settingsRepository.readingDirection.first() }
-        val orientationD = async {
-            try { settingsRepository.readerOrientation.first() } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
-                ReaderOrientation.DEFAULT
-            }
-        }
         val volumeKeysEnabledD = async { settingsRepository.volumeKeysEnabled.first() }
         val volumeKeysInvertedD = async { settingsRepository.volumeKeysInverted.first() }
         val fullscreenD = async { settingsRepository.fullscreen.first() }
@@ -238,7 +231,6 @@ class ReaderSettingsLoaderDelegate @Inject constructor(
 
         current.copy(
             mode = effectiveMode,
-            readerOrientation = orientationD.await(),
             brightness = brightnessD.await(),
             keepScreenOn = keepScreenOnD.await(),
             showPageNumber = showPageNumberD.await(),

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderSettingsLoaderDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderSettingsLoaderDelegate.kt
@@ -5,6 +5,7 @@ import app.otakureader.domain.model.PrefetchStrategy
 import app.otakureader.domain.model.ColorFilterMode
 import app.otakureader.domain.model.ImageQuality
 import app.otakureader.domain.model.ReaderMode
+import app.otakureader.domain.model.ReaderOrientation
 import app.otakureader.domain.model.ReadingDirection
 import app.otakureader.domain.model.VolumeKeyBehavior
 import app.otakureader.domain.repository.ReaderSettingsRepository
@@ -45,6 +46,12 @@ class ReaderSettingsLoaderDelegate @Inject constructor(
         val keepScreenOnD = async { settingsRepository.keepScreenOn.first() }
         val showPageNumberD = async { settingsRepository.showPageNumber.first() }
         val directionD = async { settingsRepository.readingDirection.first() }
+        val orientationD = async {
+            try { settingsRepository.readerOrientation.first() } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                ReaderOrientation.DEFAULT
+            }
+        }
         val volumeKeysEnabledD = async { settingsRepository.volumeKeysEnabled.first() }
         val volumeKeysInvertedD = async { settingsRepository.volumeKeysInverted.first() }
         val fullscreenD = async { settingsRepository.fullscreen.first() }
@@ -231,6 +238,7 @@ class ReaderSettingsLoaderDelegate @Inject constructor(
 
         current.copy(
             mode = effectiveMode,
+            readerOrientation = orientationD.await(),
             brightness = brightnessD.await(),
             keepScreenOn = keepScreenOnD.await(),
             showPageNumber = showPageNumberD.await(),

--- a/feature/reader/src/main/res/values/strings.xml
+++ b/feature/reader/src/main/res/values/strings.xml
@@ -168,6 +168,16 @@
     <string name="reader_direction_rtl">Right to Left</string>
     <string name="reader_direction_vertical">Vertical</string>
 
+    <!-- Orientation lock -->
+    <string name="reader_orientation_title">Orientation</string>
+    <string name="reader_orientation_default">Default</string>
+    <string name="reader_orientation_free">Free</string>
+    <string name="reader_orientation_portrait">Portrait</string>
+    <string name="reader_orientation_landscape">Landscape</string>
+    <string name="reader_orientation_locked_portrait">Locked portrait</string>
+    <string name="reader_orientation_locked_landscape">Locked landscape</string>
+    <string name="reader_orientation_reverse_portrait">Reverse portrait</string>
+
     <!-- Chapter-list overlay (#986) -->
     <string name="reader_chapter_list_title">Chapters</string>
 


### PR DESCRIPTION
## **User description**
## R1 — Reader screen-orientation lock (Komikku parity)

First slice of the focused Reader parity pass. Otaku's reader had **no orientation control** at all, unlike Mihon/Komikku (which offer Default / Free / Portrait / Landscape / Locked variants). This adds it end-to-end.

### Changes
- **domain** — new `ReaderOrientation` enum (`DEFAULT, FREE, PORTRAIT, LANDSCAPE, LOCKED_PORTRAIT, LOCKED_LANDSCAPE, REVERSE_PORTRAIT`). Pure Kotlin, persisted by ordinal; the `ActivityInfo` mapping lives in the feature layer per the clean-architecture rule.
- **`ReaderSettingsRepository`** (domain interface + DataStore impl) — `readerOrientation` flow + `setReaderOrientation`, new key `reader_orientation`.
- **`ReaderSettingsLoaderDelegate`** — loads orientation into state (defensive `try/catch` → `DEFAULT`, consistent with the existing optional-setting reads).
- **MVI** — `ReaderState.readerOrientation` + `ReaderEvent.OnOrientationChange`, routed through `ReaderDisplayDelegate.changeOrientation` (updates state + persists).
- **`ReaderScreen`** — a `DisposableEffect` applies `activity.requestedOrientation` from state and restores `SCREEN_ORIENTATION_UNSPECIFIED` on exit (same pattern as keep-screen-on / secure-screen).
- **`ReaderSettingsOverlay`** — orientation chip row in the quick-settings sheet.

### Also folded in
The deferred review point from #1149: the reader top bar was showing the **chapter** name as its title. Added `ReaderState.mangaTitle`, populated from the loaded manga, and wired it to `ReaderContentOverlay`'s `title` (chapter stays as the subtitle) — now matching Mihon.

### Scope / follow-ups
Orientation is global (matching how most Otaku reader settings are stored). Komikku stores it per-manga; a per-manga override is a tracked follow-up in the Reader backlog (would need a `Manga` field + schema bump).

### Verification
No local Android SDK — verified by inspection; CI is the gate. Loader read is `try/catch`-guarded so the non-relaxed `ReaderViewModelTest` mock stays green without new stubs.

Part of the Reader parity backlog (R1 of R1–R7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_


___

## **CodeAnt-AI Description**
**Add reader orientation controls and show the manga title in the top bar**

### What Changed
- The reader now includes an orientation setting, letting users choose how the screen behaves while reading, including default, free rotation, portrait, landscape, and locked variants.
- The chosen orientation is applied while the reader is open and returns to the normal device behavior when leaving the reader.
- The quick settings panel now includes orientation chips, alongside the existing reading direction and brightness controls.
- The reader top bar now shows the manga title instead of the chapter title, with the chapter name kept as the subtitle.

### Impact
`✅ Fewer accidental screen rotations while reading`
`✅ Faster access to reader orientation controls`
`✅ Clearer reader शीर्ष bar titles`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable screen orientation lock for the reader with multiple orientation modes including default, free, portrait, landscape, and various locked orientations.
  * Orientation preferences are now saved and persist across sessions.
  * Reader interface now displays the manga title in its overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->