### PR TITLE
fix(library): clear stale selectedCategory when its category is deleted

### DIFF
--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -115,6 +115,8 @@ import androidx.compose.material3.Tab
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.zIndex
 
+private const val CATEGORY_TABS_Z_INDEX = 2f
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LibraryScreen(
@@ -1171,7 +1173,7 @@ private fun LibraryCategoryTabs(
         if (showItemCount) categories.sumOf { it.count } else null
     }
 
-    Column(modifier = modifier.zIndex(2f)) {
+    Column(modifier = modifier.zIndex(CATEGORY_TABS_Z_INDEX)) {
         PrimaryScrollableTabRow(
             selectedTabIndex = selectedIndex,
             edgePadding = 0.dp,

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -633,9 +633,9 @@ class LibraryViewModel @Inject constructor(
                     }
                     // If the previously selected category was deleted, clear the selection so
                     // the tab row and filter both reflect the same "All" state.
+                    val validIds = items.mapTo(HashSet()) { it.id }
                     _state.update { state ->
-                        val validatedCategory = state.selectedCategory
-                            ?.takeIf { id -> items.any { it.id == id } }
+                        val validatedCategory = state.selectedCategory?.takeIf { it in validIds }
                         state.copy(categories = items, selectedCategory = validatedCategory)
                     }
                 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -631,7 +631,13 @@ class LibraryViewModel @Inject constructor(
                             count = category.mangaCount
                         )
                     }
-                    _state.update { it.copy(categories = items) }
+                    // If the previously selected category was deleted, clear the selection so
+                    // the tab row and filter both reflect the same "All" state.
+                    _state.update { state ->
+                        val validatedCategory = state.selectedCategory
+                            ?.takeIf { id -> items.any { it.id == id } }
+                        state.copy(categories = items, selectedCategory = validatedCategory)
+                    }
                 }
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to #1173. Addresses two issues identified by CodeRabbit after merge:

- **Bug (major):** When a category was deleted and `loadCategories()` refreshed `state.categories`, the tab row's `selectedIndex` fell back to 0 (visually "All") but `selectedCategoryId` stayed non-null in the ViewModel — the grid was still filtering by a category that no longer existed. The tab indicator and the actual filter were out of sync.
- **Nitpick:** `zIndex(2f)` was a magic number in violation of the project's no-magic-numbers convention.

## What changed

**`LibraryViewModel.kt` — `loadCategories()`**

The `_state.update` lambda now validates `selectedCategory` against the incoming list using `takeIf`. If the selected id is no longer present, it's set to `null`, which atomically resets both the tab indicator (index 0 = "All") and the category filter in the same state emission.

```kotlin
val validatedCategory = state.selectedCategory
    ?.takeIf { id -> items.any { it.id == id } }
state.copy(categories = items, selectedCategory = validatedCategory)
```

**`LibraryScreen.kt`**

Extracted `2f` to `private const val CATEGORY_TABS_Z_INDEX = 2f` at file scope.

## Why `takeIf` here

`takeIf` returns the receiver if the predicate is true, or `null` otherwise. So `selectedCategory?.takeIf { id -> items.any { it.id == id } }` returns the id unchanged when it's still in the list, and `null` (clearing the selection) when it isn't — all in one expression without an explicit `if/else`.

## Test plan

- [ ] Delete a category while it is the selected tab → tab row resets to "All", library shows all manga
- [ ] Delete a category that is NOT selected → other tabs and selection unaffected
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_