### PR TITLE
Smart-place Otaku-exclusive features: fix buried/dead entry points

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Otaku-Reader/
 - 4 reading modes: single-page, dual-page, webtoon (vertical scroll), smart-panels (auto-crop)
 - Page-level bookmarks (toggle per page, persisted in `page_bookmarks` DB table)
 - Bookmark collections (group bookmarks, filter by collection in BookmarksScreen)
-- Reader comments / notes per chapter (`reader_comments` DB table, PR #1098)
+- Reader comments / notes per chapter (`reader_comments` DB table, PR #1098; opened via the comment icon in the reader's top bar)
 - Gesture controls: tap-zones, swipe navigation, volume-key paging
 - Download while reading (per-chapter download button in top bar, PR #1127)
 - Chapter list overlay with progress indicator
@@ -88,6 +88,7 @@ Otaku-Reader/
 - Multi-select chapters: mark read, download, delete, bookmark (chapter-level bookmarks removed in PR #1130)
 - Tracker status chips inline (tap to open tracker)
 - Track manga on multiple services simultaneously
+- Add to Reading List (overflow menu, live-toggle checkbox picker against `feature/library/readinglist/`)
 
 ### Tracking (`feature/tracking/`)
 - MAL, AniList, Kitsu, MangaUpdates, Shikimori all fully integrated
@@ -113,6 +114,7 @@ Otaku-Reader/
 ### Statistics (`feature/statistics/`)
 - Total chapters read, total reading time, average per day
 - Per-manga reading stats, streak tracking (PR #1122)
+- Reading achievements — earned badges shown in a grid on the Statistics screen, checked live on every chapter read (`data/worker/AchievementCheckWorker.kt`)
 - Stats summary widget on MoreScreen (Glance)
 
 ### Settings (`feature/settings/`)
@@ -131,8 +133,13 @@ Otaku-Reader/
 - Feed screen (activity from followed manga)
 - First-run Onboarding wizard
 - About screen (version, credits, links)
-- Update Errors screen (PR #1119)
+- Update Errors dialog (PR #1119; auto-opens from the More tab entry, or via the badge icon on the Updates screen's top bar)
 - QR Library Share / Scan (PR #1110/#1125)
+
+### Home-Screen Widgets (`app/src/main/java/app/otakureader/widget/`)
+- 4 Glance-based Android home-screen widgets: `HomeWidget`, `NowReadingWidget`, `ContinueReadingWidget`, `RecentUpdatesWidget`
+- Configured via Settings → Widgets; placed via Android's native "Add Widget" home-screen flow
+- Distinct from the in-app Statistics summary card on MoreScreen (also Glance, but that's a Compose card, not a home-screen widget)
 
 ### Security
 - Certificate pinning (`cert-pin-check.yml` CI gate)

--- a/app/src/main/java/app/otakureader/OtakuReaderApplication.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderApplication.kt
@@ -25,6 +25,8 @@ import coil3.request.allowRgb565
 import coil3.request.crossfade
 import com.google.android.material.color.DynamicColors
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import okio.Path.Companion.toOkioPath
 import javax.inject.Inject
@@ -165,12 +167,17 @@ class OtakuReaderApplication : Application(), Configuration.Provider, SingletonI
                     .build()
             }
             .diskCache {
-                // Use the user-configured disk cache size if readable, otherwise fall back
-                // to the preference default so the ImageLoader can be constructed without
-                // blocking the calling thread.
+                // This factory lambda is invoked lazily by Coil on first disk-cache access
+                // (not synchronously here at ImageLoader construction time), so a blocking
+                // DataStore read is safe — it never blocks app startup or the calling thread
+                // that builds the ImageLoader. Falls back to the preference default if the
+                // read fails for any reason.
+                val sizeMb = runCatching {
+                    runBlocking { generalPreferences.coilDiskCacheSizeMb.first() }
+                }.getOrDefault(GeneralPreferences.DEFAULT_COIL_DISK_CACHE_MB)
                 DiskCache.Builder()
                     .directory(context.cacheDir.resolve("image_cache").toOkioPath())
-                    .maxSizeBytes(GeneralPreferences.DEFAULT_COIL_DISK_CACHE_MB.toLong() * 1024 * 1024)
+                    .maxSizeBytes(sizeMb.toLong() * 1024 * 1024)
                     .build()
             }
             .components {

--- a/app/src/main/java/app/otakureader/OtakuReaderApplication.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderApplication.kt
@@ -25,6 +25,7 @@ import coil3.request.allowRgb565
 import coil3.request.crossfade
 import com.google.android.material.color.DynamicColors
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
@@ -149,7 +150,9 @@ class OtakuReaderApplication : Application(), Configuration.Provider, SingletonI
      *
      * - Memory cache: capped at 15% of the application's available memory class with
      *   a hard ceiling of 256 MB, preventing excessive heap use on large-RAM tablets.
-     * - Disk cache: capped at 512 MB to support large manga chapter image caches.
+     * - Disk cache: sized from the user's Settings preference
+     *   ([GeneralPreferences.coilDiskCacheSizeMb]), falling back to
+     *   [GeneralPreferences.DEFAULT_COIL_DISK_CACHE_MB] if the read fails.
      * - allowRgb565: opaque images (most manga pages) decode as RGB_565 (2 bytes/pixel)
      *   instead of ARGB_8888 (4 bytes/pixel), halving per-page memory cost.
      * - Networking: backed by the shared [OkHttpClient] for connection pooling and
@@ -170,10 +173,11 @@ class OtakuReaderApplication : Application(), Configuration.Provider, SingletonI
                 // This factory lambda is invoked lazily by Coil on first disk-cache access
                 // (not synchronously here at ImageLoader construction time), so a blocking
                 // DataStore read is safe — it never blocks app startup or the calling thread
-                // that builds the ImageLoader. Falls back to the preference default if the
-                // read fails for any reason.
+                // that builds the ImageLoader. The read is pinned to Dispatchers.IO as
+                // defense-in-depth in case a future Coil version invokes this on the main
+                // thread. Falls back to the preference default if the read fails.
                 val sizeMb = runCatching {
-                    runBlocking { generalPreferences.coilDiskCacheSizeMb.first() }
+                    runBlocking(Dispatchers.IO) { generalPreferences.coilDiskCacheSizeMb.first() }
                 }.getOrDefault(GeneralPreferences.DEFAULT_COIL_DISK_CACHE_MB)
                 DiskCache.Builder()
                     .directory(context.cacheDir.resolve("image_cache").toOkioPath())

--- a/app/src/main/java/app/otakureader/OtakuReaderBottomBar.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderBottomBar.kt
@@ -84,7 +84,7 @@ fun OtakuReaderBottomBar(
             )
             val route: Route = when (tab) {
                 NavTab.LIBRARY -> Route.Library
-                NavTab.UPDATES -> Route.Updates
+                NavTab.UPDATES -> Route.Updates()
                 NavTab.BROWSE -> Route.Browse
                 NavTab.HISTORY -> Route.History
                 NavTab.MORE -> Route.More

--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -82,7 +82,7 @@ fun OtakuReaderNavHost(
                 onDeepLinkConsumed()
             }
             is DeepLinkResult.NavigateToUpdates -> {
-                navController.navigate(Route.Updates) {
+                navController.navigate(Route.Updates()) {
                     launchSingleTop = true
                 }
                 onDeepLinkConsumed()
@@ -306,6 +306,9 @@ fun OtakuReaderNavHost(
             onNavigateToExtensionDetail = { packageName ->
                 navController.navigate(Route.ExtensionDetail(packageName))
             },
+            onNavigateToExtensionInstall = {
+                navController.navigate(Route.ExtensionInstall)
+            },
         )
 
         // Extension detail screen (#1047)
@@ -359,6 +362,9 @@ fun OtakuReaderNavHost(
             },
             onNavigateToMigration = { mangaId ->
                 navController.navigate(Route.Migration(selectedMangaIds = listOf(mangaId)))
+            },
+            onNavigateToWebViewFallback = { url, title ->
+                navController.navigate(Route.WebViewFallback(url, title))
             }
         )
 
@@ -543,7 +549,7 @@ fun OtakuReaderNavHost(
                 navController.navigate(Route.ScanLibrary)
             },
             onNavigateToUpdateErrors = {
-                navController.navigate(Route.Updates)
+                navController.navigate(Route.Updates(openErrors = true))
             },
             onNavigateToBackup = {
                 navController.navigate(Route.SettingsBackup)

--- a/core/navigation/src/main/java/app/otakureader/core/navigation/OtakuReaderNavigator.kt
+++ b/core/navigation/src/main/java/app/otakureader/core/navigation/OtakuReaderNavigator.kt
@@ -37,7 +37,7 @@ class OtakuReaderNavigator(
         Route.Library,
         Route.Browse,
         Route.History,
-        Route.Updates,
+        Route.Updates(),
         Route.More,
     )
 

--- a/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
+++ b/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
@@ -35,8 +35,13 @@ sealed interface Route {
     @Serializable
     data object History : Route
 
+    /**
+     * @param openErrors When true, the Updates screen auto-opens the update-errors dialog on
+     * launch (used by the More tab's "Update Errors" entry). Defaults to false for normal
+     * bottom-nav tab navigation.
+     */
     @Serializable
-    data object Updates : Route
+    data class Updates(val openErrors: Boolean = false) : Route
 
     @Serializable
     data object More : Route

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/LibraryPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/LibraryPreferences.kt
@@ -96,19 +96,9 @@ class LibraryPreferences(private val dataStore: DataStore<Preferences>) {
     val updateOnlyOnWifi: Flow<Boolean> = dataStore.data.map { it[Keys.UPDATE_ONLY_ON_WIFI] ?: false }
     suspend fun setUpdateOnlyOnWifi(value: Boolean) = dataStore.edit { it[Keys.UPDATE_ONLY_ON_WIFI] = value }
 
-    /** Only update pinned categories */
-    val updateOnlyPinnedCategories: Flow<Boolean> = dataStore.data.map { it[Keys.UPDATE_ONLY_PINNED_CATEGORIES] ?: false }
-    suspend fun setUpdateOnlyPinnedCategories(value: Boolean) = dataStore.edit { it[Keys.UPDATE_ONLY_PINNED_CATEGORIES] = value }
-
     /** Skip updating categories with these IDs */
     val skipUpdateCategoryIds: Flow<Set<String>> = dataStore.data.map { it[Keys.SKIP_UPDATE_CATEGORY_IDS] ?: emptySet() }
     suspend fun setSkipUpdateCategoryIds(value: Set<String>) = dataStore.edit { it[Keys.SKIP_UPDATE_CATEGORY_IDS] = value }
-
-    /** Category to jump to when opening library (null = default/first) */
-    val jumpToCategoryOnOpen: Flow<Int?> = dataStore.data.map { it[Keys.JUMP_TO_CATEGORY_ON_OPEN] }
-    suspend fun setJumpToCategoryOnOpen(value: Int?) = dataStore.edit {
-        if (value != null) it[Keys.JUMP_TO_CATEGORY_ON_OPEN] = value else it.remove(Keys.JUMP_TO_CATEGORY_ON_OPEN)
-    }
 
     /** Auto-refresh library on app start */
     val autoRefreshOnStart: Flow<Boolean> = dataStore.data.map { it[Keys.AUTO_REFRESH_ON_START] ?: false }
@@ -239,9 +229,7 @@ class LibraryPreferences(private val dataStore: DataStore<Preferences>) {
         val SHOW_NSFW_CONTENT = booleanPreferencesKey("library_show_nsfw_content")
         val SHOW_HIDDEN_CATEGORIES = booleanPreferencesKey("library_show_hidden_categories")
         val UPDATE_ONLY_ON_WIFI = booleanPreferencesKey("library_update_only_on_wifi")
-        val UPDATE_ONLY_PINNED_CATEGORIES = booleanPreferencesKey("library_update_only_pinned_categories")
         val SKIP_UPDATE_CATEGORY_IDS = stringSetPreferencesKey("library_skip_update_category_ids")
-        val JUMP_TO_CATEGORY_ON_OPEN = intPreferencesKey("library_jump_to_category_on_open")
         val AUTO_REFRESH_ON_START = booleanPreferencesKey("library_auto_refresh_on_start")
         val SHOW_UPDATE_PROGRESS = booleanPreferencesKey("library_show_update_progress")
         val NEW_UPDATES_COUNT = intPreferencesKey("library_new_updates_count")

--- a/core/ui/src/main/java/app/otakureader/core/ui/component/StateScreens.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/component/StateScreens.kt
@@ -66,14 +66,16 @@ fun LoadingScreen(
 fun ErrorScreen(
     message: String,
     modifier: Modifier = Modifier,
-    onRetry: (() -> Unit)? = null
+    onRetry: (() -> Unit)? = null,
+    onOpenInBrowser: (() -> Unit)? = null,
 ) {
     ErrorScreen(
         icon = Icons.Default.Error,
         title = stringResource(R.string.core_ui_error_title),
         message = message,
         modifier = modifier,
-        onRetry = onRetry
+        onRetry = onRetry,
+        onOpenInBrowser = onOpenInBrowser,
     )
 }
 
@@ -85,7 +87,10 @@ fun ErrorScreen(
     message: String,
     modifier: Modifier = Modifier,
     retryText: String = stringResource(R.string.core_ui_retry),
-    onRetry: (() -> Unit)? = null
+    onRetry: (() -> Unit)? = null,
+    /** Secondary "try in browser" escape hatch; null hides the button. */
+    onOpenInBrowser: (() -> Unit)? = null,
+    openInBrowserText: String = stringResource(R.string.core_ui_open_in_browser),
 ) {
     val otaku = LocalOtakuColors.current
     Column(
@@ -127,6 +132,13 @@ fun ErrorScreen(
                 Icon(Icons.Default.Refresh, contentDescription = null)
                 Spacer(modifier = Modifier.size(8.dp))
                 Text(retryText)
+            }
+        }
+
+        if (onOpenInBrowser != null) {
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedButton(onClick = onOpenInBrowser) {
+                Text(openInBrowserText)
             }
         }
     }

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="core_ui_retry">Retry</string>
     <string name="core_ui_error_title">Something went wrong</string>
+    <string name="core_ui_open_in_browser">Try in browser</string>
     <string name="manga_cover_content_description">Cover image for %1$s</string>
     <string name="manga_card_selected">Selected</string>
     <string name="manga_card_new_badge">NEW</string>

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
@@ -362,7 +362,7 @@ private fun ExtensionsContent(
                                     },
                                 )
                                 DropdownMenuItem(
-                                    text = { Text(stringResource(R.string.extensions_install_from_url)) },
+                                    text = { Text(stringResource(R.string.extensions_menu_install_from_url)) },
                                     onClick = {
                                         overflowExpanded = false
                                         onNavigateToExtensionInstall()

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
@@ -284,6 +284,7 @@ private fun ExtensionsContent(
     onNavigateToSettings: () -> Unit = {},
     onNavigateToRepositories: () -> Unit = {},
     onNavigateToExtensionDetail: (packageName: String) -> Unit = {},
+    onNavigateToExtensionInstall: () -> Unit = {},
 ) {
     var searchActive by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
@@ -361,6 +362,13 @@ private fun ExtensionsContent(
                                     },
                                 )
                                 DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.extensions_install_from_url)) },
+                                    onClick = {
+                                        overflowExpanded = false
+                                        onNavigateToExtensionInstall()
+                                    },
+                                )
+                                DropdownMenuItem(
                                     text = {
                                         Text(
                                             if (state.showNsfw) {
@@ -419,6 +427,7 @@ fun ExtensionsScreen(
     onNavigateToSettings: () -> Unit = {},
     onNavigateToRepositories: () -> Unit = {},
     onNavigateToExtensionDetail: (packageName: String) -> Unit = {},
+    onNavigateToExtensionInstall: () -> Unit = {},
     viewModel: ExtensionsViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -441,6 +450,7 @@ fun ExtensionsScreen(
         onNavigateToSettings = onNavigateToSettings,
         onNavigateToRepositories = onNavigateToRepositories,
         onNavigateToExtensionDetail = onNavigateToExtensionDetail,
+        onNavigateToExtensionInstall = onNavigateToExtensionInstall,
     )
 }
 

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
@@ -90,6 +90,7 @@ fun NavGraphBuilder.extensionsBottomSheet(
     onNavigateToSettings: () -> Unit = {},
     onNavigateToRepositories: () -> Unit = {},
     onNavigateToExtensionDetail: (packageName: String) -> Unit = {},
+    onNavigateToExtensionInstall: () -> Unit = {},
 ) {
     composable<Route.ExtensionCatalog> {
         ExtensionsScreen(
@@ -97,6 +98,7 @@ fun NavGraphBuilder.extensionsBottomSheet(
             onNavigateToSettings = onNavigateToSettings,
             onNavigateToRepositories = onNavigateToRepositories,
             onNavigateToExtensionDetail = onNavigateToExtensionDetail,
+            onNavigateToExtensionInstall = onNavigateToExtensionInstall,
         )
     }
 }

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -140,6 +140,7 @@
     <string name="extensions_add_repository">Add repository</string>
     <string name="extensions_repositories_title">Repositories</string>
     <string name="extensions_manage_repositories">Manage repositories</string>
+    <string name="extensions_install_from_url">Install from URL/File</string>
     <!-- Repository management screen (#953) -->
     <string name="repos_screen_title">Extension Repositories</string>
     <string name="repos_back">Back</string>

--- a/feature/browse/src/main/res/values/strings.xml
+++ b/feature/browse/src/main/res/values/strings.xml
@@ -140,7 +140,7 @@
     <string name="extensions_add_repository">Add repository</string>
     <string name="extensions_repositories_title">Repositories</string>
     <string name="extensions_manage_repositories">Manage repositories</string>
-    <string name="extensions_install_from_url">Install from URL/File</string>
+    <string name="extensions_menu_install_from_url">Install from URL/File</string>
     <!-- Repository management screen (#953) -->
     <string name="repos_screen_title">Extension Repositories</string>
     <string name="repos_back">Back</string>

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsMvi.kt
@@ -9,6 +9,7 @@ import app.otakureader.domain.model.Category
 import app.otakureader.domain.model.Chapter
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MangaStatus
+import app.otakureader.domain.model.ReadingList
 import app.otakureader.core.ui.theme.OtakuColors
 import androidx.annotation.StringRes
 
@@ -70,6 +71,13 @@ object DetailsContract {
         val showCategoryPickerDialog: Boolean = false,
         /** Category IDs checked in the currently-open [showCategoryPickerDialog]. */
         val categoryPickerSelection: Set<Long> = emptySet(),
+
+        /** User-defined reading lists, for the "add to reading list" picker. */
+        val readingLists: List<ReadingList> = emptyList(),
+        /** Whether the reading-list picker dialog is open. */
+        val showReadingListPickerDialog: Boolean = false,
+        /** IDs of the reading lists this manga currently belongs to; toggled live from the picker. */
+        val readingListPickerSelection: Set<Long> = emptySet(),
     ) : UiState {
 
         /** Estimated time remaining to finish all unread chapters of this manga. */
@@ -307,10 +315,18 @@ object DetailsContract {
         /** Opens the manga's source web page in the system browser. */
         data object OpenWebView : Event
 
+        /** Error-state "try in browser" fallback — opens the in-app WebView viewer instead. */
+        data object OpenWebViewFallback : Event
+
         // Category picker shown right after favoriting
         data object DismissCategoryPicker : Event
         data class ToggleCategoryPickerSelection(val categoryId: Long) : Event
         data object ConfirmCategoryPicker : Event
+
+        // Reading-list picker, opened on demand from the overflow menu
+        data object ShowReadingListPicker : Event
+        data object DismissReadingListPicker : Event
+        data class ToggleReadingListPickerSelection(val listId: Long) : Event
 
         /** Overflow menu "Migrate" — jump straight into the migration search for this manga. */
         data object MigrateManga : Event
@@ -326,6 +342,8 @@ object DetailsContract {
         data class ShareManga(val title: String, val url: String) : Effect
         data class NavigateToTracking(val mangaId: Long, val mangaTitle: String) : Effect
         data class OpenInBrowser(val url: String) : Effect
+        /** Navigate to the in-app WebView fallback (Route.WebViewFallback) after a load failure. */
+        data class NavigateToWebViewFallback(val url: String, val title: String) : Effect
         data class NavigateToGlobalSearch(val query: String) : Effect
         /** Search [query] within a single source's browse listing (tag short-press). */
         data class NavigateToSourceSearch(val sourceId: String, val query: String) : Effect

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -1240,7 +1240,7 @@ private fun ReadingListPickerDialog(
                         ) {
                             Checkbox(
                                 checked = list.id in selectedIds,
-                                onCheckedChange = null,
+                                onCheckedChange = { onToggle(list.id) },
                             )
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(text = list.name)

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -104,6 +104,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.core.ui.adaptive.isExpanded
 import app.otakureader.core.ui.adaptive.rememberWindowWidthSizeClass
 import app.otakureader.domain.model.Category
+import app.otakureader.domain.model.ReadingList
 import app.otakureader.core.ui.component.ErrorScreen
 import app.otakureader.core.ui.component.LoadingScreen
 import app.otakureader.core.ui.theme.MangaDynamicTheme
@@ -156,6 +157,7 @@ fun DetailsScreen(
     onNavigateToGlobalSearch: (query: String) -> Unit = {},
     onNavigateToSourceSearch: (sourceId: String, query: String) -> Unit = { _, _ -> },
     onNavigateToMigration: (mangaId: Long) -> Unit = {},
+    onNavigateToWebViewFallback: (url: String, title: String) -> Unit = { _, _ -> },
     viewModel: DetailsViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -221,6 +223,9 @@ fun DetailsScreen(
                 }
                 is DetailsContract.Effect.NavigateToMigration -> {
                     onNavigateToMigration(effect.mangaId)
+                }
+                is DetailsContract.Effect.NavigateToWebViewFallback -> {
+                    onNavigateToWebViewFallback(effect.url, effect.title)
                 }
                 is DetailsContract.Effect.OpenInBrowser -> {
                     try {
@@ -430,6 +435,13 @@ fun DetailsScreen(
                                 }
                             )
                         }
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.details_add_to_reading_list)) },
+                            onClick = {
+                                viewModel.onEvent(DetailsContract.Event.ShowReadingListPicker)
+                                overflowExpanded = false
+                            }
+                        )
                         androidx.compose.material3.HorizontalDivider()
                         DropdownMenuItem(
                             text = { Text(stringResource(R.string.details_open_download_folder)) },
@@ -520,6 +532,11 @@ fun DetailsScreen(
             state.error != null -> ErrorScreen(
                 message = state.error ?: stringResource(R.string.details_unknown_error),
                 onRetry = { viewModel.onEvent(DetailsContract.Event.Refresh) },
+                onOpenInBrowser = if (state.mangaWebUrl != null) {
+                    { viewModel.onEvent(DetailsContract.Event.OpenWebViewFallback) }
+                } else {
+                    null
+                },
                 modifier = Modifier.padding(paddingValues)
             )
             state.manga != null -> DetailsContent(
@@ -790,6 +807,15 @@ private fun DetailsContent(
             onToggle = { categoryId -> onEvent(DetailsContract.Event.ToggleCategoryPickerSelection(categoryId)) },
             onConfirm = { onEvent(DetailsContract.Event.ConfirmCategoryPicker) },
             onDismiss = { onEvent(DetailsContract.Event.DismissCategoryPicker) }
+        )
+    }
+
+    if (state.showReadingListPickerDialog) {
+        ReadingListPickerDialog(
+            readingLists = state.readingLists,
+            selectedIds = state.readingListPickerSelection,
+            onToggle = { listId -> onEvent(DetailsContract.Event.ToggleReadingListPickerSelection(listId)) },
+            onDismiss = { onEvent(DetailsContract.Event.DismissReadingListPicker) }
         )
     }
 
@@ -1180,6 +1206,51 @@ private fun CategoryPickerDialog(
         },
         dismissButton = {
             TextButton(onClick = onDismiss) { Text(stringResource(R.string.details_category_picker_skip)) }
+        }
+    )
+}
+
+/**
+ * Opened on demand from the overflow menu's "Add to Reading List" item. Unlike
+ * [CategoryPickerDialog], each checkbox toggle persists immediately (add/remove from the list)
+ * rather than batching on a confirm button — [selectedIds] reflects live membership.
+ */
+@Composable
+private fun ReadingListPickerDialog(
+    readingLists: List<ReadingList>,
+    selectedIds: Set<Long>,
+    onToggle: (Long) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.details_reading_list_picker_title)) },
+        text = {
+            if (readingLists.isEmpty()) {
+                Text(stringResource(R.string.details_reading_list_picker_empty))
+            } else {
+                LazyColumn(modifier = Modifier.heightIn(max = 320.dp)) {
+                    items(readingLists, key = { it.id }) { list ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onToggle(list.id) }
+                                .padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Checkbox(
+                                checked = list.id in selectedIds,
+                                onCheckedChange = { onToggle(list.id) },
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(text = list.name)
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.details_reading_list_picker_done)) }
         }
     )
 }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -1240,7 +1240,7 @@ private fun ReadingListPickerDialog(
                         ) {
                             Checkbox(
                                 checked = list.id in selectedIds,
-                                onCheckedChange = { onToggle(list.id) },
+                                onCheckedChange = null,
                             )
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(text = list.name)

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -587,31 +587,37 @@ class DetailsViewModel @Inject constructor(
         }
     }
 
-    /** Toggles membership immediately — checking/unchecking a list persists right away. */
+    /**
+     * Toggles membership immediately — checking/unchecking a list persists right away. Serialized
+     * by [readingListMutex] so rapid taps on multiple lists can't race their DB writes (and any
+     * failure-rollback) against each other and desync the picker's state from the database.
+     */
     private fun toggleReadingListPickerSelection(listId: Long) {
-        val wasSelected = listId in _state.value.readingListPickerSelection
-        _state.update {
-            val selection = it.readingListPickerSelection
-            val updated = if (wasSelected) selection - listId else selection + listId
-            it.copy(readingListPickerSelection = updated)
-        }
         viewModelScope.launch {
-            try {
-                if (wasSelected) {
-                    readingListRepository.removeMangaFromList(listId, mangaId)
-                } else {
-                    readingListRepository.addMangaToList(listId, mangaId)
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                // Revert the optimistic toggle and let the user know.
+            readingListMutex.withLock {
+                val wasSelected = listId in _state.value.readingListPickerSelection
                 _state.update {
                     val selection = it.readingListPickerSelection
-                    val reverted = if (wasSelected) selection + listId else selection - listId
-                    it.copy(readingListPickerSelection = reverted)
+                    val updated = if (wasSelected) selection - listId else selection + listId
+                    it.copy(readingListPickerSelection = updated)
                 }
-                _effect.send(DetailsContract.Effect.ShowError("Failed to update reading list"))
+                try {
+                    if (wasSelected) {
+                        readingListRepository.removeMangaFromList(listId, mangaId)
+                    } else {
+                        readingListRepository.addMangaToList(listId, mangaId)
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // Revert the optimistic toggle and let the user know.
+                    _state.update {
+                        val selection = it.readingListPickerSelection
+                        val reverted = if (wasSelected) selection + listId else selection - listId
+                        it.copy(readingListPickerSelection = reverted)
+                    }
+                    _effect.send(DetailsContract.Effect.ShowError("Failed to update reading list"))
+                }
             }
         }
     }
@@ -1516,6 +1522,11 @@ class DetailsViewModel @Inject constructor(
     // Serializes set/remove cover operations: each mutates files + DB, so two running
     // concurrently (rapid taps) could leave the DB pointing at a deleted file.
     private val coverMutex = Mutex()
+
+    // Serializes reading-list picker toggles: each write (+ potential failure-rollback) must
+    // complete before the next tap's write starts, or rapid clicks can race and desync the
+    // picker's optimistic state from the database.
+    private val readingListMutex = Mutex()
 
     private fun setCustomCover(imageUri: String) {
         viewModelScope.launch {

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -578,11 +578,17 @@ class DetailsViewModel @Inject constructor(
 
     private fun showReadingListPicker() {
         viewModelScope.launch {
-            val currentListIds = readingListRepository.getListsForManga(mangaId).first()
-                .map { it.listId }
-                .toSet()
-            _state.update {
-                it.copy(showReadingListPickerDialog = true, readingListPickerSelection = currentListIds)
+            try {
+                val currentListIds = readingListRepository.getListsForManga(mangaId).first()
+                    .map { it.listId }
+                    .toSet()
+                _state.update {
+                    it.copy(showReadingListPickerDialog = true, readingListPickerSelection = currentListIds)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _effect.send(DetailsContract.Effect.ShowError("Failed to load reading lists"))
             }
         }
     }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -11,6 +11,7 @@ import app.otakureader.domain.repository.CategoryRepository
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.MangaRepository
+import app.otakureader.domain.repository.ReadingListRepository
 import app.otakureader.domain.repository.StatisticsRepository
 import app.otakureader.core.preferences.DeleteAfterReadMode
 import app.otakureader.core.preferences.DownloadPreferences
@@ -60,6 +61,7 @@ class DetailsViewModel @Inject constructor(
     private val setMangaNotifications: SetMangaNotificationsUseCase,
     private val statisticsRepository: StatisticsRepository,
     private val trackRepository: TrackRepository,
+    private val readingListRepository: ReadingListRepository,
 ) : ViewModel() {
 
     private val mangaId: Long = savedStateHandle.get<Long>(MANGA_ID_ARG) 
@@ -101,6 +103,7 @@ class DetailsViewModel @Inject constructor(
         loadMangaWebUrl()
         observeCategories()
         loadSourceName()
+        observeReadingLists()
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
@@ -192,6 +195,7 @@ class DetailsViewModel @Inject constructor(
             is DetailsContract.Event.GenreLongClick -> searchGlobally(event.genre)
             is DetailsContract.Event.SearchGlobally -> searchGlobally(event.query)
             is DetailsContract.Event.OpenWebView -> openInWebView()
+            is DetailsContract.Event.OpenWebViewFallback -> openWebViewFallback()
 
             is DetailsContract.Event.DismissCategoryPicker ->
                 _state.update { it.copy(showCategoryPickerDialog = false) }
@@ -200,6 +204,12 @@ class DetailsViewModel @Inject constructor(
             is DetailsContract.Event.ConfirmCategoryPicker -> confirmCategoryPicker()
             is DetailsContract.Event.MigrateManga -> migrateManga()
             is DetailsContract.Event.SourceClick -> onSourceClick()
+
+            is DetailsContract.Event.ShowReadingListPicker -> showReadingListPicker()
+            is DetailsContract.Event.DismissReadingListPicker ->
+                _state.update { it.copy(showReadingListPickerDialog = false) }
+            is DetailsContract.Event.ToggleReadingListPickerSelection ->
+                toggleReadingListPickerSelection(event.listId)
         }
     }
 
@@ -298,6 +308,14 @@ class DetailsViewModel @Inject constructor(
         val url = _state.value.mangaWebUrl ?: return
         viewModelScope.launch {
             _effect.send(DetailsContract.Effect.OpenInBrowser(url))
+        }
+    }
+
+    private fun openWebViewFallback() {
+        val url = _state.value.mangaWebUrl ?: return
+        val title = _state.value.manga?.title.orEmpty()
+        viewModelScope.launch {
+            _effect.send(DetailsContract.Effect.NavigateToWebViewFallback(url, title))
         }
     }
 
@@ -548,6 +566,52 @@ class DetailsViewModel @Inject constructor(
                 throw e
             } catch (e: Exception) {
                 _effect.send(DetailsContract.Effect.ShowError("Failed to assign categories"))
+            }
+        }
+    }
+
+    private fun observeReadingLists() {
+        readingListRepository.getAllLists()
+            .onEach { lists -> _state.update { it.copy(readingLists = lists) } }
+            .launchIn(viewModelScope)
+    }
+
+    private fun showReadingListPicker() {
+        viewModelScope.launch {
+            val currentListIds = readingListRepository.getListsForManga(mangaId).first()
+                .map { it.listId }
+                .toSet()
+            _state.update {
+                it.copy(showReadingListPickerDialog = true, readingListPickerSelection = currentListIds)
+            }
+        }
+    }
+
+    /** Toggles membership immediately — checking/unchecking a list persists right away. */
+    private fun toggleReadingListPickerSelection(listId: Long) {
+        val wasSelected = listId in _state.value.readingListPickerSelection
+        _state.update {
+            val selection = it.readingListPickerSelection
+            val updated = if (wasSelected) selection - listId else selection + listId
+            it.copy(readingListPickerSelection = updated)
+        }
+        viewModelScope.launch {
+            try {
+                if (wasSelected) {
+                    readingListRepository.removeMangaFromList(listId, mangaId)
+                } else {
+                    readingListRepository.addMangaToList(listId, mangaId)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Revert the optimistic toggle and let the user know.
+                _state.update {
+                    val selection = it.readingListPickerSelection
+                    val reverted = if (wasSelected) selection + listId else selection - listId
+                    it.copy(readingListPickerSelection = reverted)
+                }
+                _effect.send(DetailsContract.Effect.ShowError("Failed to update reading list"))
             }
         }
     }

--- a/feature/details/src/main/java/app/otakureader/feature/details/navigation/DetailsNavigation.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/navigation/DetailsNavigation.kt
@@ -13,6 +13,7 @@ fun NavGraphBuilder.detailsScreen(
     onNavigateToGlobalSearch: (query: String) -> Unit = {},
     onNavigateToSourceSearch: (sourceId: String, query: String) -> Unit = { _, _ -> },
     onNavigateToMigration: (mangaId: Long) -> Unit = {},
+    onNavigateToWebViewFallback: (url: String, title: String) -> Unit = { _, _ -> },
 ) {
     composable<Route.MangaDetails> { backStackEntry ->
         val route = backStackEntry.toRoute<Route.MangaDetails>()
@@ -24,6 +25,7 @@ fun NavGraphBuilder.detailsScreen(
             onNavigateToGlobalSearch = onNavigateToGlobalSearch,
             onNavigateToSourceSearch = onNavigateToSourceSearch,
             onNavigateToMigration = onNavigateToMigration,
+            onNavigateToWebViewFallback = onNavigateToWebViewFallback,
         )
     }
 }

--- a/feature/details/src/main/res/values/strings.xml
+++ b/feature/details/src/main/res/values/strings.xml
@@ -244,4 +244,9 @@
     <string name="details_category_picker_title">Add to categories</string>
     <string name="details_category_picker_confirm">Add</string>
     <string name="details_category_picker_skip">Skip</string>
+
+    <string name="details_add_to_reading_list">Add to Reading List</string>
+    <string name="details_reading_list_picker_title">Reading lists</string>
+    <string name="details_reading_list_picker_empty">No reading lists yet. Create one from More → Reading Lists.</string>
+    <string name="details_reading_list_picker_done">Done</string>
 </resources>

--- a/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
+++ b/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
@@ -1028,8 +1028,10 @@ class DetailsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertNull(viewModel.state.value.mangaWebUrl)
-        viewModel.onEvent(DetailsContract.Event.OpenWebViewFallback)
-        testDispatcher.scheduler.advanceUntilIdle()
-        // No assertion needed beyond "doesn't crash" — openWebViewFallback() returns early.
+        viewModel.effect.test {
+            viewModel.onEvent(DetailsContract.Event.OpenWebViewFallback)
+            testDispatcher.scheduler.advanceUntilIdle()
+            expectNoEvents()
+        }
     }
 }

--- a/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
+++ b/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
@@ -13,6 +13,7 @@ import app.otakureader.domain.repository.CategoryRepository
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.DownloadRepository
+import app.otakureader.domain.repository.ReadingListRepository
 import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.tracking.TrackRepository
 import app.otakureader.domain.usecase.SetMangaNotificationsUseCase
@@ -60,6 +61,7 @@ class DetailsViewModelTest {
     private lateinit var setMangaNotifications: SetMangaNotificationsUseCase
     private lateinit var statisticsRepository: app.otakureader.domain.repository.StatisticsRepository
     private lateinit var trackRepository: TrackRepository
+    private lateinit var readingListRepository: ReadingListRepository
     private lateinit var savedStateHandle: SavedStateHandle
 
     private val sampleManga = Manga(
@@ -92,6 +94,7 @@ class DetailsViewModelTest {
         setMangaNotifications = mockk()
         statisticsRepository = mockk(relaxed = true)
         trackRepository = mockk(relaxed = true)
+        readingListRepository = mockk(relaxed = true)
         savedStateHandle = SavedStateHandle(mapOf(DetailsViewModel.MANGA_ID_ARG to mangaId))
     }
 
@@ -114,6 +117,7 @@ class DetailsViewModelTest {
             setMangaNotifications,
             statisticsRepository,
             trackRepository,
+            readingListRepository,
         )
     }
 
@@ -928,5 +932,104 @@ class DetailsViewModelTest {
 
         coVerify { downloadRepository.deleteChapterDownload(downloadedChapterId, any(), any(), any()) }
         coVerify(exactly = 0) { downloadRepository.cancelDownload(any()) }
+    }
+
+    // ---- Reading list picker ----
+
+    @Test
+    fun onEvent_ShowReadingListPicker_seedsSelectionFromCurrentMembership() = runTest {
+        setUpDefaultMocks()
+        val existingList = app.otakureader.domain.model.ReadingList(id = 5L, name = "Currently Reading")
+        every { readingListRepository.getAllLists() } returns flowOf(listOf(existingList))
+        coEvery { readingListRepository.getListsForManga(mangaId) } returns flowOf(
+            listOf(app.otakureader.domain.model.ReadingListItem(listId = 5L, mangaId = mangaId))
+        )
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(DetailsContract.Event.ShowReadingListPicker)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertTrue(state.showReadingListPickerDialog)
+        assertEquals(setOf(5L), state.readingListPickerSelection)
+    }
+
+    @Test
+    fun onEvent_ToggleReadingListPickerSelection_addsMangaWhenNotSelected() = runTest {
+        setUpDefaultMocks()
+        coEvery { readingListRepository.getListsForManga(mangaId) } returns flowOf(emptyList())
+        coEvery { readingListRepository.addMangaToList(5L, mangaId) } returns Unit
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+        viewModel.onEvent(DetailsContract.Event.ShowReadingListPicker)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(DetailsContract.Event.ToggleReadingListPickerSelection(5L))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(5L in viewModel.state.value.readingListPickerSelection)
+        coVerify(exactly = 1) { readingListRepository.addMangaToList(5L, mangaId) }
+    }
+
+    @Test
+    fun onEvent_ToggleReadingListPickerSelection_removesMangaWhenAlreadySelected() = runTest {
+        setUpDefaultMocks()
+        coEvery { readingListRepository.getListsForManga(mangaId) } returns flowOf(
+            listOf(app.otakureader.domain.model.ReadingListItem(listId = 5L, mangaId = mangaId))
+        )
+        coEvery { readingListRepository.removeMangaFromList(5L, mangaId) } returns Unit
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+        viewModel.onEvent(DetailsContract.Event.ShowReadingListPicker)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(DetailsContract.Event.ToggleReadingListPickerSelection(5L))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(5L in viewModel.state.value.readingListPickerSelection)
+        coVerify(exactly = 1) { readingListRepository.removeMangaFromList(5L, mangaId) }
+    }
+
+    // ---- Error-state "try in browser" fallback ----
+
+    @Test
+    fun onEvent_OpenWebViewFallback_emitsNavigateEffectWithWebUrl() = runTest {
+        setUpDefaultMocks()
+        val source = mockk<app.otakureader.sourceapi.MangaSource>(relaxed = true)
+        every { source.baseUrl } returns "https://example.com"
+        coEvery { sourceRepository.getSource(sampleManga.sourceId.toString()) } returns source
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.effect.test {
+            viewModel.onEvent(DetailsContract.Event.OpenWebViewFallback)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val effect = awaitItem()
+            assertTrue(effect is DetailsContract.Effect.NavigateToWebViewFallback)
+            assertEquals(
+                "https://example.com/m/42",
+                (effect as DetailsContract.Effect.NavigateToWebViewFallback).url,
+            )
+        }
+    }
+
+    @Test
+    fun onEvent_OpenWebViewFallback_doesNothingWhenWebUrlUnavailable() = runTest {
+        setUpDefaultMocks()
+        // Default relaxed sourceRepository mock resolves an empty baseUrl, so mangaWebUrl stays null.
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(viewModel.state.value.mangaWebUrl)
+        viewModel.onEvent(DetailsContract.Event.OpenWebViewFallback)
+        testDispatcher.scheduler.advanceUntilIdle()
+        // No assertion needed beyond "doesn't crash" — openWebViewFallback() returns early.
     }
 }

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -470,6 +470,7 @@ fun ReaderScreen(
             isCurrentChapterDownloaded = state.isCurrentChapterDownloaded,
             onBookmarkPage = { viewModel.onEvent(ReaderEvent.ToggleBookmark) },
             isCurrentPageBookmarked = state.isCurrentPageBookmarked,
+            onOpenComments = { viewModel.onEvent(ReaderEvent.ToggleCommentsOverlay) },
             modifier = Modifier.align(Alignment.TopCenter)
         )
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderContentOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderContentOverlay.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Comment
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.outlined.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkBorder
@@ -63,6 +64,7 @@ private val readerTopBarFade = tween<Float>(READER_TOP_BAR_FADE_MS)
  * @param isCurrentChapterDownloaded When true, the download button is hidden.
  * @param onBookmarkPage Called when the bookmark icon is tapped; null hides the button.
  * @param isCurrentPageBookmarked When true, shows a solid bookmark; when false, shows an outlined bookmark border.
+ * @param onOpenComments Called when the comments icon is tapped; null hides the button.
  */
 @Composable
 fun ReaderContentOverlay(
@@ -76,6 +78,7 @@ fun ReaderContentOverlay(
     isCurrentChapterDownloaded: Boolean = false,
     onBookmarkPage: (() -> Unit)? = null,
     isCurrentPageBookmarked: Boolean = false,
+    onOpenComments: (() -> Unit)? = null,
 ) {
     AnimatedVisibility(
         visible = isVisible,
@@ -151,6 +154,15 @@ fun ReaderContentOverlay(
                         } else {
                             onSurfaceVariant
                         }
+                    )
+                }
+            }
+            if (onOpenComments != null) {
+                IconButton(onClick = onOpenComments) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.Comment,
+                        contentDescription = stringResource(R.string.reader_comments_title),
+                        tint = onSurfaceVariant
                     )
                 }
             }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/LibrarySettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/LibrarySettingsMvi.kt
@@ -8,7 +8,6 @@ data class LibrarySettingsState(
     val showBadges: Boolean = true,
     val showDownloadBadge: Boolean = true,
     val updateOnlyOnWifi: Boolean = false,
-    val updateOnlyPinnedCategories: Boolean = false,
     val autoRefreshOnStart: Boolean = false,
     val showUpdateProgress: Boolean = true,
     val skipUpdatesWithUnread: Boolean = false,

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsLibraryScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsLibraryScreen.kt
@@ -171,17 +171,6 @@ private fun LibraryContent(state: SettingsState, onEvent: (SettingsEvent) -> Uni
     )
 
     ListItem(
-        headlineContent = { Text(stringResource(R.string.settings_update_pinned_only)) },
-        supportingContent = { Text(stringResource(R.string.settings_update_pinned_only_description)) },
-        trailingContent = {
-            Switch(
-                checked = state.updateOnlyPinnedCategories,
-                onCheckedChange = { onEvent(SettingsEvent.SetUpdateOnlyPinnedCategories(it)) },
-            )
-        },
-    )
-
-    ListItem(
         headlineContent = { Text(stringResource(R.string.settings_auto_refresh)) },
         supportingContent = { Text(stringResource(R.string.settings_auto_refresh_description)) },
         trailingContent = {

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
@@ -125,7 +125,6 @@ data class SettingsState(
     val showBadges get() = library.showBadges
     val showDownloadBadge get() = library.showDownloadBadge
     val updateOnlyOnWifi get() = library.updateOnlyOnWifi
-    val updateOnlyPinnedCategories get() = library.updateOnlyPinnedCategories
     val autoRefreshOnStart get() = library.autoRefreshOnStart
     val showUpdateProgress get() = library.showUpdateProgress
     val skipUpdatesWithUnread get() = library.skipUpdatesWithUnread
@@ -260,7 +259,6 @@ sealed interface SettingsEvent : UiEvent {
     data class SetShowBadges(val enabled: Boolean) : SettingsEvent
     data class SetShowDownloadBadge(val enabled: Boolean) : SettingsEvent
     data class SetUpdateOnlyOnWifi(val enabled: Boolean) : SettingsEvent
-    data class SetUpdateOnlyPinnedCategories(val enabled: Boolean) : SettingsEvent
     data class SetAutoRefreshOnStart(val enabled: Boolean) : SettingsEvent
     data class SetShowUpdateProgress(val enabled: Boolean) : SettingsEvent
     data class SetSkipUpdatesWithUnread(val enabled: Boolean) : SettingsEvent

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/LibrarySettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/LibrarySettingsDelegate.kt
@@ -34,15 +34,13 @@ class LibrarySettingsDelegate @Inject constructor(
                 libraryPreferences.gridSize,
                 libraryPreferences.showBadges,
                 libraryPreferences.updateOnlyOnWifi,
-                libraryPreferences.updateOnlyPinnedCategories,
                 libraryPreferences.autoRefreshOnStart,
-            ) { gridSize, showBadges, updateOnWifi, updatePinned, autoRefresh ->
+            ) { gridSize, showBadges, updateOnWifi, autoRefresh ->
                 latestUpdateOnlyOnWifi = updateOnWifi
                 updateState { it.copy(library = it.library.copy(
                     libraryGridSize = gridSize,
                     showBadges = showBadges,
                     updateOnlyOnWifi = updateOnWifi,
-                    updateOnlyPinnedCategories = updatePinned,
                     autoRefreshOnStart = autoRefresh,
                 )) }
             }.collect { }
@@ -97,10 +95,6 @@ class LibrarySettingsDelegate @Inject constructor(
             libraryPreferences.setUpdateOnlyOnWifi(event.enabled)
             latestUpdateOnlyOnWifi = event.enabled
             scheduleLibraryUpdateOrShowError(latestUpdateCheckInterval, event.enabled, sendEffect)
-            true
-        }
-        is SettingsEvent.SetUpdateOnlyPinnedCategories -> {
-            libraryPreferences.setUpdateOnlyPinnedCategories(event.enabled)
             true
         }
         is SettingsEvent.SetAutoRefreshOnStart -> { libraryPreferences.setAutoRefreshOnStart(event.enabled); true }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -506,8 +506,6 @@
     <string name="settings_library_updates">Library Updates</string>
     <string name="settings_update_wifi_only">Update Only on Wi-Fi</string>
     <string name="settings_update_wifi_only_description">Restrict automatic updates to Wi-Fi connections</string>
-    <string name="settings_update_pinned_only">Update Pinned Categories Only</string>
-    <string name="settings_update_pinned_only_description">Only update manga in pinned categories</string>
     <string name="settings_auto_refresh">Auto-Refresh on Start</string>
     <string name="settings_auto_refresh_description">Check for updates when app opens</string>
     <string name="settings_show_update_progress">Show Update Progress</string>

--- a/feature/statistics/src/main/java/app/otakureader/feature/statistics/AchievementsSection.kt
+++ b/feature/statistics/src/main/java/app/otakureader/feature/statistics/AchievementsSection.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.otakureader.core.ui.components.HankoBadge
 import app.otakureader.domain.model.Achievement
@@ -32,7 +33,7 @@ fun AchievementsSection(
 
     Column(modifier = modifier) {
         Text(
-            text = "Achievements",
+            text = stringResource(R.string.statistics_achievements_title),
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.fillMaxWidth()
         )

--- a/feature/statistics/src/main/java/app/otakureader/feature/statistics/AchievementsSection.kt
+++ b/feature/statistics/src/main/java/app/otakureader/feature/statistics/AchievementsSection.kt
@@ -33,7 +33,7 @@ fun AchievementsSection(
 
     Column(modifier = modifier) {
         Text(
-            text = stringResource(R.string.statistics_achievements_title),
+            text = stringResource(R.string.achievements_title),
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.fillMaxWidth()
         )

--- a/feature/statistics/src/main/res/values/strings.xml
+++ b/feature/statistics/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="statistics_title">Statistics</string>
+    <string name="statistics_achievements_title">Achievements</string>
     <string name="statistics_back">Back</string>
     <string name="statistics_unknown_error">Unknown error</string>
     <string name="statistics_reading_goals">Reading Goals</string>

--- a/feature/statistics/src/main/res/values/strings.xml
+++ b/feature/statistics/src/main/res/values/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="statistics_title">Statistics</string>
-    <string name="statistics_achievements_title">Achievements</string>
     <string name="statistics_back">Back</string>
     <string name="statistics_unknown_error">Unknown error</string>
     <string name="statistics_reading_goals">Reading Goals</string>

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
@@ -73,6 +73,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -130,8 +131,13 @@ fun UpdatesScreen(
 
     // Auto-open the update-errors dialog when navigated here from the More tab's
     // "Update Errors" entry — otherwise there's no way to reach the error view from there.
+    // rememberSaveable guards against re-firing: the openErrors route arg is restored with the
+    // back stack entry, so without this the dialog would reopen every time the user navigated
+    // away from Updates and back.
+    var hasAutoOpenedErrors by rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(openErrorsOnLaunch) {
-        if (openErrorsOnLaunch) {
+        if (openErrorsOnLaunch && !hasAutoOpenedErrors) {
+            hasAutoOpenedErrors = true
             viewModel.onEvent(UpdatesEvent.ShowUpdateErrors)
         }
     }

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
@@ -115,6 +115,7 @@ fun UpdatesScreen(
     onNavigateBack: () -> Unit,
     onNavigateToDownloads: () -> Unit,
     modifier: Modifier = Modifier,
+    openErrorsOnLaunch: Boolean = false,
     viewModel: UpdatesViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -125,6 +126,14 @@ fun UpdatesScreen(
 
     BackHandler(enabled = state.selectedItems.isNotEmpty()) {
         viewModel.onEvent(UpdatesEvent.ClearSelection)
+    }
+
+    // Auto-open the update-errors dialog when navigated here from the More tab's
+    // "Update Errors" entry — otherwise there's no way to reach the error view from there.
+    LaunchedEffect(openErrorsOnLaunch) {
+        if (openErrorsOnLaunch) {
+            viewModel.onEvent(UpdatesEvent.ShowUpdateErrors)
+        }
     }
 
     LaunchedEffect(viewModel.effect) {

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/navigation/UpdatesNavigation.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/navigation/UpdatesNavigation.kt
@@ -2,6 +2,7 @@ package app.otakureader.feature.updates.navigation
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import app.otakureader.core.navigation.Route
 import app.otakureader.feature.updates.DownloadsScreen
 import app.otakureader.feature.updates.UpdatesScreen
@@ -11,11 +12,13 @@ fun NavGraphBuilder.updatesScreen(
     onNavigateBack: () -> Unit,
     onNavigateToDownloads: () -> Unit
 ) {
-    composable<Route.Updates> {
+    composable<Route.Updates> { backStackEntry ->
+        val route = backStackEntry.toRoute<Route.Updates>()
         UpdatesScreen(
             onMangaClick = onMangaClick,
             onNavigateBack = onNavigateBack,
-            onNavigateToDownloads = onNavigateToDownloads
+            onNavigateToDownloads = onNavigateToDownloads,
+            openErrorsOnLaunch = route.openErrors,
         )
     }
 }


### PR DESCRIPTION
## 📋 Description

Now that the Komikku-parity backlog is complete (#1191/#1194), this PR audits the whole app for **Otaku-exclusive features** (things Komikku has no equivalent of) and fixes the ones that turned out to be buried, dead, or silently non-functional.

Method: two parallel research passes (one inventorying every exclusive feature + the app's full nav map, one hunting specifically for dead nav-callbacks/orphaned routes/unconsumed preferences), then every finding was independently re-verified by reading the actual code before touching anything — one finding (dynamic/smart categories being "orphaned") turned out to be a false positive on re-check (it's fully built and reachable via Category Management) and was dropped.

### Fixed

- **Reader comments/notes** — the overlay (`reader_comments` DB table, full ViewModel/UI) had **zero UI trigger** anywhere in the app; the only place `ToggleCommentsOverlay` fired was the overlay's own close button. Added a comment icon to the reader's top bar (`ReaderContentOverlay.kt`), matching the bookmark/download icon pattern already there.
- **Update Errors nav gap** — More tab's "Update Errors" entry navigated to the plain Updates screen; the error dialog only opens via a badge icon that's invisible unless errors already exist, so there was no way to actually reach it from More. `Route.Updates` now takes an `openErrors: Boolean = false` param; the More-tab entry passes `true`, the bottom-nav tab keeps the default so normal tab navigation is untouched.
- **Reading Lists** — a complete CRUD feature (`feature/library/readinglist/`) had no "add this manga" entry point from Manga Details, the one place a user would look for it. Added a live-toggle checkbox picker to the overflow menu (checking/unchecking persists immediately, no separate confirm step).
- **Coil disk-cache size** — the Settings slider wrote/read the value correctly, but `OtakuReaderApplication`'s `ImageLoader` always used the hardcoded 512MB default regardless — the existing code comment described reading the user's value but the code never did. Fixed (the disk-cache factory lambda is lazy, so a blocking DataStore read here doesn't block app startup).
- **Extension install-from-URL/file** — `Route.ExtensionInstall` had a complete screen and ViewModel with zero navigation call sites. Added an entry to the Extensions screen's overflow menu.
- **WebView fallback** — `Route.WebViewFallback` ("in-app viewer for source pages that fail API extraction," per its own doc comment) was also fully built but orphaned. Added a general-purpose "Try in browser" secondary action to the shared `ErrorScreen` component, wired from Manga Details' error state (has the manga's web URL already available). Per a scoping decision, this is a **manual** escape hatch, not automatic Cloudflare-challenge detection — the latter would need real network-layer heuristics I can't verify without a device hitting an actually-blocked source.
- **Removed two dead preferences**: `updateOnlyPinnedCategories` (a Settings toggle with no backing "pin a category" concept anywhere in the app — flipping it did nothing) and `jumpToCategoryOnOpen` (persisted, zero UI, zero consumer).
- **Docs**: fixed a hardcoded `"Achievements"` string (localization convention violation), and added Achievements + the 4 Glance-based home-screen widgets to CLAUDE.md's Shipped Feature Inventory — both fully functional but previously undocumented there.

### Deliberately not done

- The reader's per-page load-failure state isn't wired to the new WebView fallback — unlike Manga Details, the reader has no existing `chapterUrl`/`sourceId` state to build the URL from; adding it would need materially more new ViewModel state in an already-large, heavily-tested ViewModel than this pass anticipated.
- `updateOnlyPinnedCategories` was removed rather than implemented — building real category-pinning (DB migration, UI affordance, `LibraryUpdateFilter` wiring) is a new feature, not a placement fix.
- Automatic Cloudflare/challenge detection for `Route.WebView` (the CAPTCHA-purpose webview, separate from `Route.WebViewFallback`) remains unwired — same reasoning as above.

## 🔄 Type of Change
- [x] 🐛 Bug fix (several genuinely dead/non-functional features)
- [ ] ✨ New feature
- [x] 📖 Documentation
- [x] 🎨 UI/UX
- [ ] ♻️ Refactoring
- [ ] 🚀 Performance
- [x] 🧪 Tests

## 🧪 Testing
- `./gradlew detekt` and `./gradlew ktlintCheck` clean on all changed files (no local Android SDK in this sandbox, so full compiles/instrumented tests run in CI).
- New/extended unit tests in `DetailsViewModelTest`: reading-list picker seeding from current membership, toggle add/remove persistence, and the WebView-fallback effect (including the "no web URL available" no-op case).
- No Compose UI test added for the Updates screen's `openErrorsOnLaunch` `LaunchedEffect` — it's a simple boolean-gated one-liner and the underlying `ShowUpdateErrors` event is already covered elsewhere.
- CI (unit tests, ktlint, coverage gate, screenshot tests, assembleDebug) is the gate for full compile correctness and any screenshot-test diffs from the new reader top-bar icon.

## 📸 Screenshots
No screenshots available — no device/emulator in this sandbox. Visual changes: a new comment icon in the reader top bar (only visible when the manga has comments enabled — always rendered here since `onOpenComments` is now always passed a non-null lambda), a new "Add to Reading List" overflow item and picker dialog on Manga Details, a new "Install from URL/File" overflow item on Extensions, and a new secondary "Try in browser" button on the shared `ErrorScreen` component (only shown when the caller passes `onOpenInBrowser`, currently just Manga Details).

## ✅ Checklist
- [x] Code follows style guidelines
- [x] Self-review completed (re-verified every finding by reading actual code, not just agent reports; caught and corrected one false-positive claim before implementing)
- [x] Comments added for complex code (Coil lazy-diskCache timing, reading-list live-toggle vs. batch-confirm rationale)
- [x] Documentation updated (CLAUDE.md Shipped Feature Inventory)
- [x] No new warnings (detekt clean)
- [ ] Tests pass (pending CI — no local Android SDK to run instrumented/unit tests in this sandbox)

## 🔗 Related Issues
None filed directly — this was a fresh whole-app audit requested after the Komikku-parity backlog closed out.


---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reader comments access from the reading overlay.
  * Added a reading-list picker and the ability to add manga to reading lists.
  * Added an “Install from URL/File” option in the extensions area.
  * Added a “Try in browser” action for certain error screens.

* **Bug Fixes**
  * Update errors can now open directly when entering Updates.
  * Improved update settings, replacing pinned-category-only updates with Wi‑Fi-only updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->