### PR TITLE
Manga Detail: title/author/artist tap-to-search across all sources

### DIFF
--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -356,6 +356,9 @@ fun OtakuReaderNavHost(
             },
             onNavigateToSourceSearch = { sourceId, query ->
                 navController.navigate(Route.SourceListing(sourceId, query))
+            },
+            onNavigateToMigration = { mangaId ->
+                navController.navigate(Route.Migration(selectedMangaIds = listOf(mangaId)))
             }
         )
 

--- a/feature/details/src/main/java/app/otakureader/feature/details/ChapterList.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/ChapterList.kt
@@ -378,7 +378,15 @@ fun ChapterListItem(
                     }
                 )
             }
-            else -> { /* Downloading - no action */ }
+            DetailsContract.DownloadStatus.DOWNLOADING -> {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.details_chapter_cancel_download)) },
+                    onClick = {
+                        onDeleteDownload()
+                        showMenu = false
+                    }
+                )
+            }
         }
     }
 }
@@ -407,14 +415,16 @@ private fun DownloadIcon(
             when (status) {
                 DetailsContract.DownloadStatus.NOT_DOWNLOADED -> onDownload()
                 DetailsContract.DownloadStatus.DOWNLOADED -> onDelete()
-                else -> { /* Do nothing while downloading */ }
+                // Same callback as DOWNLOADED — the ViewModel branches on the chapter's actual
+                // status to cancel an in-flight download instead of deleting finished files.
+                DetailsContract.DownloadStatus.DOWNLOADING -> onDelete()
             }
         },
         modifier = modifier
     ) {
         val downloadContentDesc = when (status) {
             DetailsContract.DownloadStatus.NOT_DOWNLOADED -> stringResource(R.string.details_chapter_download)
-            DetailsContract.DownloadStatus.DOWNLOADING -> stringResource(R.string.details_chapter_downloading)
+            DetailsContract.DownloadStatus.DOWNLOADING -> stringResource(R.string.details_chapter_cancel_download)
             DetailsContract.DownloadStatus.DOWNLOADED -> stringResource(R.string.details_chapter_delete_download)
         }
         Icon(

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
@@ -296,6 +296,9 @@ object DetailsContract {
         /** Genre/tag chip long-press: search this tag across all sources (global search). */
         data class GenreLongClick(val genre: String) : Event
 
+        /** Title/author/artist tap in the header: search that text across all sources. */
+        data class SearchGlobally(val query: String) : Event
+
         /** Opens the manga's source web page in the system browser. */
         data object OpenWebView : Event
 

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
@@ -322,6 +322,14 @@ object DetailsContract {
         /** Search [query] within a single source's browse listing (tag short-press). */
         data class NavigateToSourceSearch(val sourceId: String, val query: String) : Effect
         data class OpenDownloadFolder(val sourceName: String, val mangaTitle: String) : Effect
+
+        /**
+         * Shown right after removing a manga from the library when it has downloaded chapters.
+         * The UI presents this as an action snackbar ("Delete downloaded chapters?" / Delete);
+         * tapping the action sends [Event.ClearMangaDownloads] back. Downloads are kept by
+         * default — this is opt-in deletion, not an undo of the removal itself.
+         */
+        data object ShowDeleteDownloadsPrompt : Effect
     }
 }
 

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
@@ -61,6 +61,8 @@ object DetailsContract {
         val trackingCount: Int = 0,
         /** Full web URL for this manga (source baseUrl + manga url). Null for local sources. */
         val mangaWebUrl: String? = null,
+        /** Display name of the manga's source, shown next to the status (Komikku parity). */
+        val sourceName: String? = null,
 
         /** User-defined library categories, for the "add to library" category picker. */
         val libraryCategories: List<Category> = emptyList(),
@@ -299,6 +301,9 @@ object DetailsContract {
         /** Title/author/artist tap in the header: search that text across all sources. */
         data class SearchGlobally(val query: String) : Event
 
+        /** Source name tap in the header: browse the manga's own source (Komikku parity). */
+        data object SourceClick : Event
+
         /** Opens the manga's source web page in the system browser. */
         data object OpenWebView : Event
 
@@ -306,6 +311,9 @@ object DetailsContract {
         data object DismissCategoryPicker : Event
         data class ToggleCategoryPickerSelection(val categoryId: Long) : Event
         data object ConfirmCategoryPicker : Event
+
+        /** Overflow menu "Migrate" — jump straight into the migration search for this manga. */
+        data object MigrateManga : Event
     }
 
     /**
@@ -330,6 +338,9 @@ object DetailsContract {
          * default — this is opt-in deletion, not an undo of the removal itself.
          */
         data object ShowDeleteDownloadsPrompt : Effect
+
+        /** Jump straight into the migration search pre-selected with this single manga. */
+        data class NavigateToMigration(val mangaId: Long) : Effect
     }
 }
 

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -260,6 +261,16 @@ fun DetailsScreen(
                         } else {
                             snackbarHostState.showSnackbar(context.getString(R.string.details_no_downloads))
                         }
+                    }
+                }
+                is DetailsContract.Effect.ShowDeleteDownloadsPrompt -> {
+                    val result = snackbarHostState.showSnackbar(
+                        message = context.getString(R.string.details_delete_downloads_prompt),
+                        actionLabel = context.getString(R.string.details_delete_downloads_action),
+                        withDismissAction = true,
+                    )
+                    if (result == SnackbarResult.ActionPerformed) {
+                        viewModel.onEvent(DetailsContract.Event.ClearMangaDownloads)
                     }
                 }
                 else -> { /* no-op */ }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -155,6 +155,7 @@ fun DetailsScreen(
     onNavigateToTracking: (mangaId: Long, mangaTitle: String) -> Unit = { _, _ -> },
     onNavigateToGlobalSearch: (query: String) -> Unit = {},
     onNavigateToSourceSearch: (sourceId: String, query: String) -> Unit = { _, _ -> },
+    onNavigateToMigration: (mangaId: Long) -> Unit = {},
     viewModel: DetailsViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -217,6 +218,9 @@ fun DetailsScreen(
                 }
                 is DetailsContract.Effect.NavigateToSourceSearch -> {
                     onNavigateToSourceSearch(effect.sourceId, effect.query)
+                }
+                is DetailsContract.Effect.NavigateToMigration -> {
+                    onNavigateToMigration(effect.mangaId)
                 }
                 is DetailsContract.Effect.OpenInBrowser -> {
                     try {
@@ -417,6 +421,15 @@ fun DetailsScreen(
                                 overflowExpanded = false
                             },
                         )
+                        if (state.isFavorite) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.details_migrate)) },
+                                onClick = {
+                                    viewModel.onEvent(DetailsContract.Event.MigrateManga)
+                                    overflowExpanded = false
+                                }
+                            )
+                        }
                         androidx.compose.material3.HorizontalDivider()
                         DropdownMenuItem(
                             text = { Text(stringResource(R.string.details_open_download_folder)) },
@@ -718,6 +731,8 @@ private fun DetailsContent(
                     showPanoramaCover = state.showPanoramaCover,
                     onTogglePanoramaCover = { onEvent(DetailsContract.Event.TogglePanoramaCover) },
                     onSearchGlobal = { query -> onEvent(DetailsContract.Event.SearchGlobally(query)) },
+                    sourceName = state.sourceName,
+                    onSourceClick = { onEvent(DetailsContract.Event.SourceClick) },
                     scrollOffset = scrollOffset,
                 )
             }
