### PR TITLE
Add download queue sort-by menu (Komikku parity)

### DIFF
--- a/.claude/skills/komikku-parity/SKILL.md
+++ b/.claude/skills/komikku-parity/SKILL.md
@@ -40,36 +40,42 @@ For each screen area, follow this loop:
 | 1 | Browse: Extensions + Sources | Done (PR #1145) | Extension install → source appears fix |
 | 2 | Library | Done (PR #1155) | Grid/list/comfortable/cover-only modes, tristate filters, filter sheet, RANDOM sort, bulk-select |
 | 3 | Manga detail | Done (PR #1156, #1186) | Collapsing header, chapter list, tracker sheet, tag press, tap-to-search, cancel download, delete-downloads prompt, migrate action, source label |
-| 4 | Reader | **Next** | Modes, tap zones, end/start overlays, slider snap, rotation, real-time settings |
-| 5 | Updates / History / Downloads | Pending | J2K grouping, swipe actions, real-time progress |
+| 4 | Reader | Done (verified pre-existing) | Diffed against Komikku's ViewerNavigation/PagerConfig/WebtoonConfig, ChapterNavigator, ReadingModePage — tap zones (exact NavigationRegion color/enum match), slider snap, chapter transitions w/ gap warnings, live-applied settings, rotation, volume keys, save/share all already at parity. No gaps found worth a PR. |
+| 5 | Updates / History / Downloads | **Next** | J2K grouping, swipe actions, real-time progress |
 | 6 | Browse: global search / migrate / feed ordering | Pending | |
 | 7 | Settings | Pending | Match Komikku's settings tree, immediate-apply semantics |
 | 8 | More / stats / remaining screens | Pending | |
 
-## Current Session: Reader (item #4)
+## Current Session: Updates / History / Downloads (item #5)
 
 Komikku spec files to read:
-- `eu.kanade.presentation.reader.ReaderPageActionsDialog`, `ReaderContentOverlay`,
-  `ReaderAppBars.kt` (composables)
-- `eu.kanade.tachiyomi.ui.reader.ReaderActivity`, `ReaderViewModel` (state/behavior)
-- Per-mode viewers: `eu.kanade.tachiyomi.ui.reader.viewer.pager.*` (L2R/R2L/vertical pager),
-  `eu.kanade.tachiyomi.ui.reader.viewer.webtoon.*` (continuous vertical)
+- `eu.kanade.presentation.updates.UpdatesScreen` + `UpdatesScreenModel` — J2K-style date grouping,
+  swipe/long-press actions, per-item download/read state
+- `eu.kanade.presentation.history.HistoryScreen` + `HistoryScreenModel` — timeline grouping, resume
+- `eu.kanade.presentation.download.DownloadQueueScreen` — real-time progress, reorder, pause/resume
 
-Key elements to check (known Komikku behaviors):
-- Reading modes: L2R, R2L, vertical, webtoon, continuous-vertical — per-manga override + global default
-- Tap zones: configurable (L/R/edge) with a "tap zones" preview/config screen; navigation vs menu-toggle zones
-- Top/bottom overlay bars: chapter title, page slider with snap-to-page, page count, settings shortcut
-- Slider: drag to seek pages within the chapter, snapping to discrete page positions
-- Volume-key paging toggle
-- Auto-rotation / forced orientation per-manga override
-- Real-time settings changes (brightness, color filter, crop borders, background color) applied without reopening the reader
-- Chapter transition screens (previous/next chapter preview at the edges of a chapter)
-- Double-tap to zoom (pager modes); pinch-to-zoom
-- Long-press page → save/share/set-as-cover context menu
+Key elements to check:
+- Date-header grouping (Today/Yesterday/this week/older) matching J2K conventions
+- Swipe-to-* actions (mark read, delete, bookmark) vs long-press context menus
+- Real-time download queue progress (bytes/percent, reorder via drag, pause/resume/cancel per item)
+- Bulk actions + undo snackbars (compare against Otaku's existing undo patterns — CLAUDE.md
+  documents Pattern A/B already used for Library/History)
 
 Gap areas likely in Otaku:
-- `feature/reader/` Screen + ViewModel (4 modes already shipped per CLAUDE.md — verify tap zones,
-  slider snap, chapter transition screens, and real-time settings match Komikku exactly)
+- `feature/updates/`, `feature/history/`, `feature/more/downloads` (or wherever the download
+  manager screen lives) — Screen + ViewModel
+
+## Previous Session: Reader (item #4) — done, no gaps
+
+Diffed against Komikku's `ViewerNavigation`/`KindlishNavigation`/`EdgeNavigation`/
+`RightAndLeftNavigation`/`LNavigation`, `PagerConfig`, `WebtoonConfig`, `ReadingModePage.kt`
+(settings), `ChapterNavigator`. Otaku's `feature/reader/ui/TapZoneOverlay.kt` and `PageSlider.kt`
+explicitly document themselves as ports of these Komikku systems (exact `NavigationRegion` color
+values, same 6 navigation-mode layouts, same tapping-invert-mode semantics). Real-time settings
+(brightness/color filter/crop borders) are plain `StateFlow` fields consumed directly in
+`ReaderScreen.kt`, so they apply live. Chapter transitions include gap-warning detection matching
+Komikku. Rotation override, volume-key paging, and save/share hooks are all present in
+`ReaderMvi.kt`/`ReaderViewModel.kt`. Conclusion: no PR needed for this item.
 
 ## Commit / PR Workflow
 

--- a/.claude/skills/komikku-parity/SKILL.md
+++ b/.claude/skills/komikku-parity/SKILL.md
@@ -39,32 +39,37 @@ For each screen area, follow this loop:
 |---|------|--------|-------|
 | 1 | Browse: Extensions + Sources | Done (PR #1145) | Extension install → source appears fix |
 | 2 | Library | Done (PR #1155) | Grid/list/comfortable/cover-only modes, tristate filters, filter sheet, RANDOM sort, bulk-select |
-| 3 | Manga detail | **Next** | Collapsing header, chapter list, tracker sheet, tag press |
-| 4 | Reader | Pending | Modes, tap zones, end/start overlays, slider snap, rotation, real-time settings |
+| 3 | Manga detail | Done (PR #1156, #1186) | Collapsing header, chapter list, tracker sheet, tag press, tap-to-search, cancel download, delete-downloads prompt, migrate action, source label |
+| 4 | Reader | **Next** | Modes, tap zones, end/start overlays, slider snap, rotation, real-time settings |
 | 5 | Updates / History / Downloads | Pending | J2K grouping, swipe actions, real-time progress |
 | 6 | Browse: global search / migrate / feed ordering | Pending | |
 | 7 | Settings | Pending | Match Komikku's settings tree, immediate-apply semantics |
 | 8 | More / stats / remaining screens | Pending | |
 
-## Current Session: Manga Detail (item #3)
+## Current Session: Reader (item #4)
 
 Komikku spec files to read:
-- `eu.kanade.presentation.manga.MangaScreen` (the composable)
-- `eu.kanade.tachiyomi.ui.manga.MangaScreenModel` (the ScreenModel)
+- `eu.kanade.presentation.reader.ReaderPageActionsDialog`, `ReaderContentOverlay`,
+  `ReaderAppBars.kt` (composables)
+- `eu.kanade.tachiyomi.ui.reader.ReaderActivity`, `ReaderViewModel` (state/behavior)
+- Per-mode viewers: `eu.kanade.tachiyomi.ui.reader.viewer.pager.*` (L2R/R2L/vertical pager),
+  `eu.kanade.tachiyomi.ui.reader.viewer.webtoon.*` (continuous vertical)
 
 Key elements to check (known Komikku behaviors):
-- Collapsing toolbar with cover image as hero
-- Summary expandable with "Read more" — max 3 lines collapsed
-- Genre/tag chips (tap → filter library by tag)
-- Chapter list: ascending/descending sort, read/unread filter, bookmarked filter, download filter
-- Chapter download state badges per row
-- Chapter multi-select: mark read, download, delete, bookmark
-- Tracker sheet bottom sheet with per-tracker row (status, score, chapter)
-- "Start reading" / "Resume" FAB that context-switches based on read state
-- Context menu on chapter long-press: bookmark, mark read/unread, download, delete
+- Reading modes: L2R, R2L, vertical, webtoon, continuous-vertical — per-manga override + global default
+- Tap zones: configurable (L/R/edge) with a "tap zones" preview/config screen; navigation vs menu-toggle zones
+- Top/bottom overlay bars: chapter title, page slider with snap-to-page, page count, settings shortcut
+- Slider: drag to seek pages within the chapter, snapping to discrete page positions
+- Volume-key paging toggle
+- Auto-rotation / forced orientation per-manga override
+- Real-time settings changes (brightness, color filter, crop borders, background color) applied without reopening the reader
+- Chapter transition screens (previous/next chapter preview at the edges of a chapter)
+- Double-tap to zoom (pager modes); pinch-to-zoom
+- Long-press page → save/share/set-as-cover context menu
 
 Gap areas likely in Otaku:
-- `feature/details/` Screen + ViewModel
+- `feature/reader/` Screen + ViewModel (4 modes already shipped per CLAUDE.md — verify tap zones,
+  slider snap, chapter transition screens, and real-time settings match Komikku exactly)
 
 ## Commit / PR Workflow
 

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/DownloadsMvi.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/DownloadsMvi.kt
@@ -40,4 +40,10 @@ sealed interface DownloadsEvent : UiEvent {
     data object CancelSelected : DownloadsEvent
     /** Move all selected items to the front of the download queue. */
     data object PrioritizeSelected : DownloadsEvent
+
+    /** Reorder the entire queue by each chapter's upload date (Komikku parity). */
+    data class SortByUploadDate(val newestFirst: Boolean) : DownloadsEvent
+
+    /** Reorder the entire queue by each chapter's chapter number (Komikku parity). */
+    data class SortByChapterNumber(val ascending: Boolean) : DownloadsEvent
 }

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/DownloadsScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/DownloadsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -163,6 +164,40 @@ fun DownloadsScreen(
                                         overflowExpanded = false
                                     },
                                 )
+                                androidx.compose.material3.HorizontalDivider()
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.downloads_sort_newest_first)) },
+                                    leadingIcon = { Icon(Icons.AutoMirrored.Filled.Sort, contentDescription = null) },
+                                    onClick = {
+                                        viewModel.onEvent(DownloadsEvent.SortByUploadDate(newestFirst = true))
+                                        overflowExpanded = false
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.downloads_sort_oldest_first)) },
+                                    leadingIcon = { Icon(Icons.AutoMirrored.Filled.Sort, contentDescription = null) },
+                                    onClick = {
+                                        viewModel.onEvent(DownloadsEvent.SortByUploadDate(newestFirst = false))
+                                        overflowExpanded = false
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.downloads_sort_chapter_asc)) },
+                                    leadingIcon = { Icon(Icons.AutoMirrored.Filled.Sort, contentDescription = null) },
+                                    onClick = {
+                                        viewModel.onEvent(DownloadsEvent.SortByChapterNumber(ascending = true))
+                                        overflowExpanded = false
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.downloads_sort_chapter_desc)) },
+                                    leadingIcon = { Icon(Icons.AutoMirrored.Filled.Sort, contentDescription = null) },
+                                    onClick = {
+                                        viewModel.onEvent(DownloadsEvent.SortByChapterNumber(ascending = false))
+                                        overflowExpanded = false
+                                    },
+                                )
+                                androidx.compose.material3.HorizontalDivider()
                                 DropdownMenuItem(
                                     text = { Text(stringResource(R.string.downloads_clear_all)) },
                                     leadingIcon = { Icon(Icons.Default.Close, contentDescription = null) },

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/DownloadsViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/DownloadsViewModel.kt
@@ -168,19 +168,25 @@ class DownloadsViewModel @Inject constructor(
      * whole queue is reassigned sequential priorities in the new order via the existing
      * single-item [DownloadRepository.reorderDownload] call (same pattern as
      * [pauseSelected]/[resumeSelected]).
+     *
+     * Items whose chapter lookup returns null (e.g. the chapter row was deleted while still
+     * queued) can't be placed by [selector], so they're appended after the sorted items in
+     * their original queue order instead of being silently dropped — every queued item still
+     * gets an explicit, consistent priority.
      */
     private fun <R : Comparable<R>> sortQueue(descending: Boolean, selector: (app.otakureader.domain.model.Chapter) -> R) {
         viewModelScope.launch {
             val items = _state.value.items
-            val chapters = items
+            val resolved = items
                 .map { item -> async { item.chapterId to chapterRepository.getChapterById(item.chapterId) } }
                 .awaitAll()
-                .mapNotNull { (chapterId, chapter) -> chapter?.let { chapterId to it } }
+            val withChapter = resolved.mapNotNull { (chapterId, chapter) -> chapter?.let { chapterId to it } }
+            val withoutChapter = resolved.filter { (_, chapter) -> chapter == null }
 
             val comparator = compareBy<Pair<Long, app.otakureader.domain.model.Chapter>> { selector(it.second) }
-            val ordered = if (descending) chapters.sortedWith(comparator.reversed()) else chapters.sortedWith(comparator)
+            val sortable = if (descending) withChapter.sortedWith(comparator.reversed()) else withChapter.sortedWith(comparator)
 
-            ordered.forEachIndexed { index, (chapterId, _) ->
+            (sortable + withoutChapter).forEachIndexed { index, (chapterId, _) ->
                 downloadRepository.reorderDownload(chapterId, index)
             }
         }

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/DownloadsViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/DownloadsViewModel.kt
@@ -173,15 +173,15 @@ class DownloadsViewModel @Inject constructor(
         viewModelScope.launch {
             val items = _state.value.items
             val chapters = items
-                .map { item -> async { item.id to chapterRepository.getChapterById(item.chapterId) } }
+                .map { item -> async { item.chapterId to chapterRepository.getChapterById(item.chapterId) } }
                 .awaitAll()
-                .mapNotNull { (id, chapter) -> chapter?.let { id to it } }
+                .mapNotNull { (chapterId, chapter) -> chapter?.let { chapterId to it } }
 
             val comparator = compareBy<Pair<Long, app.otakureader.domain.model.Chapter>> { selector(it.second) }
             val ordered = if (descending) chapters.sortedWith(comparator.reversed()) else chapters.sortedWith(comparator)
 
-            ordered.forEachIndexed { index, (id, _) ->
-                downloadRepository.reorderDownload(id, index)
+            ordered.forEachIndexed { index, (chapterId, _) ->
+                downloadRepository.reorderDownload(chapterId, index)
             }
         }
     }

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/DownloadsViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/DownloadsViewModel.kt
@@ -2,9 +2,12 @@ package app.otakureader.feature.updates
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -15,7 +18,8 @@ import kotlinx.coroutines.launch
 
 @HiltViewModel
 class DownloadsViewModel @Inject constructor(
-    private val downloadRepository: DownloadRepository
+    private val downloadRepository: DownloadRepository,
+    private val chapterRepository: ChapterRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(DownloadsState())
@@ -63,6 +67,11 @@ class DownloadsViewModel @Inject constructor(
             DownloadsEvent.ResumeSelected -> resumeSelected()
             DownloadsEvent.CancelSelected -> cancelSelected()
             DownloadsEvent.PrioritizeSelected -> prioritizeSelected()
+
+            is DownloadsEvent.SortByUploadDate ->
+                sortQueue(descending = event.newestFirst) { it.dateUpload }
+            is DownloadsEvent.SortByChapterNumber ->
+                sortQueue(descending = !event.ascending) { it.chapterNumber }
         }
     }
 
@@ -149,6 +158,31 @@ class DownloadsViewModel @Inject constructor(
             _state.value.items
                 .filter { it.status == app.otakureader.domain.model.DownloadStatus.FAILED }
                 .forEach { downloadRepository.retryDownload(it.id) }
+        }
+    }
+
+    /**
+     * Reorders the entire queue by a comparable chapter field (upload date / chapter number),
+     * matching Komikku's download-queue "Sort" menu. Chapter metadata isn't stored on
+     * [DownloadItem] itself, so each queued chapter is looked up to read the field, then the
+     * whole queue is reassigned sequential priorities in the new order via the existing
+     * single-item [DownloadRepository.reorderDownload] call (same pattern as
+     * [pauseSelected]/[resumeSelected]).
+     */
+    private fun <R : Comparable<R>> sortQueue(descending: Boolean, selector: (app.otakureader.domain.model.Chapter) -> R) {
+        viewModelScope.launch {
+            val items = _state.value.items
+            val chapters = items
+                .map { item -> async { item.id to chapterRepository.getChapterById(item.chapterId) } }
+                .awaitAll()
+                .mapNotNull { (id, chapter) -> chapter?.let { id to it } }
+
+            val comparator = compareBy<Pair<Long, app.otakureader.domain.model.Chapter>> { selector(it.second) }
+            val ordered = if (descending) chapters.sortedWith(comparator.reversed()) else chapters.sortedWith(comparator)
+
+            ordered.forEachIndexed { index, (id, _) ->
+                downloadRepository.reorderDownload(id, index)
+            }
         }
     }
 

--- a/feature/updates/src/main/res/values/strings.xml
+++ b/feature/updates/src/main/res/values/strings.xml
@@ -28,6 +28,10 @@
     <string name="downloads_priority_high">High priority</string>
     <string name="downloads_empty_title">No downloads yet</string>
     <string name="downloads_empty_message">Start a chapter download to see progress here.</string>
+    <string name="downloads_sort_newest_first">Sort: newest upload first</string>
+    <string name="downloads_sort_oldest_first">Sort: oldest upload first</string>
+    <string name="downloads_sort_chapter_asc">Sort: chapter number ascending</string>
+    <string name="downloads_sort_chapter_desc">Sort: chapter number descending</string>
     <string name="downloads_empty_icon">No downloads</string>
     <string name="downloads_status_queued">Queued</string>
     <string name="downloads_status_downloading">Downloading</string>

--- a/feature/updates/src/test/java/app/otakureader/feature/updates/DownloadsViewModelTest.kt
+++ b/feature/updates/src/test/java/app/otakureader/feature/updates/DownloadsViewModelTest.kt
@@ -1,0 +1,93 @@
+package app.otakureader.feature.updates
+
+import app.otakureader.domain.model.Chapter
+import app.otakureader.domain.model.DownloadItem
+import app.otakureader.domain.model.DownloadStatus
+import app.otakureader.domain.repository.ChapterRepository
+import app.otakureader.domain.repository.DownloadRepository
+import io.mockk.coEvery
+import io.mockk.coVerifyOrder
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadsViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var downloadRepository: DownloadRepository
+    private lateinit var chapterRepository: ChapterRepository
+
+    // Queued in id order 1,2,3 — sort tests verify reorderDownload is called in the new order.
+    private val queueItems = listOf(
+        DownloadItem(id = 1L, mangaId = 1L, chapterId = 1L, mangaTitle = "Naruto", chapterTitle = "Ch 1", status = DownloadStatus.QUEUED),
+        DownloadItem(id = 2L, mangaId = 1L, chapterId = 2L, mangaTitle = "Naruto", chapterTitle = "Ch 2", status = DownloadStatus.QUEUED),
+        DownloadItem(id = 3L, mangaId = 1L, chapterId = 3L, mangaTitle = "Naruto", chapterTitle = "Ch 3", status = DownloadStatus.QUEUED),
+    )
+
+    private val chapters = mapOf(
+        1L to Chapter(id = 1L, mangaId = 1L, url = "/c/1", name = "Ch 1", chapterNumber = 3f, dateUpload = 300L),
+        2L to Chapter(id = 2L, mangaId = 1L, url = "/c/2", name = "Ch 2", chapterNumber = 1f, dateUpload = 100L),
+        3L to Chapter(id = 3L, mangaId = 1L, url = "/c/3", name = "Ch 3", chapterNumber = 2f, dateUpload = 200L),
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        downloadRepository = mockk(relaxed = true)
+        chapterRepository = mockk()
+        every { downloadRepository.observeDownloads() } returns flowOf(queueItems)
+        chapters.forEach { (id, chapter) ->
+            coEvery { chapterRepository.getChapterById(id) } returns chapter
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = DownloadsViewModel(downloadRepository, chapterRepository)
+
+    @Test
+    fun onEvent_SortByChapterNumber_ascending_reordersByChapterNumberLowToHigh() = runTest {
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(DownloadsEvent.SortByChapterNumber(ascending = true))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Chapter numbers: id=2 -> 1f, id=3 -> 2f, id=1 -> 3f
+        coVerifyOrder {
+            downloadRepository.reorderDownload(2L, 0)
+            downloadRepository.reorderDownload(3L, 1)
+            downloadRepository.reorderDownload(1L, 2)
+        }
+    }
+
+    @Test
+    fun onEvent_SortByUploadDate_newestFirst_reordersByDateUploadHighToLow() = runTest {
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(DownloadsEvent.SortByUploadDate(newestFirst = true))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // dateUpload: id=1 -> 300L, id=3 -> 200L, id=2 -> 100L
+        coVerifyOrder {
+            downloadRepository.reorderDownload(1L, 0)
+            downloadRepository.reorderDownload(3L, 1)
+            downloadRepository.reorderDownload(2L, 2)
+        }
+    }
+}

--- a/feature/updates/src/test/java/app/otakureader/feature/updates/DownloadsViewModelTest.kt
+++ b/feature/updates/src/test/java/app/otakureader/feature/updates/DownloadsViewModelTest.kt
@@ -28,11 +28,12 @@ class DownloadsViewModelTest {
     private lateinit var downloadRepository: DownloadRepository
     private lateinit var chapterRepository: ChapterRepository
 
-    // Queued in id order 1,2,3 — sort tests verify reorderDownload is called in the new order.
+    // DownloadItem.id is deliberately different from chapterId (offset by 100) so a regression
+    // to sorting/reordering by item.id instead of item.chapterId would fail these tests.
     private val queueItems = listOf(
-        DownloadItem(id = 1L, mangaId = 1L, chapterId = 1L, mangaTitle = "Naruto", chapterTitle = "Ch 1", status = DownloadStatus.QUEUED),
-        DownloadItem(id = 2L, mangaId = 1L, chapterId = 2L, mangaTitle = "Naruto", chapterTitle = "Ch 2", status = DownloadStatus.QUEUED),
-        DownloadItem(id = 3L, mangaId = 1L, chapterId = 3L, mangaTitle = "Naruto", chapterTitle = "Ch 3", status = DownloadStatus.QUEUED),
+        DownloadItem(id = 101L, mangaId = 1L, chapterId = 1L, mangaTitle = "Naruto", chapterTitle = "Ch 1", status = DownloadStatus.QUEUED),
+        DownloadItem(id = 102L, mangaId = 1L, chapterId = 2L, mangaTitle = "Naruto", chapterTitle = "Ch 2", status = DownloadStatus.QUEUED),
+        DownloadItem(id = 103L, mangaId = 1L, chapterId = 3L, mangaTitle = "Naruto", chapterTitle = "Ch 3", status = DownloadStatus.QUEUED),
     )
 
     private val chapters = mapOf(
@@ -87,6 +88,26 @@ class DownloadsViewModelTest {
         coVerifyOrder {
             downloadRepository.reorderDownload(1L, 0)
             downloadRepository.reorderDownload(3L, 1)
+            downloadRepository.reorderDownload(2L, 2)
+        }
+    }
+
+    @Test
+    fun onEvent_SortByChapterNumber_chapterLookupMissing_appendsItInsteadOfDropping() = runTest {
+        // Chapter 2 was deleted from the DB while still queued for download.
+        coEvery { chapterRepository.getChapterById(2L) } returns null
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(DownloadsEvent.SortByChapterNumber(ascending = true))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // id=2's chapter is missing, so it's appended after the sortable items (id=3 -> 2f, id=1 -> 3f)
+        // rather than silently dropped from the reorder.
+        coVerifyOrder {
+            downloadRepository.reorderDownload(3L, 0)
+            downloadRepository.reorderDownload(1L, 1)
             downloadRepository.reorderDownload(2L, 2)
         }
     }


### PR DESCRIPTION
## 📋 Description
Continues the Komikku parity pass (backlog item #5: Updates / History / Downloads). Diffed Otaku's Updates, History, and Downloads screens against Komikku's equivalents:

- **Updates**: already has J2K-style date grouping (`buildJk2UiModel`/`Jk2DateHeader`) and swipe-to-dismiss actions — matches Komikku.
- **History**: already has date-bucket grouping and swipe-to-dismiss — matches Komikku.
- **Downloads**: found one real gap — Komikku's `DownloadQueueScreen` has a "Sort" menu (order by upload date newest/oldest, order by chapter number asc/desc) that reorders the entire queue, in addition to per-item drag-reorder (which uses a legacy `RecyclerView`/`AndroidView` on the Komikku side — not portable to this pure-Compose project, and out of scope here). This PR adds the sort-by-upload-date and sort-by-chapter-number actions.

Also includes a small housekeeping commit updating the `komikku-parity` skill doc to mark the Reader backlog item (#4) as verified — it was already at parity with Komikku (tap zones, page slider snap, chapter transitions, live-applied settings, rotation, volume-key paging, save/share were all already implemented and explicitly documented in-code as Komikku ports) — no changes needed there.

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📖 Documentation
- [ ] 🎨 UI/UX
- [ ] ♻️ Refactoring
- [ ] 🚀 Performance
- [x] 🧪 Tests

## 🧪 Testing
- Added `DownloadsViewModelTest` covering `SortByChapterNumber` and `SortByUploadDate`, verifying `reorderDownload` is called in the expected new order.
- `./gradlew detekt` clean (no local Android SDK available in this environment, so full compile/unit tests run in CI).

## 📸 Screenshots
N/A — new items in an existing overflow menu, no layout changes.

## ✅ Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated (skill doc)
- [ ] No new warnings (pending CI)
- [ ] Tests pass (pending CI)

## 🔗 Related Issues
Part of the ongoing Komikku 1:1 parity effort (see `.claude/skills/komikku-parity/SKILL.md`).

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_