### PR TITLE
feat(history,reader): Komikku parity — cover tap, chapter progress + reader display settings

### DIFF
--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -334,7 +334,10 @@ fun OtakuReaderNavHost(
             },
             onNavigateBack = {
                 navController.popBackStack()
-            }
+            },
+            onMangaClick = { mangaId ->
+                navController.navigate(Route.MangaDetails(mangaId))
+            },
         )
 
         // Manga details

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
@@ -109,6 +109,7 @@ private object HistoryEmptyStateDefaults {
 fun HistoryScreen(
     onChapterClick: (mangaId: Long, chapterId: Long) -> Unit,
     onNavigateBack: () -> Unit,
+    onMangaClick: (mangaId: Long) -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: HistoryViewModel = hiltViewModel()
 ) {
@@ -360,6 +361,7 @@ fun HistoryScreen(
                         onFavoriteClick = { entry ->
                             viewModel.onEvent(HistoryEvent.ToggleMangaFavorite(entry.chapter.mangaId))
                         },
+                        onMangaClick = { entry -> onMangaClick(entry.chapter.mangaId) },
                     )
                 }
             }
@@ -458,6 +460,7 @@ private fun HistoryList(
     onItemLongClick: (ChapterWithHistory) -> Unit,
     onRemoveClick: (ChapterWithHistory) -> Unit,
     onFavoriteClick: (ChapterWithHistory) -> Unit,
+    onMangaClick: (ChapterWithHistory) -> Unit,
     modifier: Modifier = Modifier
 ) {
     // Build the flat list with injected date-group headers
@@ -519,6 +522,7 @@ private fun HistoryList(
                             onItemLongClick = { onItemLongClick(item.entry) },
                             onRemoveClick = { onRemoveClick(item.entry) },
                             onFavoriteClick = { onFavoriteClick(item.entry) },
+                            onMangaCoverClick = { onMangaClick(item.entry) },
                         )
                     }
                     HorizontalDivider()