@@ -813,6 +828,8 @@ private fun LazyListScope.detailsInfoItems(
             showPanoramaCover = state.showPanoramaCover,
             onTogglePanoramaCover = { onEvent(DetailsContract.Event.TogglePanoramaCover) },
             onSearchGlobal = { query -> onEvent(DetailsContract.Event.SearchGlobally(query)) },
+            sourceName = state.sourceName,
+            onSourceClick = { onEvent(DetailsContract.Event.SourceClick) },
             scrollOffset = scrollOffset,
         )
     }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -702,6 +702,7 @@ private fun DetailsContent(
                     manga = manga,
                     showPanoramaCover = state.showPanoramaCover,
                     onTogglePanoramaCover = { onEvent(DetailsContract.Event.TogglePanoramaCover) },
+                    onSearchGlobal = { query -> onEvent(DetailsContract.Event.SearchGlobally(query)) },
                     scrollOffset = scrollOffset,
                 )
             }
@@ -796,6 +797,7 @@ private fun LazyListScope.detailsInfoItems(
             manga = manga,
             showPanoramaCover = state.showPanoramaCover,
             onTogglePanoramaCover = { onEvent(DetailsContract.Event.TogglePanoramaCover) },
+            onSearchGlobal = { query -> onEvent(DetailsContract.Event.SearchGlobally(query)) },
             scrollOffset = scrollOffset,
         )
     }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -268,6 +269,9 @@ fun DetailsScreen(
                         message = context.getString(R.string.details_delete_downloads_prompt),
                         actionLabel = context.getString(R.string.details_delete_downloads_action),
                         withDismissAction = true,
+                        // Destructive action — give the user more time to notice and respond
+                        // than the default ~4s duration.
+                        duration = SnackbarDuration.Long,
                     )
                     if (result == SnackbarResult.ActionPerformed) {
                         viewModel.onEvent(DetailsContract.Event.ClearMangaDownloads)

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -100,6 +100,7 @@ class DetailsViewModel @Inject constructor(
         observeTrackingCount()
         loadMangaWebUrl()
         observeCategories()
+        loadSourceName()
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
@@ -197,6 +198,38 @@ class DetailsViewModel @Inject constructor(
             is DetailsContract.Event.ToggleCategoryPickerSelection ->
                 toggleCategoryPickerSelection(event.categoryId)
             is DetailsContract.Event.ConfirmCategoryPicker -> confirmCategoryPicker()
+            is DetailsContract.Event.MigrateManga -> migrateManga()
+            is DetailsContract.Event.SourceClick -> onSourceClick()
+        }
+    }
+
+    private fun migrateManga() {
+        viewModelScope.launch {
+            _effect.send(DetailsContract.Effect.NavigateToMigration(mangaId))
+        }
+    }
+
+    /** Source name tap in the header: reuses the source-search navigation with an empty query. */
+    private fun onSourceClick() {
+        viewModelScope.launch {
+            val manga = _state.value.manga ?: return@launch
+            _effect.send(
+                DetailsContract.Effect.NavigateToSourceSearch(sourceId = manga.sourceId.toString(), query = "")
+            )
+        }
+    }
+
+    private fun loadSourceName() {
+        viewModelScope.launch {
+            try {
+                val manga = mangaRepository.getMangaById(mangaId) ?: return@launch
+                val source = sourceRepository.getSource(manga.sourceId.toString())
+                _state.update { it.copy(sourceName = source?.name) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // Source name is a passive display detail — silently leave it unset on failure.
+            }
         }
     }
 
@@ -860,20 +893,27 @@ class DetailsViewModel @Inject constructor(
             val manga = _state.value.manga
             if (chapter == null || manga == null) return@launch
 
-            // The same download icon tap doubles as "cancel" while a chapter is mid-download
-            // and as "delete" once it has finished — there's nothing downloaded yet to delete
-            // while DOWNLOADING, so deleteChapterDownload() would be a silent no-op there.
-            if (chapter.downloadStatus == DetailsContract.DownloadStatus.DOWNLOADING) {
-                downloadRepository.cancelDownload(chapterId)
-                _effect.send(DetailsContract.Effect.ShowSnackbar("Download cancelled"))
-            } else {
-                downloadRepository.deleteChapterDownload(
-                    chapterId = chapterId,
-                    sourceName = sourceRepository.resolveDownloadFolderName(manga.sourceId),
-                    mangaTitle = manga.title,
-                    chapterTitle = chapter.name
-                )
-                _effect.send(DetailsContract.Effect.ShowSnackbar("Download removed"))
+            try {
+                // The same download icon tap doubles as "cancel" while a chapter is
+                // mid-download and as "delete" once it has finished — there's nothing
+                // downloaded yet to delete while DOWNLOADING, so deleteChapterDownload()
+                // would be a silent no-op there.
+                if (chapter.downloadStatus == DetailsContract.DownloadStatus.DOWNLOADING) {
+                    downloadRepository.cancelDownload(chapterId)
+                    _effect.send(DetailsContract.Effect.ShowSnackbar("Download cancelled"))
+                } else {
+                    downloadRepository.deleteChapterDownload(
+                        chapterId = chapterId,
+                        sourceName = sourceRepository.resolveDownloadFolderName(manga.sourceId),
+                        mangaTitle = manga.title,
+                        chapterTitle = chapter.name
+                    )
+                    _effect.send(DetailsContract.Effect.ShowSnackbar("Download removed"))
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(DetailsContract.Effect.ShowError("Failed to update download: ${e.message}"))
             }
         }
     }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -841,16 +841,21 @@ class DetailsViewModel @Inject constructor(
         viewModelScope.launch {
             val chapter = _state.value.chapters.firstOrNull { it.id == chapterId }
             val manga = _state.value.manga
-            if (chapter != null && manga != null) {
+            if (chapter == null || manga == null) return@launch
+
+            // The same download icon tap doubles as "cancel" while a chapter is mid-download
+            // and as "delete" once it has finished — there's nothing downloaded yet to delete
+            // while DOWNLOADING, so deleteChapterDownload() would be a silent no-op there.
+            if (chapter.downloadStatus == DetailsContract.DownloadStatus.DOWNLOADING) {
+                downloadRepository.cancelDownload(chapterId)
+                _effect.send(DetailsContract.Effect.ShowSnackbar("Download cancelled"))
+            } else {
                 downloadRepository.deleteChapterDownload(
                     chapterId = chapterId,
                     sourceName = sourceRepository.resolveDownloadFolderName(manga.sourceId),
                     mangaTitle = manga.title,
                     chapterTitle = chapter.name
                 )
-                _effect.send(DetailsContract.Effect.ShowSnackbar("Download removed"))
-            } else {
-                downloadRepository.cancelDownload(chapterId)
                 _effect.send(DetailsContract.Effect.ShowSnackbar("Download removed"))
             }
         }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -455,11 +455,22 @@ class DetailsViewModel @Inject constructor(
             val wasFavorite = _state.value.isFavorite
             try {
                 mangaRepository.toggleFavorite(mangaId)
-                val message = if (wasFavorite) "Removed from library" else "Added to library"
-                _effect.send(DetailsContract.Effect.ShowSnackbar(message))
-                // Mirrors Komikku: right after adding to library (not on remove), offer to file
-                // the manga into a category if any exist, instead of always leaving it uncategorized.
-                if (!wasFavorite) showCategoryPickerIfNeeded()
+                if (wasFavorite) {
+                    // Mirrors Komikku: removing keeps downloads by default, but if there are
+                    // any, offer to delete them via an action snackbar instead of the plain
+                    // confirmation — deletion only happens if the user taps the action.
+                    if (hasDownloadedOrDownloadingChapters()) {
+                        _effect.send(DetailsContract.Effect.ShowDeleteDownloadsPrompt)
+                    } else {
+                        _effect.send(DetailsContract.Effect.ShowSnackbar("Removed from library"))
+                    }
+                } else {
+                    _effect.send(DetailsContract.Effect.ShowSnackbar("Added to library"))
+                    // Mirrors Komikku: right after adding to library (not on remove), offer to
+                    // file the manga into a category if any exist, instead of always leaving it
+                    // uncategorized.
+                    showCategoryPickerIfNeeded()
+                }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -467,6 +478,12 @@ class DetailsViewModel @Inject constructor(
             }
         }
     }
+
+    private fun hasDownloadedOrDownloadingChapters(): Boolean =
+        _state.value.chapters.any {
+            it.downloadStatus == DetailsContract.DownloadStatus.DOWNLOADED ||
+                it.downloadStatus == DetailsContract.DownloadStatus.DOWNLOADING
+        }
 
     private fun observeCategories() {
         categoryRepository.getCategories()

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -227,6 +227,7 @@ class DetailsViewModel @Inject constructor(
 
     /** Tag long-press, or a title/author/artist tap: search [query] across all sources. */
     private fun searchGlobally(query: String) {
+        if (query.isBlank()) return
         viewModelScope.launch {
             _effect.send(DetailsContract.Effect.NavigateToGlobalSearch(query = query))
         }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -188,7 +188,8 @@ class DetailsViewModel @Inject constructor(
             is DetailsContract.Event.RemoveCustomCover -> removeCustomCover()
 
             is DetailsContract.Event.GenreClick -> searchGenreInSource(event.genre)
-            is DetailsContract.Event.GenreLongClick -> searchGenreGlobally(event.genre)
+            is DetailsContract.Event.GenreLongClick -> searchGlobally(event.genre)
+            is DetailsContract.Event.SearchGlobally -> searchGlobally(event.query)
             is DetailsContract.Event.OpenWebView -> openInWebView()
 
             is DetailsContract.Event.DismissCategoryPicker ->
@@ -224,10 +225,10 @@ class DetailsViewModel @Inject constructor(
         }
     }
 
-    /** Tag long-press: search [genre] across all sources (global search). */
-    private fun searchGenreGlobally(genre: String) {
+    /** Tag long-press, or a title/author/artist tap: search [query] across all sources. */
+    private fun searchGlobally(query: String) {
         viewModelScope.launch {
-            _effect.send(DetailsContract.Effect.NavigateToGlobalSearch(query = genre))
+            _effect.send(DetailsContract.Effect.NavigateToGlobalSearch(query = query))
         }
     }
 

--- a/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -69,6 +70,7 @@ internal fun MangaHeader(
     manga: app.otakureader.domain.model.Manga,
     showPanoramaCover: Boolean,
     onTogglePanoramaCover: () -> Unit,
+    onSearchGlobal: (String) -> Unit = {},
     scrollOffset: () -> Float = { 0f },
     modifier: Modifier = Modifier
 ) {
@@ -227,6 +229,7 @@ internal fun MangaHeader(
                             color = Color.White,
                             maxLines = HEADER_TITLE_MAX_LINES,
                             overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.clickable { onSearchGlobal(manga.title) },
                         )
 
                         val author = manga.author?.takeIf { it.isNotBlank() }
@@ -244,6 +247,7 @@ internal fun MangaHeader(
                                     color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
                                     maxLines = HEADER_SUBTITLE_MAX_LINES,
                                     overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.clickable { onSearchGlobal(it) },
                                 )
                             }
                             artist?.let {
@@ -253,6 +257,7 @@ internal fun MangaHeader(
                                     color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
                                     maxLines = HEADER_SUBTITLE_MAX_LINES,
                                     overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.clickable { onSearchGlobal(it) },
                                 )
                             }
                         }
@@ -279,7 +284,8 @@ internal fun MangaHeader(
                     text = manga.title,
                     style = MaterialTheme.typography.headlineSmall,
                     maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.clickable { onSearchGlobal(manga.title) },
                 )
 
                 Spacer(modifier = Modifier.height(4.dp))
@@ -288,7 +294,8 @@ internal fun MangaHeader(
                     Text(
                         text = stringResource(R.string.details_author, author),
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.clickable { onSearchGlobal(author) },
                     )
                 }
 
@@ -296,7 +303,8 @@ internal fun MangaHeader(
                     Text(
                         text = stringResource(R.string.details_artist, artist),
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.clickable { onSearchGlobal(artist) },
                     )
                 }
 

--- a/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
@@ -64,6 +64,13 @@ private const val HEADER_SUBTITLE_MAX_LINES = 1
 private const val HEADER_SUBTITLE_ALPHA = 0.8f
 private val HEADER_SUBTITLE_TOP_SPACING = 6.dp
 private val HEADER_STATUS_TOP_SPACING = 4.dp
+private val GLOBAL_SEARCH_TAP_CORNER_RADIUS = 4.dp
+
+/** Clip + click affordance shared by every tappable title/author/artist label in the header. */
+private fun Modifier.globalSearchTappable(onTap: () -> Unit): Modifier =
+    this
+        .clip(RoundedCornerShape(GLOBAL_SEARCH_TAP_CORNER_RADIUS))
+        .clickable(onClick = onTap)
 
 @Composable
 internal fun MangaHeader(
@@ -71,6 +78,8 @@ internal fun MangaHeader(
     showPanoramaCover: Boolean,
     onTogglePanoramaCover: () -> Unit,
     onSearchGlobal: (String) -> Unit = {},
+    sourceName: String? = null,
+    onSourceClick: () -> Unit = {},
     scrollOffset: () -> Float = { 0f },
     modifier: Modifier = Modifier
 ) {
@@ -229,9 +238,7 @@ internal fun MangaHeader(
                             color = Color.White,
                             maxLines = HEADER_TITLE_MAX_LINES,
                             overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier
-                                .clip(RoundedCornerShape(4.dp))
-                                .clickable { onSearchGlobal(manga.title) },
+                            modifier = Modifier.globalSearchTappable { onSearchGlobal(manga.title) },
                         )
 
                         val author = manga.author?.takeIf { it.isNotBlank() }
@@ -249,9 +256,7 @@ internal fun MangaHeader(
                                     color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
                                     maxLines = HEADER_SUBTITLE_MAX_LINES,
                                     overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier
-                                        .clip(RoundedCornerShape(4.dp))
-                                        .clickable { onSearchGlobal(it) },
+                                    modifier = Modifier.globalSearchTappable { onSearchGlobal(it) },
                                 )
                             }
                             artist?.let {
@@ -261,20 +266,30 @@ internal fun MangaHeader(
                                     color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
                                     maxLines = HEADER_SUBTITLE_MAX_LINES,
                                     overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier
-                                        .clip(RoundedCornerShape(4.dp))
-                                        .clickable { onSearchGlobal(it) },
+                                    modifier = Modifier.globalSearchTappable { onSearchGlobal(it) },
                                 )
                             }
                         }
 
                         Spacer(modifier = Modifier.height(HEADER_STATUS_TOP_SPACING))
 
-                        Text(
-                            text = stringResource(manga.status.displayTextResId()),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
-                        )
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = stringResource(manga.status.displayTextResId()),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
+                            )
+                            if (!sourceName.isNullOrBlank()) {
+                                Text(
+                                    text = " • $sourceName",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
+                                    maxLines = HEADER_SUBTITLE_MAX_LINES,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.globalSearchTappable(onSourceClick),
+                                )
+                            }
+                        }
 
                     }
                 }
@@ -291,9 +306,7 @@ internal fun MangaHeader(
                     style = MaterialTheme.typography.headlineSmall,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(4.dp))
-                        .clickable { onSearchGlobal(manga.title) },
+                    modifier = Modifier.globalSearchTappable { onSearchGlobal(manga.title) },
                 )
 
                 Spacer(modifier = Modifier.height(4.dp))
@@ -303,9 +316,7 @@ internal fun MangaHeader(
                         text = stringResource(R.string.details_author, author),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier
-                            .clip(RoundedCornerShape(4.dp))
-                            .clickable { onSearchGlobal(author) },
+                        modifier = Modifier.globalSearchTappable { onSearchGlobal(author) },
                     )
                 }
 
@@ -314,17 +325,30 @@ internal fun MangaHeader(
                         text = stringResource(R.string.details_artist, artist),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier
-                            .clip(RoundedCornerShape(4.dp))
-                            .clickable { onSearchGlobal(artist) },
+                        modifier = Modifier.globalSearchTappable { onSearchGlobal(artist) },
                     )
                 }
 
-                Text(
-                    text = stringResource(R.string.details_status, stringResource(manga.status.displayTextResId())),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = manga.status.colorValue(LocalOtakuColors.current)
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = stringResource(
+                            R.string.details_status,
+                            stringResource(manga.status.displayTextResId()),
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = manga.status.colorValue(LocalOtakuColors.current)
+                    )
+                    if (!sourceName.isNullOrBlank()) {
+                        Text(
+                            text = " • $sourceName",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = HEADER_SUBTITLE_MAX_LINES,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.globalSearchTappable(onSourceClick),
+                        )
+                    }
+                }
             }
         }
     }

