### PR TITLE
Browse: fix disabled extensions still showing sources

### DIFF
--- a/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
@@ -2,6 +2,7 @@ package app.otakureader.data.repository
 
 import android.content.Context
 import androidx.annotation.VisibleForTesting
+import app.otakureader.core.extension.domain.repository.ExtensionRepository
 import app.otakureader.core.extension.loader.ExtensionLoader
 import app.otakureader.core.extension.loader.ExtensionLoadResult
 import app.otakureader.core.preferences.LocalSourcePreferences
@@ -49,6 +50,7 @@ class SourceRepositoryImpl @Inject constructor(
     private val healthMonitor: SourceHealthMonitor,
     private val httpClient: OkHttpClient,
     private val extensionLoader: ExtensionLoader,
+    private val extensionRepository: ExtensionRepository,
     @ApplicationScope private val scope: CoroutineScope,
 ) : SourceRepository, ExtensionManagementRepository {
 
@@ -70,6 +72,7 @@ class SourceRepositoryImpl @Inject constructor(
         healthMonitor: SourceHealthMonitor,
         httpClient: OkHttpClient,
         extensionLoader: ExtensionLoader,
+        extensionRepository: ExtensionRepository,
         scope: CoroutineScope,
     ) : this(
         context,
@@ -77,6 +80,7 @@ class SourceRepositoryImpl @Inject constructor(
         healthMonitor,
         httpClient,
         extensionLoader,
+        extensionRepository,
         scope,
     )
 
@@ -460,8 +464,17 @@ class SourceRepositoryImpl @Inject constructor(
             }
             try {
                 val results = extensionLoader.loadAllExtensions()
+                // Sources are parsed fresh from the APK on every load, so ExtensionLoadResult's
+                // Extension.isEnabled is always the model default (true) and never reflects the
+                // user's stored preference. Cross-reference the DB-persisted flag here so a
+                // disabled extension's sources stay out of Browse.
+                val disabledPkgNames = extensionRepository.getInstalledExtensions().first()
+                    .filterNot { it.isEnabled }
+                    .map { it.pkgName }
+                    .toSet()
                 val extensionSources = results
                     .filterIsInstance<ExtensionLoadResult.Success>()
+                    .filterNot { it.extension.pkgName in disabledPkgNames }
                     .flatMap { success ->
                         success.sources
                             .filterIsInstance<CatalogueSource>()

--- a/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
@@ -467,11 +467,20 @@ class SourceRepositoryImpl @Inject constructor(
                 // Sources are parsed fresh from the APK on every load, so ExtensionLoadResult's
                 // Extension.isEnabled is always the model default (true) and never reflects the
                 // user's stored preference. Cross-reference the DB-persisted flag here so a
-                // disabled extension's sources stay out of Browse.
-                val disabledPkgNames = extensionRepository.getInstalledExtensions().first()
-                    .filterNot { it.isEnabled }
-                    .map { it.pkgName }
-                    .toSet()
+                // disabled extension's sources stay out of Browse. A failure to read this is
+                // non-fatal — fall back to treating nothing as disabled rather than losing every
+                // loaded source below.
+                val disabledPkgNames = try {
+                    extensionRepository.getInstalledExtensions().first()
+                        .filterNot { it.isEnabled }
+                        .map { it.pkgName }
+                        .toSet()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    android.util.Log.w(TAG, "Failed to read disabled extensions, treating all as enabled", e)
+                    emptySet()
+                }
                 val extensionSources = results
                     .filterIsInstance<ExtensionLoadResult.Success>()
                     .filterNot { it.extension.pkgName in disabledPkgNames }

--- a/data/src/test/java/app/otakureader/data/repository/SourceRepositoryImplTest.kt
+++ b/data/src/test/java/app/otakureader/data/repository/SourceRepositoryImplTest.kt
@@ -189,6 +189,35 @@ class SourceRepositoryImplTest {
     }
 
     @Test
+    fun getSources_afterRefresh_keepsAllSourcesWhenDisabledExtensionLookupFails() = runTest {
+        // A DB read failure while checking disabled state must not wipe out every
+        // loaded extension source — it should degrade to "treat nothing as disabled".
+        val localSource = makeFakeSource(id = "local", name = "Local")
+        val extSource = makeFakeCatalogueSource(id = 12345L, name = "MangaDex")
+
+        mockLocalSource(localSource)
+        every { extensionLoader.loadAllExtensions() } returns listOf(
+            makeSuccessResult(
+                pkgName = "eu.kanade.tachiyomi.extension.en.mangadex",
+                name = "MangaDex",
+                sources = listOf(extSource),
+                isNsfw = false,
+            )
+        )
+        every { extensionRepository.getInstalledExtensions() } throws
+            RuntimeException("DB unavailable")
+
+        val result = repository.refreshSources()
+        advanceUntilIdle()
+
+        assertTrue(result.isSuccess)
+        val sources = repository.getSources().first()
+        assertEquals(2, sources.size)
+        assertTrue(sources.any { it.id == "local" })
+        assertTrue(sources.any { it.id == "12345" })
+    }
+
+    @Test
     fun getSources_deduplicatesById() = runTest {
         // After refresh, only one source with id "999" should remain even if two
         // extensions both provide a CatalogueSource with the same Long ID (999).

--- a/data/src/test/java/app/otakureader/data/repository/SourceRepositoryImplTest.kt
+++ b/data/src/test/java/app/otakureader/data/repository/SourceRepositoryImplTest.kt
@@ -3,6 +3,7 @@ package app.otakureader.data.repository
 import android.content.Context
 import app.otakureader.core.extension.domain.model.Extension
 import app.otakureader.core.extension.domain.model.InstallStatus
+import app.otakureader.core.extension.domain.repository.ExtensionRepository
 import app.otakureader.core.extension.loader.ExtensionLoader
 import app.otakureader.core.extension.loader.ExtensionLoadResult
 import app.otakureader.core.preferences.LocalSourcePreferences
@@ -65,6 +66,7 @@ class SourceRepositoryImplTest {
     private lateinit var healthMonitor: SourceHealthMonitor
     private lateinit var httpClient: OkHttpClient
     private lateinit var extensionLoader: ExtensionLoader
+    private lateinit var extensionRepository: ExtensionRepository
 
     private lateinit var repository: SourceRepositoryImpl
 
@@ -78,11 +80,16 @@ class SourceRepositoryImplTest {
         healthMonitor = mockk(relaxed = true)
         httpClient = mockk(relaxed = true)
         extensionLoader = mockk(relaxed = true)
+        extensionRepository = mockk(relaxed = true)
 
         // Default: no extensions loaded
         every { extensionLoader.loadAllExtensions() } returns emptyList()
         every { extensionLoader.loadExtension(any()) } returns
             ExtensionLoadResult.Error("Not mocked")
+
+        // Default: no installed extensions are disabled
+        every { extensionRepository.getInstalledExtensions() } returns
+            kotlinx.coroutines.flow.flowOf(emptyList())
 
         // Health monitor defaults – everything healthy
         every { healthMonitor.isSourceHealthy(any()) } returns true
@@ -93,6 +100,7 @@ class SourceRepositoryImplTest {
             healthMonitor = healthMonitor,
             httpClient = httpClient,
             extensionLoader = extensionLoader,
+            extensionRepository = extensionRepository,
             scope = testScope.backgroundScope,
         )
     }
@@ -135,6 +143,49 @@ class SourceRepositoryImplTest {
         assertEquals(2, sources.size)
         assertTrue(sources.any { it.id == "local" })
         assertTrue(sources.any { it.id == "12345" })
+    }
+
+    @Test
+    fun getSources_afterRefresh_excludesSourcesFromDisabledExtension() = runTest {
+        val localSource = makeFakeSource(id = "local", name = "Local")
+        val extSource = makeFakeCatalogueSource(id = 12345L, name = "MangaDex")
+
+        mockLocalSource(localSource)
+        every { extensionLoader.loadAllExtensions() } returns listOf(
+            makeSuccessResult(
+                pkgName = "eu.kanade.tachiyomi.extension.en.mangadex",
+                name = "MangaDex",
+                sources = listOf(extSource),
+                isNsfw = false,
+            )
+        )
+        val disabledExtension = Extension(
+            id = 1L,
+            pkgName = "eu.kanade.tachiyomi.extension.en.mangadex",
+            name = "MangaDex",
+            versionCode = 1,
+            versionName = "1.0.0",
+            sources = emptyList(),
+            status = InstallStatus.INSTALLED,
+            apkPath = "/tmp/fake.apk",
+            iconUrl = null,
+            lang = "en",
+            isNsfw = false,
+            installDate = System.currentTimeMillis(),
+            signatureHash = "trusted",
+            isShared = true,
+            isEnabled = false,
+        )
+        every { extensionRepository.getInstalledExtensions() } returns
+            kotlinx.coroutines.flow.flowOf(listOf(disabledExtension))
+
+        repository.refreshSources()
+        advanceUntilIdle()
+
+        val sources = repository.getSources().first()
+        assertEquals(1, sources.size)
+        assertTrue(sources.any { it.id == "local" })
+        assertFalse(sources.any { it.id == "12345" })
     }
 
     @Test


### PR DESCRIPTION
## 📋 Description
`SourceRepositoryImpl.refreshSources()` rebuilds the Browse source list purely by rescanning APKs via `ExtensionLoader`, which parses a fresh `Extension` model on every load. That means `Extension.isEnabled` on the loaded model is always the class default (`true`) and never reflects the user's stored DB preference. Toggling "Disable" on an extension (Extensions screen, long-press menu) updated the DB row via `setExtensionEnabled`, but nothing cross-referenced that with the loaded source list — so a disabled extension's source kept appearing in Browse regardless. This is a "stub UI" violation per project conventions: a working UI control with no real effect.

Found during a broader audit of the Browse → Extensions → Sources flow for Komikku/Mihon parity (install/uninstall/update already correctly call `refreshSources()` after DB writes — that path was fine).

## 🔄 Type of Change
- [x] 🐛 Bug fix

## 🧪 Testing
- Added `getSources_afterRefresh_excludesSourcesFromDisabledExtension` to `SourceRepositoryImplTest`, verifying a source is excluded from `getSources()` when its extension's DB row has `isEnabled = false`.
- Existing tests (`getSources_afterRefresh_containsLocalAndExtensionSources`, `getSources_deduplicatesById`, etc.) updated to supply a default (empty/all-enabled) `ExtensionRepository` mock.
- No local Android SDK available in this environment to run a full build; relying on CI for `:data:compileDebugKotlin` / `:data:testDebugUnitTest` verification.

## 📸 Screenshots
No UI changes — behavior-only fix in the data layer.

## ✅ Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Tests added
- [ ] Verified on device/CI (pending CI run)

## 🔗 Related Issues
Part of the ongoing Browse/Extensions/Sources Komikku-parity audit.

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_