@@ -553,6 +557,7 @@ private fun HistoryItem(
     onItemLongClick: () -> Unit,
     onRemoveClick: () -> Unit,
     onFavoriteClick: () -> Unit,
+    onMangaCoverClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -576,17 +581,17 @@ private fun HistoryItem(
         } else {
             Surface(
                 shape = MaterialTheme.shapes.small,
-                // Tonal backdrop so a failed/missing thumbnail shows a neutral block
-                // instead of an empty hole in the row.
                 color = MaterialTheme.colorScheme.surfaceVariant,
-                modifier = Modifier.size(width = 40.dp, height = 56.dp)
+                modifier = Modifier
+                    .size(width = 40.dp, height = 56.dp)
+                    .combinedClickable(onClick = onMangaCoverClick)
             ) {
                 AsyncImage(
                     model = ImageRequest.Builder(LocalContext.current)
                         .data(entry.mangaThumbnailUrl)
                         .crossfade(true)
                         .build(),
-                    contentDescription = entry.mangaTitle,
+                    contentDescription = stringResource(R.string.history_open_manga),
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .fillMaxWidth()
@@ -607,12 +612,33 @@ private fun HistoryItem(
                     maxLines = 1,
                 )
             }
+            // Chapter number ("Ch. 12" or "Ch. 12.5") — skipped when number is unknown (-1)
+            val chapterNum = entry.chapter.chapterNumber
+            val chapterNumText = if (chapterNum >= 0f) {
+                val formatted = if (chapterNum == chapterNum.toLong().toFloat()) {
+                    chapterNum.toLong().toString()
+                } else {
+                    chapterNum.toString()
+                }
+                stringResource(R.string.history_chapter_number, formatted)
+            } else {
+                entry.chapter.name
+            }
             Text(
-                text = entry.chapter.name,
+                text = chapterNumText,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1
             )
+            // Read progress ("Page X") — only when partially read
+            val lastPage = entry.chapter.lastPageRead
+            if (lastPage > 0 && !entry.chapter.read) {
+                Text(
+                    text = stringResource(R.string.history_read_progress, lastPage + 1),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             Text(
                 text = formatReadAt(entry.readAt),
                 style = MaterialTheme.typography.labelSmall,

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
@@ -580,18 +580,17 @@ private fun HistoryItem(
             )
         } else {
             Surface(
+                onClick = onMangaCoverClick,
                 shape = MaterialTheme.shapes.small,
                 color = MaterialTheme.colorScheme.surfaceVariant,
-                modifier = Modifier
-                    .size(width = 40.dp, height = 56.dp)
-                    .combinedClickable(onClick = onMangaCoverClick)
+                modifier = Modifier.size(width = 40.dp, height = 56.dp)
             ) {
                 AsyncImage(
                     model = ImageRequest.Builder(LocalContext.current)
                         .data(entry.mangaThumbnailUrl)
                         .crossfade(true)
                         .build(),
-                    contentDescription = stringResource(R.string.history_open_manga),
+                    contentDescription = entry.mangaTitle,
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .fillMaxWidth()
@@ -612,20 +611,8 @@ private fun HistoryItem(
                     maxLines = 1,
                 )
             }
-            // Chapter number ("Ch. 12" or "Ch. 12.5") — skipped when number is unknown (-1)
-            val chapterNum = entry.chapter.chapterNumber
-            val chapterNumText = if (chapterNum >= 0f) {
-                val formatted = if (chapterNum == chapterNum.toLong().toFloat()) {
-                    chapterNum.toLong().toString()
-                } else {
-                    chapterNum.toString()
-                }
-                stringResource(R.string.history_chapter_number, formatted)
-            } else {
-                entry.chapter.name
-            }
             Text(
-                text = chapterNumText,
+                text = entry.chapter.name,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1

--- a/feature/history/src/main/java/app/otakureader/feature/history/navigation/HistoryNavigation.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/navigation/HistoryNavigation.kt
@@ -8,11 +8,13 @@ import app.otakureader.feature.history.HistoryScreen
 fun NavGraphBuilder.historyScreen(
     onChapterClick: (mangaId: Long, chapterId: Long) -> Unit,
     onNavigateBack: () -> Unit,
+    onMangaClick: (mangaId: Long) -> Unit,
 ) {
     composable<Route.History> {
         HistoryScreen(
             onChapterClick = onChapterClick,
-            onNavigateBack = onNavigateBack
+            onNavigateBack = onNavigateBack,
+            onMangaClick = onMangaClick,
         )
     }
 }

--- a/feature/history/src/main/res/values/strings.xml
+++ b/feature/history/src/main/res/values/strings.xml
@@ -46,8 +46,7 @@
     <string name="history_add_to_library">Add to library</string>
     <string name="history_in_library">In library</string>
     <string name="history_open_manga">Open manga</string>
-    <!-- Chapter number and read progress in history row -->
-    <string name="history_chapter_number">Ch. %1$s</string>
+    <!-- Read progress in history row -->
     <string name="history_read_progress">Page %1$d</string>
     <!-- Active-filter indicator -->
     <string name="history_filter_active_indicator">Filters active</string>

--- a/feature/history/src/main/res/values/strings.xml
+++ b/feature/history/src/main/res/values/strings.xml
@@ -45,6 +45,10 @@
     <!-- Add to library from history row -->
     <string name="history_add_to_library">Add to library</string>
     <string name="history_in_library">In library</string>
+    <string name="history_open_manga">Open manga</string>
+    <!-- Chapter number and read progress in history row -->
+    <string name="history_chapter_number">Ch. %1$s</string>
+    <string name="history_read_progress">Page %1$d</string>
     <!-- Active-filter indicator -->
     <string name="history_filter_active_indicator">Filters active</string>
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/components/ZoomableImage.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/components/ZoomableImage.kt
@@ -117,7 +117,10 @@ fun ZoomableImage(
                             val cancelled = event.changes.any { it.isConsumed }
 
                             if (!cancelled) {
-                                val zoomChange = event.calculateZoom()
+                                // When pinch-to-zoom is disabled, treat zoom as 1f so scale never
+                                // changes via pinch, but still allow pan for images already zoomed
+                                // (e.g. after a double-tap zoom).
+                                val zoomChange = if (pinchToZoomEnabled) event.calculateZoom() else 1f
                                 val panChange = event.calculatePan()
                                 val centroid = event.calculateCentroid(useCurrent = false)
 


### PR DESCRIPTION
## Description

Two parity areas in one branch:

**History screen** (Komikku/Mihon parity):
- Cover thumbnail is now a distinct click target that navigates to the manga detail screen
- Chapter name is displayed directly in each row (matching Komikku's behaviour — full title, not a formatted number)
- "Page X" read-progress label shown for partially-read chapters (hidden when fully read)
- Navigation wired in `OtakuReaderNavHost` via new `onMangaClick` callback on the history route

**Reader display settings** (Komikku parity):
- Page layout setting: Single / Dual / Automatic (pager mode, per-session visual override on top of reading mode)
- Landscape zoom scale type: Fit Width / Fit Height / Fit Page / Smart
- Webtoon pinch-to-zoom toggle (pan still works when disabled — fixed bug where early-return blocked drag after double-tap zoom)
- Webtoon scale type: Fit Width / Fit Height / Original Size

Settings are persisted via DataStore, loaded into `ReaderState` on startup (`loadSettings()`), and wired through the `ReaderSettingsLoaderDelegate` + `ReaderDisplayDelegate` MVI delegates.

## Type of Change
- [x] ✨ New feature
- [x] 🎨 UI/UX
- [x] 🐛 Bug fix

## Testing

- History: open History screen, tap a cover thumbnail → should navigate to manga detail; verify chapter name shows full title; verify "Page X" appears only for partially-read chapters.
- Reader: open reader settings overlay → verify Page Layout / Landscape Zoom / Webtoon Pinch-to-Zoom / Webtoon Scale Type controls appear; change each and reopen reader to verify settings persist.
- Webtoon pan: set pinch-to-zoom disabled, double-tap to zoom in, then drag — pan should still work.

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] No new warnings
- [x] Tests pass

## Related Issues

Part of the ongoing Komikku 1:1 parity effort.