--- a/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/MangaHeader.kt
@@ -229,7 +229,9 @@ internal fun MangaHeader(
                             color = Color.White,
                             maxLines = HEADER_TITLE_MAX_LINES,
                             overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.clickable { onSearchGlobal(manga.title) },
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(4.dp))
+                                .clickable { onSearchGlobal(manga.title) },
                         )
 
                         val author = manga.author?.takeIf { it.isNotBlank() }
@@ -247,7 +249,9 @@ internal fun MangaHeader(
                                     color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
                                     maxLines = HEADER_SUBTITLE_MAX_LINES,
                                     overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.clickable { onSearchGlobal(it) },
+                                    modifier = Modifier
+                                        .clip(RoundedCornerShape(4.dp))
+                                        .clickable { onSearchGlobal(it) },
                                 )
                             }
                             artist?.let {
@@ -257,7 +261,9 @@ internal fun MangaHeader(
                                     color = Color.White.copy(alpha = HEADER_SUBTITLE_ALPHA),
                                     maxLines = HEADER_SUBTITLE_MAX_LINES,
                                     overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.clickable { onSearchGlobal(it) },
+                                    modifier = Modifier
+                                        .clip(RoundedCornerShape(4.dp))
+                                        .clickable { onSearchGlobal(it) },
                                 )
                             }
                         }
