### PR TITLE
feat(library): full group-type selector — BY_DEFAULT/BY_SOURCE/BY_STATUS/UNGROUPED

### DIFF
--- a/core/preferences/src/main/java/app/otakureader/core/preferences/LibraryPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/LibraryPreferences.kt
@@ -17,9 +17,9 @@ import kotlinx.coroutines.flow.map
  */
 class LibraryPreferences(private val dataStore: DataStore<Preferences>) {
 
-    /** Whether to group library items by category visually. */
-    val groupByCategory: Flow<Boolean> = dataStore.data.map { it[Keys.GROUP_BY_CATEGORY] ?: false }
-    suspend fun setGroupByCategory(value: Boolean) = dataStore.edit { it[Keys.GROUP_BY_CATEGORY] = value }
+    /** Group type: 0=BY_DEFAULT, 1=BY_SOURCE, 2=BY_STATUS, 3=BY_TRACK_STATUS, 4=UNGROUPED */
+    val groupType: Flow<Int> = dataStore.data.map { it[Keys.LIBRARY_GROUP_TYPE] ?: 0 }
+    suspend fun setGroupType(value: Int) = dataStore.edit { it[Keys.LIBRARY_GROUP_TYPE] = value }
 
     // --- Grid ---
 
@@ -251,7 +251,7 @@ class LibraryPreferences(private val dataStore: DataStore<Preferences>) {
         val CATEGORY_LAST_UPDATE_MS = stringPreferencesKey("category_last_update_ms")
         val SHOW_RECOMMENDATIONS = booleanPreferencesKey("library_show_recommendations")
         val DISMISSED_RECOMMENDATIONS = stringSetPreferencesKey("library_dismissed_recommendations")
-        val GROUP_BY_CATEGORY = booleanPreferencesKey("library_group_by_category")
+        val LIBRARY_GROUP_TYPE = intPreferencesKey("library_group_type")
         val SAVED_VIEWS = stringPreferencesKey("library_saved_views")
         val SHOW_CATEGORY_TABS = booleanPreferencesKey("library_show_category_tabs")
         val SHOW_CATEGORY_ITEM_COUNT = booleanPreferencesKey("library_show_category_item_count")

--- a/feature/library/src/main/java/app/otakureader/feature/library/FilterSortParams.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/FilterSortParams.kt
@@ -24,4 +24,5 @@ internal data class FilterSortParams(
     val filterCompleted: LibraryTriState = LibraryTriState.DISABLED,
     val bookmarkedMangaIds: Set<Long> = emptySet(),
     val randomSeed: Long = 0L,
+    val groupType: Int = LibraryGroup.BY_DEFAULT,
 )

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
@@ -475,40 +475,69 @@ private fun GroupTab(
     state: LibraryState,
     onEvent: (LibraryEvent) -> Unit,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+    val groupOptions = listOf(
+        LibraryGroup.BY_DEFAULT to stringResource(R.string.group_type_by_default),
+        LibraryGroup.BY_SOURCE to stringResource(R.string.group_type_by_source),
+        LibraryGroup.BY_STATUS to stringResource(R.string.group_type_by_status),
+        LibraryGroup.BY_TRACK_STATUS to stringResource(R.string.group_type_by_track_status),
+        LibraryGroup.UNGROUPED to stringResource(R.string.group_type_ungrouped),
+    )
+
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Text(
             text = stringResource(R.string.group_category_label),
             style = MaterialTheme.typography.labelLarge,
             color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(bottom = 8.dp),
         )
 
-        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            FilterChip(
-                selected = state.selectedCategory == null,
-                onClick = { onEvent(LibraryEvent.OnCategorySelected(null)) },
-                label = { Text(stringResource(R.string.library_category_all)) },
-            )
-            state.categories.forEach { category ->
-                FilterChip(
-                    selected = state.selectedCategory == category.id,
-                    onClick = { onEvent(LibraryEvent.OnCategorySelected(category.id)) },
-                    label = { Text("${category.name} (${category.count})") },
-                )
+        groupOptions.forEach { (type, label) ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onEvent(LibraryEvent.SetGroupType(type)) }
+                    .padding(vertical = 12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(label, style = MaterialTheme.typography.bodyMedium)
+                if (state.groupType == type) {
+                    Icon(
+                        imageVector = Icons.Default.Check,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
             }
         }
 
-        HorizontalDivider()
+        if (state.groupType == LibraryGroup.BY_DEFAULT && state.categories.isNotEmpty()) {
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(stringResource(R.string.group_by_category))
-            Switch(
-                checked = state.groupByCategory,
-                onCheckedChange = { onEvent(LibraryEvent.SetGroupByCategory(it)) },
+            Text(
+                text = stringResource(R.string.group_category_label),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.padding(top = 8.dp),
+            ) {
+                FilterChip(
+                    selected = state.selectedCategory == null,
+                    onClick = { onEvent(LibraryEvent.OnCategorySelected(null)) },
+                    label = { Text(stringResource(R.string.library_category_all)) },
+                )
+                state.categories.forEach { category ->
+                    FilterChip(
+                        selected = state.selectedCategory == category.id,
+                        onClick = { onEvent(LibraryEvent.OnCategorySelected(category.id)) },
+                        label = { Text("${category.name} (${category.count})") },
+                    )
+                }
+            }
         }
     }
 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 
@@ -475,13 +476,16 @@ private fun GroupTab(
     state: LibraryState,
     onEvent: (LibraryEvent) -> Unit,
 ) {
-    val groupOptions = listOf(
-        LibraryGroup.BY_DEFAULT to stringResource(R.string.group_type_by_default),
-        LibraryGroup.BY_SOURCE to stringResource(R.string.group_type_by_source),
-        LibraryGroup.BY_STATUS to stringResource(R.string.group_type_by_status),
-        LibraryGroup.BY_TRACK_STATUS to stringResource(R.string.group_type_by_track_status),
-        LibraryGroup.UNGROUPED to stringResource(R.string.group_type_ungrouped),
-    )
+    val context = LocalContext.current
+    val groupOptions = remember(context) {
+        listOf(
+            LibraryGroup.BY_DEFAULT to context.getString(R.string.group_type_by_default),
+            LibraryGroup.BY_SOURCE to context.getString(R.string.group_type_by_source),
+            LibraryGroup.BY_STATUS to context.getString(R.string.group_type_by_status),
+            LibraryGroup.BY_TRACK_STATUS to context.getString(R.string.group_type_by_track_status),
+            LibraryGroup.UNGROUPED to context.getString(R.string.group_type_ungrouped),
+        )
+    }
 
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Text(

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
@@ -20,8 +20,14 @@ internal fun applyFiltersAndSort(items: List<LibraryMangaItem>, params: FilterSo
     return applySort(filtered, params)
 }
 
-internal fun applyCategoryFilter(items: List<LibraryMangaItem>, params: FilterSortParams): List<LibraryMangaItem> =
-    if (params.selectedCategory != null) items.filter { it.id in params.categoryMangaIds } else items
+internal fun applyCategoryFilter(items: List<LibraryMangaItem>, params: FilterSortParams): List<LibraryMangaItem> {
+    val selected = params.selectedCategory ?: return items
+    return when (params.groupType) {
+        LibraryGroup.BY_SOURCE -> items.filter { it.sourceId == selected }
+        LibraryGroup.BY_STATUS -> items.filter { (it.status.ordinal + 1).toLong() == selected }
+        else -> items.filter { it.id in params.categoryMangaIds }
+    }
+}
 
 internal fun applyNsfwFilter(items: List<LibraryMangaItem>, params: FilterSortParams): List<LibraryMangaItem> =
     if (!params.showNsfw) items.filter { !it.isNsfw } else items
@@ -99,6 +105,7 @@ internal fun applySort(items: List<LibraryMangaItem>, params: FilterSortParams):
 internal fun Manga.toLibraryItem(
     isDownloaded: Boolean = false,
     hasTracking: Boolean = false,
+    sourceName: String = "",
 ) = LibraryMangaItem(
     id = id,
     title = title,
@@ -118,4 +125,5 @@ internal fun Manga.toLibraryItem(
     userCompleted = userCompleted,
     userDropped = userDropped,
     genres = genre,
+    sourceName = sourceName,
 )

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -57,6 +57,20 @@ enum class LibraryBottomSheetTab {
 }
 
 /**
+ * Library grouping modes — mirrors Komikku's `LibraryGroup` constants.
+ *
+ * Ordinals are intentionally NOT used for persistence; use the named constants instead.
+ * Persisted as an `Int` via [LibraryPreferences.groupType].
+ */
+object LibraryGroup {
+    const val BY_DEFAULT = 0
+    const val BY_SOURCE = 1
+    const val BY_STATUS = 2
+    const val BY_TRACK_STATUS = 3
+    const val UNGROUPED = 4
+}
+
+/**
  * Top-level layout for the library grid.
  *
  * - [GRID]: cover-centric grid (the [LibraryState.isStaggeredGrid] flag further selects
@@ -131,7 +145,7 @@ data class LibraryState(
     val availableGenres: List<String> = emptyList(),
     val showBottomSheet: Boolean = false,
     val bottomSheetTab: LibraryBottomSheetTab = LibraryBottomSheetTab.FILTER,
-    val groupByCategory: Boolean = false,
+    val groupType: Int = LibraryGroup.BY_DEFAULT,
     // Recommendations carousel
     val recommendations: List<LibraryMangaItem> = emptyList(),
     val showRecommendations: Boolean = true,
@@ -149,6 +163,8 @@ data class LibraryState(
     // Move to category bulk action (GAP 2)
     val showMoveToCategoryDialog: Boolean = false,
     val moveToCategoryMangaIds: Set<Long> = emptySet(),
+    // Full unfiltered list — used by composable to compute synthetic group tabs
+    val allMangaList: List<LibraryMangaItem> = emptyList(),
 )
 
 data class LibraryMangaItem(
@@ -170,6 +186,7 @@ data class LibraryMangaItem(
     val userCompleted: Boolean = false,
     val userDropped: Boolean = false,
     val genres: List<String> = emptyList(),
+    val sourceName: String = "",
 )
 
 data class CategoryItem(
@@ -231,7 +248,7 @@ sealed class LibraryEvent {
     data class SetFilterCompleted(val state: LibraryTriState) : LibraryEvent()
     data object ToggleBottomSheet : LibraryEvent()
     data class SetBottomSheetTab(val tab: LibraryBottomSheetTab) : LibraryEvent()
-    data class SetGroupByCategory(val enabled: Boolean) : LibraryEvent()
+    data class SetGroupType(val type: Int) : LibraryEvent()
     data class SetGridSize(val size: Int) : LibraryEvent()
     data class SetPortraitColumns(val count: Int) : LibraryEvent()
     data class SetLandscapeColumns(val count: Int) : LibraryEvent()

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -98,6 +98,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedTextField
+import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.model.SavedLibraryView
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
@@ -749,9 +750,47 @@ private fun LibraryContent(
         }
 
         // Category tabs (Komikku parity): scrollable tab row with optional count badges.
-        if (state.showCategoryTabs && state.categories.isNotEmpty()) {
+        // For non-default group modes, derive synthetic tabs from the full unfiltered list.
+        val statusLabels = mapOf(
+            MangaStatus.UNKNOWN to stringResource(R.string.manga_status_unknown),
+            MangaStatus.ONGOING to stringResource(R.string.manga_status_ongoing),
+            MangaStatus.COMPLETED to stringResource(R.string.manga_status_completed),
+            MangaStatus.LICENSED to stringResource(R.string.manga_status_licensed),
+            MangaStatus.PUBLISHING_FINISHED to stringResource(R.string.manga_status_publishing_finished),
+            MangaStatus.CANCELLED to stringResource(R.string.manga_status_cancelled),
+            MangaStatus.ON_HIATUS to stringResource(R.string.manga_status_on_hiatus),
+        )
+        val displayCategories: List<CategoryItem> = remember(
+            state.groupType, state.allMangaList, state.categories
+        ) {
+            when (state.groupType) {
+                LibraryGroup.BY_SOURCE -> state.allMangaList
+                    .groupBy { it.sourceId }
+                    .map { (sourceId, items) ->
+                        CategoryItem(
+                            id = sourceId,
+                            name = items.first().sourceName.ifBlank { sourceId.toString() },
+                            count = items.size,
+                        )
+                    }
+                    .sortedBy { it.name }
+                LibraryGroup.BY_STATUS -> state.allMangaList
+                    .groupBy { it.status }
+                    .map { (status, items) ->
+                        CategoryItem(
+                            id = (status.ordinal + 1).toLong(),
+                            name = statusLabels[status] ?: status.name,
+                            count = items.size,
+                        )
+                    }
+                    .sortedBy { it.name }
+                LibraryGroup.UNGROUPED, LibraryGroup.BY_TRACK_STATUS -> emptyList()
+                else -> state.categories
+            }
+        }
+        if (state.showCategoryTabs && displayCategories.isNotEmpty()) {
             LibraryCategoryTabs(
-                categories = state.categories,
+                categories = displayCategories,
                 selectedCategoryId = state.selectedCategory,
                 showItemCount = state.showCategoryItemCount,
                 onTabSelected = { onEvent(LibraryEvent.OnCategorySelected(it)) },

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -751,17 +751,20 @@ private fun LibraryContent(
 
         // Category tabs (Komikku parity): scrollable tab row with optional count badges.
         // For non-default group modes, derive synthetic tabs from the full unfiltered list.
-        val statusLabels = mapOf(
-            MangaStatus.UNKNOWN to stringResource(R.string.manga_status_unknown),
-            MangaStatus.ONGOING to stringResource(R.string.manga_status_ongoing),
-            MangaStatus.COMPLETED to stringResource(R.string.manga_status_completed),
-            MangaStatus.LICENSED to stringResource(R.string.manga_status_licensed),
-            MangaStatus.PUBLISHING_FINISHED to stringResource(R.string.manga_status_publishing_finished),
-            MangaStatus.CANCELLED to stringResource(R.string.manga_status_cancelled),
-            MangaStatus.ON_HIATUS to stringResource(R.string.manga_status_on_hiatus),
-        )
+        val context = LocalContext.current
+        val statusLabels = remember(context) {
+            mapOf(
+                MangaStatus.UNKNOWN to context.getString(R.string.manga_status_unknown),
+                MangaStatus.ONGOING to context.getString(R.string.manga_status_ongoing),
+                MangaStatus.COMPLETED to context.getString(R.string.manga_status_completed),
+                MangaStatus.LICENSED to context.getString(R.string.manga_status_licensed),
+                MangaStatus.PUBLISHING_FINISHED to context.getString(R.string.manga_status_publishing_finished),
+                MangaStatus.CANCELLED to context.getString(R.string.manga_status_cancelled),
+                MangaStatus.ON_HIATUS to context.getString(R.string.manga_status_on_hiatus),
+            )
+        }
         val displayCategories: List<CategoryItem> = remember(
-            state.groupType, state.allMangaList, state.categories
+            state.groupType, state.allMangaList, state.categories, statusLabels
         ) {
             when (state.groupType) {
                 LibraryGroup.BY_SOURCE -> state.allMangaList

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -713,10 +713,11 @@ class LibraryViewModel @Inject constructor(
                 )
             }.distinctUntilChanged()
         ) { items, matchingIds, params ->
-            applyFiltersAndSort(items, params.copy(searchMatchingIds = matchingIds)) to items.size
+            val filtered = applyFiltersAndSort(items, params.copy(searchMatchingIds = matchingIds))
+            Triple(filtered, items.size, items)
         }
-            .onEach { (filtered, totalCount) ->
-                _state.update { it.copy(mangaList = filtered, totalMangaCount = totalCount, allMangaList = _allItems.value) }
+            .onEach { (filtered, totalCount, unfiltered) ->
+                _state.update { it.copy(mangaList = filtered, totalMangaCount = totalCount, allMangaList = unfiltered) }
             }
             .launchIn(viewModelScope)
     }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -23,6 +23,7 @@ import app.otakureader.domain.usecase.SearchLibraryMangaUseCase
 import app.otakureader.domain.usecase.ToggleFavoriteMangaUseCase
 import app.otakureader.domain.repository.EhFavoritesRepository
 import app.otakureader.domain.repository.PageBookmarkRepository
+import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.usecase.SyncEhFavoritesUseCase
 import app.otakureader.domain.usecase.SyncLibraryUseCase
 import app.otakureader.domain.usecase.downloads.ReindexDownloadsUseCase
@@ -81,6 +82,7 @@ class LibraryViewModel @Inject constructor(
     private val ehFavoritesRepository: EhFavoritesRepository,
     private val syncLibrary: SyncLibraryUseCase,
     private val pageBookmarkRepository: PageBookmarkRepository,
+    private val sourceRepository: SourceRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(LibraryState())
@@ -144,7 +146,7 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.ToggleFilterSheet -> _state.update { it.copy(showBottomSheet = !it.showBottomSheet) }
             is LibraryEvent.ToggleBottomSheet -> _state.update { it.copy(showBottomSheet = !it.showBottomSheet) }
             is LibraryEvent.SetBottomSheetTab -> _state.update { it.copy(bottomSheetTab = event.tab) }
-            is LibraryEvent.SetGroupByCategory -> viewModelScope.launch { libraryPreferences.setGroupByCategory(event.enabled) }
+            is LibraryEvent.SetGroupType -> viewModelScope.launch { libraryPreferences.setGroupType(event.type) }
             is LibraryEvent.SetGridSize, is LibraryEvent.SetShowBadges,
             is LibraryEvent.SetShowDownloadBadge, is LibraryEvent.SetStaggeredGrid,
             is LibraryEvent.SetShowTitle, is LibraryEvent.SetDisplayMode,
@@ -513,8 +515,8 @@ class LibraryViewModel @Inject constructor(
         libraryUpdateScheduler.isUpdating()
             .onEach { updating -> _state.update { it.copy(isLibraryUpdating = updating) } }
             .launchIn(viewModelScope)
-        libraryPreferences.groupByCategory
-            .onEach { v -> _state.update { it.copy(groupByCategory = v) } }
+        libraryPreferences.groupType
+            .onEach { v -> _state.update { it.copy(groupType = v) } }
             .launchIn(viewModelScope)
     }
 
@@ -572,6 +574,13 @@ class LibraryViewModel @Inject constructor(
         getLibraryManga()
             .map { mangaList ->
                 coroutineScope {
+                    // Build source name lookup in parallel
+                    val sourceNamesDeferred = async {
+                        sourceRepository.getSources().first()
+                            .mapNotNull { source -> source.id.toLongOrNull()?.let { it to source.name } }
+                            .toMap()
+                    }
+
                     // Build tracking lookup in parallel
                     val trackingDeferred = mangaList.map { manga ->
                         async {
@@ -592,13 +601,15 @@ class LibraryViewModel @Inject constructor(
                         }
                     }
 
+                    val sourceNames = sourceNamesDeferred.await()
                     val trackedMangaIds = trackingDeferred.awaitAll().filterNotNull().toSet()
                     val downloadedMangaIds = downloadDeferred.awaitAll().filterNotNull().toSet()
 
                     mangaList.map { manga ->
                         manga.toLibraryItem(
                             isDownloaded = manga.id in downloadedMangaIds,
-                            hasTracking = manga.id in trackedMangaIds
+                            hasTracking = manga.id in trackedMangaIds,
+                            sourceName = sourceNames[manga.sourceId] ?: "",
                         )
                     }
                 }
@@ -643,12 +654,12 @@ class LibraryViewModel @Inject constructor(
     }
 
     private fun observeFilteredItems() {
-        // When category selection changes, fetch the manga IDs in that category
+        // When category selection changes, fetch the manga IDs in that category (BY_DEFAULT mode only)
         viewModelScope.launch {
-            _state.map { it.selectedCategory }
+            _state.map { it.selectedCategory to it.groupType }
                 .distinctUntilChanged()
-                .collect { categoryId ->
-                    if (categoryId != null) {
+                .collect { (categoryId, groupType) ->
+                    if (categoryId != null && groupType == LibraryGroup.BY_DEFAULT) {
                         val mangaIds = getCategories.getMangaIdsForCategory(categoryId).first()
                         _state.update { it.copy(categoryFilterMangaIds = mangaIds.toSet()) }
                     } else {
@@ -698,13 +709,14 @@ class LibraryViewModel @Inject constructor(
                     filterCompleted = it.filterCompleted,
                     bookmarkedMangaIds = it.bookmarkedMangaIds,
                     randomSeed = randomSeed,
+                    groupType = it.groupType,
                 )
             }.distinctUntilChanged()
         ) { items, matchingIds, params ->
             applyFiltersAndSort(items, params.copy(searchMatchingIds = matchingIds)) to items.size
         }
             .onEach { (filtered, totalCount) ->
-                _state.update { it.copy(mangaList = filtered, totalMangaCount = totalCount) }
+                _state.update { it.copy(mangaList = filtered, totalMangaCount = totalCount, allMangaList = _allItems.value) }
             }
             .launchIn(viewModelScope)
     }

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -215,8 +215,14 @@
     <string name="display_mode_comfortable">Comfortable</string>
     <string name="display_mode_list">List</string>
     <string name="display_mode_cover_only">Cover only</string>
-    <string name="group_category_label">Category</string>
+    <string name="group_category_label">Group by</string>
     <string name="group_by_category">Group by category</string>
+    <string name="group_type_by_default">By category</string>
+    <string name="group_type_by_source">By source</string>
+    <string name="group_type_by_status">By status</string>
+    <string name="group_type_by_track_status">By tracker status</string>
+    <string name="group_type_ungrouped">No grouping</string>
+    <string name="manga_status_unknown">Unknown</string>
     <!-- Filter sheet -->
     <string name="filter_sheet_title">Filters &amp; Sort</string>
     <string name="filter_sheet_clear_all">Clear all</string>

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -30,6 +30,7 @@ import app.otakureader.domain.usecase.downloads.ReindexDownloadsUseCase
 import app.otakureader.domain.model.ReindexResult
 import app.otakureader.domain.repository.EhFavoritesRepository
 import app.otakureader.domain.repository.PageBookmarkRepository
+import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.usecase.SyncEhFavoritesUseCase
 import app.otakureader.domain.usecase.SyncLibraryUseCase
 import app.otakureader.domain.repository.TrackerSyncRepository
@@ -90,6 +91,9 @@ class LibraryViewModelTest {
     private val syncLibrary: SyncLibraryUseCase = mockk(relaxed = true)
     private val pageBookmarkRepository: PageBookmarkRepository = mockk {
         every { getMangaIdsWithBookmarks() } returns flowOf(emptySet())
+    }
+    private val sourceRepository: SourceRepository = mockk {
+        every { getSources() } returns flowOf(emptyList())
     }
 
     private val sampleMangas = listOf(
@@ -163,7 +167,7 @@ class LibraryViewModelTest {
         every { libraryDisplayMode } returns flowOf(0)
         every { showRecommendations } returns flowOf(false)
         every { dismissedRecommendations } returns flowOf(emptySet())
-        every { groupByCategory } returns flowOf(false)
+        every { groupType } returns flowOf(LibraryGroup.BY_DEFAULT)
         every { savedViewsJson } returns flowOf("[]")
         coEvery { setSavedViewsJson(any()) } just Awaits
         every { showTitle } returns flowOf(true)
@@ -205,6 +209,7 @@ class LibraryViewModelTest {
             ehFavoritesRepository,
             syncLibrary,
             pageBookmarkRepository,
+            sourceRepository,
         )
     }
 


### PR DESCRIPTION
## Summary

- Replaces the two-state `groupByCategory: Boolean` toggle with a five-mode `groupType: Int` selector matching Komikku's `LibraryGroup` constants (BY_DEFAULT=0, BY_SOURCE=1, BY_STATUS=2, BY_TRACK_STATUS=3, UNGROUPED=4)
- The Group tab in the library bottom sheet now shows a radio-style row list for all five modes; category chips are shown only when BY_DEFAULT is selected
- BY_SOURCE and BY_STATUS modes produce synthetic scrollable tabs from the full manga list, filtering accordingly; UNGROUPED/BY_TRACK_STATUS hides tabs

## Changes

**`LibraryMvi.kt`**
- Add `LibraryGroup` object with five named constants
- Replace `groupByCategory: Boolean` with `groupType: Int` in `LibraryState`
- Replace `SetGroupByCategory` with `SetGroupType(type: Int)` event
- Add `sourceName: String` to `LibraryMangaItem`
- Add `allMangaList: List<LibraryMangaItem>` to `LibraryState` for synthetic tab computation

**`LibraryPreferences.kt`**
- Replace `groupByCategory` / `GROUP_BY_CATEGORY` boolean key with `groupType` / `LIBRARY_GROUP_TYPE` int key

**`FilterSortParams.kt`** — add `groupType: Int` field

**`LibraryFilterLogic.kt`**
- `applyCategoryFilter` dispatches on `groupType`: BY_SOURCE filters by `sourceId`, BY_STATUS filters by `(status.ordinal+1).toLong()`, else falls back to DB category membership
- `toLibraryItem` gains `sourceName: String` param

**`LibraryViewModel.kt`**
- Inject `SourceRepository`; populate `sourceName` in `loadLibrary` from loaded sources
- Observe `groupType` preference; skip DB category ID lookup when `groupType != BY_DEFAULT`
- Pass `groupType` into `FilterSortParams`; emit `allMangaList` with filtered list

**`LibraryBottomSheet.kt`** — GroupTab replaced with check-row list; category chips conditional on BY_DEFAULT

**`LibraryScreen.kt`** — compute `displayCategories` from `allMangaList` based on `groupType`

**`strings.xml`** — add `group_type_*` and `manga_status_unknown` strings

**`LibraryViewModelTest.kt`** — add `SourceRepository` mock, replace `groupByCategory` stub with `groupType`, pass `sourceRepository` to `createViewModel`

## Test plan

- [ ] Unit tests pass (LibraryViewModelTest)
- [ ] Detekt / ktlint pass
- [ ] Assemble debug APK succeeds
- [ ] Coverage gate holds

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multiple library grouping options, including grouping by category, source, status, tracker status, or no grouping.
  * Library tabs can now show grouped entries based on the selected grouping mode.

* **Bug Fixes**
  * Improved library filtering so selected tabs behave correctly across different grouping modes.
  * Updated labels and status text to better match the new grouping options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->