### PR TITLE
feat(library): Komikku parity — add Migrate action to bulk-select bar

### DIFF
--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -265,6 +265,7 @@ sealed class LibraryEvent {
     data object OpenMoveToCategoryDialog : LibraryEvent()
     data object DismissMoveToCategoryDialog : LibraryEvent()
     data class MoveToCategory(val mangaIds: Set<Long>, val categoryId: Long) : LibraryEvent()
+    data object MigrateSelected : LibraryEvent()
 }
 
 sealed class LibraryEffect {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -446,6 +447,7 @@ fun LibraryScreen(
                 onMarkAsUnreadClicked = { viewModel.onEvent(LibraryEvent.MarkSelectedAsUnread) },
                 onDownloadClicked = { viewModel.onEvent(LibraryEvent.DownloadSelected) },
                 onDeleteClicked = { pendingBulkAction = LibraryEvent.RemoveSelectedFromLibrary },
+                onMigrateClicked = { viewModel.onEvent(LibraryEvent.MigrateSelected) },
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -996,6 +998,7 @@ private fun LibrarySelectionBottomBar(
     onMarkAsUnreadClicked: () -> Unit,
     onDownloadClicked: () -> Unit,
     onDeleteClicked: () -> Unit,
+    onMigrateClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(
@@ -1080,6 +1083,20 @@ private fun LibrarySelectionBottomBar(
                     }
                     Text(
                         text = stringResource(R.string.library_remove_selected),
+                        style = MaterialTheme.typography.labelSmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    IconButton(onClick = onMigrateClicked) {
+                        Icon(
+                            Icons.Default.SwapHoriz,
+                            contentDescription = stringResource(R.string.library_context_menu_migrate),
+                        )
+                    }
+                    Text(
+                        text = stringResource(R.string.library_context_menu_migrate),
                         style = MaterialTheme.typography.labelSmall,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -163,7 +163,7 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.MarkSelectedAsDropped, is LibraryEvent.ShareSelectedManga,
             is LibraryEvent.ViewSelectedManga, is LibraryEvent.UndoLibraryDelete,
             is LibraryEvent.OpenMoveToCategoryDialog, is LibraryEvent.DismissMoveToCategoryDialog,
-            is LibraryEvent.MoveToCategory -> handleActionEvent(event)
+            is LibraryEvent.MoveToCategory, is LibraryEvent.MigrateSelected -> handleActionEvent(event)
             is LibraryEvent.UpdateLibrary, is LibraryEvent.UpdateCategory,
             is LibraryEvent.OpenRandomEntry, is LibraryEvent.ReindexDownloads,
             is LibraryEvent.SyncEhFavorites,
@@ -283,7 +283,16 @@ class LibraryViewModel @Inject constructor(
                 it.copy(showMoveToCategoryDialog = false, moveToCategoryMangaIds = emptySet())
             }
             is LibraryEvent.MoveToCategory -> moveMangaToCategory(event.mangaIds, event.categoryId)
+            is LibraryEvent.MigrateSelected -> migrateSelected()
             else -> Unit
+        }
+    }
+
+    private fun migrateSelected() {
+        val ids = _state.value.selectedManga.toList()
+        if (ids.isEmpty()) return
+        viewModelScope.launch {
+            _effect.send(LibraryEffect.NavigateToMigration(ids))
         }
     }
 

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -289,7 +289,7 @@ class LibraryViewModel @Inject constructor(
     }
 
     private fun migrateSelected() {
-        val ids = _state.value.selectedManga.toList()
+        val ids = selection.snapshotAndClear().toList()
         if (ids.isEmpty()) return
         viewModelScope.launch {
             _effect.send(LibraryEffect.NavigateToMigration(ids))

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -782,4 +782,30 @@ class LibraryViewModelTest {
             assertEquals(listOf(5), snackbar.formatArgs)
         }
     }
+
+    @Test
+    fun migrateSelected_emitsNavigateToMigrationWithSelectedIds_andClearsSelection() = runTest {
+        every { getLibraryManga() } returns flowOf(sampleMangas)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(LibraryEvent.SelectMangaFromMenu(1L))
+        viewModel.onEvent(LibraryEvent.SelectMangaFromMenu(2L))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.effect.test {
+            viewModel.onEvent(LibraryEvent.MigrateSelected)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val effect = awaitItem()
+            assertTrue(effect is LibraryEffect.NavigateToMigration)
+            assertEquals(
+                listOf(1L, 2L),
+                (effect as LibraryEffect.NavigateToMigration).selectedMangaIds.sorted()
+            )
+        }
+
+        assertTrue(viewModel.state.value.selectedManga.isEmpty())
+    }
 }


### PR DESCRIPTION
## Summary

- **`LibraryMvi`** — add `MigrateSelected` event
- **`LibraryViewModel`** — add `migrateSelected()` handler that emits `NavigateToMigration` with the current selection IDs; wire the event into `handleActionEvent`
- **`LibraryScreen`** — add Migrate (`SwapHoriz`) button to `LibrarySelectionBottomBar`, matching Komikku's bulk-select action set (Change Category · Mark Read · Mark Unread · Download · Delete · **Migrate**)

The `NavigateToMigration` effect handler and the `onNavigateToMigration` callback were already wired up in `LibraryScreen`; what was missing was the event to fire it and the UI button to surface it.

## Test plan

- [ ] Enter selection mode (long-press a manga) → bottom bar shows 6 actions including Migrate
- [ ] Tap Migrate with 1+ manga selected → navigates to migration screen with selected IDs
- [ ] Tap Migrate with 0 selected → no-op (guarded by `if (ids.isEmpty()) return`)
- [ ] All other bulk actions (Category, Read, Unread, Download, Delete) still work
- [ ] `./gradlew :feature:library:compileDebugKotlin` — clean compile

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_