@@ -285,7 +291,9 @@ internal fun MangaHeader(
                     style = MaterialTheme.typography.headlineSmall,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.clickable { onSearchGlobal(manga.title) },
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(4.dp))
+                        .clickable { onSearchGlobal(manga.title) },
                 )
 
                 Spacer(modifier = Modifier.height(4.dp))
@@ -295,7 +303,9 @@ internal fun MangaHeader(
                         text = stringResource(R.string.details_author, author),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.clickable { onSearchGlobal(author) },
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(4.dp))
+                            .clickable { onSearchGlobal(author) },
                     )
                 }
 
@@ -304,7 +314,9 @@ internal fun MangaHeader(
                         text = stringResource(R.string.details_artist, artist),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.clickable { onSearchGlobal(artist) },
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(4.dp))
+                            .clickable { onSearchGlobal(artist) },
                     )
                 }
 

--- a/feature/details/src/main/java/app/otakureader/feature/details/navigation/DetailsNavigation.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/navigation/DetailsNavigation.kt
@@ -12,6 +12,7 @@ fun NavGraphBuilder.detailsScreen(
     onNavigateToTracking: (mangaId: Long, mangaTitle: String) -> Unit = { _, _ -> },
     onNavigateToGlobalSearch: (query: String) -> Unit = {},
     onNavigateToSourceSearch: (sourceId: String, query: String) -> Unit = { _, _ -> },
+    onNavigateToMigration: (mangaId: Long) -> Unit = {},
 ) {
     composable<Route.MangaDetails> { backStackEntry ->
         val route = backStackEntry.toRoute<Route.MangaDetails>()
@@ -22,6 +23,7 @@ fun NavGraphBuilder.detailsScreen(
             onNavigateToTracking = onNavigateToTracking,
             onNavigateToGlobalSearch = onNavigateToGlobalSearch,
             onNavigateToSourceSearch = onNavigateToSourceSearch,
+            onNavigateToMigration = onNavigateToMigration,
         )
     }
 }

