### PR TITLE
feat(library): language badge on library cards — Komikku parity

### DIFF
--- a/core/ui/src/main/java/app/otakureader/core/ui/components/MangaCard.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/components/MangaCard.kt
@@ -86,6 +86,7 @@ fun MangaCard(
     onClickContinueReading: (() -> Unit)? = null,
     isNew: Boolean = false,
     sourceIcon: @Composable (() -> Unit)? = null,
+    languageBadge: @Composable (() -> Unit)? = null,
     showTitle: Boolean = true,
 ) {
     val context = LocalContext.current
@@ -246,6 +247,17 @@ fun MangaCard(
                         .align(Alignment.BottomEnd)
                         .padding(4.dp)
                         .padding(bottom = if (readProgress != null) 10.dp else 4.dp)
+                ) {
+                    it()
+                }
+            }
+
+            // Language badge — bottom-start corner (Komikku coverBadgeEnd parity)
+            languageBadge?.let {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(4.dp)
                 ) {
                     it()
                 }

--- a/core/ui/src/main/java/app/otakureader/core/ui/components/MangaCard.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/components/MangaCard.kt
@@ -156,7 +156,7 @@ fun MangaCard(
                     modifier = Modifier
                         .align(Alignment.BottomStart)
                         .padding(
-                            start = 8.dp,
+                            start = if (languageBadge != null) 40.dp else 8.dp,
                             end = if (onClickContinueReading != null) {
                                 MangaCardDefaults.TITLE_END_PADDING_WITH_BUTTON_DP.dp
                             } else {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
@@ -106,6 +106,7 @@ internal fun Manga.toLibraryItem(
     isDownloaded: Boolean = false,
     hasTracking: Boolean = false,
     sourceName: String = "",
+    sourceLanguage: String = "",
 ) = LibraryMangaItem(
     id = id,
     title = title,
@@ -126,4 +127,5 @@ internal fun Manga.toLibraryItem(
     userDropped = userDropped,
     genres = genre,
     sourceName = sourceName,
+    sourceLanguage = sourceLanguage,
 )

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -333,6 +333,7 @@ private fun LibraryMangaPageContent(
                     isSelected = manga.id in state.selectedManga,
                     unreadCount = if (state.showBadges) manga.unreadCount else 0,
                     downloadCount = if (state.showDownloadBadge) downloadCount else 0,
+                    showLanguageBadge = state.showBadges,
                     onClick = { onMangaTap(manga) },
                     onLongClick = { onMangaLongClick(manga.id) },
                 )
@@ -409,6 +410,9 @@ private fun LibraryMangaPageContent(
                                 manga.userDropped -> { { DroppedBadge() } }
                                 else -> null
                             },
+                            languageBadge = if (state.showBadges && manga.sourceLanguage.isNotBlank()) {
+                                { LanguageBadge(manga.sourceLanguage) }
+                            } else null,
                             modifier = Modifier.fillMaxWidth()
                         )
                     }
@@ -493,6 +497,9 @@ private fun LibraryMangaPageContent(
                             manga.userDropped -> { { DroppedBadge() } }
                             else -> null
                         },
+                        languageBadge = if (state.showBadges && manga.sourceLanguage.isNotBlank()) {
+                            { LanguageBadge(manga.sourceLanguage) }
+                        } else null,
                         modifier = Modifier.fillMaxWidth()
                     )
                 }
@@ -565,6 +572,7 @@ private fun LibraryListRow(
     onClick: () -> Unit,
     onLongClick: () -> Unit,
     modifier: Modifier = Modifier,
+    showLanguageBadge: Boolean = true,
 ) {
     Row(
         modifier = modifier
@@ -603,6 +611,9 @@ private fun LibraryListRow(
         }
         if (unreadCount > 0) {
             UnreadBadge(count = unreadCount)
+        }
+        if (showLanguageBadge && manga.sourceLanguage.isNotBlank()) {
+            LanguageBadge(manga.sourceLanguage)
         }
     }
 }
