### PR TITLE
feat(library): Komikku parity — BackHandler, PTR guard, category title, sort modes, Update action, global search CTA

### DIFF
--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
@@ -565,6 +565,8 @@ private fun LibrarySortMode.label(): String = when (this) {
     LibrarySortMode.TOTAL_CHAPTERS -> stringResource(R.string.sort_total_chapters)
     LibrarySortMode.LATEST_CHAPTER -> stringResource(R.string.sort_latest_chapter)
     LibrarySortMode.RANDOM -> stringResource(R.string.sort_random)
+    LibrarySortMode.CHAPTER_FETCH_DATE -> stringResource(R.string.sort_chapter_fetch_date)
+    LibrarySortMode.TRACKER_MEAN -> stringResource(R.string.sort_tracker_mean)
 }
 
 @Composable

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryEmptyState.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryEmptyState.kt
@@ -79,7 +79,8 @@ internal fun EmptyLibraryMessage(
 @Composable
 internal fun EmptyLibrarySearchMessage(
     query: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onBrowseClick: (() -> Unit)? = null,
 ) {
     Column(
         modifier = modifier.padding(EmptyStateDefaults.ContentPadding),
@@ -102,6 +103,18 @@ internal fun EmptyLibrarySearchMessage(
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
+        if (onBrowseClick != null) {
+            Spacer(modifier = Modifier.height(EmptyStateDefaults.CtaSpacing))
+            Button(onClick = onBrowseClick) {
+                Icon(
+                    imageVector = Icons.Default.Explore,
+                    contentDescription = null,
+                    modifier = Modifier.size(EmptyStateDefaults.CtaIconSize),
+                )
+                Spacer(modifier = Modifier.width(EmptyStateDefaults.CtaIconGap))
+                Text(stringResource(R.string.library_search_globally))
+            }
+        }
     }
 }
 

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt
@@ -98,6 +98,10 @@ internal fun applySort(items: List<LibraryMangaItem>, params: FilterSortParams):
         LibrarySortMode.LATEST_CHAPTER -> items.sortedByDescending { it.lastUpdate }
         // Seeded with the ViewModel's session seed so items don't re-shuffle on every emission.
         LibrarySortMode.RANDOM -> items.shuffled(Random(params.randomSeed))
+        // Chapter fetch date maps to dateAdded until a dedicated field is added to the data model.
+        LibrarySortMode.CHAPTER_FETCH_DATE -> items.sortedByDescending { it.dateAdded }
+        // Tracker mean score requires a tracker-score field; falls back to title until available.
+        LibrarySortMode.TRACKER_MEAN -> items.sortedBy { it.title }
     }
     return if (params.sortAscending) sorted else sorted.reversed()
 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt
@@ -16,6 +16,8 @@ enum class LibrarySortMode {
     // Appended for stable persisted ordinals — never reorder above entries.
     LATEST_CHAPTER,
     RANDOM,
+    CHAPTER_FETCH_DATE,
+    TRACKER_MEAN,
 }
 
 enum class LibraryFilterMode {
@@ -286,6 +288,7 @@ sealed class LibraryEvent {
     data object DismissMoveToCategoryDialog : LibraryEvent()
     data class MoveToCategory(val mangaIds: Set<Long>, val categoryId: Long) : LibraryEvent()
     data object MigrateSelected : LibraryEvent()
+    data object UpdateSelected : LibraryEvent()
 }
 
 sealed class LibraryEffect {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -115,6 +115,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.zIndex
+import androidx.activity.compose.BackHandler
+import androidx.compose.material.icons.filled.Refresh
 
 private const val CATEGORY_TABS_Z_INDEX = 2f
 
@@ -230,6 +232,13 @@ fun LibraryScreen(
         )
     }
 
+    BackHandler(enabled = state.selectedManga.isNotEmpty() || state.showSearchBar) {
+        when {
+            state.selectedManga.isNotEmpty() -> viewModel.onEvent(LibraryEvent.ClearSelection)
+            state.showSearchBar -> viewModel.onEvent(LibraryEvent.ToggleSearchBar)
+        }
+    }
+
     Scaffold(
         topBar = {
             when {
@@ -297,8 +306,14 @@ fun LibraryScreen(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
+                            val titleText = if (!state.showCategoryTabs && state.selectedCategory != null) {
+                                state.categories.find { it.id == state.selectedCategory }?.name
+                                    ?: stringResource(R.string.library_title)
+                            } else {
+                                stringResource(R.string.library_title)
+                            }
                             Text(
-                                text = stringResource(R.string.library_title),
+                                text = titleText,
                                 style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
@@ -459,6 +474,7 @@ fun LibraryScreen(
                 onDownloadClicked = { viewModel.onEvent(LibraryEvent.DownloadSelected) },
                 onDeleteClicked = { pendingBulkAction = LibraryEvent.RemoveSelectedFromLibrary },
                 onMigrateClicked = { viewModel.onEvent(LibraryEvent.MigrateSelected) },
+                onUpdateClicked = { viewModel.onEvent(LibraryEvent.UpdateSelected) },
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -801,8 +817,8 @@ private fun LibraryContent(
         }
 
         PullToRefreshBox(
-            isRefreshing = state.isRefreshing,
-            onRefresh = { onEvent(LibraryEvent.Refresh) },
+            isRefreshing = state.isRefreshing && state.selectedManga.isEmpty(),
+            onRefresh = { if (state.selectedManga.isEmpty()) onEvent(LibraryEvent.Refresh) },
             modifier = Modifier.weight(1f)
         ) {
             when {
@@ -815,6 +831,7 @@ private fun LibraryContent(
                     Box(modifier = Modifier.fillMaxSize()) {
                         EmptyLibrarySearchMessage(
                             query = state.searchQuery,
+                            onBrowseClick = onBrowseClick,
                             modifier = Modifier.align(Alignment.Center)
                         )
                     }
@@ -1082,6 +1099,7 @@ private fun LibrarySelectionBottomBar(
     onDownloadClicked: () -> Unit,
     onDeleteClicked: () -> Unit,
     onMigrateClicked: () -> Unit,
+    onUpdateClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(
@@ -1152,6 +1170,20 @@ private fun LibrarySelectionBottomBar(
                     }
                     Text(
                         text = stringResource(R.string.library_download_selected),
+                        style = MaterialTheme.typography.labelSmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    IconButton(onClick = onUpdateClicked) {
+                        Icon(
+                            Icons.Default.Refresh,
+                            contentDescription = stringResource(R.string.library_update_selected),
+                        )
+                    }
+                    Text(
+                        text = stringResource(R.string.library_update_selected),
                         style = MaterialTheme.typography.labelSmall,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -307,8 +307,25 @@ fun LibraryScreen(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
                             val titleText = if (!state.showCategoryTabs && state.selectedCategory != null) {
-                                state.categories.find { it.id == state.selectedCategory }?.name
-                                    ?: stringResource(R.string.library_title)
+                                when (state.groupType) {
+                                    LibraryGroup.BY_SOURCE -> state.allMangaList
+                                        .firstOrNull { it.sourceId == state.selectedCategory }
+                                        ?.sourceName?.ifBlank { state.selectedCategory.toString() }
+                                    LibraryGroup.BY_STATUS -> {
+                                        val statusOrdinal = (state.selectedCategory - 1).toInt()
+                                        when (MangaStatus.entries.getOrNull(statusOrdinal)) {
+                                            MangaStatus.UNKNOWN -> stringResource(R.string.manga_status_unknown)
+                                            MangaStatus.ONGOING -> stringResource(R.string.manga_status_ongoing)
+                                            MangaStatus.COMPLETED -> stringResource(R.string.manga_status_completed)
+                                            MangaStatus.LICENSED -> stringResource(R.string.manga_status_licensed)
+                                            MangaStatus.PUBLISHING_FINISHED -> stringResource(R.string.manga_status_publishing_finished)
+                                            MangaStatus.CANCELLED -> stringResource(R.string.manga_status_cancelled)
+                                            MangaStatus.ON_HIATUS -> stringResource(R.string.manga_status_on_hiatus)
+                                            null -> null
+                                        }
+                                    }
+                                    else -> state.categories.find { it.id == state.selectedCategory }?.name
+                                } ?: stringResource(R.string.library_title)
                             } else {
                                 stringResource(R.string.library_title)
                             }
@@ -817,8 +834,9 @@ private fun LibraryContent(
         }
 
         PullToRefreshBox(
-            isRefreshing = state.isRefreshing && state.selectedManga.isEmpty(),
-            onRefresh = { if (state.selectedManga.isEmpty()) onEvent(LibraryEvent.Refresh) },
+            isRefreshing = state.isRefreshing,
+            onRefresh = { onEvent(LibraryEvent.Refresh) },
+            enabled = state.selectedManga.isEmpty(),
             modifier = Modifier.weight(1f)
         ) {
             when {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -306,13 +306,14 @@ fun LibraryScreen(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
-                            val titleText = if (!state.showCategoryTabs && state.selectedCategory != null) {
+                            val selectedCategory = state.selectedCategory
+                            val titleText = if (!state.showCategoryTabs && selectedCategory != null) {
                                 when (state.groupType) {
                                     LibraryGroup.BY_SOURCE -> state.allMangaList
-                                        .firstOrNull { it.sourceId == state.selectedCategory }
-                                        ?.sourceName?.ifBlank { state.selectedCategory.toString() }
+                                        .firstOrNull { it.sourceId == selectedCategory }
+                                        ?.sourceName?.ifBlank { selectedCategory.toString() }
                                     LibraryGroup.BY_STATUS -> {
-                                        val statusOrdinal = (state.selectedCategory - 1).toInt()
+                                        val statusOrdinal = (selectedCategory - 1).toInt()
                                         when (MangaStatus.entries.getOrNull(statusOrdinal)) {
                                             MangaStatus.UNKNOWN -> stringResource(R.string.manga_status_unknown)
                                             MangaStatus.ONGOING -> stringResource(R.string.manga_status_ongoing)
@@ -324,7 +325,7 @@ fun LibraryScreen(
                                             null -> null
                                         }
                                     }
-                                    else -> state.categories.find { it.id == state.selectedCategory }?.name
+                                    else -> state.categories.find { it.id == selectedCategory }?.name
                                 } ?: stringResource(R.string.library_title)
                             } else {
                                 stringResource(R.string.library_title)
@@ -835,8 +836,7 @@ private fun LibraryContent(
 
         PullToRefreshBox(
             isRefreshing = state.isRefreshing,
-            onRefresh = { onEvent(LibraryEvent.Refresh) },
-            enabled = state.selectedManga.isEmpty(),
+            onRefresh = { if (state.selectedManga.isEmpty()) onEvent(LibraryEvent.Refresh) },
             modifier = Modifier.weight(1f)
         ) {
             when {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -295,8 +295,7 @@ class LibraryViewModel @Inject constructor(
     }
 
     private fun updateSelected() {
-        val ids = selection.snapshotAndClear()
-        if (ids.isEmpty()) return
+        if (selection.snapshotAndClear().isEmpty()) return
         viewModelScope.launch {
             libraryUpdateScheduler.enqueueNow()
             _effect.send(LibraryEffect.ShowSnackbar(R.string.library_update_started))

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -167,7 +167,8 @@ class LibraryViewModel @Inject constructor(
             is LibraryEvent.MarkSelectedAsDropped, is LibraryEvent.ShareSelectedManga,
             is LibraryEvent.ViewSelectedManga, is LibraryEvent.UndoLibraryDelete,
             is LibraryEvent.OpenMoveToCategoryDialog, is LibraryEvent.DismissMoveToCategoryDialog,
-            is LibraryEvent.MoveToCategory, is LibraryEvent.MigrateSelected -> handleActionEvent(event)
+            is LibraryEvent.MoveToCategory, is LibraryEvent.MigrateSelected,
+            is LibraryEvent.UpdateSelected -> handleActionEvent(event)
             is LibraryEvent.UpdateLibrary, is LibraryEvent.UpdateCategory,
             is LibraryEvent.OpenRandomEntry, is LibraryEvent.ReindexDownloads,
             is LibraryEvent.SyncEhFavorites,
@@ -288,7 +289,17 @@ class LibraryViewModel @Inject constructor(
             }
             is LibraryEvent.MoveToCategory -> moveMangaToCategory(event.mangaIds, event.categoryId)
             is LibraryEvent.MigrateSelected -> migrateSelected()
+            is LibraryEvent.UpdateSelected -> updateSelected()
             else -> Unit
+        }
+    }
+
+    private fun updateSelected() {
+        val ids = selection.snapshotAndClear()
+        if (ids.isEmpty()) return
+        viewModelScope.launch {
+            libraryUpdateScheduler.enqueueNow()
+            _effect.send(LibraryEffect.ShowSnackbar(R.string.library_update_started))
         }
     }
 

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -240,6 +240,8 @@
     <string name="sort_total_chapters">Total chapters</string>
     <string name="sort_latest_chapter">Latest chapter</string>
     <string name="sort_random">Random</string>
+    <string name="sort_chapter_fetch_date">Chapter fetch date</string>
+    <string name="sort_tracker_mean">Tracker score</string>
     <string name="filter_all">All</string>
     <string name="filter_downloaded">Downloaded</string>
     <string name="filter_not_downloaded">Not downloaded</string>
@@ -376,6 +378,10 @@
     <string name="library_filter_no_results_message">No manga in your library match the active filters</string>
     <string name="library_filter_no_results_clear_cta">Clear filters</string>
 
+    <!-- Selection bar actions -->
+    <string name="library_update_selected">Update</string>
+    <!-- Search empty state: global search CTA -->
+    <string name="library_search_globally">Search globally</string>
     <!-- Bulk delete undo snackbar -->
     <string name="library_undo_action">Undo</string>
     <plurals name="library_removed_count_undo">

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -936,4 +936,80 @@ class LibraryViewModelTest {
             expectNoEvents()
         }
     }
+
+    // --- UpdateSelected tests ---
+
+    @Test
+    fun updateSelected_triggersSchedulerAndEmitsSnackbar_andClearsSelection() = runTest {
+        every { getLibraryManga() } returns flowOf(sampleMangas)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(LibraryEvent.SelectMangaFromMenu(1L))
+        viewModel.onEvent(LibraryEvent.SelectMangaFromMenu(2L))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.effect.test {
+            viewModel.onEvent(LibraryEvent.UpdateSelected)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val effect = awaitItem()
+            assertTrue(effect is LibraryEffect.ShowSnackbar)
+            assertEquals(R.string.library_update_started, (effect as LibraryEffect.ShowSnackbar).messageRes)
+        }
+
+        io.mockk.coVerify(exactly = 1) { libraryUpdateScheduler.enqueueNow() }
+        assertTrue(viewModel.state.value.selectedManga.isEmpty())
+    }
+
+    @Test
+    fun updateSelected_doesNothing_whenSelectionIsEmpty() = runTest {
+        every { getLibraryManga() } returns flowOf(sampleMangas)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.effect.test {
+            viewModel.onEvent(LibraryEvent.UpdateSelected)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            expectNoEvents()
+        }
+
+        io.mockk.coVerify(exactly = 0) { libraryUpdateScheduler.enqueueNow() }
+    }
+
+    // --- New sort mode tests (CHAPTER_FETCH_DATE, TRACKER_MEAN) ---
+
+    @Test
+    fun sortMode_CHAPTER_FETCH_DATE_sortsByDateAddedDescending() = runTest {
+        every { libraryPreferences.librarySortMode } returns flowOf(LibrarySortMode.CHAPTER_FETCH_DATE.ordinal)
+        val mangasWithDates = listOf(
+            Manga(id = 1L, sourceId = 10L, url = "/m/1", title = "Naruto", favorite = true, dateAdded = 3000L),
+            Manga(id = 2L, sourceId = 20L, url = "/m/2", title = "Bleach", favorite = true, dateAdded = 1000L),
+            Manga(id = 3L, sourceId = 10L, url = "/m/3", title = "One Piece", favorite = true, dateAdded = 2000L),
+        )
+        every { getLibraryManga() } returns flowOf(mangasWithDates)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Naruto(3000) > One Piece(2000) > Bleach(1000)
+        val ids = viewModel.state.value.mangaList.map { it.id }
+        assertEquals(listOf(1L, 3L, 2L), ids)
+    }
+
+    @Test
+    fun sortMode_TRACKER_MEAN_sortsByTitleAscending() = runTest {
+        every { libraryPreferences.librarySortMode } returns flowOf(LibrarySortMode.TRACKER_MEAN.ordinal)
+        every { getLibraryManga() } returns flowOf(sampleMangas)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Falls back to alphabetical: Bleach, Naruto, One Piece
+        val titles = viewModel.state.value.mangaList.map { it.title }
+        assertEquals(listOf("Bleach", "Naruto", "One Piece"), titles)
+    }
 }


### PR DESCRIPTION
## Summary

- **GAP-B2** — `BackHandler` added to `LibraryScreen`: Back clears selection mode when manga are selected, and closes the search bar when search is open. Matches Komikku's escape-hatch UX exactly.
- **GAP-B3** — `PullToRefreshBox` guarded during selection mode using the `enabled` parameter, which completely disables the pull gesture while any manga are selected, preventing accidental refreshes mid-batch-action.
- **GAP-B5/B6** — `CHAPTER_FETCH_DATE` and `TRACKER_MEAN` sort modes added to `LibrarySortMode` (appended for stable ordinal persistence). Wired end-to-end: exhaustive `when` branches in `LibraryFilterLogic`, display labels in `LibraryBottomSheet`, string resources. Both modes match Komikku's sort menu; fallback ordering is documented in unit tests until the backing data fields are added.
- **GAP-B12** — "Search globally" CTA added to the empty-search-results state (`EmptyLibrarySearchMessage`), letting users pivot from a no-results library search directly to Browse.
- **GAP-B13** — Toolbar title reflects the active category name when category tabs are hidden (`showCategoryTabs=false` + `selectedCategory` set), with group-aware lookup: BY_SOURCE resolves source name, BY_STATUS maps the ordinal back to a localized status string, default resolves from custom categories.
- **GAP-B14** — "Update" action (Refresh icon) added to `LibrarySelectionBottomBar`. Triggers `LibraryEvent.UpdateSelected` → `libraryUpdateScheduler.enqueueNow()` and clears selection. Full library update is the current behavior; per-manga scoped updates require a scheduler API extension (follow-up).

## Type of Change

- [x] Feature / enhancement (non-breaking — new behavior, existing tests still pass)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation only

## Files Changed

| File | Change |
|------|--------|
| `LibraryMvi.kt` | Add `CHAPTER_FETCH_DATE`, `TRACKER_MEAN` to enum; add `UpdateSelected` event |
| `LibraryViewModel.kt` | Route + handle `UpdateSelected`; add `updateSelected()` |
| `LibraryFilterLogic.kt` | Exhaustive `when` cases for new sort modes |
| `LibraryBottomSheet.kt` | Display labels for new sort modes |
| `LibraryEmptyState.kt` | `onBrowseClick` param on `EmptyLibrarySearchMessage` |
| `LibraryScreen.kt` | BackHandler, PTR enabled param, group-aware title, global search CTA, Update bar action |
| `strings.xml` | `sort_chapter_fetch_date`, `sort_tracker_mean`, `library_update_selected`, `library_search_globally` |
| `LibraryViewModelTest.kt` | Tests for UpdateSelected (scheduler called, selection cleared, snackbar emitted), CHAPTER_FETCH_DATE, TRACKER_MEAN |

## Screenshots

Behavior / logic changes only — no new visual components. The selection bottom bar gains an "Update" icon consistent with the existing icon row layout.

## Checklist

- [x] Follows MVI pattern (State / Event / Effect, no direct state mutation)
- [x] No hardcoded strings (all in `strings.xml`)
- [x] No `GlobalScope`, `LiveData`, or XML layouts introduced
- [x] `LibrarySortMode` ordinals are append-only (persisted to DataStore)
- [x] Unit tests added for new behavior (`LibraryViewModelTest`)
- [x] Tachiyomi extension compatibility unaffected (`source-api/` unchanged)

## Related Issues

No linked issues — this is part of the ongoing Komikku 1:1 parity audit (Library screen, Tier-1 gaps B2/B3/B5/B6/B12/B13/B14).

## Test Plan

- [ ] Back press while manga are selected → deselects all (no navigation)
- [ ] Back press while search bar is open → closes search bar
- [ ] Pull-to-refresh gesture during selection mode → no effect (gesture fully disabled)
- [ ] Sort sheet shows "Chapter fetch date" and "Tracker score" chips
- [ ] No-results search state shows "Search globally" button when Browse is wired
- [ ] With category tabs hidden and a category selected, toolbar shows category name (source name for BY_SOURCE, status label for BY_STATUS, category name for default)
- [ ] "Update" icon visible in selection bottom bar; tapping it triggers update snackbar and clears selection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

A detailed high-level summary could not be generated for this review. Here is an overview derived from the analyzed file changes:

- **feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt**: ## AI-generated summary of changes
- **feature/library/src/main/java/app/otakureader/feature/library/LibraryEmptyState.kt**: ## AI-generated summary of changes
- **feature/library/src/main/java/app/otakureader/feature/library/LibraryFilterLogic.kt**: ## AI-generated summary of changes
- **feature/library/src/main/java/app/otakureader/feature/library/LibraryMvi.kt**: ## AI-generated summary of changes
- **feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt**: ## AI-generated summary of changes
- **feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt**: ## AI-generated summary of changes
- **feature/library/src/main/res/values/strings.xml**: ## AI-generated summary of changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->