--- a/feature/details/src/main/res/values/strings.xml
+++ b/feature/details/src/main/res/values/strings.xml
@@ -124,8 +124,8 @@
     <string name="details_chapter_edit_note">Edit note</string>
     <string name="details_chapter_note_preview">📝 %1$s</string>
     <string name="details_chapter_download">Download chapter</string>
-    <string name="details_chapter_downloading">Downloading</string>
     <string name="details_chapter_delete_download">Delete download</string>
+    <string name="details_chapter_cancel_download">Cancel download</string>
     <string name="details_chapter_thumbnail_cd">Chapter thumbnail</string>
     <string name="details_chapter_load_preview">Load\npreview</string>
     <string name="details_chapter_reading_progress">Page %1$d / %2$d</string>

--- a/feature/details/src/main/res/values/strings.xml
+++ b/feature/details/src/main/res/values/strings.xml
@@ -174,6 +174,8 @@
     <string name="details_clear_downloads">Clear Downloads</string>
     <string name="details_no_downloads">No downloads found for this manga</string>
     <string name="details_no_file_manager">No file manager app found</string>
+    <string name="details_delete_downloads_prompt">Delete downloaded chapters?</string>
+    <string name="details_delete_downloads_action">Delete</string>
     <!-- Per-manga theme override (#947) -->
     <string name="details_theme_inherit">Cover theme: follow app setting</string>
     <string name="details_theme_force_on">Cover theme: force on</string>

--- a/feature/details/src/main/res/values/strings.xml
+++ b/feature/details/src/main/res/values/strings.xml
@@ -170,6 +170,7 @@
     <string name="details_unmark_completed">Unmark completed</string>
     <string name="details_mark_dropped">Mark as dropped</string>
     <string name="details_unmark_dropped">Unmark dropped</string>
+    <string name="details_migrate">Migrate</string>
     <string name="details_open_download_folder">Open Download Folder</string>
     <string name="details_clear_downloads">Clear Downloads</string>
     <string name="details_no_downloads">No downloads found for this manga</string>

--- a/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
+++ b/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
@@ -705,4 +705,38 @@ class DetailsViewModelTest {
         val sorted = viewModel.state.value.sortedChapters
         assertTrue(sorted[0].chapterNumber >= sorted[1].chapterNumber)
     }
+
+    // ---- SearchGlobally (title/author/artist tap, and genre long-press) ----
+
+    @Test
+    fun onEvent_SearchGlobally_emitsNavigateToGlobalSearchEffect() = runTest {
+        setUpDefaultMocks()
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.effect.test {
+            viewModel.onEvent(DetailsContract.Event.SearchGlobally("Attack on Titan"))
+
+            val effect = awaitItem()
+            assertTrue(effect is DetailsContract.Effect.NavigateToGlobalSearch)
+            assertEquals("Attack on Titan", (effect as DetailsContract.Effect.NavigateToGlobalSearch).query)
+        }
+    }
+
+    @Test
+    fun onEvent_GenreLongClick_emitsNavigateToGlobalSearchEffect() = runTest {
+        setUpDefaultMocks()
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.effect.test {
+            viewModel.onEvent(DetailsContract.Event.GenreLongClick("Shounen"))
+
+            val effect = awaitItem()
+            assertTrue(effect is DetailsContract.Effect.NavigateToGlobalSearch)
+            assertEquals("Shounen", (effect as DetailsContract.Effect.NavigateToGlobalSearch).query)
+        }
+    }
 }

