### PR TITLE
feat(library): Komikku parity — tristate filters, cover-only mode, direct long-press selection

### DIFF
--- a/feature/library/src/main/java/app/otakureader/feature/library/FilterSortParams.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/FilterSortParams.kt
@@ -19,6 +19,6 @@ internal data class FilterSortParams(
     val filterDownloaded: LibraryTriState = LibraryTriState.DISABLED,
     val filterUnread: LibraryTriState = LibraryTriState.DISABLED,
     val filterStarted: LibraryTriState = LibraryTriState.DISABLED,
-    val filterBookmarked: LibraryTriState = LibraryTriState.DISABLED,
+    val filterTracking: LibraryTriState = LibraryTriState.DISABLED,
     val filterCompleted: LibraryTriState = LibraryTriState.DISABLED,
 )

--- a/feature/library/src/main/java/app/otakureader/feature/library/FilterSortParams.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/FilterSortParams.kt
@@ -15,4 +15,10 @@ internal data class FilterSortParams(
     val readingListMangaIds: Set<Long> = emptySet(),
     val filterGenres: Set<String> = emptySet(),
     val sortAscending: Boolean = true,
+    // Independent tristate filters (Komikku parity)
+    val filterDownloaded: LibraryTriState = LibraryTriState.DISABLED,
+    val filterUnread: LibraryTriState = LibraryTriState.DISABLED,
+    val filterStarted: LibraryTriState = LibraryTriState.DISABLED,
+    val filterBookmarked: LibraryTriState = LibraryTriState.DISABLED,
+    val filterCompleted: LibraryTriState = LibraryTriState.DISABLED,
 )

--- a/feature/library/src/main/java/app/otakureader/feature/library/FilterSortParams.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/FilterSortParams.kt
@@ -21,4 +21,5 @@ internal data class FilterSortParams(
     val filterStarted: LibraryTriState = LibraryTriState.DISABLED,
     val filterTracking: LibraryTriState = LibraryTriState.DISABLED,
     val filterCompleted: LibraryTriState = LibraryTriState.DISABLED,
+    val randomSeed: Long = 0L,
 )

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
@@ -9,15 +9,19 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -169,12 +173,12 @@ private fun DisplayTab(
             horizontalArrangement = Arrangement.spacedBy(DISPLAY_MODE_CHIP_SPACING),
             verticalArrangement = Arrangement.spacedBy(DISPLAY_MODE_CHIP_SPACING),
         ) {
-            // Explicit display order (Grid → Comfortable → List), independent of the enum's
-            // declaration/ordinal order, which keeps COMFORTABLE_GRID appended for stable
-            // persisted ordinals.
+            // Explicit display order (Grid → Comfortable → Cover-only → List), independent of the
+            // enum's declaration/ordinal order, which keeps appended entries stable.
             listOf(
                 LibraryDisplayMode.GRID,
                 LibraryDisplayMode.COMFORTABLE_GRID,
+                LibraryDisplayMode.COVER_ONLY,
                 LibraryDisplayMode.LIST,
             ).forEach { mode ->
                 FilterChip(
@@ -264,7 +268,7 @@ private fun FilterTab(
     state: LibraryState,
     onEvent: (LibraryEvent) -> Unit,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         // Header row with clear all
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -281,23 +285,32 @@ private fun FilterTab(
             }
         }
 
-        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            LibraryFilterMode.entries.forEach { mode ->
-                if (mode != LibraryFilterMode.READING_LIST) {
-                    FilterChip(
-                        selected = state.filterMode == mode,
-                        onClick = {
-                            onEvent(
-                                LibraryEvent.SetFilterMode(
-                                    if (state.filterMode == mode) LibraryFilterMode.ALL else mode
-                                )
-                            )
-                        },
-                        label = { Text(mode.label()) },
-                    )
-                }
-            }
-        }
+        // Independent tristate filters — each cycles DISABLED → IS → NOT on click.
+        TriStateFilterRow(
+            label = stringResource(R.string.filter_downloaded),
+            state = state.filterDownloaded,
+            onClick = { onEvent(LibraryEvent.SetFilterDownloaded(state.filterDownloaded.next())) },
+        )
+        TriStateFilterRow(
+            label = stringResource(R.string.filter_unread),
+            state = state.filterUnread,
+            onClick = { onEvent(LibraryEvent.SetFilterUnread(state.filterUnread.next())) },
+        )
+        TriStateFilterRow(
+            label = stringResource(R.string.filter_started),
+            state = state.filterStarted,
+            onClick = { onEvent(LibraryEvent.SetFilterStarted(state.filterStarted.next())) },
+        )
+        TriStateFilterRow(
+            label = stringResource(R.string.filter_bookmarked),
+            state = state.filterBookmarked,
+            onClick = { onEvent(LibraryEvent.SetFilterBookmarked(state.filterBookmarked.next())) },
+        )
+        TriStateFilterRow(
+            label = stringResource(R.string.filter_completed),
+            state = state.filterCompleted,
+            onClick = { onEvent(LibraryEvent.SetFilterCompleted(state.filterCompleted.next())) },
+        )
 
         if (state.availableGenres.isNotEmpty()) {
             Spacer(modifier = Modifier.height(4.dp))
@@ -324,6 +337,53 @@ private fun FilterTab(
                         label = { Text(genre) },
                     )
                 }
+            }
+        }
+    }
+}
+
+/**
+ * A single row that shows a filter label and a cycling tristate icon button.
+ * Tapping it advances DISABLED → ENABLED_IS → ENABLED_NOT → DISABLED.
+ */
+@Composable
+private fun TriStateFilterRow(
+    label: String,
+    state: LibraryTriState,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        IconButton(onClick = onClick) {
+            when (state) {
+                LibraryTriState.DISABLED -> Icon(
+                    imageVector = Icons.Default.Remove,
+                    contentDescription = stringResource(R.string.tristate_disabled),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp),
+                )
+                LibraryTriState.ENABLED_IS -> Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = stringResource(R.string.tristate_include),
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp),
+                )
+                LibraryTriState.ENABLED_NOT -> Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = stringResource(R.string.tristate_exclude),
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(20.dp),
+                )
             }
         }
     }
@@ -378,6 +438,7 @@ private fun LibraryDisplayMode.label(): String = when (this) {
     LibraryDisplayMode.GRID -> stringResource(R.string.display_mode_grid)
     LibraryDisplayMode.COMFORTABLE_GRID -> stringResource(R.string.display_mode_comfortable)
     LibraryDisplayMode.LIST -> stringResource(R.string.display_mode_list)
+    LibraryDisplayMode.COVER_ONLY -> stringResource(R.string.display_mode_cover_only)
 }
 
 @Composable
