### PR TITLE
feat(library): source icon badge on library cards — Komikku parity

### DIFF
--- a/feature/library/build.gradle.kts
+++ b/feature/library/build.gradle.kts
@@ -28,6 +28,7 @@ android {
 dependencies {
     implementation(projects.core.common)
     implementation(projects.core.database)
+    implementation(projects.core.extension)
     implementation(projects.core.preferences)
     implementation(projects.sourceApi)
     implementation(libs.paging.compose)

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
@@ -107,6 +107,7 @@ internal fun Manga.toLibraryItem(
     hasTracking: Boolean = false,
     sourceName: String = "",
     sourceLanguage: String = "",
+    sourceIconUrl: String? = null,
 ) = LibraryMangaItem(
     id = id,
     title = title,
@@ -128,4 +129,5 @@ internal fun Manga.toLibraryItem(
     genres = genre,
     sourceName = sourceName,
     sourceLanguage = sourceLanguage,
+    sourceIconUrl = sourceIconUrl,
 )

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -414,6 +414,9 @@ private fun LibraryMangaPageContent(
                             languageBadge = if (state.showBadges && manga.sourceLanguage.isNotBlank()) {
                                 { LanguageBadge(manga.sourceLanguage) }
                             } else null,
+                            sourceIcon = if (state.showBadges && manga.sourceIconUrl != null) {
+                                { SourceIconBadge(manga.sourceIconUrl) }
+                            } else null,
                             modifier = Modifier.fillMaxWidth()
                         )
                     }
@@ -500,6 +503,9 @@ private fun LibraryMangaPageContent(
                         },
                         languageBadge = if (state.showBadges && manga.sourceLanguage.isNotBlank()) {
                             { LanguageBadge(manga.sourceLanguage) }
+                        } else null,
+                        sourceIcon = if (state.showBadges && manga.sourceIconUrl != null) {
+                            { SourceIconBadge(manga.sourceIconUrl) }
                         } else null,
                         modifier = Modifier.fillMaxWidth()
                     )
@@ -615,6 +621,9 @@ private fun LibraryListRow(
         }
         if (showLanguageBadge && manga.sourceLanguage.isNotBlank()) {
             LanguageBadge(manga.sourceLanguage)
+        }
+        if (showLanguageBadge && manga.sourceIconUrl != null) {
+            SourceIconBadge(manga.sourceIconUrl)
         }
     }
 }
@@ -742,6 +751,21 @@ internal fun LanguageBadge(
             color = MaterialTheme.colorScheme.onTertiary,
         )
     }
+}
+
+@Composable
+internal fun SourceIconBadge(
+    iconUrl: String,
+    modifier: Modifier = Modifier,
+) {
+    AsyncImage(
+        model = iconUrl,
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        modifier = modifier
+            .size(20.dp)
+            .clip(RoundedCornerShape(4.dp)),
+    )
 }
 
 @Composable

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -73,6 +73,12 @@ import coil3.compose.AsyncImage
 import java.util.Calendar
 import java.util.Locale
 