--- a/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
+++ b/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
@@ -150,6 +150,19 @@ class DetailsViewModelTest {
     }
 
     @Test
+    fun init_loadsSourceNameFromSourceRepository() = runTest {
+        setUpDefaultMocks()
+        val source = mockk<app.otakureader.sourceapi.MangaSource>(relaxed = true)
+        every { source.name } returns "MangaDex"
+        coEvery { sourceRepository.getSource(sampleManga.sourceId.toString()) } returns source
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("MangaDex", viewModel.state.value.sourceName)
+    }
+
+    @Test
     fun init_setsFavoriteStatus() = runTest {
         setUpDefaultMocks()
         every { mangaRepository.isFavorite(mangaId) } returns flowOf(true)
@@ -304,6 +317,7 @@ class DetailsViewModelTest {
 
         viewModel.effect.test {
             viewModel.onEvent(DetailsContract.Event.ToggleFavorite)
+            testDispatcher.scheduler.advanceUntilIdle()
 
             val effect = awaitItem()
             assertTrue(effect is DetailsContract.Effect.ShowDeleteDownloadsPrompt)
@@ -327,6 +341,7 @@ class DetailsViewModelTest {
 
         viewModel.effect.test {
             viewModel.onEvent(DetailsContract.Event.ToggleFavorite)
+            testDispatcher.scheduler.advanceUntilIdle()
 
             val effect = awaitItem()
             assertTrue(effect is DetailsContract.Effect.ShowSnackbar)
@@ -781,6 +796,7 @@ class DetailsViewModelTest {
 
         viewModel.effect.test {
             viewModel.onEvent(DetailsContract.Event.SearchGlobally("Attack on Titan"))
+            testDispatcher.scheduler.advanceUntilIdle()
 
             val effect = awaitItem()
             assertTrue(effect is DetailsContract.Effect.NavigateToGlobalSearch)
@@ -810,10 +826,47 @@ class DetailsViewModelTest {
 
         viewModel.effect.test {
             viewModel.onEvent(DetailsContract.Event.GenreLongClick("Shounen"))
+            testDispatcher.scheduler.advanceUntilIdle()
 
             val effect = awaitItem()
             assertTrue(effect is DetailsContract.Effect.NavigateToGlobalSearch)
             assertEquals("Shounen", (effect as DetailsContract.Effect.NavigateToGlobalSearch).query)
+        }
+    }
+
+    @Test
+    fun onEvent_SourceClick_emitsNavigateToSourceSearchWithEmptyQuery() = runTest {
+        setUpDefaultMocks()
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.effect.test {
+            viewModel.onEvent(DetailsContract.Event.SourceClick)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val effect = awaitItem()
+            assertTrue(effect is DetailsContract.Effect.NavigateToSourceSearch)
+            val navigate = effect as DetailsContract.Effect.NavigateToSourceSearch
+            assertEquals(sampleManga.sourceId.toString(), navigate.sourceId)
+            assertEquals("", navigate.query)
+        }
+    }
+
+    @Test
+    fun onEvent_MigrateManga_emitsNavigateToMigrationWithMangaId() = runTest {
+        setUpDefaultMocks()
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.effect.test {
+            viewModel.onEvent(DetailsContract.Event.MigrateManga)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val effect = awaitItem()
+            assertTrue(effect is DetailsContract.Effect.NavigateToMigration)
+            assertEquals(mangaId, (effect as DetailsContract.Effect.NavigateToMigration).mangaId)
         }
     }
 

--- a/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
+++ b/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
@@ -38,6 +38,11 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+// DetailsViewModel covers a large surface area (favorite/categories, chapters, downloads,
+// reader settings, tracking, notes, custom cover...), so its test class grows past Detekt's
+// LargeClass threshold along with it. Splitting by concern would fragment the shared fixtures
+// and mock setup more than it would help readability.
+@Suppress("LargeClass")
 @OptIn(ExperimentalCoroutinesApi::class)
 class DetailsViewModelTest {
 
@@ -269,6 +274,63 @@ class DetailsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertFalse(viewModel.state.value.showCategoryPickerDialog)
+    }
+
+    @Test
+    fun onEvent_ToggleFavorite_removingWithDownloads_showsDeleteDownloadsPrompt() = runTest {
+        stubManga(sampleManga.copy(favorite = true))
+        every { chapterRepository.getChaptersByMangaId(mangaId) } returns flowOf(sampleChapters)
+        every { mangaRepository.isFavorite(mangaId) } returns flowOf(true)
+        every { downloadRepository.observeDownloads() } returns flowOf(
+            listOf(
+                DownloadItem(
+                    id = 1L,
+                    mangaId = mangaId,
+                    chapterId = sampleChapters[0].id,
+                    mangaTitle = sampleManga.title,
+                    chapterTitle = sampleChapters[0].name,
+                    status = DownloadStatus.COMPLETED,
+                )
+            )
+        )
+        coEvery { chapterRepository.getNextUnreadChapter(mangaId) } returns sampleChapters[1]
+        every { downloadPreferences.deleteAfterReading } returns flowOf(false)
+        every { downloadPreferences.perMangaOverrides } returns flowOf(emptyMap())
+        every { categoryRepository.getCategories() } returns flowOf(emptyList())
+        coEvery { mangaRepository.toggleFavorite(mangaId) } returns Unit
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.effect.test {
+            viewModel.onEvent(DetailsContract.Event.ToggleFavorite)
+
+            val effect = awaitItem()
+            assertTrue(effect is DetailsContract.Effect.ShowDeleteDownloadsPrompt)
+        }
+    }
+
+    @Test
+    fun onEvent_ToggleFavorite_removingWithNoDownloads_showsPlainSnackbar() = runTest {
+        stubManga(sampleManga.copy(favorite = true))
+        every { chapterRepository.getChaptersByMangaId(mangaId) } returns flowOf(sampleChapters)
+        every { mangaRepository.isFavorite(mangaId) } returns flowOf(true)
+        every { downloadRepository.observeDownloads() } returns flowOf(emptyList())
+        coEvery { chapterRepository.getNextUnreadChapter(mangaId) } returns sampleChapters[1]
+        every { downloadPreferences.deleteAfterReading } returns flowOf(false)
+        every { downloadPreferences.perMangaOverrides } returns flowOf(emptyMap())
+        every { categoryRepository.getCategories() } returns flowOf(emptyList())
+        coEvery { mangaRepository.toggleFavorite(mangaId) } returns Unit
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.effect.test {
+            viewModel.onEvent(DetailsContract.Event.ToggleFavorite)
+
+            val effect = awaitItem()
+            assertTrue(effect is DetailsContract.Effect.ShowSnackbar)
+        }
     }
 
     // ---- Category picker ----

--- a/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
+++ b/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
@@ -725,6 +725,19 @@ class DetailsViewModelTest {
     }
 
     @Test
+    fun onEvent_SearchGlobally_withBlankQuery_doesNotEmitEffect() = runTest {
+        setUpDefaultMocks()
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.effect.test {
+            viewModel.onEvent(DetailsContract.Event.SearchGlobally("   "))
+            expectNoEvents()
+        }
+    }
+
+    @Test
     fun onEvent_GenreLongClick_emitsNavigateToGlobalSearchEffect() = runTest {
         setUpDefaultMocks()
 

--- a/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
+++ b/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
@@ -5,6 +5,8 @@ import app.otakureader.core.preferences.DownloadPreferences
 import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.domain.model.Category
 import app.otakureader.domain.model.Chapter
+import app.otakureader.domain.model.DownloadItem
+import app.otakureader.domain.model.DownloadStatus
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.repository.CategoryRepository
@@ -751,5 +753,65 @@ class DetailsViewModelTest {
             assertTrue(effect is DetailsContract.Effect.NavigateToGlobalSearch)
             assertEquals("Shounen", (effect as DetailsContract.Effect.NavigateToGlobalSearch).query)
         }
+    }
+
+    // ---- DeleteChapterDownload (cancel while downloading vs delete once downloaded) ----
+
+    @Test
+    fun onEvent_DeleteChapterDownload_whileDownloading_cancelsInsteadOfDeletingFiles() = runTest {
+        setUpDefaultMocks()
+        val downloadingChapterId = sampleChapters[1].id
+        every { downloadRepository.observeDownloads() } returns flowOf(
+            listOf(
+                DownloadItem(
+                    id = 1L,
+                    mangaId = mangaId,
+                    chapterId = downloadingChapterId,
+                    mangaTitle = sampleManga.title,
+                    chapterTitle = "Chapter 2",
+                    status = DownloadStatus.DOWNLOADING,
+                )
+            )
+        )
+        coEvery { downloadRepository.cancelDownload(downloadingChapterId) } returns Unit
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(DetailsContract.Event.DeleteChapterDownload(downloadingChapterId))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { downloadRepository.cancelDownload(downloadingChapterId) }
+        coVerify(exactly = 0) { downloadRepository.deleteChapterDownload(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun onEvent_DeleteChapterDownload_whenDownloaded_deletesFilesInsteadOfCancelling() = runTest {
+        setUpDefaultMocks()
+        val downloadedChapterId = sampleChapters[1].id
+        every { downloadRepository.observeDownloads() } returns flowOf(
+            listOf(
+                DownloadItem(
+                    id = 1L,
+                    mangaId = mangaId,
+                    chapterId = downloadedChapterId,
+                    mangaTitle = sampleManga.title,
+                    chapterTitle = "Chapter 2",
+                    status = DownloadStatus.COMPLETED,
+                )
+            )
+        )
+        coEvery {
+            downloadRepository.deleteChapterDownload(downloadedChapterId, any(), any(), any())
+        } returns Unit
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(DetailsContract.Event.DeleteChapterDownload(downloadedChapterId))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { downloadRepository.deleteChapterDownload(downloadedChapterId, any(), any(), any()) }
+        coVerify(exactly = 0) { downloadRepository.cancelDownload(any()) }
     }
 }


### PR DESCRIPTION
## Description
Next fix from the Manga Detail parity pass (Komikku parity backlog item #3).

Komikku's manga detail header lets you tap the title, author, or artist to run a global search for that text — useful for finding the same series (or other work by the same creator) on a different source. Otaku's header rendered these as plain, non-interactive text.

- `MangaHeader` gains an `onSearchGlobal: (String) -> Unit` callback, wired to short-press on the title, author, and artist `Text`s in both the compact hero layout and the panorama layout.
- Reuses the existing `NavigateToGlobalSearch` effect (the same one genre-tag long-press already sends). Renamed the private handler from `searchGenreGlobally` to `searchGlobally` since it's no longer genre-specific, and both `GenreLongClick` and the new `SearchGlobally` event route through it.
- Long-press "search this tag/text + copy to clipboard" context menu (Komikku's KMK-specific addition) is intentionally out of scope here — this covers the primary tap-to-search behavior that was the actual gap.

## Type of Change
- [x] ✨ New feature (parity gap fill)

## Testing
- Added `DetailsViewModelTest` cases for `SearchGlobally` and `GenreLongClick` emitting `NavigateToGlobalSearch` with the right query.
- `ktlintCheck` and `detekt` run clean locally (no Android SDK available in this sandbox to run the Robolectric unit test suite — relying on CI for that).

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [ ] Documentation updated
- [x] No new warnings
- [ ] Tests pass (pending CI — no local Android SDK)

## Related Issues
Part of the Manga Detail Komikku-parity backlog item.


---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tapping the title, author, or artist now starts a global search.
  * Chapter download menus now include a clear **Cancel download** action while a chapter is still downloading.

* **Bug Fixes**
  * Removing a manga from the library now prompts you to delete any downloaded chapters instead of removing them silently.
  * Download actions now behave correctly for in-progress downloads, with clearer on-screen labels and feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->