### PR TITLE
feat(library): category tabs row — Komikku parity

### DIFF
--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -1159,11 +1159,16 @@ private fun LibraryCategoryTabs(
     onTabSelected: (Long?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val selectedIndex = if (selectedCategoryId == null) {
-        0
-    } else {
-        val idx = categories.indexOfFirst { it.id == selectedCategoryId }
-        if (idx < 0) 0 else idx + 1
+    val selectedIndex = remember(categories, selectedCategoryId) {
+        if (selectedCategoryId == null) {
+            0
+        } else {
+            val idx = categories.indexOfFirst { it.id == selectedCategoryId }
+            if (idx < 0) 0 else idx + 1
+        }
+    }
+    val totalCount = remember(categories, showItemCount) {
+        if (showItemCount) categories.sumOf { it.count } else null
     }
 
     Column(modifier = modifier.zIndex(2f)) {
@@ -1178,7 +1183,7 @@ private fun LibraryCategoryTabs(
                 text = {
                     LibraryTabText(
                         text = stringResource(R.string.library_filter_all),
-                        badgeCount = if (showItemCount) categories.sumOf { it.count } else null,
+                        badgeCount = totalCount,
                     )
                 },
                 unselectedContentColor = MaterialTheme.colorScheme.onSurface,
@@ -1206,9 +1211,9 @@ private fun LibraryTabText(
     text: String,
     badgeCount: Int? = null,
 ) {
-    BadgedBox(
-        badge = {
-            if (badgeCount != null && badgeCount > 0) {
+    if (badgeCount != null && badgeCount > 0) {
+        BadgedBox(
+            badge = {
                 Badge(
                     containerColor = MaterialTheme.colorScheme.primary,
                     contentColor = MaterialTheme.colorScheme.onPrimary,
@@ -1219,9 +1224,15 @@ private fun LibraryTabText(
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-            }
-        },
-    ) {
+            },
+        ) {
+            Text(
+                text = text,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    } else {
         Text(
             text = text,
             maxLines = 1,

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -107,8 +107,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.outlined.FlipToBack
 import androidx.compose.material.icons.outlined.SelectAll
 import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.zIndex
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -741,6 +746,16 @@ private fun LibraryContent(
             )
         }
 
+        // Category tabs (Komikku parity): scrollable tab row with optional count badges.
+        if (state.showCategoryTabs && state.categories.isNotEmpty()) {
+            LibraryCategoryTabs(
+                categories = state.categories,
+                selectedCategoryId = state.selectedCategory,
+                showItemCount = state.showCategoryItemCount,
+                onTabSelected = { onEvent(LibraryEvent.OnCategorySelected(it)) },
+            )
+        }
+
         PullToRefreshBox(
             isRefreshing = state.isRefreshing,
             onRefresh = { onEvent(LibraryEvent.Refresh) },
@@ -1128,5 +1143,89 @@ private fun LibrarySelectionBottomBar(
                 }
             }
         }
+    }
+}
+
+/**
+ * Scrollable tab row showing each library category as a tab, matching Komikku's LibraryTabs.
+ * The leading "All" tab selects [selectedCategoryId] = null (no category filter).
+ * Item-count badges are shown when [showItemCount] is true.
+ */
+@Composable
+private fun LibraryCategoryTabs(
+    categories: List<CategoryItem>,
+    selectedCategoryId: Long?,
+    showItemCount: Boolean,
+    onTabSelected: (Long?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val selectedIndex = if (selectedCategoryId == null) {
+        0
+    } else {
+        val idx = categories.indexOfFirst { it.id == selectedCategoryId }
+        if (idx < 0) 0 else idx + 1
+    }
+
+    Column(modifier = modifier.zIndex(2f)) {
+        PrimaryScrollableTabRow(
+            selectedTabIndex = selectedIndex,
+            edgePadding = 0.dp,
+            divider = {},
+        ) {
+            Tab(
+                selected = selectedCategoryId == null,
+                onClick = { onTabSelected(null) },
+                text = {
+                    LibraryTabText(
+                        text = stringResource(R.string.library_filter_all),
+                        badgeCount = if (showItemCount) categories.sumOf { it.count } else null,
+                    )
+                },
+                unselectedContentColor = MaterialTheme.colorScheme.onSurface,
+            )
+            categories.forEach { category ->
+                Tab(
+                    selected = selectedCategoryId == category.id,
+                    onClick = { onTabSelected(category.id) },
+                    text = {
+                        LibraryTabText(
+                            text = category.name,
+                            badgeCount = if (showItemCount) category.count else null,
+                        )
+                    },
+                    unselectedContentColor = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+        }
+        HorizontalDivider()
+    }
+}
+
+@Composable
+private fun LibraryTabText(
+    text: String,
+    badgeCount: Int? = null,
+) {
+    BadgedBox(
+        badge = {
+            if (badgeCount != null && badgeCount > 0) {
+                Badge(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                ) {
+                    Text(
+                        text = badgeCount.toString(),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        },
+    ) {
+        Text(
+            text = text,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }


### PR DESCRIPTION
## Summary

- Adds `LibraryCategoryTabs` composable: a `PrimaryScrollableTabRow` that renders each user category as a scrollable tab, with an implicit **All** tab pinned at position 0
- Tab item-count badges (matching Komikku's `TabText` pattern) shown when the **Show category item count** display preference is enabled
- Tabs wire into the existing `selectedCategory` state and `OnCategorySelected` event — category filtering was already implemented in the ViewModel
- Controlled by the existing **Show category tabs** preference toggle already present in the Display tab of the bottom sheet

## What changed

`feature/library/…/LibraryScreen.kt`
- Added `LibraryCategoryTabs` private composable (PrimaryScrollableTabRow + HorizontalDivider, `divider = {}` to suppress the default double-line, matching Komikku exactly)
- Added `LibraryTabText` private composable (BadgedBox wrapping Text, Badge shown only when count > 0)
- Inserted the tabs between the SavedViews row and PullToRefreshBox inside `LibraryContent`, guarded by `state.showCategoryTabs && state.categories.isNotEmpty()`
- Added 5 imports: `BadgedBox`, `HorizontalDivider`, `PrimaryScrollableTabRow`, `Tab`, `zIndex`

## Komikku reference

`eu.kanade.presentation.library.components.LibraryTabs` — identical `PrimaryScrollableTabRow` structure with `edgePadding = 0.dp`, `divider = {}`, per-tab `unselectedContentColor = MaterialTheme.colorScheme.onSurface`, and `HorizontalDivider` below the row.

## Test plan

- [ ] Library with no user categories: tab row hidden (categories list is empty)
- [ ] Library with 1+ categories: All tab + each category shown, correct tab highlighted on selection
- [ ] Tapping a category tab filters the grid to that category's manga
- [ ] Tapping **All** clears the category filter (shows full library)
- [ ] Count badges appear when Display → Show category item count is on; hidden when off
- [ ] Tab row hidden when Display → Show category tabs is off
- [ ] CI green (assemble, detekt, ktlint, unit tests)


---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scrollable category tabs in the library view.
  * Included an **All** tab plus per-category tabs, with optional item-count badges.
  * Updated tab selection to switch between all items or a specific category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->