@@ -389,6 +450,8 @@ private fun LibrarySortMode.label(): String = when (this) {
     LibrarySortMode.SOURCE -> stringResource(R.string.sort_source)
     LibrarySortMode.LAST_UPDATED -> stringResource(R.string.sort_last_updated)
     LibrarySortMode.TOTAL_CHAPTERS -> stringResource(R.string.sort_total_chapters)
+    LibrarySortMode.LATEST_CHAPTER -> stringResource(R.string.sort_latest_chapter)
+    LibrarySortMode.RANDOM -> stringResource(R.string.sort_random)
 }
 
 @Composable

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
@@ -13,15 +13,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -302,9 +304,9 @@ private fun FilterTab(
             onClick = { onEvent(LibraryEvent.SetFilterStarted(state.filterStarted.next())) },
         )
         TriStateFilterRow(
-            label = stringResource(R.string.filter_bookmarked),
-            state = state.filterBookmarked,
-            onClick = { onEvent(LibraryEvent.SetFilterBookmarked(state.filterBookmarked.next())) },
+            label = stringResource(R.string.filter_tracking),
+            state = state.filterTracking,
+            onClick = { onEvent(LibraryEvent.SetFilterTracking(state.filterTracking.next())) },
         )
         TriStateFilterRow(
             label = stringResource(R.string.filter_completed),
@@ -356,6 +358,7 @@ private fun TriStateFilterRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
+            .clickable(onClick = onClick)
             .padding(vertical = 2.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
@@ -364,7 +367,12 @@ private fun TriStateFilterRow(
             text = label,
             style = MaterialTheme.typography.bodyMedium,
         )
-        IconButton(onClick = onClick) {
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .padding(12.dp),
+            contentAlignment = Alignment.Center,
+        ) {
             when (state) {
                 LibraryTriState.DISABLED -> Icon(
                     imageVector = Icons.Default.Remove,
@@ -379,7 +387,7 @@ private fun TriStateFilterRow(
                     modifier = Modifier.size(20.dp),
                 )
                 LibraryTriState.ENABLED_NOT -> Icon(
-                    imageVector = Icons.Default.Check,
+                    imageVector = Icons.Default.Close,
                     contentDescription = stringResource(R.string.tristate_exclude),
                     tint = MaterialTheme.colorScheme.error,
                     modifier = Modifier.size(20.dp),

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
@@ -12,7 +12,10 @@ internal fun applyFiltersAndSort(items: List<LibraryMangaItem>, params: FilterSo
         .let { applySourceFilter(it, params) }
         .let { applyReadingListFilter(it, params) }
         .let { applyGenreFilter(it, params.filterGenres) }
+        // Legacy single-select filter: drives the quick-access chips in the search bar.
         .let { applyFilterMode(it, params.filterMode) }
+        // Independent tristate filters: drives the per-attribute toggles in the filter sheet.
+        .let { applyTriStateFilters(it, params) }
     return applySort(filtered, params.sortMode, params.sortAscending)
 }
 
@@ -49,6 +52,27 @@ internal fun applyFilterMode(items: List<LibraryMangaItem>, filterMode: LibraryF
         LibraryFilterMode.READING_LIST, LibraryFilterMode.ALL -> items
     }
 
+/** Applies independent tristate filters (Komikku parity). Each filter is additive. */
+internal fun applyTriStateFilters(items: List<LibraryMangaItem>, params: FilterSortParams): List<LibraryMangaItem> {
+    var result = items
+    result = applyTriState(result, params.filterDownloaded) { it.isDownloaded }
+    result = applyTriState(result, params.filterUnread) { it.unreadCount > 0 }
+    result = applyTriState(result, params.filterStarted) { it.lastRead != null }
+    result = applyTriState(result, params.filterBookmarked) { it.hasTracking }
+    result = applyTriState(result, params.filterCompleted) { it.userCompleted }
+    return result
+}
+
+private fun applyTriState(
+    items: List<LibraryMangaItem>,
+    state: LibraryTriState,
+    predicate: (LibraryMangaItem) -> Boolean,
+): List<LibraryMangaItem> = when (state) {
+    LibraryTriState.DISABLED -> items
+    LibraryTriState.ENABLED_IS -> items.filter(predicate)
+    LibraryTriState.ENABLED_NOT -> items.filterNot(predicate)
+}
+
 internal fun applySort(items: List<LibraryMangaItem>, sortMode: LibrarySortMode, ascending: Boolean): List<LibraryMangaItem> {
     val sorted = when (sortMode) {
         LibrarySortMode.ALPHABETICAL -> items.sortedBy { it.title }
@@ -58,6 +82,8 @@ internal fun applySort(items: List<LibraryMangaItem>, sortMode: LibrarySortMode,
         LibrarySortMode.SOURCE -> items.sortedBy { it.sourceId }
         LibrarySortMode.LAST_UPDATED -> items.sortedByDescending { it.lastUpdate }
         LibrarySortMode.TOTAL_CHAPTERS -> items.sortedByDescending { it.totalChapterCount }
+        LibrarySortMode.LATEST_CHAPTER -> items.sortedByDescending { it.lastUpdate }
+        LibrarySortMode.RANDOM -> items.shuffled()
     }
     return if (ascending) sorted else sorted.reversed()
 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
@@ -2,6 +2,7 @@ package app.otakureader.feature.library
 
 import app.otakureader.domain.model.ContentRating
 import app.otakureader.domain.model.Manga
+import kotlin.random.Random
 
 internal fun applyFiltersAndSort(items: List<LibraryMangaItem>, params: FilterSortParams): List<LibraryMangaItem> {
     val filtered = items
@@ -16,7 +17,7 @@ internal fun applyFiltersAndSort(items: List<LibraryMangaItem>, params: FilterSo
         .let { applyFilterMode(it, params.filterMode) }
         // Independent tristate filters: drives the per-attribute toggles in the filter sheet.
         .let { applyTriStateFilters(it, params) }
-    return applySort(filtered, params.sortMode, params.sortAscending)
+    return applySort(filtered, params)
 }
 
 internal fun applyCategoryFilter(items: List<LibraryMangaItem>, params: FilterSortParams): List<LibraryMangaItem> =
@@ -52,29 +53,31 @@ internal fun applyFilterMode(items: List<LibraryMangaItem>, filterMode: LibraryF
         LibraryFilterMode.READING_LIST, LibraryFilterMode.ALL -> items
     }
 
-/** Applies independent tristate filters (Komikku parity). Each filter is additive. */
+/** Applies independent tristate filters (Komikku parity) in a single pass. */
 internal fun applyTriStateFilters(items: List<LibraryMangaItem>, params: FilterSortParams): List<LibraryMangaItem> {
-    var result = items
-    result = applyTriState(result, params.filterDownloaded) { it.isDownloaded }
-    result = applyTriState(result, params.filterUnread) { it.unreadCount > 0 }
-    result = applyTriState(result, params.filterStarted) { it.lastRead != null }
-    result = applyTriState(result, params.filterTracking) { it.hasTracking }
-    result = applyTriState(result, params.filterCompleted) { it.userCompleted }
-    return result
+    val anyActive = params.filterDownloaded != LibraryTriState.DISABLED ||
+        params.filterUnread != LibraryTriState.DISABLED ||
+        params.filterStarted != LibraryTriState.DISABLED ||
+        params.filterTracking != LibraryTriState.DISABLED ||
+        params.filterCompleted != LibraryTriState.DISABLED
+    if (!anyActive) return items
+    return items.filter { item ->
+        triStateMatches(params.filterDownloaded, item.isDownloaded) &&
+            triStateMatches(params.filterUnread, item.unreadCount > 0) &&
+            triStateMatches(params.filterStarted, item.lastRead != null) &&
+            triStateMatches(params.filterTracking, item.hasTracking) &&
+            triStateMatches(params.filterCompleted, item.userCompleted)
+    }
 }
 
-private fun applyTriState(
-    items: List<LibraryMangaItem>,
-    state: LibraryTriState,
-    predicate: (LibraryMangaItem) -> Boolean,
-): List<LibraryMangaItem> = when (state) {
-    LibraryTriState.DISABLED -> items
-    LibraryTriState.ENABLED_IS -> items.filter(predicate)
-    LibraryTriState.ENABLED_NOT -> items.filterNot(predicate)
+private fun triStateMatches(state: LibraryTriState, value: Boolean): Boolean = when (state) {
+    LibraryTriState.DISABLED -> true
+    LibraryTriState.ENABLED_IS -> value
+    LibraryTriState.ENABLED_NOT -> !value
 }
 
-internal fun applySort(items: List<LibraryMangaItem>, sortMode: LibrarySortMode, ascending: Boolean): List<LibraryMangaItem> {
-    val sorted = when (sortMode) {
+internal fun applySort(items: List<LibraryMangaItem>, params: FilterSortParams): List<LibraryMangaItem> {
+    val sorted = when (params.sortMode) {
         LibrarySortMode.ALPHABETICAL -> items.sortedBy { it.title }
         LibrarySortMode.LAST_READ -> items.sortedByDescending { it.lastRead ?: 0L }
         LibrarySortMode.DATE_ADDED -> items.sortedByDescending { it.dateAdded }
@@ -85,9 +88,10 @@ internal fun applySort(items: List<LibraryMangaItem>, sortMode: LibrarySortMode,
         // Both LATEST_CHAPTER and LAST_UPDATED use the same lastUpdate field; a dedicated
         // latestChapterUpload field would be needed to distinguish them in the data model.
         LibrarySortMode.LATEST_CHAPTER -> items.sortedByDescending { it.lastUpdate }
-        LibrarySortMode.RANDOM -> items.shuffled()
+        // Seeded with the ViewModel's session seed so items don't re-shuffle on every emission.
+        LibrarySortMode.RANDOM -> items.shuffled(Random(params.randomSeed))
     }
-    return if (ascending) sorted else sorted.reversed()
+    return if (params.sortAscending) sorted else sorted.reversed()
 }
 
 internal fun Manga.toLibraryItem(

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
@@ -58,7 +58,7 @@ internal fun applyTriStateFilters(items: List<LibraryMangaItem>, params: FilterS
     result = applyTriState(result, params.filterDownloaded) { it.isDownloaded }
     result = applyTriState(result, params.filterUnread) { it.unreadCount > 0 }
     result = applyTriState(result, params.filterStarted) { it.lastRead != null }
-    result = applyTriState(result, params.filterBookmarked) { it.hasTracking }
+    result = applyTriState(result, params.filterTracking) { it.hasTracking }
     result = applyTriState(result, params.filterCompleted) { it.userCompleted }
     return result
 }
@@ -82,6 +82,8 @@ internal fun applySort(items: List<LibraryMangaItem>, sortMode: LibrarySortMode,
         LibrarySortMode.SOURCE -> items.sortedBy { it.sourceId }
         LibrarySortMode.LAST_UPDATED -> items.sortedByDescending { it.lastUpdate }
         LibrarySortMode.TOTAL_CHAPTERS -> items.sortedByDescending { it.totalChapterCount }
+        // Both LATEST_CHAPTER and LAST_UPDATED use the same lastUpdate field; a dedicated
+        // latestChapterUpload field would be needed to distinguish them in the data model.
         LibrarySortMode.LATEST_CHAPTER -> items.sortedByDescending { it.lastUpdate }
         LibrarySortMode.RANDOM -> items.shuffled()
     }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -295,7 +295,6 @@ internal fun MangaGrid(
                 displayedManga = displayedManga,
                 onMangaTap = onMangaTap,
                 onMangaLongClick = onMangaLongClick,
-                onEvent = onEvent,
             )
         }
     }
@@ -308,7 +307,6 @@ private fun LibraryMangaPageContent(
     displayedManga: List<LibraryMangaItem>,
     onMangaTap: (LibraryMangaItem) -> Unit,
     onMangaLongClick: (Long) -> Unit,
-    onEvent: (LibraryEvent) -> Unit,
 ) {
     if (state.displayMode == LibraryDisplayMode.LIST) {
         LazyColumn(

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -120,12 +120,12 @@ internal fun MangaGrid(
         stringResource(R.string.library_content_tab_manhwa),
     )
 
-    // Long-press opens the quick context menu. Fire haptic so the gesture is felt (#L7).
+    // Long-press enters selection mode directly (Komikku parity) — no context-menu indirection.
     val haptic = LocalHapticFeedback.current
     val onMangaLongClick: (Long) -> Unit = remember(haptic, onEvent) {
         { mangaId ->
             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-            onEvent(LibraryEvent.ShowContextMenu(mangaId))
+            onEvent(LibraryEvent.OnMangaLongClick(mangaId))
         }
     }
     // Taps open the detail pane only in two-pane mode with no active selection; otherwise route
@@ -348,7 +348,8 @@ private fun LibraryMangaPageContent(
                 }
             }
         }
-    } else if (state.isStaggeredGrid && state.displayMode != LibraryDisplayMode.COMFORTABLE_GRID) {
+    } else if (state.isStaggeredGrid && state.displayMode != LibraryDisplayMode.COMFORTABLE_GRID &&
+        state.displayMode != LibraryDisplayMode.COVER_ONLY) {
         LazyVerticalStaggeredGrid(
             columns = StaggeredGridCells.Adaptive(130.dp),
             contentPadding = PaddingValues(8.dp),
@@ -458,9 +459,9 @@ private fun LibraryMangaPageContent(
                 } else null
                 val downloadCount = state.downloadCountByManga[manga.id] ?: 0
                 val continueReading = manga.lastRead != null && manga.unreadCount > 0
-                // Comfortable grid (#Komikku parity): cover with the title shown as a caption
-                // below it rather than overlaid on the cover.
+                // Comfortable grid: cover with title caption below; Cover-only: no title at all.
                 val comfortable = state.displayMode == LibraryDisplayMode.COMFORTABLE_GRID
+                val coverOnly = state.displayMode == LibraryDisplayMode.COVER_ONLY
                 val card: @Composable () -> Unit = {
                     MangaCard(
                         title = manga.title,
@@ -471,7 +472,7 @@ private fun LibraryMangaPageContent(
                         readProgress = readProgress,
                         continueReading = continueReading,
                         isNew = manga.unreadCount > 0,
-                        showTitle = if (comfortable) false else state.showTitle,
+                        showTitle = if (comfortable || coverOnly) false else state.showTitle,
                         badge = when {
                             state.showBadges && manga.unreadCount > 0 &&
                                 state.showDownloadBadge && downloadCount > 0 -> {
@@ -526,6 +527,7 @@ private fun LibraryMangaPageContent(
                             )
                         }
                     } else {
+                        // Cover-only and default grid modes — just the card, no extra caption.
                         card()
                     }
                 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -66,16 +66,6 @@ import app.otakureader.core.ui.theme.LocalOtakuColors
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.OpenInNew
-import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Share
-import androidx.compose.material.icons.filled.SwapHoriz
-import androidx.compose.material.icons.filled.TouchApp
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.Icon
 import androidx.compose.material3.TextButton
 import coil3.compose.AsyncImage
 import java.util.Calendar
@@ -331,21 +321,14 @@ private fun LibraryMangaPageContent(
                 contentType = { "manga_row" },
             ) { manga ->
                 val downloadCount = state.downloadCountByManga[manga.id] ?: 0
-                Box {
-                    LibraryListRow(
-                        manga = manga,
-                        isSelected = manga.id in state.selectedManga,
-                        unreadCount = if (state.showBadges) manga.unreadCount else 0,
-                        downloadCount = if (state.showDownloadBadge) downloadCount else 0,
-                        onClick = { onMangaTap(manga) },
-                        onLongClick = { onMangaLongClick(manga.id) },
-                    )
-                    MangaContextMenu(
-                        expanded = state.contextMenuMangaId == manga.id,
-                        mangaId = manga.id,
-                        onEvent = onEvent,
-                    )
-                }
+                LibraryListRow(
+                    manga = manga,
+                    isSelected = manga.id in state.selectedManga,
+                    unreadCount = if (state.showBadges) manga.unreadCount else 0,
+                    downloadCount = if (state.showDownloadBadge) downloadCount else 0,
+                    onClick = { onMangaTap(manga) },
+                    onLongClick = { onMangaLongClick(manga.id) },
+                )
             }
         }
     } else if (state.isStaggeredGrid && state.displayMode != LibraryDisplayMode.COMFORTABLE_GRID &&
@@ -431,11 +414,6 @@ private fun LibraryMangaPageContent(
                     } else {
                         cardContent()
                     }
-                    MangaContextMenu(
-                        expanded = state.contextMenuMangaId == manga.id,
-                        mangaId = manga.id,
-                        onEvent = onEvent,
-                    )
                 }
             }
         }
@@ -545,11 +523,6 @@ private fun LibraryMangaPageContent(
                     } else {
                         cardContent()
                     }
-                    MangaContextMenu(
-                        expanded = state.contextMenuMangaId == manga.id,
-                        mangaId = manga.id,
-                        onEvent = onEvent,
-                    )
                 }
             }
         }
@@ -612,54 +585,6 @@ private fun LibraryListRow(
         if (unreadCount > 0) {
             UnreadBadge(count = unreadCount)
         }
-    }
-}
-
-@Composable
-private fun MangaContextMenu(
-    expanded: Boolean,
-    mangaId: Long,
-    onEvent: (LibraryEvent) -> Unit,
-) {
-    DropdownMenu(
-        expanded = expanded,
-        onDismissRequest = { onEvent(LibraryEvent.DismissContextMenu) },
-    ) {
-        DropdownMenuItem(
-            text = { Text(stringResource(R.string.library_context_menu_open)) },
-            leadingIcon = {
-                Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null)
-            },
-            onClick = {
-                onEvent(LibraryEvent.DismissContextMenu)
-                onEvent(LibraryEvent.OnMangaClick(mangaId))
-            },
-        )
-        DropdownMenuItem(
-            text = { Text(stringResource(R.string.library_context_menu_resume)) },
-            leadingIcon = { Icon(Icons.Default.PlayArrow, contentDescription = null) },
-            onClick = { onEvent(LibraryEvent.ResumeFromContextMenu(mangaId)) },
-        )
-        DropdownMenuItem(
-            text = { Text(stringResource(R.string.library_context_menu_mark_read)) },
-            leadingIcon = { Icon(Icons.Default.CheckCircle, contentDescription = null) },
-            onClick = { onEvent(LibraryEvent.MarkMangaAsReadFromMenu(mangaId)) },
-        )
-        DropdownMenuItem(
-            text = { Text(stringResource(R.string.library_context_menu_share)) },
-            leadingIcon = { Icon(Icons.Default.Share, contentDescription = null) },
-            onClick = { onEvent(LibraryEvent.ShareMangaFromMenu(mangaId)) },
-        )
-        DropdownMenuItem(
-            text = { Text(stringResource(R.string.library_context_menu_migrate)) },
-            leadingIcon = { Icon(Icons.Default.SwapHoriz, contentDescription = null) },
-            onClick = { onEvent(LibraryEvent.MigrateMangaFromMenu(mangaId)) },
-        )
-        DropdownMenuItem(
-            text = { Text(stringResource(R.string.library_context_menu_select)) },
-            leadingIcon = { Icon(Icons.Default.TouchApp, contentDescription = null) },
-            onClick = { onEvent(LibraryEvent.SelectMangaFromMenu(mangaId)) },
-        )
     }
 }
 

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -12,7 +12,10 @@ enum class LibrarySortMode {
     UNREAD_COUNT,
     SOURCE,
     LAST_UPDATED,
-    TOTAL_CHAPTERS
+    TOTAL_CHAPTERS,
+    // Appended for stable persisted ordinals — never reorder above entries.
+    LATEST_CHAPTER,
+    RANDOM,
 }
 
 enum class LibraryFilterMode {
@@ -23,6 +26,27 @@ enum class LibraryFilterMode {
     DROPPED,
     TRACKING,
     READING_LIST
+}
+
+/**
+ * Three-state filter for independent per-attribute library filtering.
+ *
+ * - [DISABLED]: filter is off (include all items).
+ * - [ENABLED_IS]: include only items that match.
+ * - [ENABLED_NOT]: exclude items that match.
+ *
+ * Cycles DISABLED → ENABLED_IS → ENABLED_NOT → DISABLED on each tap.
+ */
+enum class LibraryTriState {
+    DISABLED,
+    ENABLED_IS,
+    ENABLED_NOT;
+
+    fun next(): LibraryTriState = when (this) {
+        DISABLED -> ENABLED_IS
+        ENABLED_IS -> ENABLED_NOT
+        ENABLED_NOT -> DISABLED
+    }
 }
 
 enum class LibraryBottomSheetTab {
@@ -48,6 +72,8 @@ enum class LibraryDisplayMode {
     GRID,
     LIST,
     COMFORTABLE_GRID,
+    // Appended for stable persisted ordinals — never reorder above entries.
+    COVER_ONLY,
 }
 
 data class LibraryState(
@@ -74,6 +100,12 @@ data class LibraryState(
     val filterHasNotes: Boolean = false,
     val sortMode: LibrarySortMode = LibrarySortMode.ALPHABETICAL,
     val filterMode: LibraryFilterMode = LibraryFilterMode.ALL,
+    // Independent tristate filters (Komikku parity) — each can be DISABLED/ENABLED_IS/ENABLED_NOT
+    val filterDownloaded: LibraryTriState = LibraryTriState.DISABLED,
+    val filterUnread: LibraryTriState = LibraryTriState.DISABLED,
+    val filterStarted: LibraryTriState = LibraryTriState.DISABLED,
+    val filterBookmarked: LibraryTriState = LibraryTriState.DISABLED,
+    val filterCompleted: LibraryTriState = LibraryTriState.DISABLED,
     val filterSourceId: Long? = null,
     val showNsfw: Boolean = false,
     val newUpdatesCount: Int = 0,
@@ -182,6 +214,12 @@ sealed class LibraryEvent {
     data class SetGenreFilter(val genres: Set<String>) : LibraryEvent()
     data class SetSortAscending(val ascending: Boolean) : LibraryEvent()
     data object ClearAllFilters : LibraryEvent()
+    // Independent tristate filter events (Komikku parity)
+    data class SetFilterDownloaded(val state: LibraryTriState) : LibraryEvent()
+    data class SetFilterUnread(val state: LibraryTriState) : LibraryEvent()
+    data class SetFilterStarted(val state: LibraryTriState) : LibraryEvent()
+    data class SetFilterBookmarked(val state: LibraryTriState) : LibraryEvent()
+    data class SetFilterCompleted(val state: LibraryTriState) : LibraryEvent()
     data object ToggleBottomSheet : LibraryEvent()
     data class SetBottomSheetTab(val tab: LibraryBottomSheetTab) : LibraryEvent()
     data class SetGroupByCategory(val enabled: Boolean) : LibraryEvent()

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -135,8 +135,6 @@ data class LibraryState(
     val savedViews: List<SavedLibraryView> = emptyList(),
     val showSaveViewDialog: Boolean = false,
     val saveViewName: String = "",
-    // L2/L3: long-press context menu — holds the id of the manga whose popup is open
-    val contextMenuMangaId: Long? = null,
     val displayName: String = "",
     // Move to category bulk action (GAP 2)
     val showMoveToCategoryDialog: Boolean = false,
@@ -245,13 +243,7 @@ sealed class LibraryEvent {
     data class DeleteSavedView(val id: String) : LibraryEvent()
     // EH favorites sync (#1024)
     data object SyncEhFavorites : LibraryEvent()
-    // L2/L3: long-press context menu
-    data class ShowContextMenu(val mangaId: Long) : LibraryEvent()
-    data object DismissContextMenu : LibraryEvent()
-    data class ResumeFromContextMenu(val mangaId: Long) : LibraryEvent()
-    data class MarkMangaAsReadFromMenu(val mangaId: Long) : LibraryEvent()
-    data class ShareMangaFromMenu(val mangaId: Long) : LibraryEvent()
-    data class MigrateMangaFromMenu(val mangaId: Long) : LibraryEvent()
+    // Selection via context menu (used by tests and selection-mode entry)
     data class SelectMangaFromMenu(val mangaId: Long) : LibraryEvent()
     data class UndoLibraryDelete(val mangaIds: Set<Long>) : LibraryEvent()
     // Move to category bulk action (GAP 2)

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -104,7 +104,7 @@ data class LibraryState(
     val filterDownloaded: LibraryTriState = LibraryTriState.DISABLED,
     val filterUnread: LibraryTriState = LibraryTriState.DISABLED,
     val filterStarted: LibraryTriState = LibraryTriState.DISABLED,
-    val filterBookmarked: LibraryTriState = LibraryTriState.DISABLED,
+    val filterTracking: LibraryTriState = LibraryTriState.DISABLED,
     val filterCompleted: LibraryTriState = LibraryTriState.DISABLED,
     val filterSourceId: Long? = null,
     val showNsfw: Boolean = false,
@@ -218,7 +218,7 @@ sealed class LibraryEvent {
     data class SetFilterDownloaded(val state: LibraryTriState) : LibraryEvent()
     data class SetFilterUnread(val state: LibraryTriState) : LibraryEvent()
     data class SetFilterStarted(val state: LibraryTriState) : LibraryEvent()
-    data class SetFilterBookmarked(val state: LibraryTriState) : LibraryEvent()
+    data class SetFilterTracking(val state: LibraryTriState) : LibraryEvent()
     data class SetFilterCompleted(val state: LibraryTriState) : LibraryEvent()
     data object ToggleBottomSheet : LibraryEvent()
     data class SetBottomSheetTab(val tab: LibraryBottomSheetTab) : LibraryEvent()

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -386,6 +386,9 @@ fun LibraryScreen(
                         }
                         val hasActiveFilter = state.filterGenres.isNotEmpty() ||
                             state.filterMode != LibraryFilterMode.ALL ||
+                            state.filterHasNotes ||
+                            state.filterSourceId != null ||
+                            state.filterReadingListId != null ||
                             state.filterDownloaded != LibraryTriState.DISABLED ||
                             state.filterUnread != LibraryTriState.DISABLED ||
                             state.filterStarted != LibraryTriState.DISABLED ||
@@ -605,6 +608,9 @@ private fun LibraryContent(
         val hasActiveFilters = state.filterMode != LibraryFilterMode.ALL ||
             state.filterGenres.isNotEmpty() ||
             state.sortMode != LibrarySortMode.ALPHABETICAL ||
+            state.filterHasNotes ||
+            state.filterSourceId != null ||
+            state.filterReadingListId != null ||
             state.filterDownloaded != LibraryTriState.DISABLED ||
             state.filterUnread != LibraryTriState.DISABLED ||
             state.filterStarted != LibraryTriState.DISABLED ||
@@ -648,11 +654,41 @@ private fun LibraryContent(
                         trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
                     )
                 }
+                if (state.filterHasNotes) {
+                    FilterChip(
+                        selected = true,
+                        onClick = { onEvent(LibraryEvent.FilterHasNotes(false)) },
+                        label = { Text(stringResource(R.string.library_filter_has_notes)) },
+                        trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
+                    )
+                }
+                if (state.filterSourceId != null) {
+                    FilterChip(
+                        selected = true,
+                        onClick = { onEvent(LibraryEvent.SetFilterSource(null)) },
+                        label = { Text(stringResource(R.string.filter_source)) },
+                        trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
+                    )
+                }
+                if (state.filterReadingListId != null) {
+                    FilterChip(
+                        selected = true,
+                        onClick = { onEvent(LibraryEvent.SetFilterReadingList(null)) },
+                        label = { Text(stringResource(R.string.filter_reading_list)) },
+                        trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
+                    )
+                }
                 if (state.filterDownloaded != LibraryTriState.DISABLED) {
                     FilterChip(
                         selected = true,
                         onClick = { onEvent(LibraryEvent.SetFilterDownloaded(LibraryTriState.DISABLED)) },
-                        label = { Text(stringResource(R.string.filter_downloaded)) },
+                        label = {
+                            Text(
+                                if (state.filterDownloaded == LibraryTriState.ENABLED_NOT)
+                                    stringResource(R.string.filter_not_downloaded)
+                                else stringResource(R.string.filter_downloaded)
+                            )
+                        },
                         trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
                     )
                 }
@@ -660,7 +696,13 @@ private fun LibraryContent(
                     FilterChip(
                         selected = true,
                         onClick = { onEvent(LibraryEvent.SetFilterUnread(LibraryTriState.DISABLED)) },
-                        label = { Text(stringResource(R.string.filter_unread)) },
+                        label = {
+                            Text(
+                                if (state.filterUnread == LibraryTriState.ENABLED_NOT)
+                                    stringResource(R.string.filter_not_unread)
+                                else stringResource(R.string.filter_unread)
+                            )
+                        },
                         trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
                     )
                 }
@@ -668,7 +710,13 @@ private fun LibraryContent(
                     FilterChip(
                         selected = true,
                         onClick = { onEvent(LibraryEvent.SetFilterStarted(LibraryTriState.DISABLED)) },
-                        label = { Text(stringResource(R.string.filter_started)) },
+                        label = {
+                            Text(
+                                if (state.filterStarted == LibraryTriState.ENABLED_NOT)
+                                    stringResource(R.string.filter_not_started)
+                                else stringResource(R.string.filter_started)
+                            )
+                        },
                         trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
                     )
                 }
@@ -676,7 +724,13 @@ private fun LibraryContent(
                     FilterChip(
                         selected = true,
                         onClick = { onEvent(LibraryEvent.SetFilterTracking(LibraryTriState.DISABLED)) },
-                        label = { Text(stringResource(R.string.filter_tracking)) },
+                        label = {
+                            Text(
+                                if (state.filterTracking == LibraryTriState.ENABLED_NOT)
+                                    stringResource(R.string.filter_not_tracking)
+                                else stringResource(R.string.filter_tracking)
+                            )
+                        },
                         trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
                     )
                 }
@@ -684,7 +738,13 @@ private fun LibraryContent(
                     FilterChip(
                         selected = true,
                         onClick = { onEvent(LibraryEvent.SetFilterCompleted(LibraryTriState.DISABLED)) },
-                        label = { Text(stringResource(R.string.filter_completed)) },
+                        label = {
+                            Text(
+                                if (state.filterCompleted == LibraryTriState.ENABLED_NOT)
+                                    stringResource(R.string.filter_not_completed)
+                                else stringResource(R.string.filter_completed)
+                            )
+                        },
                         trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
                     )
                 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -384,20 +384,19 @@ fun LibraryScreen(
                         IconButton(onClick = { viewModel.onEvent(LibraryEvent.ToggleSearchBar) }) {
                             Icon(Icons.Default.Search, contentDescription = stringResource(R.string.library_search))
                         }
+                        val hasActiveFilter = state.filterGenres.isNotEmpty() ||
+                            state.filterMode != LibraryFilterMode.ALL ||
+                            state.filterDownloaded != LibraryTriState.DISABLED ||
+                            state.filterUnread != LibraryTriState.DISABLED ||
+                            state.filterStarted != LibraryTriState.DISABLED ||
+                            state.filterTracking != LibraryTriState.DISABLED ||
+                            state.filterCompleted != LibraryTriState.DISABLED
                         IconButton(onClick = { viewModel.onEvent(LibraryEvent.ToggleBottomSheet) }) {
                             Icon(
                                 Icons.Default.FilterList,
                                 contentDescription = stringResource(R.string.filter_sheet_title),
-                                tint = if (state.filterGenres.isNotEmpty() ||
-                                    state.filterMode != LibraryFilterMode.ALL ||
-                                    state.filterDownloaded != LibraryTriState.DISABLED ||
-                                    state.filterUnread != LibraryTriState.DISABLED ||
-                                    state.filterStarted != LibraryTriState.DISABLED ||
-                                    state.filterBookmarked != LibraryTriState.DISABLED ||
-                                    state.filterCompleted != LibraryTriState.DISABLED)
-                                    MaterialTheme.colorScheme.primary
-                                else
-                                    MaterialTheme.colorScheme.onSurface,
+                                tint = if (hasActiveFilter) MaterialTheme.colorScheme.primary
+                                else MaterialTheme.colorScheme.onSurface,
                             )
                         }
                         IconButton(onClick = { showMenu = true }) {
@@ -609,7 +608,7 @@ private fun LibraryContent(
             state.filterDownloaded != LibraryTriState.DISABLED ||
             state.filterUnread != LibraryTriState.DISABLED ||
             state.filterStarted != LibraryTriState.DISABLED ||
-            state.filterBookmarked != LibraryTriState.DISABLED ||
+            state.filterTracking != LibraryTriState.DISABLED ||
             state.filterCompleted != LibraryTriState.DISABLED
         if (hasActiveFilters && !state.showSearchBar) {
             FlowRow(
@@ -646,6 +645,46 @@ private fun LibraryContent(
                                 )
                             )
                         },
+                        trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
+                    )
+                }
+                if (state.filterDownloaded != LibraryTriState.DISABLED) {
+                    FilterChip(
+                        selected = true,
+                        onClick = { onEvent(LibraryEvent.SetFilterDownloaded(LibraryTriState.DISABLED)) },
+                        label = { Text(stringResource(R.string.filter_downloaded)) },
+                        trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
+                    )
+                }
+                if (state.filterUnread != LibraryTriState.DISABLED) {
+                    FilterChip(
+                        selected = true,
+                        onClick = { onEvent(LibraryEvent.SetFilterUnread(LibraryTriState.DISABLED)) },
+                        label = { Text(stringResource(R.string.filter_unread)) },
+                        trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
+                    )
+                }
+                if (state.filterStarted != LibraryTriState.DISABLED) {
+                    FilterChip(
+                        selected = true,
+                        onClick = { onEvent(LibraryEvent.SetFilterStarted(LibraryTriState.DISABLED)) },
+                        label = { Text(stringResource(R.string.filter_started)) },
+                        trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
+                    )
+                }
+                if (state.filterTracking != LibraryTriState.DISABLED) {
+                    FilterChip(
+                        selected = true,
+                        onClick = { onEvent(LibraryEvent.SetFilterTracking(LibraryTriState.DISABLED)) },
+                        label = { Text(stringResource(R.string.filter_tracking)) },
+                        trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
+                    )
+                }
+                if (state.filterCompleted != LibraryTriState.DISABLED) {
+                    FilterChip(
+                        selected = true,
+                        onClick = { onEvent(LibraryEvent.SetFilterCompleted(LibraryTriState.DISABLED)) },
+                        label = { Text(stringResource(R.string.filter_completed)) },
                         trailingIcon = { Icon(Icons.Default.Close, contentDescription = null) },
                     )
                 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -388,7 +388,13 @@ fun LibraryScreen(
                             Icon(
                                 Icons.Default.FilterList,
                                 contentDescription = stringResource(R.string.filter_sheet_title),
-                                tint = if (state.filterGenres.isNotEmpty() || state.filterMode != LibraryFilterMode.ALL)
+                                tint = if (state.filterGenres.isNotEmpty() ||
+                                    state.filterMode != LibraryFilterMode.ALL ||
+                                    state.filterDownloaded != LibraryTriState.DISABLED ||
+                                    state.filterUnread != LibraryTriState.DISABLED ||
+                                    state.filterStarted != LibraryTriState.DISABLED ||
+                                    state.filterBookmarked != LibraryTriState.DISABLED ||
+                                    state.filterCompleted != LibraryTriState.DISABLED)
                                     MaterialTheme.colorScheme.primary
                                 else
                                     MaterialTheme.colorScheme.onSurface,
@@ -599,7 +605,12 @@ private fun LibraryContent(
 
         val hasActiveFilters = state.filterMode != LibraryFilterMode.ALL ||
             state.filterGenres.isNotEmpty() ||
-            state.sortMode != LibrarySortMode.ALPHABETICAL
+            state.sortMode != LibrarySortMode.ALPHABETICAL ||
+            state.filterDownloaded != LibraryTriState.DISABLED ||
+            state.filterUnread != LibraryTriState.DISABLED ||
+            state.filterStarted != LibraryTriState.DISABLED ||
+            state.filterBookmarked != LibraryTriState.DISABLED ||
+            state.filterCompleted != LibraryTriState.DISABLED
         if (hasActiveFilters && !state.showSearchBar) {
             FlowRow(
                 modifier = Modifier

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -131,7 +131,7 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.SetGenreFilter, is LibraryEvent.SetSortAscending,
             is LibraryEvent.ClearAllFilters,
             is LibraryEvent.SetFilterDownloaded, is LibraryEvent.SetFilterUnread,
-            is LibraryEvent.SetFilterStarted, is LibraryEvent.SetFilterBookmarked,
+            is LibraryEvent.SetFilterStarted, is LibraryEvent.SetFilterTracking,
             is LibraryEvent.SetFilterCompleted -> handleFilterSortEvent(event)
             is LibraryEvent.ToggleFilterSheet -> _state.update { it.copy(showBottomSheet = !it.showBottomSheet) }
             is LibraryEvent.ToggleBottomSheet -> _state.update { it.copy(showBottomSheet = !it.showBottomSheet) }
@@ -236,7 +236,7 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.SetFilterDownloaded -> _state.update { it.copy(filterDownloaded = event.state) }
             is LibraryEvent.SetFilterUnread -> _state.update { it.copy(filterUnread = event.state) }
             is LibraryEvent.SetFilterStarted -> _state.update { it.copy(filterStarted = event.state) }
-            is LibraryEvent.SetFilterBookmarked -> _state.update { it.copy(filterBookmarked = event.state) }
+            is LibraryEvent.SetFilterTracking -> _state.update { it.copy(filterTracking = event.state) }
             is LibraryEvent.SetFilterCompleted -> _state.update { it.copy(filterCompleted = event.state) }
             is LibraryEvent.ClearAllFilters -> _state.update {
                 it.copy(
@@ -249,7 +249,7 @@ class LibraryViewModel @Inject constructor(
                     filterDownloaded = LibraryTriState.DISABLED,
                     filterUnread = LibraryTriState.DISABLED,
                     filterStarted = LibraryTriState.DISABLED,
-                    filterBookmarked = LibraryTriState.DISABLED,
+                    filterTracking = LibraryTriState.DISABLED,
                     filterCompleted = LibraryTriState.DISABLED,
                 )
             }
@@ -650,7 +650,7 @@ class LibraryViewModel @Inject constructor(
                     filterDownloaded = it.filterDownloaded,
                     filterUnread = it.filterUnread,
                     filterStarted = it.filterStarted,
-                    filterBookmarked = it.filterBookmarked,
+                    filterTracking = it.filterTracking,
                     filterCompleted = it.filterCompleted,
                 )
             }.distinctUntilChanged()

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -129,7 +129,10 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.FilterHasNotes, is LibraryEvent.SetSortMode, is LibraryEvent.SetFilterMode,
             is LibraryEvent.SetFilterSource, is LibraryEvent.ToggleNsfw, is LibraryEvent.SetFilterReadingList,
             is LibraryEvent.SetGenreFilter, is LibraryEvent.SetSortAscending,
-            is LibraryEvent.ClearAllFilters -> handleFilterSortEvent(event)
+            is LibraryEvent.ClearAllFilters,
+            is LibraryEvent.SetFilterDownloaded, is LibraryEvent.SetFilterUnread,
+            is LibraryEvent.SetFilterStarted, is LibraryEvent.SetFilterBookmarked,
+            is LibraryEvent.SetFilterCompleted -> handleFilterSortEvent(event)
             is LibraryEvent.ToggleFilterSheet -> _state.update { it.copy(showBottomSheet = !it.showBottomSheet) }
             is LibraryEvent.ToggleBottomSheet -> _state.update { it.copy(showBottomSheet = !it.showBottomSheet) }
             is LibraryEvent.SetBottomSheetTab -> _state.update { it.copy(bottomSheetTab = event.tab) }
@@ -230,6 +233,11 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.SetFilterReadingList -> onSetFilterReadingList(event.listId)
             is LibraryEvent.SetGenreFilter -> _state.update { it.copy(filterGenres = event.genres) }
             is LibraryEvent.SetSortAscending -> _state.update { it.copy(sortAscending = event.ascending) }
+            is LibraryEvent.SetFilterDownloaded -> _state.update { it.copy(filterDownloaded = event.state) }
+            is LibraryEvent.SetFilterUnread -> _state.update { it.copy(filterUnread = event.state) }
+            is LibraryEvent.SetFilterStarted -> _state.update { it.copy(filterStarted = event.state) }
+            is LibraryEvent.SetFilterBookmarked -> _state.update { it.copy(filterBookmarked = event.state) }
+            is LibraryEvent.SetFilterCompleted -> _state.update { it.copy(filterCompleted = event.state) }
             is LibraryEvent.ClearAllFilters -> _state.update {
                 it.copy(
                     filterMode = LibraryFilterMode.ALL,
@@ -238,6 +246,11 @@ class LibraryViewModel @Inject constructor(
                     filterSourceId = null,
                     filterReadingListId = null,
                     sortAscending = true,
+                    filterDownloaded = LibraryTriState.DISABLED,
+                    filterUnread = LibraryTriState.DISABLED,
+                    filterStarted = LibraryTriState.DISABLED,
+                    filterBookmarked = LibraryTriState.DISABLED,
+                    filterCompleted = LibraryTriState.DISABLED,
                 )
             }
             else -> Unit
@@ -634,6 +647,11 @@ class LibraryViewModel @Inject constructor(
                     readingListMangaIds = it.readingListMangaIds,
                     filterGenres = it.filterGenres,
                     sortAscending = it.sortAscending,
+                    filterDownloaded = it.filterDownloaded,
+                    filterUnread = it.filterUnread,
+                    filterStarted = it.filterStarted,
+                    filterBookmarked = it.filterBookmarked,
+                    filterCompleted = it.filterCompleted,
                 )
             }.distinctUntilChanged()
         ) { items, matchingIds, params ->
@@ -661,7 +679,7 @@ class LibraryViewModel @Inject constructor(
     }
 
     private fun onMangaLongClick(mangaId: Long) {
-        _state.update { it.copy(contextMenuMangaId = mangaId) }
+        selection.toggle(mangaId)
     }
 
     private fun onSearchQueryChange(query: String) {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -87,6 +87,10 @@ class LibraryViewModel @Inject constructor(
     /** Atomic selection manager — keys are manga IDs. */
     private val selection = SelectionManager<Long>()
 
+    /** Stable seed for RANDOM sort — fixed for the lifetime of this ViewModel so items don't
+     *  re-shuffle on unrelated state changes (e.g. download count updates). */
+    private val randomSeed: Long = System.currentTimeMillis()
+
     private val _effect = Channel<LibraryEffect>(Channel.BUFFERED)
     val effect: Flow<LibraryEffect> = _effect.receiveAsFlow()
 
@@ -159,28 +163,7 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.ShowSaveViewDialog, is LibraryEvent.HideSaveViewDialog,
             is LibraryEvent.UpdateSaveViewName, is LibraryEvent.ConfirmSaveView,
             is LibraryEvent.ApplySavedView, is LibraryEvent.DeleteSavedView -> handleSavedViewEvent(event)
-            is LibraryEvent.ShowContextMenu, is LibraryEvent.DismissContextMenu,
-            is LibraryEvent.ResumeFromContextMenu, is LibraryEvent.MarkMangaAsReadFromMenu,
-            is LibraryEvent.ShareMangaFromMenu, is LibraryEvent.MigrateMangaFromMenu,
-            is LibraryEvent.SelectMangaFromMenu -> handleContextMenuEvent(event)
-        }
-    }
-
-    private fun handleContextMenuEvent(event: LibraryEvent) {
-        when (event) {
-            is LibraryEvent.ShowContextMenu ->
-                _state.update { it.copy(contextMenuMangaId = event.mangaId) }
-            is LibraryEvent.DismissContextMenu ->
-                _state.update { it.copy(contextMenuMangaId = null) }
-            is LibraryEvent.ResumeFromContextMenu -> resumeFromContextMenu(event.mangaId)
-            is LibraryEvent.MarkMangaAsReadFromMenu -> markMangaAsReadFromMenu(event.mangaId)
-            is LibraryEvent.ShareMangaFromMenu -> shareMangaFromMenu(event.mangaId)
-            is LibraryEvent.MigrateMangaFromMenu -> migrateMangaFromMenu(event.mangaId)
-            is LibraryEvent.SelectMangaFromMenu -> {
-                selection.toggle(event.mangaId)
-                _state.update { it.copy(contextMenuMangaId = null) }
-            }
-            else -> Unit
+            is LibraryEvent.SelectMangaFromMenu -> selection.toggle(event.mangaId)
         }
     }
 
@@ -240,6 +223,7 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.SetFilterCompleted -> _state.update { it.copy(filterCompleted = event.state) }
             is LibraryEvent.ClearAllFilters -> _state.update {
                 it.copy(
+                    selectedCategory = null,
                     filterMode = LibraryFilterMode.ALL,
                     filterGenres = emptySet(),
                     filterHasNotes = false,
@@ -652,6 +636,7 @@ class LibraryViewModel @Inject constructor(
                     filterStarted = it.filterStarted,
                     filterTracking = it.filterTracking,
                     filterCompleted = it.filterCompleted,
+                    randomSeed = randomSeed,
                 )
             }.distinctUntilChanged()
         ) { items, matchingIds, params ->
@@ -823,49 +808,6 @@ class LibraryViewModel @Inject constructor(
         val mangaId = _state.value.selectedManga.singleOrNull() ?: return
         selection.clear()
         viewModelScope.launch { _effect.send(LibraryEffect.NavigateToManga(mangaId)) }
-    }
-
-    private fun resumeFromContextMenu(mangaId: Long) {
-        _state.update { it.copy(contextMenuMangaId = null) }
-        val continueItem = _state.value.continueReadingItems.find { it.mangaId == mangaId }
-        viewModelScope.launch {
-            if (continueItem != null) {
-                _effect.send(LibraryEffect.NavigateToReader(continueItem.mangaId, continueItem.chapterId))
-            } else {
-                _effect.send(LibraryEffect.NavigateToManga(mangaId))
-            }
-        }
-    }
-
-    private fun markMangaAsReadFromMenu(mangaId: Long) {
-        _state.update { it.copy(contextMenuMangaId = null) }
-        viewModelScope.launch {
-            try {
-                val chapters = chapterRepository.getChaptersByMangaIdSync(mangaId)
-                val ids = chapters.map { it.id }
-                if (ids.isNotEmpty()) {
-                    chapterRepository.updateChapterProgress(ids, read = true, lastPageRead = 0)
-                }
-            } catch (_: Exception) {}
-        }
-    }
-
-    private fun shareMangaFromMenu(mangaId: Long) {
-        _state.update { it.copy(contextMenuMangaId = null) }
-        viewModelScope.launch {
-            val manga = mangaRepository.getMangaById(mangaId) ?: return@launch
-            val url = manga.url.takeIf {
-                it.startsWith("http://") || it.startsWith("https://")
-            } ?: ""
-            _effect.send(LibraryEffect.ShareManga(title = manga.title, url = url))
-        }
-    }
-
-    private fun migrateMangaFromMenu(mangaId: Long) {
-        _state.update { it.copy(contextMenuMangaId = null) }
-        viewModelScope.launch {
-            _effect.send(LibraryEffect.NavigateToMigration(listOf(mangaId)))
-        }
     }
 
     private fun toggleFavorite(mangaId: Long) {

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -205,6 +205,7 @@
     <string name="display_mode_grid">Grid</string>
     <string name="display_mode_comfortable">Comfortable</string>
     <string name="display_mode_list">List</string>
+    <string name="display_mode_cover_only">Cover only</string>
     <string name="group_category_label">Category</string>
     <string name="group_by_category">Group by category</string>
     <!-- Filter sheet -->
@@ -222,11 +223,18 @@
     <string name="sort_source">Source</string>
     <string name="sort_last_updated">Last updated</string>
     <string name="sort_total_chapters">Total chapters</string>
+    <string name="sort_latest_chapter">Latest chapter</string>
+    <string name="sort_random">Random</string>
     <string name="filter_all">All</string>
     <string name="filter_downloaded">Downloaded</string>
     <string name="filter_unread">Unread</string>
+    <string name="filter_started">Started</string>
+    <string name="filter_bookmarked">Bookmarked</string>
     <string name="filter_completed">Completed</string>
     <string name="filter_dropped">Dropped</string>
+    <string name="tristate_disabled">Filter disabled</string>
+    <string name="tristate_include">Include</string>
+    <string name="tristate_exclude">Exclude</string>
     <string name="filter_tracking">Tracking</string>
     <string name="filter_reading_list">Reading list</string>
     <string name="library_active_filters">Active filters</string>

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -227,15 +227,21 @@
     <string name="sort_random">Random</string>
     <string name="filter_all">All</string>
     <string name="filter_downloaded">Downloaded</string>
+    <string name="filter_not_downloaded">Not downloaded</string>
     <string name="filter_unread">Unread</string>
+    <string name="filter_not_unread">Not unread</string>
     <string name="filter_started">Started</string>
+    <string name="filter_not_started">Not started</string>
     <string name="filter_bookmarked">Bookmarked</string>
     <string name="filter_completed">Completed</string>
+    <string name="filter_not_completed">Not completed</string>
     <string name="filter_dropped">Dropped</string>
     <string name="tristate_disabled">Filter disabled</string>
     <string name="tristate_include">Include</string>
     <string name="tristate_exclude">Exclude</string>
     <string name="filter_tracking">Tracking</string>
+    <string name="filter_not_tracking">Not tracking</string>
+    <string name="filter_source">Source</string>
     <string name="filter_reading_list">Reading list</string>
     <string name="library_active_filters">Active filters</string>
     <!-- Browse scope / search history -->

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -465,42 +465,70 @@ class LibraryViewModelTest {
         assertTrue(sourceIds.first() < sourceIds.last())
     }
 
-    // --- Filter mode tests ---
+    // --- Tristate filter tests (Komikku parity) ---
 
     @Test
-    fun filterMode_UNREAD_showsOnlyUnreadManga() = runTest {
-        every { libraryPreferences.libraryFilterMode } returns flowOf(LibraryFilterMode.UNREAD.ordinal)
+    fun triStateFilter_unread_ENABLED_IS_showsOnlyUnreadManga() = runTest {
         every { getLibraryManga() } returns flowOf(sampleMangas)
 
         val viewModel = createViewModel()
+        viewModel.onEvent(LibraryEvent.SetFilterUnread(LibraryTriState.ENABLED_IS))
         testDispatcher.scheduler.advanceUntilIdle()
 
-        // Only Naruto(3) and One Piece(7) have unread > 0
+        // Only Naruto(unread=3) and One Piece(unread=7) have unread > 0
         assertEquals(2, viewModel.state.value.mangaList.size)
         assertTrue(viewModel.state.value.mangaList.none { it.id == 2L })
     }
 
     @Test
-    fun filterMode_COMPLETED_showsOnlyCompletedManga() = runTest {
-        every { libraryPreferences.libraryFilterMode } returns flowOf(LibraryFilterMode.COMPLETED.ordinal)
+    fun triStateFilter_unread_ENABLED_NOT_excludesUnreadManga() = runTest {
         every { getLibraryManga() } returns flowOf(sampleMangas)
 
         val viewModel = createViewModel()
+        viewModel.onEvent(LibraryEvent.SetFilterUnread(LibraryTriState.ENABLED_NOT))
         testDispatcher.scheduler.advanceUntilIdle()
 
-        // Only Bleach has status COMPLETED
+        // Only Bleach has unreadCount = 0
         assertEquals(1, viewModel.state.value.mangaList.size)
         assertEquals(2L, viewModel.state.value.mangaList.first().id)
     }
 
     @Test
-    fun filterMode_ALL_showsAllManga() = runTest {
-        every { libraryPreferences.libraryFilterMode } returns flowOf(LibraryFilterMode.ALL.ordinal)
+    fun triStateFilter_completed_ENABLED_IS_showsOnlyCompletedManga() = runTest {
+        every { getLibraryManga() } returns flowOf(sampleMangas)
+
+        val viewModel = createViewModel()
+        viewModel.onEvent(LibraryEvent.SetFilterCompleted(LibraryTriState.ENABLED_IS))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Only Bleach has userCompleted = true
+        assertEquals(1, viewModel.state.value.mangaList.size)
+        assertEquals(2L, viewModel.state.value.mangaList.first().id)
+    }
+
+    @Test
+    fun triStateFilter_DISABLED_showsAllManga() = runTest {
         every { getLibraryManga() } returns flowOf(sampleMangas)
 
         val viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
 
+        // All filters DISABLED by default — all 3 items shown
+        assertEquals(3, viewModel.state.value.mangaList.size)
+    }
+
+    @Test
+    fun triStateFilter_clearAll_resetsAllTristates() = runTest {
+        every { getLibraryManga() } returns flowOf(sampleMangas)
+
+        val viewModel = createViewModel()
+        viewModel.onEvent(LibraryEvent.SetFilterUnread(LibraryTriState.ENABLED_IS))
+        viewModel.onEvent(LibraryEvent.SetFilterCompleted(LibraryTriState.ENABLED_NOT))
+        viewModel.onEvent(LibraryEvent.ClearAllFilters)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(LibraryTriState.DISABLED, viewModel.state.value.filterUnread)
+        assertEquals(LibraryTriState.DISABLED, viewModel.state.value.filterCompleted)
         assertEquals(3, viewModel.state.value.mangaList.size)
     }
 

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -255,7 +255,7 @@ class LibraryViewModelTest {
     }
 
     @Test
-    fun onEvent_OnMangaLongClick_opensContextMenu() = runTest {
+    fun onEvent_OnMangaLongClick_selectsManga() = runTest {
         every { getLibraryManga() } returns flowOf(sampleMangas)
 
         val viewModel = createViewModel()
@@ -264,12 +264,12 @@ class LibraryViewModelTest {
         viewModel.onEvent(LibraryEvent.OnMangaLongClick(1L))
         testDispatcher.scheduler.advanceUntilIdle()
 
-        // Long-press now opens the context menu popup, not direct selection (L2 feature).
-        assertEquals(1L, viewModel.state.value.contextMenuMangaId)
+        // Long-press directly toggles selection (Komikku parity — no context menu indirection).
+        assertTrue(viewModel.state.value.selectedManga.contains(1L))
     }
 
     @Test
-    fun onEvent_OnMangaLongClick_twice_opensMenuBothTimes() = runTest {
+    fun onEvent_OnMangaLongClick_twice_selectsBoth() = runTest {
         every { getLibraryManga() } returns flowOf(sampleMangas)
 
         val viewModel = createViewModel()
@@ -277,9 +277,10 @@ class LibraryViewModelTest {
 
         viewModel.onEvent(LibraryEvent.OnMangaLongClick(1L))
         viewModel.onEvent(LibraryEvent.OnMangaLongClick(2L))
+        testDispatcher.scheduler.advanceUntilIdle()
 
-        // Second long-click on a different manga replaces the context menu target
-        assertEquals(2L, viewModel.state.value.contextMenuMangaId)
+        // Each long-press toggles its own manga into selection.
+        assertEquals(setOf(1L, 2L), viewModel.state.value.selectedManga)
     }
 
     @Test


### PR DESCRIPTION
## **User description**
## Description

Library screen parity with Komikku/Mihon. Four independent gap closures: tristate filter sheet, cover-only display mode, two new sort options, and direct long-press selection entry.

## Type of Change
- [x] ✨ New feature
- [x] 🎨 UI/UX
- [x] 🧪 Tests

## Changes

### Tristate independent filters (Komikku parity)
- Add `LibraryTriState` enum (`DISABLED` / `ENABLED_IS` / `ENABLED_NOT`) with `.next()` cycle
- Add five independent filter fields to `LibraryState`: `filterDownloaded`, `filterUnread`, `filterStarted`, `filterBookmarked`, `filterCompleted` — all default `DISABLED`
- Replace the Filter tab's single-enum `FilterChip` row with per-attribute `TriStateFilterRow` components that cycle state on each tap (check = include, red check = exclude, dash = off)
- Add `applyTriStateFilters()` to the filter pipeline alongside the existing `applyFilterMode` (which still drives the quick-access chips in the search bar)
- `ClearAllFilters` resets all tristate fields back to `DISABLED`
- Filter icon tint and `hasActiveFilters` in `LibraryScreen` now account for active tristate states

### Cover-only display mode
- Add `COVER_ONLY` to `LibraryDisplayMode` (appended for stable persisted ordinals)
- Renders manga covers with `showTitle = false` and no comfortable-grid caption — pure cover grid

### New sort modes
- `LATEST_CHAPTER` — sorts descending by `lastUpdate` (chapter fetch timestamp)
- `RANDOM` — shuffles the list; both appended to `LibrarySortMode` for stable ordinals

### Direct long-press → selection (Komikku parity)
- Long-press now calls `OnMangaLongClick` which directly toggles the item into selection mode via `SelectionManager.toggle()`, removing the context-menu indirection that was in place before

## Testing
- Replaced three legacy `filterMode`-based ViewModel tests with five tristate-specific unit tests:
  - `ENABLED_IS` shows only matching items
  - `ENABLED_NOT` excludes matching items
  - Default `DISABLED` shows all items
  - `ClearAllFilters` resets tristate fields
- All existing library ViewModel tests still pass (quick-chip filter path unchanged)

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] No new warnings
- [x] Tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_


___

## **CodeAnt-AI Description**
**Add Komikku-style library filters, cover-only display, new sort options, and direct long-press selection**

### What Changed
- The library filter sheet now lets users include, exclude, or turn off filters for downloaded, unread, started, bookmarked, and completed items
- A new cover-only display mode shows manga covers without titles
- Two new sort options are available: latest chapter and random
- Long-pressing a manga now selects it directly instead of opening the context menu first
- The filter icon and active filter chips now reflect the new per-item filters
- Added coverage for the new filter behavior and reset flow

### Impact
`✅ Finer library filtering`
`✅ Cleaner cover-only browsing`
`✅ More sorting choices`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent tristate filters for library items: downloaded, unread, started, tracking, and completed.
  * Added new display/sort options: cover-only view, latest-chapter sorting, and random order.
  * When filters are active, the UI now shows filter chips that can clear individual tristate selections.
* **Bug Fixes**
  * Improved filtering/sorting so the new tristate controls consistently affect results.
  * Updated long-press behavior to select items directly (matching expected interaction).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->