### PR TITLE
feat(details): Komikku parity — TopAppBar enterAlwaysScrollBehavior

### DIFF
--- a/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
+++ b/feature/browse/src/test/java/app/otakureader/feature/browse/BrowseViewModelTest.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
@@ -128,6 +129,7 @@ class BrowseViewModelTest {
 
     @After
     fun teardown() {
+        viewModel.viewModelScope.cancel()
         collectScope.cancel()
         Dispatchers.resetMain()
     }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -84,6 +84,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
@@ -154,6 +155,7 @@ fun DetailsScreen(
     val context = LocalContext.current
     val isExpanded = rememberWindowWidthSizeClass().isExpanded
     val listState = rememberLazyListState()
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val heroScrollOffset by remember {
         derivedStateOf {
             if (listState.firstVisibleItemIndex == 0)
@@ -274,6 +276,7 @@ fun DetailsScreen(
             viewModel.onEvent(DetailsContract.Event.ClearChapterSelection)
         }
         Scaffold(
+            modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
             topBar = {
             if (selectedVisibleChapters.isNotEmpty()) {
                 ChapterSelectionTopBar(
@@ -297,7 +300,9 @@ fun DetailsScreen(
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.surface.copy(alpha = topBarAlpha),
+                    scrolledContainerColor = MaterialTheme.colorScheme.surface,
                 ),
+                scrollBehavior = scrollBehavior,
                 actions = {
                     val filterActive = state.chapterFilter.isActive
                     IconButton(onClick = { viewModel.onEvent(DetailsContract.Event.ShowChapterFilter) }) {

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -85,8 +85,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -275,7 +275,11 @@ fun DetailsScreen(
             viewModel.onEvent(DetailsContract.Event.ClearChapterSelection)
         }
         Scaffold(
-            modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+            modifier = if (selectedVisibleChapters.isEmpty()) {
+                Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+            } else {
+                Modifier
+            },
             topBar = {
             if (selectedVisibleChapters.isNotEmpty()) {
                 ChapterSelectionTopBar(

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -80,6 +80,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -155,7 +156,13 @@ fun DetailsScreen(
     val context = LocalContext.current
     val isExpanded = rememberWindowWidthSizeClass().isExpanded
     val listState = rememberLazyListState()
-    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+    val selectedVisibleChapters = remember(state.sortedChapters, state.selectedChapters) {
+        state.sortedChapters.filter { it.id in state.selectedChapters }
+    }
+    val isScrollAllowed = rememberUpdatedState(!isExpanded && selectedVisibleChapters.isEmpty())
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(
+        canScroll = { isScrollAllowed.value },
+    )
     val heroScrollOffset by remember {
         derivedStateOf {
             if (listState.firstVisibleItemIndex == 0)
@@ -262,14 +269,6 @@ fun DetailsScreen(
         // Per-manga override (#947) takes precedence over the global autoThemeColor pref.
         enabled = state.manga?.mangaThemeOverride ?: state.autoThemeEnabled
     )
-
-    // Single source of truth for both selection bars: the selected chapters that are actually
-    // visible in the current (filtered/sorted) list. Deriving the top bar count and the bottom
-    // action menu from the same list keeps them in sync even if some selected IDs become stale
-    // after a list refresh or are hidden by a filter.
-    val selectedVisibleChapters = remember(state.sortedChapters, state.selectedChapters) {
-        state.sortedChapters.filter { it.id in state.selectedChapters }
-    }
 
     MangaDynamicTheme(colorScheme = dynamicScheme) {
         BackHandler(enabled = selectedVisibleChapters.isNotEmpty()) {


### PR DESCRIPTION
## Summary

- Wires `TopAppBarDefaults.enterAlwaysScrollBehavior()` to the Details screen `TopAppBar`, matching Komikku's scroll-away behavior: the bar slides off screen when scrolling down through the chapter list and slides back when scrolling up.
- Adds `Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)` to the `Scaffold` so the scroll offset is properly tracked.
- Sets `scrolledContainerColor = MaterialTheme.colorScheme.surface` on `TopAppBarDefaults.topAppBarColors()` so the bar becomes fully opaque (no alpha fade) once the hero cover has scrolled out of view, preventing a transparent bar floating over the chapter list.

## What changed

`feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt`
- Import `androidx.compose.ui.input.nestedscroll.nestedScroll`
- `val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()` after `rememberLazyListState()`
- `Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)` on `Scaffold`
- `scrolledContainerColor` + `scrollBehavior` on `TopAppBar`

## Test plan

- [ ] Scroll down in chapter list — TopAppBar slides off screen
- [ ] Scroll up — TopAppBar slides back into view
- [ ] Hero-scrolled state: bar is fully opaque (not transparent) over chapter rows
- [ ] At top of list (hero visible): bar retains the existing alpha fade behavior
- [ ] CI: Detekt, ktlint, unit tests, assembleDebug all green

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling behavior on the details screen so the app bar only reacts when scrolling is appropriate.
  * Prevented scroll interactions from conflicting with chapter selection mode.
  * Refined the details page appearance so the top bar blends more consistently with the page background.
  * Made test cleanup more reliable by ensuring background activity is fully stopped after tests run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->