@@ -707,6 +718,27 @@ internal fun LibraryGreetingHeader(
             text = stringResource(R.string.library_greeting_stats, mangaCount, unreadCount),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+internal fun LanguageBadge(
+    language: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .background(
+                color = MaterialTheme.colorScheme.tertiary,
+                shape = RoundedCornerShape(4.dp)
+            )
+            .padding(horizontal = 4.dp, vertical = 2.dp),
+    ) {
+        Text(
+            text = language.uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onTertiary,
         )
     }
 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -71,6 +71,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.TextButton
 import coil3.compose.AsyncImage
 import java.util.Calendar
+import java.util.Locale
 
 /** Layout constants for the compact list-mode row. */
 private object LibraryListRowDefaults {
@@ -736,7 +737,7 @@ internal fun LanguageBadge(
             .padding(horizontal = 4.dp, vertical = 2.dp),
     ) {
         Text(
-            text = language.uppercase(),
+            text = language.uppercase(Locale.ROOT),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onTertiary,
         )

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -187,6 +187,7 @@ data class LibraryMangaItem(
     val userDropped: Boolean = false,
     val genres: List<String> = emptyList(),
     val sourceName: String = "",
+    val sourceLanguage: String = "",
 )
 
 data class CategoryItem(

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -608,11 +608,12 @@ class LibraryViewModel @Inject constructor(
                     val downloadedMangaIds = downloadDeferred.awaitAll().filterNotNull().toSet()
 
                     mangaList.map { manga ->
+                        val meta = sourceMeta[manga.sourceId]
                         manga.toLibraryItem(
                             isDownloaded = manga.id in downloadedMangaIds,
                             hasTracking = manga.id in trackedMangaIds,
-                            sourceName = sourceMeta[manga.sourceId]?.first ?: "",
-                            sourceLanguage = sourceMeta[manga.sourceId]?.second ?: "",
+                            sourceName = meta?.first ?: "",
+                            sourceLanguage = meta?.second ?: "",
                         )
                     }
                 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -574,10 +574,12 @@ class LibraryViewModel @Inject constructor(
         getLibraryManga()
             .map { mangaList ->
                 coroutineScope {
-                    // Build source name lookup in parallel
-                    val sourceNamesDeferred = async {
+                    // Build source metadata (name + lang) lookup in parallel
+                    val sourceMetaDeferred = async {
                         sourceRepository.getSources().first()
-                            .mapNotNull { source -> source.id.toLongOrNull()?.let { it to source.name } }
+                            .mapNotNull { source ->
+                                source.id.toLongOrNull()?.let { id -> id to Pair(source.name, source.lang) }
+                            }
                             .toMap()
                     }
 
@@ -601,7 +603,7 @@ class LibraryViewModel @Inject constructor(
                         }
                     }
 
-                    val sourceNames = sourceNamesDeferred.await()
+                    val sourceMeta = sourceMetaDeferred.await()
                     val trackedMangaIds = trackingDeferred.awaitAll().filterNotNull().toSet()
                     val downloadedMangaIds = downloadDeferred.awaitAll().filterNotNull().toSet()
 
@@ -609,7 +611,8 @@ class LibraryViewModel @Inject constructor(
                         manga.toLibraryItem(
                             isDownloaded = manga.id in downloadedMangaIds,
                             hasTracking = manga.id in trackedMangaIds,
-                            sourceName = sourceNames[manga.sourceId] ?: "",
+                            sourceName = sourceMeta[manga.sourceId]?.first ?: "",
+                            sourceLanguage = sourceMeta[manga.sourceId]?.second ?: "",
                         )
                     }
                 }


### PR DESCRIPTION
## Summary

- `LibraryMangaItem` gains `sourceLanguage: String` populated from `MangaSource.lang` at library load time
- `LibraryFilterLogic.toLibraryItem` accepts and wires the new `sourceLanguage` param
- `LibraryViewModel.loadLibrary` combines name + lang in a single source-lookup pass (`Pair<String,String>`) instead of two separate maps
- `MangaCard` (`core/ui`) gets a `languageBadge` composable slot at `Alignment.BottomStart` — does not conflict with the existing `badge` (TopEnd), `statusBadge` (TopStart), or `onClickContinueReading` (BottomEnd)
- `LanguageBadge` composable added to `LibraryMangaGrid` — tertiary-colored rounded chip showing uppercase ISO language code (e.g. `EN`, `JA`, `FR`)
- Badge wired in compact grid, comfortable grid, staggered grid, and list mode; respects `showBadges` preference (hidden when off)

## Parity gap closed

Komikku renders a language badge on every library card in all display modes (`LibraryBadges.kt` → `LanguageBadge`). Otaku had no language badge at all. This commit closes that gap.

## Test plan

- [ ] Existing unit tests pass (`LibraryViewModelTest` — source mock returns `emptyList()`, resulting in `sourceLanguage = ""` which correctly suppresses the badge)
- [ ] Assemble debug APK green
- [ ] Detekt / Ktlint green

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a source language badge in the library view for items that have language information available.
  * Library cards now make room for the badge so titles remain readable.
  * Library items now carry and display language details alongside source information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->