### PR TITLE
feat(reader): Komikku parity — title click, bookmark icon, WebView/Browser/Share/PageLayout/ShiftPage buttons

### DIFF
--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -465,6 +465,7 @@ fun ReaderScreen(
             chapterTitle = state.chapterTitle,
             isVisible = state.isMenuVisible && !state.isGalleryOpen && !state.isLoading,
             onDismiss = onNavigateBack,
+            onTitleClick = { viewModel.onEvent(ReaderEvent.ToggleChapterListOverlay) },
             onDownloadChapter = { viewModel.onEvent(ReaderEvent.DownloadCurrentChapter) },
             isCurrentChapterDownloaded = state.isCurrentChapterDownloaded,
             onBookmarkPage = { viewModel.onEvent(ReaderEvent.ToggleBookmark) },

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderBottomBar.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderBottomBar.kt
@@ -71,10 +71,8 @@ fun ReaderBottomBar(
     onWebView: (() -> Unit)? = null,
     onBrowser: (() -> Unit)? = null,
     onShare: (() -> Unit)? = null,
-    showPageLayoutButton: Boolean = false,
-    onPageLayout: () -> Unit = {},
-    showShiftPageButton: Boolean = false,
-    onShiftPage: () -> Unit = {},
+    onPageLayout: (() -> Unit)? = null,
+    onShiftPage: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(
@@ -154,7 +152,7 @@ fun ReaderBottomBar(
                     tint = if (state.cropBordersEnabled) iconColor else dimColor,
                 )
             }
-            if (showPageLayoutButton) {
+            if (onPageLayout != null) {
                 IconButton(onClick = onPageLayout) {
                     Icon(
                         imageVector = Icons.Default.MenuBook,
@@ -163,7 +161,7 @@ fun ReaderBottomBar(
                     )
                 }
             }
-            if (showShiftPageButton) {
+            if (onShiftPage != null) {
                 IconButton(onClick = onShiftPage) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.NavigateNext,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderBottomBar.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderBottomBar.kt
@@ -22,8 +22,11 @@ import androidx.compose.material.icons.filled.MenuBook
 import androidx.compose.material.icons.filled.ScreenRotation
 import androidx.compose.material.icons.outlined.BurstMode
 import androidx.compose.material.icons.outlined.Crop
+import androidx.compose.material.icons.outlined.Explore
 import androidx.compose.material.icons.outlined.FormatListNumbered
+import androidx.compose.material.icons.outlined.Public
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -65,6 +68,13 @@ fun ReaderBottomBar(
     onToggleThumbnailStrip: () -> Unit,
     onSettings: () -> Unit,
     isVisible: Boolean,
+    onWebView: (() -> Unit)? = null,
+    onBrowser: (() -> Unit)? = null,
+    onShare: (() -> Unit)? = null,
+    showPageLayoutButton: Boolean = false,
+    onPageLayout: () -> Unit = {},
+    showShiftPageButton: Boolean = false,
+    onShiftPage: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(
@@ -96,6 +106,33 @@ fun ReaderBottomBar(
                     tint = iconColor,
                 )
             }
+            if (onWebView != null) {
+                IconButton(onClick = onWebView) {
+                    Icon(
+                        imageVector = Icons.Outlined.Public,
+                        contentDescription = stringResource(R.string.reader_open_in_web_view),
+                        tint = iconColor,
+                    )
+                }
+            }
+            if (onBrowser != null) {
+                IconButton(onClick = onBrowser) {
+                    Icon(
+                        imageVector = Icons.Outlined.Explore,
+                        contentDescription = stringResource(R.string.reader_open_in_browser),
+                        tint = iconColor,
+                    )
+                }
+            }
+            if (onShare != null) {
+                IconButton(onClick = onShare) {
+                    Icon(
+                        imageVector = Icons.Outlined.Share,
+                        contentDescription = stringResource(R.string.reader_share),
+                        tint = iconColor,
+                    )
+                }
+            }
             IconButton(onClick = onModeClick) {
                 Icon(
                     imageVector = state.mode.icon,
@@ -116,6 +153,24 @@ fun ReaderBottomBar(
                     contentDescription = stringResource(R.string.reader_crop_borders),
                     tint = if (state.cropBordersEnabled) iconColor else dimColor,
                 )
+            }
+            if (showPageLayoutButton) {
+                IconButton(onClick = onPageLayout) {
+                    Icon(
+                        imageVector = Icons.Default.MenuBook,
+                        contentDescription = stringResource(R.string.reader_page_layout),
+                        tint = iconColor,
+                    )
+                }
+            }
+            if (showShiftPageButton) {
+                IconButton(onClick = onShiftPage) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.NavigateNext,
+                        contentDescription = stringResource(R.string.reader_shift_double_pages),
+                        tint = iconColor,
+                    )
+                }
             }
             IconButton(onClick = onToggleThumbnailStrip) {
                 Icon(

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderContentOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderContentOverlay.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,8 +15,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.outlined.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -69,6 +70,7 @@ fun ReaderContentOverlay(
     isVisible: Boolean,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
+    onTitleClick: (() -> Unit)? = null,
     onDownloadChapter: (() -> Unit)? = null,
     isCurrentChapterDownloaded: Boolean = false,
     onBookmarkPage: (() -> Unit)? = null,
@@ -102,7 +104,14 @@ fun ReaderContentOverlay(
                     tint = onSurface
                 )
             }
-            Column(modifier = Modifier.weight(1f)) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .then(
+                        if (onTitleClick != null) Modifier.clickable(onClick = onTitleClick)
+                        else Modifier
+                    )
+            ) {
                 Text(
                     title,
                     style = MaterialTheme.typography.titleSmall,
@@ -131,7 +140,7 @@ fun ReaderContentOverlay(
                 IconButton(onClick = onBookmarkPage) {
                     Icon(
                         imageVector = if (isCurrentPageBookmarked) {
-                            Icons.Default.Bookmark
+                            Icons.Outlined.Bookmark
                         } else {
                             Icons.Outlined.BookmarkBorder
                         },

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderContentOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderContentOverlay.kt
@@ -58,10 +58,11 @@ private val readerTopBarFade = tween<Float>(READER_TOP_BAR_FADE_MS)
  * @param chapterTitle  Current chapter title displayed below the series title.
  * @param isVisible     Whether the overlay is shown.
  * @param onDismiss     Called when the back arrow is tapped — typically navigates back.
+ * @param onTitleClick Called when the title/chapter area is tapped; null makes the area non-interactive.
  * @param onDownloadChapter Called when the download icon is tapped; null hides the button.
  * @param isCurrentChapterDownloaded When true, the download button is hidden.
  * @param onBookmarkPage Called when the bookmark icon is tapped; null hides the button.
- * @param isCurrentPageBookmarked When true, shows a filled bookmark icon.
+ * @param isCurrentPageBookmarked When true, shows a solid bookmark; when false, shows an outlined bookmark border.
  */
 @Composable
 fun ReaderContentOverlay(

--- a/feature/reader/src/main/res/values/strings.xml
+++ b/feature/reader/src/main/res/values/strings.xml
@@ -295,4 +295,9 @@
     <string name="reader_tap_invert_vertical">Vertical</string>
     <string name="reader_tap_invert_both">Both</string>
     <string name="reader_smaller_tap_zone">Smaller tap zone</string>
+    <string name="reader_open_in_web_view">Open in web view</string>
+    <string name="reader_open_in_browser">Open in browser</string>
+    <string name="reader_share">Share</string>
+    <string name="reader_page_layout">Page layout</string>
+    <string name="reader_shift_double_pages">Shift double pages</string>
 </resources>

--- a/feature/reader/src/main/res/values/strings.xml
+++ b/feature/reader/src/main/res/values/strings.xml
@@ -295,7 +295,7 @@
     <string name="reader_tap_invert_vertical">Vertical</string>
     <string name="reader_tap_invert_both">Both</string>
     <string name="reader_smaller_tap_zone">Smaller tap zone</string>
-    <string name="reader_open_in_web_view">Open in web view</string>
+    <string name="reader_open_in_web_view">Open in WebView</string>
     <string name="reader_open_in_browser">Open in browser</string>
     <string name="reader_share">Share</string>
     <string name="reader_page_layout">Page layout</string>


### PR DESCRIPTION
## Summary

Brings the reader top bar and bottom bar to visual and structural parity with Komikku/Mihon.

### Top bar (`ReaderContentOverlay`)

- **Title area is now tappable** — `Modifier.clickable` added to the title/chapter Column when `onTitleClick` is provided, matching Komikku's `clickable(onClick = onClickTopAppBar)` wrapper. Wired in `ReaderScreen` to `ToggleChapterListOverlay`, the same destination Komikku uses.
- **Bookmark icon style** — changed from `Icons.Default.Bookmark` (solid fill) to `Icons.Outlined.Bookmark`, matching Komikku's use of the outlined variant. Both states now use outlined icons (`Bookmark` / `BookmarkBorder`) for visual consistency.

### Bottom bar (`ReaderBottomBar`)

- **WebView / Browser / Share buttons** — added `onWebView`, `onBrowser`, `onShare` nullable parameters. A non-null value renders the `Public`, `Explore`, `Share` icons in Komikku's sequence (after chapter list, before reading mode). Currently passed as `null` from `ReaderScreen`; will be wired to source page URLs in a follow-up PR once the source URL plumbing exists.
- **Page layout / Shift page buttons** — added `showPageLayoutButton`/`onPageLayout` and `showShiftPageButton`/`onShiftPage` for dual-page layout toggling and double-page shift, matching Komikku's `PageLayout` and `ShiftPage` buttons. Currently hidden (`false`) pending dual-page split implementation.
- **Button order** now matches Komikku exactly: ChapterList → WebView → Browser → Share → ReadingMode → Orientation → CropBorders → PageLayout → ShiftPage → ThumbnailStrip (Otaku-exclusive, additive) → Settings.
- All new parameters have safe defaults — no existing call sites break.

### Strings

Added `reader_open_in_web_view`, `reader_open_in_browser`, `reader_share`, `reader_page_layout`, `reader_shift_double_pages` content descriptions.

## Test plan

- [ ] Open reader, tap center to show menu — tap the title/chapter area → chapter list overlay opens
- [ ] Bookmark a page — bookmark icon shows outlined style (both filled-outline and hollow-outline are consistent)
- [ ] Bottom bar shows correct button order: chapter list, reading mode, orientation, crop, thumbnail strip, settings (WebView/Browser/Share/PageLayout/ShiftPage hidden since callbacks are null/false)
- [ ] No regressions in existing bottom bar buttons (tap each, verify actions fire)
- [ ] Unit tests pass, Detekt/Ktlint clean

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_