### PR TITLE
fix(browse): Komikku parity — enabledSourceLanguages default + Extensions search UI

### DIFF
--- a/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/GeneralPreferences.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
+import java.util.Locale
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -93,9 +94,15 @@ class GeneralPreferences(private val dataStore: DataStore<Preferences>) {
     val showNsfwContent: Flow<Boolean> = dataStore.data.map { it[Keys.SHOW_NSFW_CONTENT] ?: true }
     suspend fun setShowNsfwContent(value: Boolean) = dataStore.edit { it[Keys.SHOW_NSFW_CONTENT] = value }
 
-    /** Language codes (e.g. "en", "ja") the user wants to see in Browse. Default: all English sources. */
+    /**
+     * Language codes the user wants to see in Browse.
+     *
+     * Default matches Komikku: "all" (multi-language sources like MangaDex), "en" (English),
+     * and the device's current locale language. Without "all", multi-language sources are
+     * silently hidden on fresh installs — the user installs MangaDex and it never appears.
+     */
     val enabledSourceLanguages: Flow<Set<String>> = dataStore.data.map {
-        it[Keys.ENABLED_SOURCE_LANGUAGES] ?: setOf("en")
+        it[Keys.ENABLED_SOURCE_LANGUAGES] ?: setOf("all", "en", Locale.getDefault().language)
     }
     suspend fun setEnabledSourceLanguages(languages: Set<String>) = dataStore.edit {
         it[Keys.ENABLED_SOURCE_LANGUAGES] = languages

--- a/feature/browse/build.gradle.kts
+++ b/feature/browse/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(libs.lifecycle.viewmodel.ktx)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.coil.compose)
+    implementation(libs.androidx.activity.compose)
 
     testImplementation(libs.junit)
     testImplementation(libs.mockk)

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
@@ -1,6 +1,7 @@
 @file:Suppress("MaxLineLength")
 package app.otakureader.feature.browse
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
@@ -18,11 +19,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Update
 import androidx.compose.material.icons.filled.Visibility
@@ -38,6 +41,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -279,66 +283,104 @@ private fun ExtensionsContent(
     onNavigateToRepositories: () -> Unit = {},
     onNavigateToExtensionDetail: (packageName: String) -> Unit = {},
 ) {
+    var searchActive by remember { mutableStateOf(false) }
+
+    BackHandler(enabled = searchActive) {
+        searchActive = false
+        onEvent(ExtensionsEvent.OnSearchQueryChange(""))
+    }
+
     Scaffold(
         topBar = {
             var overflowExpanded by remember { mutableStateOf(false) }
             TopAppBar(
-                title = { Text(stringResource(R.string.extensions_sheet_title)) },
+                title = {
+                    if (searchActive) {
+                        OutlinedTextField(
+                            value = state.searchQuery,
+                            onValueChange = { onEvent(ExtensionsEvent.OnSearchQueryChange(it)) },
+                            modifier = Modifier.fillMaxWidth(),
+                            placeholder = { Text(stringResource(R.string.extensions_search_placeholder)) },
+                            singleLine = true,
+                        )
+                    } else {
+                        Text(stringResource(R.string.extensions_sheet_title))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(onClick = onClose) {
-                        Icon(Icons.Default.Close, contentDescription = stringResource(R.string.extensions_close))
+                    IconButton(onClick = {
+                        if (searchActive) {
+                            searchActive = false
+                            onEvent(ExtensionsEvent.OnSearchQueryChange(""))
+                        } else {
+                            onClose()
+                        }
+                    }) {
+                        Icon(
+                            if (searchActive) {
+                                Icons.AutoMirrored.Filled.ArrowBack
+                            } else {
+                                Icons.Default.Close
+                            },
+                            contentDescription = if (searchActive) null else stringResource(R.string.extensions_close),
+                        )
                     }
                 },
                 actions = {
-                    IconButton(onClick = { onEvent(ExtensionsEvent.Refresh) }) {
-                        Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.extensions_refresh))
-                    }
-                    Box {
-                        IconButton(onClick = { overflowExpanded = true }) {
-                            Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.browse_more_options))
+                    if (!searchActive) {
+                        IconButton(onClick = { searchActive = true }) {
+                            Icon(Icons.Default.Search, contentDescription = stringResource(R.string.extensions_search_cd))
                         }
-                        DropdownMenu(
-                            expanded = overflowExpanded,
-                            onDismissRequest = { overflowExpanded = false },
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.extensions_manage_repositories)) },
-                                onClick = {
-                                    overflowExpanded = false
-                                    onNavigateToRepositories()
-                                },
-                            )
-                            DropdownMenuItem(
-                                text = {
-                                    Text(
-                                        if (state.showNsfw) {
-                                            stringResource(R.string.browse_hide_nsfw)
-                                        } else {
-                                            stringResource(R.string.browse_show_nsfw)
-                                        },
-                                    )
-                                },
-                                leadingIcon = {
-                                    Icon(
-                                        if (state.showNsfw) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                                        contentDescription = null,
-                                    )
-                                },
-                                onClick = {
-                                    onEvent(ExtensionsEvent.ToggleNsfw(!state.showNsfw))
-                                    overflowExpanded = false
-                                },
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.extensions_settings)) },
-                                onClick = {
-                                    overflowExpanded = false
-                                    onNavigateToSettings()
-                                },
-                            )
+                        IconButton(onClick = { onEvent(ExtensionsEvent.Refresh) }) {
+                            Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.extensions_refresh))
+                        }
+                        Box {
+                            IconButton(onClick = { overflowExpanded = true }) {
+                                Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.browse_more_options))
+                            }
+                            DropdownMenu(
+                                expanded = overflowExpanded,
+                                onDismissRequest = { overflowExpanded = false },
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.extensions_manage_repositories)) },
+                                    onClick = {
+                                        overflowExpanded = false
+                                        onNavigateToRepositories()
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            if (state.showNsfw) {
+                                                stringResource(R.string.browse_hide_nsfw)
+                                            } else {
+                                                stringResource(R.string.browse_show_nsfw)
+                                            },
+                                        )
+                                    },
+                                    leadingIcon = {
+                                        Icon(
+                                            if (state.showNsfw) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                                            contentDescription = null,
+                                        )
+                                    },
+                                    onClick = {
+                                        onEvent(ExtensionsEvent.ToggleNsfw(!state.showNsfw))
+                                        overflowExpanded = false
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.extensions_settings)) },
+                                    onClick = {
+                                        overflowExpanded = false
+                                        onNavigateToSettings()
+                                    },
+                                )
+                            }
                         }
                     }