+/** Layout constants for the source icon badge. */
+private object SourceIconBadgeDefaults {
+    val IconSize = 20.dp
+    val CornerRadius = 4.dp
+}
+
 /** Layout constants for the compact list-mode row. */
 private object LibraryListRowDefaults {
     val HorizontalPadding = 12.dp
@@ -334,7 +340,7 @@ private fun LibraryMangaPageContent(
                     isSelected = manga.id in state.selectedManga,
                     unreadCount = if (state.showBadges) manga.unreadCount else 0,
                     downloadCount = if (state.showDownloadBadge) downloadCount else 0,
-                    showLanguageBadge = state.showBadges,
+                    showBadges = state.showBadges,
                     onClick = { onMangaTap(manga) },
                     onLongClick = { onMangaLongClick(manga.id) },
                 )
@@ -579,7 +585,7 @@ private fun LibraryListRow(
     onClick: () -> Unit,
     onLongClick: () -> Unit,
     modifier: Modifier = Modifier,
-    showLanguageBadge: Boolean = true,
+    showBadges: Boolean = true,
 ) {
     Row(
         modifier = modifier
@@ -619,11 +625,11 @@ private fun LibraryListRow(
         if (unreadCount > 0) {
             UnreadBadge(count = unreadCount)
         }
-        if (showLanguageBadge && manga.sourceLanguage.isNotBlank()) {
+        if (showBadges && manga.sourceLanguage.isNotBlank()) {
             LanguageBadge(manga.sourceLanguage)
         }
-        if (showLanguageBadge && manga.sourceIconUrl != null) {
-            SourceIconBadge(manga.sourceIconUrl)
+        if (showBadges && manga.sourceIconUrl != null) {
+            SourceIconBadge(manga.sourceIconUrl, contentDescription = manga.sourceName.ifBlank { null })
         }
     }
 }
@@ -757,14 +763,15 @@ internal fun LanguageBadge(
 internal fun SourceIconBadge(
     iconUrl: String,
     modifier: Modifier = Modifier,
+    contentDescription: String? = null,
 ) {
     AsyncImage(
         model = iconUrl,
-        contentDescription = null,
+        contentDescription = contentDescription,
         contentScale = ContentScale.Crop,
         modifier = modifier
-            .size(20.dp)
-            .clip(RoundedCornerShape(4.dp)),
+            .size(SourceIconBadgeDefaults.IconSize)
+            .clip(RoundedCornerShape(SourceIconBadgeDefaults.CornerRadius)),
     )
 }
 

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -188,6 +188,7 @@ data class LibraryMangaItem(
     val genres: List<String> = emptyList(),
     val sourceName: String = "",
     val sourceLanguage: String = "",
+    val sourceIconUrl: String? = null,
 )
 
 data class CategoryItem(

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -21,6 +21,7 @@ import app.otakureader.domain.usecase.GetLibraryMangaUseCase
 import app.otakureader.domain.usecase.GetRecommendationsUseCase
 import app.otakureader.domain.usecase.SearchLibraryMangaUseCase
 import app.otakureader.domain.usecase.ToggleFavoriteMangaUseCase
+import app.otakureader.core.extension.domain.repository.ExtensionRepository
 import app.otakureader.domain.repository.EhFavoritesRepository
 import app.otakureader.domain.repository.PageBookmarkRepository
 import app.otakureader.domain.repository.SourceRepository
@@ -83,6 +84,7 @@ class LibraryViewModel @Inject constructor(
     private val syncLibrary: SyncLibraryUseCase,
     private val pageBookmarkRepository: PageBookmarkRepository,
     private val sourceRepository: SourceRepository,
+    private val extensionRepository: ExtensionRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(LibraryState())
@@ -583,6 +585,13 @@ class LibraryViewModel @Inject constructor(
                             .toMap()
                     }
 
+                    // Build extension icon URL lookup in parallel (sourceId → iconUrl)
+                    val sourceIconUrlDeferred = async {
+                        extensionRepository.getInstalledExtensions().first()
+                            .flatMap { ext -> ext.sources.map { src -> src.id to ext.iconUrl } }
+                            .toMap()
+                    }
+
                     // Build tracking lookup in parallel
                     val trackingDeferred = mangaList.map { manga ->
                         async {
@@ -604,6 +613,7 @@ class LibraryViewModel @Inject constructor(
                     }
 
                     val sourceMeta = sourceMetaDeferred.await()
+                    val sourceIconUrls = sourceIconUrlDeferred.await()
                     val trackedMangaIds = trackingDeferred.awaitAll().filterNotNull().toSet()
                     val downloadedMangaIds = downloadDeferred.awaitAll().filterNotNull().toSet()
 
@@ -614,6 +624,7 @@ class LibraryViewModel @Inject constructor(
                             hasTracking = manga.id in trackedMangaIds,
                             sourceName = meta?.first ?: "",
                             sourceLanguage = meta?.second ?: "",
+                            sourceIconUrl = sourceIconUrls[manga.sourceId],
                         )
                     }
                 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -569,6 +569,11 @@ class LibraryViewModel @Inject constructor(
             .launchIn(viewModelScope)
     }
 
+    private suspend fun buildSourceIconUrlMap(): Map<Long, String?> =
+        extensionRepository.getInstalledExtensions().first()
+            .flatMap { ext -> ext.sources.map { src -> src.id to ext.iconUrl } }
+            .toMap()
+
     private fun loadLibrary() {
         val isRefreshing = _state.value.mangaList.isNotEmpty()
         _state.update { it.copy(isLoading = !isRefreshing, isRefreshing = isRefreshing) }
@@ -585,12 +590,7 @@ class LibraryViewModel @Inject constructor(
                             .toMap()
                     }
 
-                    // Build extension icon URL lookup in parallel (sourceId → iconUrl)
-                    val sourceIconUrlDeferred = async {
-                        extensionRepository.getInstalledExtensions().first()
-                            .flatMap { ext -> ext.sources.map { src -> src.id to ext.iconUrl } }
-                            .toMap()
-                    }
+                    val sourceIconUrlDeferred = async { buildSourceIconUrlMap() }
 
                     // Build tracking lookup in parallel
                     val trackingDeferred = mangaList.map { manga ->

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -230,6 +230,47 @@ class LibraryViewModelTest {
     }
 
     @Test
+    fun loadLibrary_populatesSourceIconUrl_fromInstalledExtensions() = runTest {
+        every { getLibraryManga() } returns flowOf(sampleMangas)
+        val testIconUrl = "https://test.icon/source10.png"
+        val fakeExtension = app.otakureader.core.extension.domain.model.Extension(
+            id = 1L,
+            pkgName = "eu.kanade.tachiyomi.extension.en.testsource",
+            name = "Test Source",
+            versionCode = 1,
+            versionName = "1.0",
+            sources = listOf(
+                app.otakureader.core.extension.domain.model.ExtensionSource(
+                    id = 10L,
+                    name = "Test Source",
+                    lang = "en",
+                    baseUrl = "https://example.com",
+                )
+            ),
+            status = app.otakureader.core.extension.domain.model.InstallStatus.INSTALLED,
+            apkPath = null,
+            iconUrl = testIconUrl,
+            lang = "en",
+            isNsfw = false,
+            installDate = null,
+            signatureHash = "abc123",
+        )
+        every { extensionRepository.getInstalledExtensions() } returns flowOf(listOf(fakeExtension))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // sourceId 10 → icon URL from the extension
+        viewModel.state.value.mangaList
+            .filter { it.sourceId == 10L }
+            .forEach { assertEquals(testIconUrl, it.sourceIconUrl) }
+        // sourceId 20 → no matching extension, so null
+        viewModel.state.value.mangaList
+            .filter { it.sourceId == 20L }
+            .forEach { assertNull(it.sourceIconUrl) }
+    }
+
+    @Test
     fun init_setsLoadingFalseAfterLoad() = runTest {
         every { getLibraryManga() } returns flowOf(sampleMangas)
 

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -29,6 +29,7 @@ import app.otakureader.domain.usecase.ToggleFavoriteMangaUseCase
 import app.otakureader.domain.usecase.downloads.ReindexDownloadsUseCase
 import app.otakureader.domain.model.ReindexResult
 import app.otakureader.domain.repository.EhFavoritesRepository
+import app.otakureader.core.extension.domain.repository.ExtensionRepository
 import app.otakureader.domain.repository.PageBookmarkRepository
 import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.usecase.SyncEhFavoritesUseCase
@@ -94,6 +95,9 @@ class LibraryViewModelTest {
     }
     private val sourceRepository: SourceRepository = mockk {
         every { getSources() } returns flowOf(emptyList())
+    }
+    private val extensionRepository: ExtensionRepository = mockk {
+        every { getInstalledExtensions() } returns flowOf(emptyList())
     }
 
     private val sampleMangas = listOf(
@@ -210,6 +214,7 @@ class LibraryViewModelTest {
             syncLibrary,
             pageBookmarkRepository,
             sourceRepository,
+            extensionRepository,
         )
     }
 


### PR DESCRIPTION
## Summary

- Adds source extension icon badge to every library card (grid, staggered grid, and list mode), matching Komikku's `SourceIconBadge` in `LibraryBadges.kt`
- Loads icon URL from `ExtensionRepository.getInstalledExtensions()` in parallel with the existing source-meta lookup; maps each `ExtensionSource.id → Extension.iconUrl`
- Adds `sourceIconUrl: String?` to `LibraryMangaItem` and `Manga.toLibraryItem()`
- New `SourceIconBadge` composable (20 dp `AsyncImage`, 4 dp rounded clip) rendered in the existing `MangaCard.sourceIcon` slot (bottom-end corner); gate: `showBadges && iconUrl != null`
- Adds `core:extension` dependency to `feature:library` module (needed for `ExtensionRepository` injection)
- Unit test updated: `extensionRepository` mock added returning `emptyList()`

## Test plan

- [ ] Build passes (`./gradlew :feature:library:compileDebugKotlin`)
- [ ] Unit tests pass (`./gradlew :feature:library:testDebugUnitTest`)
- [ ] Library grid shows extension favicon in bottom-right corner of each card when extension is installed with a known icon URL
- [ ] Badge hidden when `showBadges` is disabled in Display settings
- [ ] Badge hidden for manga whose source has no icon URL (null)
- [ ] List mode shows icon badge inline after the language badge

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Library items now can show a source icon alongside existing badges.
  * The library view now displays source icons in grid, comfortable, and list layouts when available.

* **Bug Fixes**
  * Library entries now populate source icon information more consistently during loading.

* **Tests**
  * Updated library view tests to cover the new source icon data flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->