### PR TITLE
fix(library): filter-empty state must not show when library is truly empty

### DIFF
--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -82,6 +82,7 @@ data class LibraryState(
     /** True while a background library update (the WorkManager job) is running. */
     val isLibraryUpdating: Boolean = false,
     val mangaList: List<LibraryMangaItem> = emptyList(),
+    val totalMangaCount: Int = 0,
     val selectedManga: Set<Long> = emptySet(),
     val searchQuery: String = "",
     val showSearchBar: Boolean = false,

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -760,7 +760,7 @@ private fun LibraryContent(
                         )
                     }
                 }
-                state.mangaList.isEmpty() && hasActiveItemFilters -> {
+                state.mangaList.isEmpty() && hasActiveItemFilters && state.totalMangaCount > 0 -> {
                     Box(modifier = Modifier.fillMaxSize()) {
                         EmptyLibraryFilterMessage(
                             onClearFilters = { onEvent(LibraryEvent.ClearAllFilters) },

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -698,7 +698,7 @@ class LibraryViewModel @Inject constructor(
             applyFiltersAndSort(items, params.copy(searchMatchingIds = matchingIds))
         }
             .onEach { filtered ->
-                _state.update { it.copy(mangaList = filtered) }
+                _state.update { it.copy(mangaList = filtered, totalMangaCount = _allItems.value.size) }
             }
             .launchIn(viewModelScope)
     }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -695,10 +695,10 @@ class LibraryViewModel @Inject constructor(
                 )
             }.distinctUntilChanged()
         ) { items, matchingIds, params ->
-            applyFiltersAndSort(items, params.copy(searchMatchingIds = matchingIds))
+            applyFiltersAndSort(items, params.copy(searchMatchingIds = matchingIds)) to items.size
         }
-            .onEach { filtered ->
-                _state.update { it.copy(mangaList = filtered, totalMangaCount = _allItems.value.size) }
+            .onEach { (filtered, totalCount) ->
+                _state.update { it.copy(mangaList = filtered, totalMangaCount = totalCount) }
             }
             .launchIn(viewModelScope)
     }


### PR DESCRIPTION
## Summary

Follow-up to #1171. Copilot identified that `state.mangaList.isEmpty() && hasActiveItemFilters` fires even when the library has **0 manga** and the user happens to have filters active — showing "No manga match / Clear filters" instead of the correct "Your library is empty / Browse sources" state.

**Root cause:** `state.mangaList` is the post-filter list. It's empty for two different reasons that need different UX: truly empty library vs. filters hiding all manga.

**Fix:**
- Add `totalMangaCount: Int = 0` to `LibraryState`, populated from the unfiltered `_allItems` in the combine block alongside the existing `mangaList` update
- Guard the filter-empty `when` branch with `state.totalMangaCount > 0` so it only fires when the library genuinely has manga that filters are hiding

## Files changed

| File | Change |
|------|--------|
| `LibraryMvi.kt` | Add `totalMangaCount: Int = 0` field to `LibraryState` |
| `LibraryViewModel.kt` | Populate `totalMangaCount = _allItems.value.size` in the combine `.onEach` block |
| `LibraryScreen.kt` | Add `&& state.totalMangaCount > 0` guard to the filter-empty branch |

## Test plan

- [ ] Library with 0 manga + active filters → "Your library is empty" state (not "No manga match")
- [ ] Library with manga + active item filters hiding all → "No manga match" + Clear filters button
- [ ] Library with manga + no active filters → normal grid/list view
- [ ] CI: Unit Tests, Detekt, Ktlint, Assemble all green

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_