### PR TITLE
feat(details): Komikku parity — tracker count badge, WebView button, chapter filter icon

### DIFF
--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
@@ -56,6 +56,10 @@ object DetailsContract {
         val averageChapterDurationMs: Long = 0L,
         /** Whether the Edit Manga Info bottom-sheet is open (#998). */
         val isEditInfoSheetVisible: Boolean = false,
+        /** Number of active tracker services for this manga. 0 = not tracked. */
+        val trackingCount: Int = 0,
+        /** Full web URL for this manga (source baseUrl + manga url). Null for local sources. */
+        val mangaWebUrl: String? = null,
     ) : UiState {
 
         /** Estimated time remaining to finish all unread chapters of this manga. */
@@ -283,6 +287,9 @@ object DetailsContract {
 
         /** Genre/tag chip long-press: search this tag across all sources (global search). */
         data class GenreLongClick(val genre: String) : Event
+
+        /** Opens the manga's source web page in the system browser. */
+        data object OpenWebView : Event
     }
 
     /**

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -131,6 +131,9 @@ private const val SINGLE_CHAPTER_SELECTION = 1
 // Action labels in the selection bottom bar are kept to a single line so the row stays compact.
 private const val CHAPTER_ACTION_LABEL_MAX_LINES = 1
 
+// Alpha for action buttons that represent a disabled/inactive state in MangaActionRow.
+private const val MANGA_ACTION_INACTIVE_ALPHA = 0.6f
+
 // Bottom content padding for the phone single-scroll list — enough to clear the FAB
 // (56 dp FAB height + 16 dp bottom margin + 16 dp list breathing room).
 private val FAB_CONTENT_PADDING_BOTTOM = 88.dp
@@ -201,13 +204,13 @@ fun DetailsScreen(
                     onNavigateToSourceSearch(effect.sourceId, effect.query)
                 }
                 is DetailsContract.Effect.OpenInBrowser -> {
-                    runCatching {
+                    try {
                         val intent = android.content.Intent(
                             android.content.Intent.ACTION_VIEW,
                             android.net.Uri.parse(effect.url),
                         )
                         context.startActivity(intent)
-                    }.onFailure {
+                    } catch (_: Exception) {
                         snackbarHostState.showSnackbar(context.getString(R.string.details_no_browser))
                     }
                 }
@@ -869,7 +872,7 @@ private fun MangaActionRow(
     onOpenWebView: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val inactiveColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+    val inactiveColor = MaterialTheme.colorScheme.onSurface.copy(alpha = MANGA_ACTION_INACTIVE_ALPHA)
     val primaryColor = MaterialTheme.colorScheme.primary
     Row(
         modifier = modifier

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -302,7 +302,7 @@ fun DetailsScreen(
                             Icons.Default.FilterList,
                             contentDescription = stringResource(R.string.details_filter_chapters),
                             tint = if (filterActive) MaterialTheme.colorScheme.primary
-                                   else androidx.compose.ui.graphics.Color.Unspecified,
+                                   else androidx.compose.material3.LocalContentColor.current,
                         )
                     }
                     IconButton(onClick = { viewModel.onEvent(DetailsContract.Event.Refresh) }) {

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -44,7 +44,9 @@ import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.FlipToBack
+import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.QueryStats
@@ -84,6 +86,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -197,6 +200,17 @@ fun DetailsScreen(
                 is DetailsContract.Effect.NavigateToSourceSearch -> {
                     onNavigateToSourceSearch(effect.sourceId, effect.query)
                 }
+                is DetailsContract.Effect.OpenInBrowser -> {
+                    runCatching {
+                        val intent = android.content.Intent(
+                            android.content.Intent.ACTION_VIEW,
+                            android.net.Uri.parse(effect.url),
+                        )
+                        context.startActivity(intent)
+                    }.onFailure {
+                        snackbarHostState.showSnackbar(context.getString(R.string.details_no_browser))
+                    }
+                }
                 is DetailsContract.Effect.OpenDownloadFolder -> {
                     val externalFilesDir = context.getExternalFilesDir(null)
                     if (externalFilesDir != null) {
@@ -282,16 +296,23 @@ fun DetailsScreen(
                     containerColor = MaterialTheme.colorScheme.surface.copy(alpha = topBarAlpha),
                 ),
                 actions = {
+                    val filterActive = state.chapterFilter.isActive
+                    IconButton(onClick = { viewModel.onEvent(DetailsContract.Event.ShowChapterFilter) }) {
+                        Icon(
+                            Icons.Default.FilterList,
+                            contentDescription = stringResource(R.string.details_filter_chapters),
+                            tint = if (filterActive) MaterialTheme.colorScheme.primary
+                                   else androidx.compose.ui.graphics.Color.Unspecified,
+                        )
+                    }
                     IconButton(onClick = { viewModel.onEvent(DetailsContract.Event.Refresh) }) {
                         Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.details_refresh))
                     }
                     IconButton(onClick = { viewModel.onEvent(DetailsContract.Event.ShareManga) }) {
                         Icon(Icons.Default.Share, contentDescription = stringResource(R.string.details_share))
                     }
-                    IconButton(onClick = { viewModel.onEvent(DetailsContract.Event.OpenTracking) }) {
-                        Icon(Icons.Default.QueryStats, contentDescription = stringResource(R.string.details_tracking))
-                    }
                     var overflowExpanded by remember { mutableStateOf(false) }
+
                     // System image picker for custom cover art. The picked content:// URI is
                     // passed to the ViewModel, which copies the image into app storage.
                     val coverPickerLauncher = rememberLauncherForActivityResult(
@@ -672,8 +693,11 @@ private fun DetailsContent(
             item(key = "action_row") {
                 MangaActionRow(
                     isFavorite = state.isFavorite,
+                    trackingCount = state.trackingCount,
+                    webUrl = state.mangaWebUrl,
                     onToggleFavorite = { onEvent(DetailsContract.Event.ToggleFavorite) },
                     onOpenTracking = { onEvent(DetailsContract.Event.OpenTracking) },
+                    onOpenWebView = { onEvent(DetailsContract.Event.OpenWebView) },
                 )
             }
             item(key = "stats") { DetailsStatsRow(state = state) }
@@ -753,8 +777,11 @@ private fun LazyListScope.detailsInfoItems(
     item {
         MangaActionRow(
             isFavorite = state.isFavorite,
+            trackingCount = state.trackingCount,
+            webUrl = state.mangaWebUrl,
             onToggleFavorite = { onEvent(DetailsContract.Event.ToggleFavorite) },
             onOpenTracking = { onEvent(DetailsContract.Event.OpenTracking) },
+            onOpenWebView = { onEvent(DetailsContract.Event.OpenWebView) },
         )
     }
     detailsInfoTabItems(manga = manga, state = state, onEvent = onEvent)
@@ -835,11 +862,15 @@ private fun LazyListScope.detailsInfoTabItems(
 @Composable
 private fun MangaActionRow(
     isFavorite: Boolean,
+    trackingCount: Int,
+    webUrl: String?,
     onToggleFavorite: () -> Unit,
     onOpenTracking: () -> Unit,
+    onOpenWebView: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val inactiveColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+    val primaryColor = MaterialTheme.colorScheme.primary
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -849,15 +880,26 @@ private fun MangaActionRow(
             title = if (isFavorite) stringResource(R.string.details_in_library)
                     else stringResource(R.string.details_add_to_library),
             icon = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-            color = if (isFavorite) MaterialTheme.colorScheme.primary else inactiveColor,
+            color = if (isFavorite) primaryColor else inactiveColor,
             onClick = onToggleFavorite,
         )
         MangaActionButton(
-            title = stringResource(R.string.details_action_tracking),
-            icon = Icons.Default.QueryStats,
-            color = inactiveColor,
+            title = if (trackingCount > 0)
+                pluralStringResource(R.plurals.details_tracking_count, trackingCount, trackingCount)
+            else
+                stringResource(R.string.details_action_tracking),
+            icon = if (trackingCount > 0) Icons.Default.Done else Icons.Default.QueryStats,
+            color = if (trackingCount > 0) primaryColor else inactiveColor,
             onClick = onOpenTracking,
         )
+        if (webUrl != null) {
+            MangaActionButton(
+                title = stringResource(R.string.details_action_webview),
+                icon = Icons.Default.Language,
+                color = inactiveColor,
+                onClick = onOpenWebView,
+            )
+        }
     }
 }
 

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import app.otakureader.domain.repository.SourceRepository
+import app.otakureader.domain.tracking.TrackRepository
 import app.otakureader.sourceapi.SourceChapter
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -55,6 +56,7 @@ class DetailsViewModel @Inject constructor(
     private val updateMangaNote: UpdateMangaNoteUseCase,
     private val setMangaNotifications: SetMangaNotificationsUseCase,
     private val statisticsRepository: StatisticsRepository,
+    private val trackRepository: TrackRepository,
 ) : ViewModel() {
 
     private val mangaId: Long = savedStateHandle.get<Long>(MANGA_ID_ARG) 
@@ -86,6 +88,8 @@ class DetailsViewModel @Inject constructor(
         loadChapters()
         loadNextUnreadChapter()
         observeStaticSettings()
+        observeTrackingCount()
+        loadMangaWebUrl()
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
@@ -176,6 +180,7 @@ class DetailsViewModel @Inject constructor(
 
             is DetailsContract.Event.GenreClick -> searchGenreInSource(event.genre)
             is DetailsContract.Event.GenreLongClick -> searchGenreGlobally(event.genre)
+            is DetailsContract.Event.OpenWebView -> openInWebView()
         }
     }
 
@@ -208,6 +213,32 @@ class DetailsViewModel @Inject constructor(
     private fun searchGenreGlobally(genre: String) {
         viewModelScope.launch {
             _effect.send(DetailsContract.Effect.NavigateToGlobalSearch(query = genre))
+        }
+    }
+
+    private fun observeTrackingCount() {
+        trackRepository.observeEntriesForManga(mangaId)
+            .onEach { entries -> _state.update { it.copy(trackingCount = entries.size) } }
+            .launchIn(viewModelScope)
+    }
+
+    private fun loadMangaWebUrl() {
+        viewModelScope.launch {
+            val manga = mangaRepository.getMangaById(mangaId) ?: return@launch
+            val source = sourceRepository.getSource(manga.sourceId.toString()) ?: return@launch
+            val baseUrl = source.baseUrl.trimEnd('/')
+            if (baseUrl.isNotEmpty() && manga.url.isNotEmpty()) {
+                val fullUrl = if (manga.url.startsWith("http")) manga.url
+                              else "$baseUrl${manga.url}"
+                _state.update { it.copy(mangaWebUrl = fullUrl) }
+            }
+        }
+    }
+
+    private fun openInWebView() {
+        val url = _state.value.mangaWebUrl ?: return
+        viewModelScope.launch {
+            _effect.send(DetailsContract.Effect.OpenInBrowser(url))
         }
     }
 

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -224,13 +224,22 @@ class DetailsViewModel @Inject constructor(
 
     private fun loadMangaWebUrl() {
         viewModelScope.launch {
-            val manga = mangaRepository.getMangaById(mangaId) ?: return@launch
-            val source = sourceRepository.getSource(manga.sourceId.toString()) ?: return@launch
-            val baseUrl = source.baseUrl.trimEnd('/')
-            if (baseUrl.isNotEmpty() && manga.url.isNotEmpty()) {
-                val fullUrl = if (manga.url.startsWith("http")) manga.url
-                              else "$baseUrl/${manga.url.removePrefix("/")}"
+            try {
+                val manga = mangaRepository.getMangaById(mangaId) ?: return@launch
+                if (manga.url.isEmpty()) return@launch
+                val fullUrl = if (manga.url.startsWith("http")) {
+                    manga.url
+                } else {
+                    val source = sourceRepository.getSource(manga.sourceId.toString()) ?: return@launch
+                    val baseUrl = source.baseUrl.trimEnd('/')
+                    if (baseUrl.isEmpty()) return@launch
+                    "$baseUrl/${manga.url.removePrefix("/")}"
+                }
                 _state.update { it.copy(mangaWebUrl = fullUrl) }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                _state.update { it.copy(mangaWebUrl = null) }
             }
         }
     }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -229,7 +229,7 @@ class DetailsViewModel @Inject constructor(
             val baseUrl = source.baseUrl.trimEnd('/')
             if (baseUrl.isNotEmpty() && manga.url.isNotEmpty()) {
                 val fullUrl = if (manga.url.startsWith("http")) manga.url
-                              else "$baseUrl${manga.url}"
+                              else "$baseUrl/${manga.url.removePrefix("/")}"
                 _state.update { it.copy(mangaWebUrl = fullUrl) }
             }
         }

--- a/feature/details/src/main/res/values/strings.xml
+++ b/feature/details/src/main/res/values/strings.xml
@@ -235,6 +235,6 @@
         <item quantity="one">%1$d missing chapter</item>
         <item quantity="other">%1$d missing chapters</item>
     </plurals>
-    <string name="details_action_webview">WebView</string>
+    <string name="details_action_webview">Web</string>
     <string name="details_no_browser">No browser app found</string>
 </resources>

--- a/feature/details/src/main/res/values/strings.xml
+++ b/feature/details/src/main/res/values/strings.xml
@@ -235,4 +235,6 @@
         <item quantity="one">%1$d missing chapter</item>
         <item quantity="other">%1$d missing chapters</item>
     </plurals>
+    <string name="details_action_webview">WebView</string>
+    <string name="details_no_browser">No browser app found</string>
 </resources>

--- a/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
+++ b/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
@@ -10,6 +10,7 @@ import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.SourceRepository
+import app.otakureader.domain.tracking.TrackRepository
 import app.otakureader.domain.usecase.SetMangaNotificationsUseCase
 import app.otakureader.domain.usecase.UpdateMangaNoteUseCase
 import app.cash.turbine.test
@@ -48,6 +49,7 @@ class DetailsViewModelTest {
     private lateinit var updateMangaNote: UpdateMangaNoteUseCase
     private lateinit var setMangaNotifications: SetMangaNotificationsUseCase
     private lateinit var statisticsRepository: app.otakureader.domain.repository.StatisticsRepository
+    private lateinit var trackRepository: TrackRepository
     private lateinit var savedStateHandle: SavedStateHandle
 
     private val sampleManga = Manga(
@@ -78,6 +80,7 @@ class DetailsViewModelTest {
         updateMangaNote = mockk()
         setMangaNotifications = mockk()
         statisticsRepository = mockk(relaxed = true)
+        trackRepository = mockk(relaxed = true)
         savedStateHandle = SavedStateHandle(mapOf(DetailsViewModel.MANGA_ID_ARG to mangaId))
     }
 
@@ -98,11 +101,13 @@ class DetailsViewModelTest {
             updateMangaNote,
             setMangaNotifications,
             statisticsRepository,
+            trackRepository,
         )
     }
 
     private fun setUpDefaultMocks() {
         every { mangaRepository.getMangaByIdFlow(mangaId) } returns flowOf(sampleManga)
+        coEvery { mangaRepository.getMangaById(mangaId) } returns sampleManga
         every { chapterRepository.getChaptersByMangaId(mangaId) } returns flowOf(sampleChapters)
         every { mangaRepository.isFavorite(mangaId) } returns flowOf(false)
         every { downloadRepository.observeDownloads() } returns flowOf(emptyList())

--- a/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
+++ b/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
@@ -258,6 +258,7 @@ class DetailsViewModelTest {
     @Test
     fun onEvent_StartReading_withNoChapters_emitsErrorEffect() = runTest {
         every { mangaRepository.getMangaByIdFlow(mangaId) } returns flowOf(sampleManga)
+        coEvery { mangaRepository.getMangaById(mangaId) } returns sampleManga
         every { chapterRepository.getChaptersByMangaId(mangaId) } returns flowOf(emptyList())
         every { mangaRepository.isFavorite(mangaId) } returns flowOf(false)
         every { downloadRepository.observeDownloads() } returns flowOf(emptyList())
@@ -422,6 +423,7 @@ class DetailsViewModelTest {
     @Test
     fun onEvent_ShareManga_whenMangaIsNull_emitsNoEffect() = runTest {
         every { mangaRepository.getMangaByIdFlow(mangaId) } returns flowOf(null)
+        coEvery { mangaRepository.getMangaById(mangaId) } returns null
         every { chapterRepository.getChaptersByMangaId(mangaId) } returns flowOf(emptyList())
         every { mangaRepository.isFavorite(mangaId) } returns flowOf(false)
         every { downloadRepository.observeDownloads() } returns flowOf(emptyList())
@@ -466,6 +468,7 @@ class DetailsViewModelTest {
     fun onEvent_ToggleNotifications_enablesNotifications_whenCurrentlyMuted() = runTest {
         val mutedManga = sampleManga.copy(notifyNewChapters = false)
         every { mangaRepository.getMangaByIdFlow(mangaId) } returns flowOf(mutedManga)
+        coEvery { mangaRepository.getMangaById(mangaId) } returns mutedManga
         every { chapterRepository.getChaptersByMangaId(mangaId) } returns flowOf(sampleChapters)
         every { mangaRepository.isFavorite(mangaId) } returns flowOf(false)
         every { downloadRepository.observeDownloads() } returns flowOf(emptyList())

--- a/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
+++ b/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
@@ -105,9 +105,13 @@ class DetailsViewModelTest {
         )
     }
 
+    private fun stubManga(manga: Manga?) {
+        every { mangaRepository.getMangaByIdFlow(mangaId) } returns flowOf(manga)
+        coEvery { mangaRepository.getMangaById(mangaId) } returns manga
+    }
+
     private fun setUpDefaultMocks() {
-        every { mangaRepository.getMangaByIdFlow(mangaId) } returns flowOf(sampleManga)
-        coEvery { mangaRepository.getMangaById(mangaId) } returns sampleManga
+        stubManga(sampleManga)
         every { chapterRepository.getChaptersByMangaId(mangaId) } returns flowOf(sampleChapters)
         every { mangaRepository.isFavorite(mangaId) } returns flowOf(false)
         every { downloadRepository.observeDownloads() } returns flowOf(emptyList())
@@ -257,8 +261,7 @@ class DetailsViewModelTest {
 
     @Test
     fun onEvent_StartReading_withNoChapters_emitsErrorEffect() = runTest {
-        every { mangaRepository.getMangaByIdFlow(mangaId) } returns flowOf(sampleManga)
-        coEvery { mangaRepository.getMangaById(mangaId) } returns sampleManga
+        stubManga(sampleManga)
         every { chapterRepository.getChaptersByMangaId(mangaId) } returns flowOf(emptyList())
         every { mangaRepository.isFavorite(mangaId) } returns flowOf(false)
         every { downloadRepository.observeDownloads() } returns flowOf(emptyList())
@@ -422,8 +425,7 @@ class DetailsViewModelTest {
 
     @Test
     fun onEvent_ShareManga_whenMangaIsNull_emitsNoEffect() = runTest {
-        every { mangaRepository.getMangaByIdFlow(mangaId) } returns flowOf(null)
-        coEvery { mangaRepository.getMangaById(mangaId) } returns null
+        stubManga(null)
         every { chapterRepository.getChaptersByMangaId(mangaId) } returns flowOf(emptyList())
         every { mangaRepository.isFavorite(mangaId) } returns flowOf(false)
         every { downloadRepository.observeDownloads() } returns flowOf(emptyList())
@@ -467,8 +469,7 @@ class DetailsViewModelTest {
     @Test
     fun onEvent_ToggleNotifications_enablesNotifications_whenCurrentlyMuted() = runTest {
         val mutedManga = sampleManga.copy(notifyNewChapters = false)
-        every { mangaRepository.getMangaByIdFlow(mangaId) } returns flowOf(mutedManga)
-        coEvery { mangaRepository.getMangaById(mangaId) } returns mutedManga
+        stubManga(mutedManga)
         every { chapterRepository.getChaptersByMangaId(mangaId) } returns flowOf(sampleChapters)
         every { mangaRepository.isFavorite(mangaId) } returns flowOf(false)
         every { downloadRepository.observeDownloads() } returns flowOf(emptyList())


### PR DESCRIPTION
## Summary

- **Tracker count badge in action row**: The Tracking button now shows live tracker count ("1 tracker", "2 trackers") with a `Done` checkmark icon and primary color when active — matching Komikku's `MangaActionRow`. Falls back to the inactive `QueryStats` icon when untracked.
- **WebView button in action row**: A `Language` (globe) icon button appears next to Tracking when the manga's source has a resolvable web URL. Tapping fires `OpenInBrowser` which launches the system browser to the manga's source page. Hidden for local sources.
- **Chapter filter icon in TopAppBar**: `FilterList` icon added to the top bar, highlighted in primary color when a filter is active — matching Komikku's details screen filter entry point (previously only accessible via the chapter list).
- **DetailsViewModel wiring**: Injects `TrackRepository` to `observeEntriesForManga()` live, and resolves `sourceBaseUrl + manga.url` on init. Both are stored in `DetailsContract.State` (`trackingCount`, `mangaWebUrl`).
- **Duplicate import cleanup**: Removed duplicate `ExperimentalFoundationApi` and `combinedClickable` imports that ktlint would flag.
- **String resources**: Added `details_action_webview` and `details_no_browser`.

## Test plan

- [ ] Build passes: `./gradlew :feature:details:compileDebugKotlin`
- [ ] Open a manga tracked on 1+ services → action row Tracking button shows count + Done icon + primary color
- [ ] Open an untracked manga → Tracking button shows "Tracking" label + QueryStats icon + inactive color
- [ ] Open a manga from an online source → WebView button visible; tap → browser opens correct URL
- [ ] Open a local/offline-source manga → WebView button absent
- [ ] Tap FilterList icon in TopAppBar → filter sheet opens; set a filter → icon turns primary color
- [ ] Unit tests pass: `./gradlew :feature:details:test`

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new web-view action on the manga details screen to open the source page in the browser.
  * Display now reflects tracking status with a count and shows the web link action only when available.
  * Updated the top action bar with a chapter filter control.

* **Bug Fixes**
  * Shows a helpful message when no browser app is available for opening links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->