### PR TITLE
Potential fix for code scanning alert no. 70: Use of implicit PendingIntents

### DIFF
--- a/data/src/main/java/app/otakureader/data/worker/GoalCompletionNotifier.kt
+++ b/data/src/main/java/app/otakureader/data/worker/GoalCompletionNotifier.kt
@@ -79,9 +79,28 @@ class GoalCompletionNotifier @Inject constructor(
 
         val launchIntent = context.packageManager
             .getLaunchIntentForPackage(context.packageName)
-            ?: Intent(Intent.ACTION_MAIN).apply {
-                addCategory(Intent.CATEGORY_LAUNCHER)
-                setPackage(context.packageName)
+            ?: run {
+                val launcherResolveIntent = Intent(Intent.ACTION_MAIN).apply {
+                    addCategory(Intent.CATEGORY_LAUNCHER)
+                    setPackage(context.packageName)
+                }
+                val launcherActivity = context.packageManager
+                    .queryIntentActivities(launcherResolveIntent, 0)
+                    .firstOrNull()
+                    ?.activityInfo
+                    ?.name
+
+                if (launcherActivity != null) {
+                    Intent(Intent.ACTION_MAIN).apply {
+                        addCategory(Intent.CATEGORY_LAUNCHER)
+                        setClassName(context.packageName, launcherActivity)
+                    }
+                } else {
+                    Intent(Intent.ACTION_MAIN).apply {
+                        addCategory(Intent.CATEGORY_LAUNCHER)
+                        setPackage(context.packageName)
+                    }
+                }
             }
 
         val pendingIntent = PendingIntent.getActivity(


### PR DESCRIPTION
Potential fix for [https://github.com/HeartlessVeteran2/Otaku-Reader/security/code-scanning/70](https://github.com/HeartlessVeteran2/Otaku-Reader/security/code-scanning/70)

Use an **explicit launch intent** before creating the `PendingIntent`.

Best fix in this snippet: keep using `getLaunchIntentForPackage(...)` when available, and for the fallback path, resolve the app’s launcher activity and set it as an explicit class name on the intent. This preserves behavior (open app from notification tap) while removing the implicit-intent pattern.

Edit `data/src/main/java/app/otakureader/data/worker/GoalCompletionNotifier.kt` in `showNotification(...)` around lines 80–85:

- Replace the fallback `Intent(Intent.ACTION_MAIN)...setPackage(...)` with:
  - Query launcher activities for this package via `PackageManager.queryIntentActivities(...)`.
  - Pick the first resolved launcher activity.
  - Build fallback with `Intent(Intent.ACTION_MAIN).addCategory(...).setClassName(context.packageName, resolvedActivityName)`.
  - As final fallback (if none resolved), keep package-scoped main intent.

No new dependencies are needed; only Android framework APIs already available in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Resolve use of implicit PendingIntent by resolving the app’s launcher activity and using an explicit main activity intent as fallback when opening the app from a notification tap.