-                }
+                },
             )
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
@@ -3,6 +3,8 @@ package app.otakureader.feature.browse
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -284,6 +286,13 @@ private fun ExtensionsContent(
     onNavigateToExtensionDetail: (packageName: String) -> Unit = {},
 ) {
     var searchActive by remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(searchActive) {
+        if (searchActive) {
+            focusRequester.requestFocus()
+        }
+    }
 
     BackHandler(enabled = searchActive) {
         searchActive = false
@@ -299,7 +308,9 @@ private fun ExtensionsContent(
                         OutlinedTextField(
                             value = state.searchQuery,
                             onValueChange = { onEvent(ExtensionsEvent.OnSearchQueryChange(it)) },
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .focusRequester(focusRequester),
                             placeholder = { Text(stringResource(R.string.extensions_search_placeholder)) },
                             singleLine = true,
                         )
@@ -322,7 +333,7 @@ private fun ExtensionsContent(
                             } else {
                                 Icons.Default.Close
                             },
-                            contentDescription = if (searchActive) null else stringResource(R.string.extensions_close),
+                            contentDescription = stringResource(R.string.extensions_close),
                         )
                     }
                 },


### PR DESCRIPTION
## Summary

- **`GeneralPreferences`** — fix `enabledSourceLanguages` default from `setOf("en")` to `setOf("all", "en", Locale.getDefault().language)` to match Komikku. Without `"all"`, multi-language sources like MangaDex (whose `lang` field is `"all"`) are silently hidden on fresh installs — the user installs MangaDex and it never appears in Browse.
- **`ExtensionsBottomSheet`** — wire the existing `OnSearchQueryChange` event and `searchQuery` state (both already in the ViewModel) to a search icon in the top bar. Tapping the icon replaces the title with an `OutlinedTextField`; back press or the nav-icon clears the query and collapses back to the title. This matches Komikku's Extensions screen where search is a top-bar icon, not an always-visible inline bar.
- **`feature/browse/build.gradle.kts`** — add explicit `implementation(libs.androidx.activity.compose)` so `BackHandler` compiles. The convention plugin and other transitive paths do not provide it for this module.

## Test plan

- [ ] Fresh install: install MangaDex extension → it appears in Browse/Sources without changing any language filter
- [ ] Extensions top bar: search icon visible; tapping shows text field; typing filters list; back press clears and collapses
- [ ] Existing installs: `enabledSourceLanguages` DataStore key is unset on fresh install so the new default applies; existing users who already saved a value are unaffected
- [ ] `./gradlew :feature:browse:compileDebugKotlin` — no unresolved reference for `BackHandler`
- [ ] `./gradlew :app:assembleDebug` — clean build

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a search mode in the extensions browser, making it easier to filter and find content directly from the top bar.
  * Improved the default browsing experience on fresh installs by showing more relevant source languages, including the device language.

* **Bug Fixes**
  * Back navigation now exits search cleanly and clears the current query.
  * Search-related actions are now hidden when not needed, reducing UI clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->