### PR TITLE
feat(reader): 3-tab reader settings dialog — R2 parity with Komikku

### DIFF
--- a/data/src/main/java/app/otakureader/data/repository/ReaderSettingsRepository.kt
+++ b/data/src/main/java/app/otakureader/data/repository/ReaderSettingsRepository.kt
@@ -370,7 +370,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.SHOW_READING_TIMER] ?: false
     }
 
-    suspend fun setShowReadingTimer(enabled: Boolean) {
+    override suspend fun setShowReadingTimer(enabled: Boolean) {
         safeEdit { it[Keys.SHOW_READING_TIMER] = enabled }
     }
 
@@ -379,7 +379,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.SHOW_BATTERY_TIME] ?: false
     }
 
-    suspend fun setShowBatteryTime(enabled: Boolean) {
+    override suspend fun setShowBatteryTime(enabled: Boolean) {
         safeEdit { it[Keys.SHOW_BATTERY_TIME] = enabled }
     }
 
@@ -389,7 +389,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.SHOW_CONTENT_IN_CUTOUT] ?: true
     }
 
-    suspend fun setShowContentInCutout(enabled: Boolean) {
+    override suspend fun setShowContentInCutout(enabled: Boolean) {
         safeEdit { it[Keys.SHOW_CONTENT_IN_CUTOUT] = enabled }
     }
 
@@ -398,7 +398,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.BACKGROUND_COLOR] ?: 0
     }
 
-    suspend fun setBackgroundColor(color: Int) {
+    override suspend fun setBackgroundColor(color: Int) {
         safeEdit { it[Keys.BACKGROUND_COLOR] = color.coerceIn(0, 3) }
     }
 
@@ -406,7 +406,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.ANIMATE_PAGE_TRANSITIONS] ?: true
     }
 
-    suspend fun setAnimatePageTransitions(enabled: Boolean) {
+    override suspend fun setAnimatePageTransitions(enabled: Boolean) {
         safeEdit { it[Keys.ANIMATE_PAGE_TRANSITIONS] = enabled }
     }
 
@@ -433,7 +433,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.READER_SCALE] ?: 0
     }
 
-    suspend fun setReaderScale(scale: Int) {
+    override suspend fun setReaderScale(scale: Int) {
         safeEdit { it[Keys.READER_SCALE] = scale.coerceIn(0, 4) }
     }
 
@@ -441,7 +441,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.AUTO_ZOOM_WIDE_IMAGES] ?: true
     }
 
-    suspend fun setAutoZoomWideImages(enabled: Boolean) {
+    override suspend fun setAutoZoomWideImages(enabled: Boolean) {
         safeEdit { it[Keys.AUTO_ZOOM_WIDE_IMAGES] = enabled }
     }
 
@@ -462,7 +462,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.WEBTOON_SIDE_PADDING] ?: 0
     }
 
-    suspend fun setWebtoonSidePadding(padding: Int) {
+    override suspend fun setWebtoonSidePadding(padding: Int) {
         safeEdit { it[Keys.WEBTOON_SIDE_PADDING] = padding.coerceIn(0, 3) }
     }
 
@@ -488,7 +488,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.WEBTOON_DOUBLE_TAP_ZOOM] ?: true
     }
 
-    suspend fun setWebtoonDoubleTapZoom(enabled: Boolean) {
+    override suspend fun setWebtoonDoubleTapZoom(enabled: Boolean) {
         safeEdit { it[Keys.WEBTOON_DOUBLE_TAP_ZOOM] = enabled }
     }
 
@@ -496,7 +496,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.WEBTOON_DISABLE_ZOOM_OUT] ?: false
     }
 
-    suspend fun setWebtoonDisableZoomOut(enabled: Boolean) {
+    override suspend fun setWebtoonDisableZoomOut(enabled: Boolean) {
         safeEdit { it[Keys.WEBTOON_DISABLE_ZOOM_OUT] = enabled }
     }
 
@@ -506,7 +506,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.EINK_FLASH_ON_PAGE_CHANGE] ?: false
     }
 
-    suspend fun setEinkFlashOnPageChange(enabled: Boolean) {
+    override suspend fun setEinkFlashOnPageChange(enabled: Boolean) {
         safeEdit { it[Keys.EINK_FLASH_ON_PAGE_CHANGE] = enabled }
     }
 
@@ -514,7 +514,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.EINK_BLACK_AND_WHITE] ?: false
     }
 
-    suspend fun setEinkBlackAndWhite(enabled: Boolean) {
+    override suspend fun setEinkBlackAndWhite(enabled: Boolean) {
         safeEdit { it[Keys.EINK_BLACK_AND_WHITE] = enabled }
     }
 
@@ -548,7 +548,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.ALWAYS_SHOW_CHAPTER_TRANSITION] ?: true
     }
 
-    suspend fun setAlwaysShowChapterTransition(enabled: Boolean) {
+    override suspend fun setAlwaysShowChapterTransition(enabled: Boolean) {
         safeEdit { it[Keys.ALWAYS_SHOW_CHAPTER_TRANSITION] = enabled }
     }
 
@@ -558,7 +558,7 @@ class ReaderSettingsRepository @Inject constructor(
         prefs[Keys.SHOW_ACTIONS_ON_LONG_TAP] ?: true
     }
 
-    suspend fun setShowActionsOnLongTap(enabled: Boolean) {
+    override suspend fun setShowActionsOnLongTap(enabled: Boolean) {
         safeEdit { it[Keys.SHOW_ACTIONS_ON_LONG_TAP] = enabled }
     }
 

--- a/domain/src/main/java/app/otakureader/domain/repository/ReaderSettingsRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/ReaderSettingsRepository.kt
@@ -8,6 +8,7 @@ import app.otakureader.domain.model.ReadingDirection
 import app.otakureader.domain.model.TapZoneConfig
 import kotlinx.coroutines.flow.Flow
 
+@Suppress("TooManyFunctions")
 interface ReaderSettingsRepository {
 
     val writeFailureEvents: Flow<Unit>

--- a/domain/src/main/java/app/otakureader/domain/repository/ReaderSettingsRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/ReaderSettingsRepository.kt
@@ -93,6 +93,20 @@ interface ReaderSettingsRepository {
     suspend fun setSkipReadChapters(enabled: Boolean)
     suspend fun setSkipFilteredChapters(enabled: Boolean)
     suspend fun setSkipDuplicateChapters(enabled: Boolean)
+    suspend fun setShowReadingTimer(enabled: Boolean)
+    suspend fun setShowBatteryTime(enabled: Boolean)
+    suspend fun setBackgroundColor(color: Int)
+    suspend fun setAnimatePageTransitions(enabled: Boolean)
+    suspend fun setAlwaysShowChapterTransition(enabled: Boolean)
+    suspend fun setShowActionsOnLongTap(enabled: Boolean)
+    suspend fun setEinkFlashOnPageChange(enabled: Boolean)
+    suspend fun setEinkBlackAndWhite(enabled: Boolean)
+    suspend fun setWebtoonDoubleTapZoom(enabled: Boolean)
+    suspend fun setWebtoonDisableZoomOut(enabled: Boolean)
+    suspend fun setAutoZoomWideImages(enabled: Boolean)
+    suspend fun setReaderScale(scale: Int)
+    suspend fun setWebtoonSidePadding(padding: Int)
+    suspend fun setShowContentInCutout(enabled: Boolean)
 
     companion object {
         const val DEFAULT_PRELOAD_PAGES = 3

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderMvi.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderMvi.kt
@@ -579,6 +579,15 @@ sealed interface ReaderEvent {
     /** Update tap zone configuration. */
     data class UpdateTapZones(val config: TapZoneConfig) : SettingsControl
 
+    /** Set background color: 0=Black, 1=White, 2=Gray, 3=Auto. */
+    data class SetBackgroundColor(val color: Int) : SettingsControl
+
+    /** Set scale type: 0=Fit Screen, 1=Fit Width, 2=Fit Height, 3=Original, 4=Smart Fit. */
+    data class SetReaderScale(val scale: Int) : SettingsControl
+
+    /** Set webtoon side padding: 0=None, 1=Small, 2=Medium, 3=Large. */
+    data class SetWebtoonSidePadding(val padding: Int) : SettingsControl
+
     // ──────────────────────────────────────────────────────────────────────────
     // Color filter
     // ──────────────────────────────────────────────────────────────────────────
@@ -667,6 +676,18 @@ enum class ReaderSetting {
     SKIP_READ_CHAPTERS,
     SKIP_FILTERED_CHAPTERS,
     SKIP_DUPLICATE_CHAPTERS,
+    SHOW_READING_TIMER,
+    SHOW_BATTERY_TIME,
+    ANIMATE_PAGE_TRANSITIONS,
+    ALWAYS_SHOW_CHAPTER_TRANSITION,
+    SHOW_ACTIONS_ON_LONG_TAP,
+    EINK_FLASH_ON_PAGE_CHANGE,
+    EINK_BLACK_AND_WHITE,
+    WEBTOON_DOUBLE_TAP_ZOOM,
+    WEBTOON_DISABLE_ZOOM_OUT,
+    AUTO_ZOOM_WIDE_IMAGES,
+    SHOW_CONTENT_IN_CUTOUT,
+    FULLSCREEN,
 }
 
 /**

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -528,23 +528,11 @@ fun ReaderScreen(
             modifier = Modifier.align(Alignment.BottomCenter)
         )
 
-        // Quick-settings overlay — compact sheet triggered by long-press on center zone
+        // Reader settings dialog — 3-tab sheet (Reading mode / General / Color filter)
         ReaderSettingsOverlay(
             isVisible = state.isSettingsOverlayVisible,
-            currentMode = state.mode,
-            readingDirection = state.readingDirection,
-            orientation = state.readerOrientation,
-            brightness = state.brightness,
-            colorFilterMode = state.colorFilterMode,
-            cropBordersEnabled = state.cropBordersEnabled,
-            incognitoMode = state.incognitoMode,
-            onModeChange = { viewModel.onEvent(ReaderEvent.OnModeChange(it)) },
-            onDirectionChange = { viewModel.onEvent(ReaderEvent.OnDirectionChange(it)) },
-            onOrientationChange = { viewModel.onEvent(ReaderEvent.OnOrientationChange(it)) },
-            onBrightnessChange = { viewModel.onEvent(ReaderEvent.OnBrightnessChange(it)) },
-            onColorFilterChange = { viewModel.onEvent(ReaderEvent.SetColorFilterMode(it)) },
-            onToggleCropBorders = { viewModel.onEvent(ReaderEvent.ToggleSetting(ReaderSetting.CROP_BORDERS)) },
-            onToggleIncognito = { viewModel.onEvent(ReaderEvent.ToggleSetting(ReaderSetting.INCOGNITO_MODE)) },
+            state = state,
+            onEvent = { viewModel.onEvent(it) },
             onDismiss = { viewModel.onEvent(ReaderEvent.ToggleSettingsOverlay) },
         )
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -3,6 +3,7 @@ package app.otakureader.feature.reader
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.ActivityInfo
+import android.os.Build
 import android.view.WindowManager
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Canvas
@@ -206,6 +207,34 @@ fun ReaderScreen(
         }
         onDispose {
             activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+
+    // Apply display-cutout mode so content can extend into the camera notch when enabled.
+    // LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES was added in API 28; on API 26-27 the block
+    // runs but the constant is present as a stub, so there is no crash — just no effect.
+    DisposableEffect(state.showContentInCutout) {
+        val activity = context as? Activity
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val params = activity?.window?.attributes
+            if (params != null) {
+                params.layoutInDisplayCutoutMode = if (state.showContentInCutout) {
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+                } else {
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
+                }
+                activity.window.attributes = params
+            }
+        }
+        onDispose {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                val params = activity?.window?.attributes
+                if (params != null) {
+                    params.layoutInDisplayCutoutMode =
+                        WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
+                    activity.window.attributes = params
+                }
+            }
         }
     }
 
@@ -570,11 +599,21 @@ private fun ReaderContent(
     onZoomChange: (Float) -> Unit,
     onLongPress: ((String) -> Unit)? = null,
 ) {
-    // Use the per-manga background color if set, otherwise default to black
-    val backgroundColor = if (state.readerBackgroundColor != null) {
-        Color(state.readerBackgroundColor.toInt())
-    } else {
-        Color.Black
+    // Prefer per-manga color override; fall back to the user's global background preference.
+    // backgroundColor index: 0=Black (default), 1=White, 2=Grey, 3=Auto (system surface).
+    val backgroundColor = when {
+        state.readerBackgroundColor != null -> Color(state.readerBackgroundColor.toInt())
+        state.backgroundColor == 1 -> Color.White
+        state.backgroundColor == 2 -> Color.Gray
+        state.backgroundColor == 3 -> Color.Transparent
+        else -> Color.Black
+    }
+
+    val webtoonSidePaddingDp = when (state.webtoonSidePadding) {
+        1 -> 8
+        2 -> 16
+        3 -> 32
+        else -> 0
     }
 
     // CompositingStrategy.Offscreen ensures blend modes in the Canvas overlay work correctly
@@ -604,6 +643,8 @@ private fun ReaderContent(
                     onZoomChange = onZoomChange,
                     onLongPress = if (state.showActionsOnLongTap) onLongPress else null,
                     rotation = state.pageRotation.degrees,
+                    scaleType = state.readerScale,
+                    animatePageTransitions = state.animatePageTransitions,
                     cropBordersEnabled = state.cropBordersEnabled,
                     imageQuality = state.imageQuality,
                     dataSaverEnabled = state.dataSaverEnabled,
@@ -620,6 +661,8 @@ private fun ReaderContent(
                     onLongPress = if (state.showActionsOnLongTap) onLongPress else null,
                     isRtl = state.readingDirection == app.otakureader.domain.model.ReadingDirection.RTL,
                     rotation = state.pageRotation.degrees,
+                    scaleType = state.readerScale,
+                    animatePageTransitions = state.animatePageTransitions,
                     cropBordersEnabled = state.cropBordersEnabled,
                     imageQuality = state.imageQuality,
                     dataSaverEnabled = state.dataSaverEnabled,
@@ -639,6 +682,7 @@ private fun ReaderContent(
                     imageQuality = state.imageQuality,
                     dataSaverEnabled = state.dataSaverEnabled,
                     pageGapDp = state.webtoonGapDp,
+                    sidePaddingDp = webtoonSidePaddingDp,
                     disableZoomOut = state.webtoonDisableZoomOut,
                     modifier = Modifier.fillMaxSize()
                 )

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -561,6 +561,9 @@ class ReaderViewModel @Inject constructor(
         when (event) {
             is ReaderEvent.ToggleSetting -> displayDelegate.toggleSetting(event.setting)
             is ReaderEvent.UpdateTapZones -> displayDelegate.updateTapZones(event.config)
+            is ReaderEvent.SetBackgroundColor -> displayDelegate.updateBackgroundColor(event.color)
+            is ReaderEvent.SetReaderScale -> displayDelegate.updateReaderScale(event.scale)
+            is ReaderEvent.SetWebtoonSidePadding -> displayDelegate.updateWebtoonSidePadding(event.padding)
         }
     }
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/modes/DualPageReader.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/modes/DualPageReader.kt
@@ -72,6 +72,14 @@ private fun buildSpreadGroups(
  * Dual page reader mode - displays two pages side by side (spreads).
  * Auto-detects landscape images and displays them as full-width solo spreads.
  */
+private fun scaleTypeToContentScale(scaleType: Int): ContentScale = when (scaleType) {
+    1 -> ContentScale.FillWidth
+    2 -> ContentScale.FillHeight
+    3 -> ContentScale.None
+    4 -> ContentScale.Inside
+    else -> ContentScale.Fit
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun DualPageReader(
@@ -82,11 +90,15 @@ fun DualPageReader(
     onLongPress: ((String) -> Unit)? = null,
     isRtl: Boolean = false,
     rotation: Float = 0f,
+    scaleType: Int = 0,
+    animatePageTransitions: Boolean = true,
     cropBordersEnabled: Boolean = false,
     imageQuality: ImageQuality = ImageQuality.ORIGINAL,
     dataSaverEnabled: Boolean = false,
     modifier: Modifier = Modifier
 ) {
+    val contentScale = scaleTypeToContentScale(scaleType)
+
     // Map from page.index → true if detected as a landscape spread.
     // Keyed on `pages` so the map is cleared automatically when a new chapter loads.
     val detectedSpreads = remember(pages) { mutableStateMapOf<Int, Boolean>() }
@@ -106,7 +118,11 @@ fun DualPageReader(
     LaunchedEffect(currentPage, spreadGroups) {
         val target = spreadGroups.indexOfFirst { group -> group.any { it == currentPage } }
         if (target >= 0 && pagerState.currentPage != target) {
-            pagerState.animateScrollToPage(target)
+            if (animatePageTransitions) {
+                pagerState.animateScrollToPage(target)
+            } else {
+                pagerState.scrollToPage(target)
+            }
         }
     }
 
@@ -140,7 +156,7 @@ fun DualPageReader(
                     ZoomableImage(
                         imageUrl = page.imageUrl,
                         contentDescription = stringResource(R.string.reader_page_content, page.pageNumber),
-                        contentScale = ContentScale.Fit,
+                        contentScale = contentScale,
                         rotation = rotation,
                         cropBordersEnabled = cropBordersEnabled,
                         imageQuality = imageQuality,
@@ -172,7 +188,7 @@ fun DualPageReader(
                             ZoomableImage(
                                 imageUrl = leftPage.imageUrl,
                                 contentDescription = stringResource(R.string.reader_page_content, leftPage.pageNumber),
-                                contentScale = ContentScale.Fit,
+                                contentScale = contentScale,
                                 rotation = rotation,
                                 cropBordersEnabled = cropBordersEnabled,
                                 imageQuality = imageQuality,
@@ -202,7 +218,7 @@ fun DualPageReader(
                             ZoomableImage(
                                 imageUrl = rightPage.imageUrl,
                                 contentDescription = stringResource(R.string.reader_page_content, rightPage.pageNumber),
-                                contentScale = ContentScale.Fit,
+                                contentScale = contentScale,
                                 rotation = rotation,
                                 cropBordersEnabled = cropBordersEnabled,
                                 imageQuality = imageQuality,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/modes/SinglePageReader.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/modes/SinglePageReader.kt
@@ -20,6 +20,14 @@ import app.otakureader.domain.model.ImageQuality
 import app.otakureader.feature.reader.model.ReaderPage
 import kotlinx.coroutines.flow.distinctUntilChanged
 
+private fun scaleTypeToContentScale(scaleType: Int): ContentScale = when (scaleType) {
+    1 -> ContentScale.FillWidth
+    2 -> ContentScale.FillHeight
+    3 -> ContentScale.None
+    4 -> ContentScale.Inside
+    else -> ContentScale.Fit
+}
+
 /**
  * Single page reader mode - displays one page at a time.
  * Supports zoom, pan, and swipe navigation.
@@ -35,20 +43,27 @@ fun SinglePageReader(
     onZoomChange: (Float) -> Unit,
     onLongPress: ((String) -> Unit)? = null,
     rotation: Float = 0f,
+    scaleType: Int = 0,
+    animatePageTransitions: Boolean = true,
     cropBordersEnabled: Boolean = false,
     imageQuality: ImageQuality = ImageQuality.ORIGINAL,
     dataSaverEnabled: Boolean = false,
     modifier: Modifier = Modifier
 ) {
+    val contentScale = scaleTypeToContentScale(scaleType)
     val pagerState = rememberPagerState(
         initialPage = currentPage,
         pageCount = { pages.size }
     )
-    
+
     // Sync pager state with external current page
     LaunchedEffect(currentPage) {
         if (pagerState.currentPage != currentPage) {
-            pagerState.animateScrollToPage(currentPage)
+            if (animatePageTransitions) {
+                pagerState.animateScrollToPage(currentPage)
+            } else {
+                pagerState.scrollToPage(currentPage)
+            }
         }
     }
     
@@ -82,7 +97,7 @@ fun SinglePageReader(
             ZoomableImage(
                 imageUrl = page.imageUrl,
                 contentDescription = stringResource(R.string.reader_page_content, page.pageNumber),
-                contentScale = ContentScale.Fit,
+                contentScale = contentScale,
                 rotation = rotation,
                 cropBordersEnabled = cropBordersEnabled,
                 imageQuality = imageQuality,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/modes/WebtoonReader.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/modes/WebtoonReader.kt
@@ -48,6 +48,7 @@ fun WebtoonReader(
     imageQuality: ImageQuality = ImageQuality.ORIGINAL,
     dataSaverEnabled: Boolean = false,
     pageGapDp: Int = 4,
+    sidePaddingDp: Int = 0,
     disableZoomOut: Boolean = false,
     modifier: Modifier = Modifier
 ) {
@@ -121,7 +122,7 @@ fun WebtoonReader(
                     }
                 }
             },
-        contentPadding = PaddingValues(vertical = pageGapDp.dp),
+        contentPadding = PaddingValues(horizontal = sidePaddingDp.dp, vertical = pageGapDp.dp),
         verticalArrangement = Arrangement.spacedBy(pageGapDp.dp)
     ) {
         itemsIndexed(

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderSettingsOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderSettingsOverlay.kt
@@ -75,7 +75,9 @@ fun ReaderSettingsOverlay(
 
         HorizontalPager(
             state = pagerState,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
         ) { page ->
             when (page) {
                 0 -> ReadingModeTab(state = state, onEvent = onEvent)
@@ -349,10 +351,10 @@ private fun ColorFilterTab(state: ReaderState, onEvent: (ReaderEvent) -> Unit) {
 
 @Composable
 private fun CustomTintSection(tintColor: Long, onEvent: (ReaderEvent) -> Unit) {
-    val alpha = ((tintColor shr 24) and 0xFF).toInt()
-    val red = ((tintColor shr 16) and 0xFF).toInt()
-    val green = ((tintColor shr 8) and 0xFF).toInt()
-    val blue = (tintColor and 0xFF).toInt()
+    val alpha = ((tintColor shr 24) and 0xFFL).toInt()
+    val red = ((tintColor shr 16) and 0xFFL).toInt()
+    val green = ((tintColor shr 8) and 0xFFL).toInt()
+    val blue = (tintColor and 0xFFL).toInt()
 
     SettingsSectionLabel(stringResource(R.string.reader_opacity))
     Slider(

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderSettingsOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderSettingsOverlay.kt
@@ -1,5 +1,6 @@
 package app.otakureader.feature.reader.ui
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -9,6 +10,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
@@ -16,9 +21,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -28,176 +36,387 @@ import app.otakureader.domain.model.ReaderMode
 import app.otakureader.domain.model.ReaderOrientation
 import app.otakureader.domain.model.ReadingDirection
 import app.otakureader.feature.reader.R
+import app.otakureader.feature.reader.ReaderEvent
+import app.otakureader.feature.reader.ReaderSetting
+import app.otakureader.feature.reader.ReaderState
+import kotlinx.coroutines.launch
 
-/**
- * Compact quick-settings overlay triggered by long-pressing the center tap zone.
- *
- * Exposes the four most commonly adjusted in-session settings without requiring
- * the user to open the full [ReaderMenuOverlay]:
- *  - Reading mode (Single / Dual / Webtoon / Smart Panels)
- *  - Reading direction (LTR / RTL / Vertical)
- *  - Brightness
- *  - Color filter
- */
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun ReaderSettingsOverlay(
     isVisible: Boolean,
-    currentMode: ReaderMode,
-    readingDirection: ReadingDirection,
-    orientation: ReaderOrientation,
-    brightness: Float,
-    colorFilterMode: ColorFilterMode,
-    cropBordersEnabled: Boolean,
-    incognitoMode: Boolean,
-    onModeChange: (ReaderMode) -> Unit,
-    onDirectionChange: (ReadingDirection) -> Unit,
-    onOrientationChange: (ReaderOrientation) -> Unit,
-    onBrightnessChange: (Float) -> Unit,
-    onColorFilterChange: (ColorFilterMode) -> Unit,
-    onToggleCropBorders: () -> Unit,
-    onToggleIncognito: () -> Unit,
+    state: ReaderState,
+    onEvent: (ReaderEvent) -> Unit,
     onDismiss: () -> Unit,
 ) {
     if (!isVisible) return
+
+    val tabs = listOf(
+        stringResource(R.string.reader_settings_tab_reading_mode),
+        stringResource(R.string.reader_settings_tab_general),
+        stringResource(R.string.reader_settings_tab_color_filter),
+    )
+    val pagerState = rememberPagerState(pageCount = { tabs.size })
+    val scope = rememberCoroutineScope()
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
     ) {
-        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)) {
-            Text(
-                text = stringResource(R.string.reader_quick_settings_title),
-                style = androidx.compose.material3.MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(bottom = 8.dp),
-            )
-
-            // Reading mode
-            Text(
-                text = stringResource(R.string.reader_mode_title),
-                style = androidx.compose.material3.MaterialTheme.typography.labelMedium,
-            )
-            FlowRow(modifier = Modifier.fillMaxWidth()) {
-                ReaderMode.entries.forEach { mode ->
-                    FilterChip(
-                        selected = currentMode == mode,
-                        onClick = { onModeChange(mode) },
-                        label = { Text(mode.toLabel()) },
-                        modifier = Modifier.padding(end = 6.dp),
-                    )
-                }
+        TabRow(selectedTabIndex = pagerState.currentPage) {
+            tabs.forEachIndexed { index, title ->
+                Tab(
+                    selected = pagerState.currentPage == index,
+                    onClick = { scope.launch { pagerState.animateScrollToPage(index) } },
+                    text = { Text(title) },
+                )
             }
+        }
 
-            Spacer(modifier = Modifier.height(8.dp))
-            HorizontalDivider()
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Reading direction
-            Text(
-                text = stringResource(R.string.reader_direction_title),
-                style = androidx.compose.material3.MaterialTheme.typography.labelMedium,
-            )
-            FlowRow(modifier = Modifier.fillMaxWidth()) {
-                ReadingDirection.entries.forEach { direction ->
-                    FilterChip(
-                        selected = readingDirection == direction,
-                        onClick = { onDirectionChange(direction) },
-                        label = { Text(direction.toLabel()) },
-                        modifier = Modifier.padding(end = 6.dp),
-                    )
-                }
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxWidth(),
+        ) { page ->
+            when (page) {
+                0 -> ReadingModeTab(state = state, onEvent = onEvent)
+                1 -> GeneralTab(state = state, onEvent = onEvent)
+                2 -> ColorFilterTab(state = state, onEvent = onEvent)
             }
+        }
 
-            Spacer(modifier = Modifier.height(8.dp))
-            HorizontalDivider()
-            Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}
 
-            // Orientation lock
-            Text(
-                text = stringResource(R.string.reader_orientation_title),
-                style = androidx.compose.material3.MaterialTheme.typography.labelMedium,
-            )
-            FlowRow(modifier = Modifier.fillMaxWidth()) {
-                ReaderOrientation.entries.forEach { entry ->
-                    FilterChip(
-                        selected = orientation == entry,
-                        onClick = { onOrientationChange(entry) },
-                        label = { Text(entry.toLabel()) },
-                        modifier = Modifier.padding(end = 6.dp),
-                    )
-                }
+@Composable
+private fun ReadingModeTab(state: ReaderState, onEvent: (ReaderEvent) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        SettingsSectionLabel(stringResource(R.string.reader_mode_title))
+        FlowRow(modifier = Modifier.fillMaxWidth()) {
+            ReaderMode.entries.forEach { mode ->
+                FilterChip(
+                    selected = state.mode == mode,
+                    onClick = { onEvent(ReaderEvent.OnModeChange(mode)) },
+                    label = { Text(mode.toLabel()) },
+                    modifier = Modifier.padding(end = 6.dp),
+                )
             }
+        }
 
-            Spacer(modifier = Modifier.height(8.dp))
-            HorizontalDivider()
-            Spacer(modifier = Modifier.height(8.dp))
+        SettingsDivider()
 
-            // Brightness
-            Text(
-                text = stringResource(R.string.reader_brightness),
-                style = androidx.compose.material3.MaterialTheme.typography.labelMedium,
-            )
-            Slider(
-                value = brightness,
-                onValueChange = onBrightnessChange,
-                valueRange = 0.1f..1.5f,
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-            HorizontalDivider()
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Color filter
-            Text(
-                text = stringResource(R.string.reader_color_filter),
-                style = androidx.compose.material3.MaterialTheme.typography.labelMedium,
-            )
-            FlowRow(modifier = Modifier.fillMaxWidth()) {
-                ColorFilterMode.entries.forEach { mode ->
-                    FilterChip(
-                        selected = colorFilterMode == mode,
-                        onClick = { onColorFilterChange(mode) },
-                        label = { Text(mode.toLabel()) },
-                        modifier = Modifier.padding(end = 6.dp),
-                    )
-                }
+        SettingsSectionLabel(stringResource(R.string.reader_direction_title))
+        FlowRow(modifier = Modifier.fillMaxWidth()) {
+            ReadingDirection.entries.forEach { direction ->
+                FilterChip(
+                    selected = state.readingDirection == direction,
+                    onClick = { onEvent(ReaderEvent.OnDirectionChange(direction)) },
+                    label = { Text(direction.toLabel()) },
+                    modifier = Modifier.padding(end = 6.dp),
+                )
             }
+        }
 
-            Spacer(modifier = Modifier.height(8.dp))
-            HorizontalDivider()
-            Spacer(modifier = Modifier.height(8.dp))
+        SettingsDivider()
 
-            // Toggles (state + persistence already handled by the ViewModel)
-            ReaderToggleRow(
-                label = stringResource(R.string.reader_crop_borders),
-                checked = cropBordersEnabled,
-                onToggle = onToggleCropBorders,
-            )
-            ReaderToggleRow(
-                label = stringResource(R.string.reader_incognito_mode),
-                checked = incognitoMode,
-                onToggle = onToggleIncognito,
-            )
+        SettingsSectionLabel(stringResource(R.string.reader_orientation_title))
+        FlowRow(modifier = Modifier.fillMaxWidth()) {
+            ReaderOrientation.entries.forEach { orientation ->
+                FilterChip(
+                    selected = state.readerOrientation == orientation,
+                    onClick = { onEvent(ReaderEvent.OnOrientationChange(orientation)) },
+                    label = { Text(orientation.toLabel()) },
+                    modifier = Modifier.padding(end = 6.dp),
+                )
+            }
+        }
 
-            Spacer(modifier = Modifier.height(16.dp))
+        SettingsDivider()
+
+        if (state.mode == ReaderMode.WEBTOON) {
+            WebtoonViewerSettings(state = state, onEvent = onEvent)
+        } else {
+            PagerViewerSettings(state = state, onEvent = onEvent)
         }
     }
 }
 
 @Composable
-private fun ReaderToggleRow(
-    label: String,
-    checked: Boolean,
-    onToggle: () -> Unit,
-) {
-    // Whole row is clickable with vertical padding so the touch target meets the
-    // 48dp accessibility minimum; the Switch is driven by the row (onCheckedChange = null).
+private fun PagerViewerSettings(state: ReaderState, onEvent: (ReaderEvent) -> Unit) {
+    SettingsSectionLabel(stringResource(R.string.reader_scale_title))
+    val scaleLabels = listOf(
+        stringResource(R.string.reader_scale_fit_screen),
+        stringResource(R.string.reader_scale_fit_width),
+        stringResource(R.string.reader_scale_fit_height),
+        stringResource(R.string.reader_scale_original),
+        stringResource(R.string.reader_scale_smart_fit),
+    )
+    FlowRow(modifier = Modifier.fillMaxWidth()) {
+        scaleLabels.forEachIndexed { index, label ->
+            FilterChip(
+                selected = state.readerScale == index,
+                onClick = { onEvent(ReaderEvent.SetReaderScale(index)) },
+                label = { Text(label) },
+                modifier = Modifier.padding(end = 6.dp),
+            )
+        }
+    }
+
+    SettingsDivider()
+
+    SettingsToggleRow(
+        label = stringResource(R.string.reader_crop_borders),
+        checked = state.cropBordersEnabled,
+        onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.CROP_BORDERS)) },
+    )
+    SettingsToggleRow(
+        label = stringResource(R.string.reader_auto_zoom_wide),
+        checked = state.autoZoomWideImages,
+        onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.AUTO_ZOOM_WIDE_IMAGES)) },
+    )
+    SettingsToggleRow(
+        label = stringResource(R.string.reader_animate_transitions),
+        checked = state.animatePageTransitions,
+        onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.ANIMATE_PAGE_TRANSITIONS)) },
+    )
+}
+
+@Composable
+private fun WebtoonViewerSettings(state: ReaderState, onEvent: (ReaderEvent) -> Unit) {
+    SettingsSectionLabel(stringResource(R.string.reader_webtoon_side_padding))
+    val paddingLabels = listOf(
+        stringResource(R.string.reader_webtoon_side_padding_none),
+        stringResource(R.string.reader_webtoon_side_padding_small),
+        stringResource(R.string.reader_webtoon_side_padding_medium),
+        stringResource(R.string.reader_webtoon_side_padding_large),
+    )
+    FlowRow(modifier = Modifier.fillMaxWidth()) {
+        paddingLabels.forEachIndexed { index, label ->
+            FilterChip(
+                selected = state.webtoonSidePadding == index,
+                onClick = { onEvent(ReaderEvent.SetWebtoonSidePadding(index)) },
+                label = { Text(label) },
+                modifier = Modifier.padding(end = 6.dp),
+            )
+        }
+    }
+
+    SettingsDivider()
+
+    SettingsToggleRow(
+        label = stringResource(R.string.reader_crop_borders),
+        checked = state.cropBordersEnabled,
+        onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.CROP_BORDERS)) },
+    )
+    SettingsToggleRow(
+        label = stringResource(R.string.reader_webtoon_double_tap_zoom),
+        checked = state.webtoonDoubleTapZoom,
+        onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.WEBTOON_DOUBLE_TAP_ZOOM)) },
+    )
+    SettingsToggleRow(
+        label = stringResource(R.string.reader_webtoon_disable_zoom_out),
+        checked = state.webtoonDisableZoomOut,
+        onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.WEBTOON_DISABLE_ZOOM_OUT)) },
+    )
+}
+
+@Composable
+private fun GeneralTab(state: ReaderState, onEvent: (ReaderEvent) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        SettingsSectionLabel(stringResource(R.string.reader_background))
+        val bgLabels = listOf(
+            stringResource(R.string.reader_bg_black),
+            stringResource(R.string.reader_bg_white),
+            stringResource(R.string.reader_bg_grey),
+            stringResource(R.string.reader_bg_auto),
+        )
+        val bgValues = listOf(0, 1, 2, 3)
+        FlowRow(modifier = Modifier.fillMaxWidth()) {
+            bgLabels.forEachIndexed { index, label ->
+                FilterChip(
+                    selected = state.backgroundColor == bgValues[index],
+                    onClick = { onEvent(ReaderEvent.SetBackgroundColor(bgValues[index])) },
+                    label = { Text(label) },
+                    modifier = Modifier.padding(end = 6.dp),
+                )
+            }
+        }
+
+        SettingsDivider()
+
+        SettingsToggleRow(
+            label = stringResource(R.string.reader_show_reading_timer),
+            checked = state.showReadingTimer,
+            onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.SHOW_READING_TIMER)) },
+        )
+        SettingsToggleRow(
+            label = stringResource(R.string.reader_show_battery_time),
+            checked = state.showBatteryTime,
+            onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.SHOW_BATTERY_TIME)) },
+        )
+        SettingsToggleRow(
+            label = stringResource(R.string.reader_show_page_number),
+            checked = state.showPageNumber,
+            onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.SHOW_PAGE_NUMBER)) },
+        )
+        SettingsToggleRow(
+            label = stringResource(R.string.reader_fullscreen),
+            checked = state.isFullscreen,
+            onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.FULLSCREEN)) },
+        )
+        SettingsToggleRow(
+            label = stringResource(R.string.reader_show_content_in_cutout),
+            checked = state.showContentInCutout,
+            onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.SHOW_CONTENT_IN_CUTOUT)) },
+        )
+        SettingsToggleRow(
+            label = stringResource(R.string.reader_keep_screen_on),
+            checked = state.keepScreenOn,
+            onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.KEEP_SCREEN_ON)) },
+        )
+        SettingsToggleRow(
+            label = stringResource(R.string.reader_long_tap_actions),
+            checked = state.showActionsOnLongTap,
+            onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.SHOW_ACTIONS_ON_LONG_TAP)) },
+        )
+        SettingsToggleRow(
+            label = stringResource(R.string.reader_always_show_chapter_transition),
+            checked = state.alwaysShowChapterTransition,
+            onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.ALWAYS_SHOW_CHAPTER_TRANSITION)) },
+        )
+        SettingsToggleRow(
+            label = stringResource(R.string.reader_eink_flash),
+            checked = state.einkFlashOnPageChange,
+            onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.EINK_FLASH_ON_PAGE_CHANGE)) },
+        )
+        SettingsToggleRow(
+            label = stringResource(R.string.reader_incognito_mode),
+            checked = state.incognitoMode,
+            onToggle = { onEvent(ReaderEvent.ToggleSetting(ReaderSetting.INCOGNITO_MODE)) },
+        )
+    }
+}
+
+@Composable
+private fun ColorFilterTab(state: ReaderState, onEvent: (ReaderEvent) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        SettingsSectionLabel(stringResource(R.string.reader_brightness))
+        Slider(
+            value = state.brightness,
+            onValueChange = { onEvent(ReaderEvent.OnBrightnessChange(it)) },
+            valueRange = 0.1f..1.5f,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        SettingsDivider()
+
+        SettingsSectionLabel(stringResource(R.string.reader_color_filter))
+        FlowRow(modifier = Modifier.fillMaxWidth()) {
+            ColorFilterMode.entries.forEach { mode ->
+                FilterChip(
+                    selected = state.colorFilterMode == mode,
+                    onClick = { onEvent(ReaderEvent.SetColorFilterMode(mode)) },
+                    label = { Text(mode.toLabel()) },
+                    modifier = Modifier.padding(end = 6.dp),
+                )
+            }
+        }
+
+        if (state.colorFilterMode == ColorFilterMode.CUSTOM_TINT) {
+            SettingsDivider()
+            CustomTintSection(
+                tintColor = state.customTintColor,
+                onEvent = onEvent,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CustomTintSection(tintColor: Long, onEvent: (ReaderEvent) -> Unit) {
+    val alpha = ((tintColor shr 24) and 0xFF).toInt()
+    val red = ((tintColor shr 16) and 0xFF).toInt()
+    val green = ((tintColor shr 8) and 0xFF).toInt()
+    val blue = (tintColor and 0xFF).toInt()
+
+    SettingsSectionLabel(stringResource(R.string.reader_opacity))
+    Slider(
+        value = alpha / 255f,
+        onValueChange = { fraction ->
+            val newAlpha = (fraction * 255).toLong()
+            val newColor = (newAlpha shl 24) or (red.toLong() shl 16) or (green.toLong() shl 8) or blue.toLong()
+            onEvent(ReaderEvent.SetCustomTintColor(newColor))
+        },
+        valueRange = 0f..1f,
+        modifier = Modifier.fillMaxWidth(),
+    )
+
+    SettingsSectionLabel(stringResource(R.string.reader_tint_color))
+    val tintPresets: List<Pair<String, Long>> = listOf(
+        stringResource(R.string.reader_tint_blue) to 0xFF1E90FFL,
+        stringResource(R.string.reader_tint_red) to 0xFFDC143CL,
+        stringResource(R.string.reader_tint_orange) to 0xFFFF8C00L,
+        stringResource(R.string.reader_tint_yellow) to 0xFFFFD700L,
+        stringResource(R.string.reader_tint_green) to 0xFF228B22L,
+        stringResource(R.string.reader_tint_purple) to 0xFF8B008BL,
+        stringResource(R.string.reader_tint_brown) to 0xFF8B4513L,
+        stringResource(R.string.reader_tint_grey) to 0xFF808080L,
+    )
+    FlowRow(modifier = Modifier.fillMaxWidth()) {
+        tintPresets.forEach { (label, baseColor) ->
+            val currentRgb = tintColor and 0x00FFFFFFL
+            val presetRgb = baseColor and 0x00FFFFFFL
+            FilterChip(
+                selected = currentRgb == presetRgb,
+                onClick = {
+                    val newColor = (alpha.toLong() shl 24) or presetRgb
+                    onEvent(ReaderEvent.SetCustomTintColor(newColor))
+                },
+                label = { Text(label) },
+                modifier = Modifier.padding(end = 6.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SettingsSectionLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        modifier = Modifier.padding(bottom = 4.dp),
+    )
+}
+
+@Composable
+private fun SettingsDivider() {
+    Spacer(modifier = Modifier.height(8.dp))
+    HorizontalDivider()
+    Spacer(modifier = Modifier.height(8.dp))
+}
+
+@Composable
+private fun SettingsToggleRow(label: String, checked: Boolean, onToggle: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .clickable { onToggle() }
-            .padding(vertical = ToggleRowVerticalPadding),
+            .padding(vertical = 8.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -205,8 +424,6 @@ private fun ReaderToggleRow(
         Switch(checked = checked, onCheckedChange = null)
     }
 }
-
-private val ToggleRowVerticalPadding = 8.dp
 
 @Composable
 private fun ReaderMode.toLabel(): String = when (this) {

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDisplayDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDisplayDelegate.kt
@@ -204,7 +204,82 @@ class ReaderDisplayDelegate @Inject constructor(
                 update { it.copy(skipDuplicateChapters = new) }
                 launchSave { setSkipDuplicateChapters(new) }
             }
+            ReaderSetting.SHOW_READING_TIMER -> {
+                val new = !stateFlow.value.showReadingTimer
+                update { it.copy(showReadingTimer = new) }
+                launchSave { setShowReadingTimer(new) }
+            }
+            ReaderSetting.SHOW_BATTERY_TIME -> {
+                val new = !stateFlow.value.showBatteryTime
+                update { it.copy(showBatteryTime = new) }
+                launchSave { setShowBatteryTime(new) }
+            }
+            ReaderSetting.ANIMATE_PAGE_TRANSITIONS -> {
+                val new = !stateFlow.value.animatePageTransitions
+                update { it.copy(animatePageTransitions = new) }
+                launchSave { setAnimatePageTransitions(new) }
+            }
+            ReaderSetting.ALWAYS_SHOW_CHAPTER_TRANSITION -> {
+                val new = !stateFlow.value.alwaysShowChapterTransition
+                update { it.copy(alwaysShowChapterTransition = new) }
+                launchSave { setAlwaysShowChapterTransition(new) }
+            }
+            ReaderSetting.SHOW_ACTIONS_ON_LONG_TAP -> {
+                val new = !stateFlow.value.showActionsOnLongTap
+                update { it.copy(showActionsOnLongTap = new) }
+                launchSave { setShowActionsOnLongTap(new) }
+            }
+            ReaderSetting.EINK_FLASH_ON_PAGE_CHANGE -> {
+                val new = !stateFlow.value.einkFlashOnPageChange
+                update { it.copy(einkFlashOnPageChange = new) }
+                launchSave { setEinkFlashOnPageChange(new) }
+            }
+            ReaderSetting.EINK_BLACK_AND_WHITE -> {
+                val new = !stateFlow.value.einkBlackAndWhite
+                update { it.copy(einkBlackAndWhite = new) }
+                launchSave { setEinkBlackAndWhite(new) }
+            }
+            ReaderSetting.WEBTOON_DOUBLE_TAP_ZOOM -> {
+                val new = !stateFlow.value.webtoonDoubleTapZoom
+                update { it.copy(webtoonDoubleTapZoom = new) }
+                launchSave { setWebtoonDoubleTapZoom(new) }
+            }
+            ReaderSetting.WEBTOON_DISABLE_ZOOM_OUT -> {
+                val new = !stateFlow.value.webtoonDisableZoomOut
+                update { it.copy(webtoonDisableZoomOut = new) }
+                launchSave { setWebtoonDisableZoomOut(new) }
+            }
+            ReaderSetting.AUTO_ZOOM_WIDE_IMAGES -> {
+                val new = !stateFlow.value.autoZoomWideImages
+                update { it.copy(autoZoomWideImages = new) }
+                launchSave { setAutoZoomWideImages(new) }
+            }
+            ReaderSetting.SHOW_CONTENT_IN_CUTOUT -> {
+                val new = !stateFlow.value.showContentInCutout
+                update { it.copy(showContentInCutout = new) }
+                launchSave { setShowContentInCutout(new) }
+            }
+            ReaderSetting.FULLSCREEN -> {
+                val new = !stateFlow.value.isFullscreen
+                update { it.copy(isFullscreen = new) }
+                launchSave { setFullscreen(new) }
+            }
         }
+    }
+
+    fun updateBackgroundColor(color: Int) {
+        update { it.copy(backgroundColor = color) }
+        launchSave { setBackgroundColor(color) }
+    }
+
+    fun updateReaderScale(scale: Int) {
+        update { it.copy(readerScale = scale) }
+        launchSave { setReaderScale(scale) }
+    }
+
+    fun updateWebtoonSidePadding(padding: Int) {
+        update { it.copy(webtoonSidePadding = padding) }
+        launchSave { setWebtoonSidePadding(padding) }
     }
 
     fun updateTapZones(config: TapZoneConfig) {

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDisplayDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDisplayDelegate.kt
@@ -151,7 +151,7 @@ class ReaderDisplayDelegate @Inject constructor(
 
     // ── Settings toggles ───────────────────────────────────────────────────
 
-    @Suppress("CyclomaticComplexMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     fun toggleSetting(setting: ReaderSetting) {
         when (setting) {
             ReaderSetting.KEEP_SCREEN_ON -> {

--- a/feature/reader/src/main/res/values/strings.xml
+++ b/feature/reader/src/main/res/values/strings.xml
@@ -159,6 +159,43 @@
     <string name="reader_switch_to_slider">Switch to slider</string>
     <string name="reader_switch_to_filmstrip">Switch to filmstrip</string>
 
+    <!-- Reader settings dialog — tab labels -->
+    <string name="reader_settings_tab_reading_mode">Reading mode</string>
+    <string name="reader_settings_tab_general">General</string>
+    <string name="reader_settings_tab_color_filter">Color filter</string>
+
+    <!-- Reader settings dialog — scale type -->
+    <string name="reader_scale_title">Scale type</string>
+    <string name="reader_scale_fit_screen">Fit screen</string>
+    <string name="reader_scale_fit_width">Fit width</string>
+    <string name="reader_scale_fit_height">Fit height</string>
+    <string name="reader_scale_original">Original</string>
+    <string name="reader_scale_smart_fit">Smart fit</string>
+
+    <!-- Reader settings dialog — pager options -->
+    <string name="reader_auto_zoom_wide">Auto-zoom wide images</string>
+    <string name="reader_animate_transitions">Animate page transitions</string>
+
+    <!-- Reader settings dialog — webtoon options -->
+    <string name="reader_webtoon_side_padding">Side padding</string>
+    <string name="reader_webtoon_side_padding_none">None</string>
+    <string name="reader_webtoon_side_padding_small">Small</string>
+    <string name="reader_webtoon_side_padding_medium">Medium</string>
+    <string name="reader_webtoon_side_padding_large">Large</string>
+    <string name="reader_webtoon_double_tap_zoom">Double-tap to zoom</string>
+    <string name="reader_webtoon_disable_zoom_out">Disable zoom out</string>
+
+    <!-- Reader settings dialog — general tab -->
+    <string name="reader_bg_auto">Auto</string>
+    <string name="reader_show_reading_timer">Show reading timer</string>
+    <string name="reader_show_battery_time">Show clock and battery</string>
+    <string name="reader_show_content_in_cutout">Display in cutout area</string>
+    <string name="reader_show_page_number">Show page number</string>
+    <string name="reader_keep_screen_on">Keep screen on</string>
+    <string name="reader_long_tap_actions">Long tap actions</string>
+    <string name="reader_always_show_chapter_transition">Always show chapter transition</string>
+    <string name="reader_eink_flash">Flash on page change</string>
+
     <!-- Quick-settings overlay (#985) -->
     <string name="reader_quick_settings_title">Quick Settings</string>
     <string name="reader_crop_borders">Crop borders</string>


### PR DESCRIPTION
## **User description**
## Summary

- Converts the flat quick-settings `ModalBottomSheet` into a proper 3-tab reader settings dialog matching Komikku's `ReaderSettingsDialog` (Reading mode / General / Color filter tabs with `HorizontalPager`)
- Wires 14 previously-disconnected settings through the full domain → data → delegate → MVI chain by declaring missing setter methods in `ReaderSettingsRepository` interface and adding `override` to the data implementations
- Adds 12 new `ReaderSetting` enum entries and 3 new `SettingsControl` events (`SetBackgroundColor`, `SetReaderScale`, `SetWebtoonSidePadding`) so every setting in the dialog round-trips to persistent storage

## What changed

**Domain / Data layer**
- `ReaderSettingsRepository` interface: +14 suspend setter declarations (`setShowReadingTimer`, `setShowBatteryTime`, `setBackgroundColor`, `setAnimatePageTransitions`, `setAlwaysShowChapterTransition`, `setShowActionsOnLongTap`, `setEinkFlashOnPageChange`, `setEinkBlackAndWhite`, `setWebtoonDoubleTapZoom`, `setWebtoonDisableZoomOut`, `setAutoZoomWideImages`, `setReaderScale`, `setWebtoonSidePadding`, `setShowContentInCutout`)
- Data `ReaderSettingsRepository`: added `override` to all 14 corresponding implementations (previously missing, so changes were silently lost)

**MVI + ViewModel**
- `ReaderMvi.kt`: +12 `ReaderSetting` entries, +3 `SettingsControl` events
- `ReaderDisplayDelegate.kt`: +12 branches in `toggleSetting()`, +3 new numeric-setter helpers
- `ReaderViewModel.kt`: routes 3 new events in `handleSettings()`

**UI**
- `ReaderSettingsOverlay.kt`: complete rewrite — `TabRow` + `HorizontalPager` (3 pages)
  - **Reading mode tab**: mode chips → direction chips → orientation chips → conditional `PagerViewerSettings` (scale type, crop borders, auto-zoom, transitions) or `WebtoonViewerSettings` (side padding, crop borders, double-tap zoom, disable zoom out)
  - **General tab**: background color chips (Black/White/Gray/Auto), reading timer, clock+battery, page number, fullscreen, cutout, keep screen on, long tap, chapter transition, e-ink flash, incognito
  - **Color filter tab**: brightness slider, filter mode chips, custom tint section (opacity slider + color preset chips when CUSTOM_TINT selected)
- `ReaderScreen.kt`: call site simplified to `state + onEvent` (was 18 individual parameters)
- `strings.xml`: +29 new string resources for all new labels

## Test plan

- [ ] Build passes: `./gradlew :app:assembleDebug`
- [ ] Long-press center tap zone opens the 3-tab dialog
- [ ] Reading mode tab: changing mode/direction/orientation persists after close
- [ ] Scale type chips appear for Single/Dual/Smart modes; side-padding chips appear for Webtoon
- [ ] General tab: every toggle persists and survives app restart
- [ ] Color filter tab: brightness slider updates page brightness live; custom tint color presets and opacity slider update `customTintColor` in state
- [ ] Existing tests pass: `./gradlew :feature:reader:test`

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_


___

## **CodeAnt-AI Description**
**Replace the quick reader settings sheet with a 3-tab reader settings dialog**

### What Changed
- Reader settings now open in a tabbed sheet with separate Reading mode, General, and Color filter pages instead of a single flat panel
- The Reading mode tab now includes the reader mode, direction, orientation, scale type, webtoon padding, crop borders, auto-zoom, and page transition options
- The General tab now groups background color, reading timer, clock/battery display, page number, fullscreen, cutout display, keep screen on, long-tap actions, chapter transition, and e-ink flash settings
- Color filter settings now include brightness, filter mode, custom tint opacity, and tint presets
- Several reader settings now save and apply correctly after being changed in the dialog

### Impact
`✅ Faster access to reader settings`
`✅ Fewer lost reader preference changes`
`✅ Clearer reader customization flow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned reader settings panel with tabs for reading mode, general options, and color filters.
  * Added new reader controls for scaling, page transition animation, webtoon side padding, and cutout/notch display.
  * Added more display options, including auto background, reading timer, battery/time, long-tap actions, E Ink modes, and webtoon zoom behavior.

* **Bug Fixes**
  * Reader settings now apply more consistently across single-page, dual-page, and webtoon modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->