### PR TITLE
Delete-after-reading: keep the last N read chapters (removeAfterReadSlots)

### DIFF
--- a/core/preferences/src/main/java/app/otakureader/core/preferences/DownloadPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/DownloadPreferences.kt
@@ -70,6 +70,15 @@ class DownloadPreferences(private val dataStore: DataStore<Preferences>) {
     suspend fun setDeleteAfterReading(value: Boolean) = dataStore.edit { it[Keys.DELETE_AFTER_READING] = value }
 
     /**
+     * How many of the most recently read chapters to keep downloaded when delete-after-reading
+     * is on. 0 = delete the just-read chapter immediately (default); N = delete the chapter N
+     * positions earlier in reading order, keeping the last N read chapters on disk.
+     */
+    val removeAfterReadSlots: Flow<Int> = dataStore.data.map { it[Keys.REMOVE_AFTER_READ_SLOTS] ?: 0 }
+    suspend fun setRemoveAfterReadSlots(value: Int) =
+        dataStore.edit { it[Keys.REMOVE_AFTER_READ_SLOTS] = value.coerceIn(0, MAX_REMOVE_AFTER_READ_SLOTS) }
+
+    /**
      * Per-manga delete-after-reading overrides stored as "mangaId:MODE" comma-separated string.
      * Example: "123:ENABLED,456:DISABLED"
      */
@@ -191,11 +200,17 @@ class DownloadPreferences(private val dataStore: DataStore<Preferences>) {
         val DOWNLOAD_AHEAD_ONLY_ON_WIFI = booleanPreferencesKey("download_ahead_only_on_wifi")
         val SAVE_AS_CBZ = booleanPreferencesKey("save_as_cbz")
         val DELETE_AFTER_READING = booleanPreferencesKey("delete_after_reading")
+        val REMOVE_AFTER_READ_SLOTS = intPreferencesKey("remove_after_read_slots")
         val PER_MANGA_OVERRIDES = stringPreferencesKey("delete_after_reading_overrides")
         val DATA_SAVER_ENABLED = booleanPreferencesKey("data_saver_enabled")
         val MONTHLY_DATA_BUDGET_MB = intPreferencesKey("monthly_data_budget_mb")
         val AUTO_DOWNLOAD_CATEGORY_INCLUDE = stringSetPreferencesKey("auto_download_category_include")
         val AUTO_DOWNLOAD_CATEGORY_EXCLUDE = stringSetPreferencesKey("auto_download_category_exclude")
         val CBZ_ENCRYPTION_ENABLED = booleanPreferencesKey("cbz_encryption_enabled")
+    }
+
+    companion object {
+        /** Upper bound for [removeAfterReadSlots] (matches Komikku's "keep last N" range). */
+        const val MAX_REMOVE_AFTER_READ_SLOTS = 4
     }
 }

--- a/data/src/main/java/app/otakureader/data/worker/RecordReadingHistoryWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/RecordReadingHistoryWorker.kt
@@ -12,6 +12,7 @@ import androidx.work.workDataOf
 import app.otakureader.core.preferences.DeleteAfterReadMode
 import app.otakureader.core.preferences.DownloadPreferences
 import app.otakureader.core.preferences.resolveShouldDeleteAfterRead
+import app.otakureader.domain.download.selectChapterToDeleteAfterRead
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.MangaRepository
@@ -117,12 +118,22 @@ class RecordReadingHistoryWorker @AssistedInject constructor(
         if (!shouldDelete) return
 
         val manga = mangaRepository.getMangaById(mangaId) ?: return
-        val chapter = chapterRepository.getChapterById(chapterId) ?: return
+        // slots > 0 keeps the last N read chapters downloaded and deletes the one N back instead.
+        val slots = downloadPreferences.removeAfterReadSlots.first()
+        val chapter = if (slots <= 0) {
+            chapterRepository.getChapterById(chapterId)
+        } else {
+            selectChapterToDeleteAfterRead(
+                chapters = chapterRepository.getChaptersByMangaIdSync(mangaId),
+                justReadChapterId = chapterId,
+                slots = slots,
+            )
+        } ?: return
         val downloadFolderName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
         if (!downloadRepository.isChapterDownloaded(downloadFolderName, manga.title, chapter.name)) return
 
         downloadRepository.deleteChapterDownload(
-            chapterId = chapterId,
+            chapterId = chapter.id,
             sourceName = downloadFolderName,
             mangaTitle = manga.title,
             chapterTitle = chapter.name,

--- a/data/src/test/java/app/otakureader/data/worker/RecordReadingHistoryWorkerTest.kt
+++ b/data/src/test/java/app/otakureader/data/worker/RecordReadingHistoryWorkerTest.kt
@@ -93,6 +93,8 @@ class RecordReadingHistoryWorkerTest {
         // No installed source for this fixture id — resolveDownloadFolderName falls back to the
         // numeric sourceId string.
         coEvery { sourceRepository.getSource(any()) } returns null
+        // Default: immediate delete-after-read (slots = 0).
+        every { downloadPreferences.removeAfterReadSlots } returns flowOf(0)
     }
 
     private fun readCompletedInputData(): androidx.work.Data = workDataOf(
@@ -138,6 +140,37 @@ class RecordReadingHistoryWorkerTest {
         coVerify(exactly = 1) {
             downloadRepository.deleteChapterDownload(chapterId, "99", "Test Manga", "Chapter 10")
         }
+    }
+
+    @Test
+    fun `with slots deletes the chapter N back in reading order instead of the just-read one`() = runTest {
+        every { downloadPreferences.deleteAfterReading } returns flowOf(true)
+        every { downloadPreferences.perMangaOverrides } returns flowOf(emptyMap())
+        every { downloadPreferences.removeAfterReadSlots } returns flowOf(2)
+        val earlier = testChapter.copy(id = 8L, name = "Chapter 8", chapterNumber = 8f)
+        val middle = testChapter.copy(id = 9L, name = "Chapter 9", chapterNumber = 9f)
+        coEvery { chapterRepository.getChaptersByMangaIdSync(mangaId) } returns
+            listOf(testChapter, earlier, middle)
+
+        buildWorker(readCompletedInputData()).doWork()
+
+        // Read ch10 with keep-last-2 → ch8 is deleted, ch9 and ch10 stay.
+        coVerify(exactly = 1) {
+            downloadRepository.deleteChapterDownload(8L, "99", "Test Manga", "Chapter 8")
+        }
+    }
+
+    @Test
+    fun `with slots does not delete anything when no chapter is far enough back`() = runTest {
+        every { downloadPreferences.deleteAfterReading } returns flowOf(true)
+        every { downloadPreferences.perMangaOverrides } returns flowOf(emptyMap())
+        every { downloadPreferences.removeAfterReadSlots } returns flowOf(2)
+        coEvery { chapterRepository.getChaptersByMangaIdSync(mangaId) } returns
+            listOf(testChapter, testChapter.copy(id = 9L, name = "Chapter 9", chapterNumber = 9f))
+
+        buildWorker(readCompletedInputData()).doWork()
+
+        coVerify(exactly = 0) { downloadRepository.deleteChapterDownload(any(), any(), any(), any()) }
     }
 
     @Test

--- a/domain/src/main/java/app/otakureader/domain/download/SelectChapterToDeleteAfterRead.kt
+++ b/domain/src/main/java/app/otakureader/domain/download/SelectChapterToDeleteAfterRead.kt
@@ -1,0 +1,26 @@
+package app.otakureader.domain.download
+
+import app.otakureader.domain.model.Chapter
+
+/**
+ * Picks which chapter's download should be deleted after the chapter with [justReadChapterId]
+ * has been read, honouring the "keep last N read chapters" preference.
+ *
+ * - [slots] = 0 → the just-read chapter itself (immediate delete-after-read).
+ * - [slots] = N → the chapter N positions *earlier* in reading order (ascending
+ *   [Chapter.chapterNumber]), so the N most recently read chapters stay downloaded.
+ *
+ * Returns null when the just-read chapter isn't in [chapters] or there is no chapter that far
+ * back — in both cases nothing should be deleted.
+ */
+fun selectChapterToDeleteAfterRead(
+    chapters: List<Chapter>,
+    justReadChapterId: Long,
+    slots: Int,
+): Chapter? {
+    if (slots <= 0) return chapters.firstOrNull { it.id == justReadChapterId }
+    val readingOrder = chapters.sortedBy { it.chapterNumber }
+    val justReadIndex = readingOrder.indexOfFirst { it.id == justReadChapterId }
+    if (justReadIndex == -1) return null
+    return readingOrder.getOrNull(justReadIndex - slots)
+}

--- a/domain/src/test/java/app/otakureader/domain/download/SelectChapterToDeleteAfterReadTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/download/SelectChapterToDeleteAfterReadTest.kt
@@ -1,0 +1,72 @@
+package app.otakureader.domain.download
+
+import app.otakureader.domain.model.Chapter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SelectChapterToDeleteAfterReadTest {
+
+    private fun makeChapter(id: Long, number: Float) = Chapter(
+        id = id,
+        mangaId = 1L,
+        url = "url/$id",
+        name = "Chapter $number",
+        chapterNumber = number,
+    )
+
+    // Chapters deliberately out of order to prove the function sorts by chapterNumber.
+    private val chapters = listOf(
+        makeChapter(id = 30L, number = 3f),
+        makeChapter(id = 10L, number = 1f),
+        makeChapter(id = 50L, number = 5f),
+        makeChapter(id = 20L, number = 2f),
+        makeChapter(id = 40L, number = 4f),
+    )
+
+    @Test
+    fun `slots zero returns the just-read chapter itself`() {
+        val target = selectChapterToDeleteAfterRead(chapters, justReadChapterId = 30L, slots = 0)
+        assertEquals(30L, target?.id)
+    }
+
+    @Test
+    fun `slots one returns the previous chapter in reading order`() {
+        // Just read chapter 3 with keep-last-1 → chapter 2 gets deleted
+        val target = selectChapterToDeleteAfterRead(chapters, justReadChapterId = 30L, slots = 1)
+        assertEquals(20L, target?.id)
+    }
+
+    @Test
+    fun `slots two skips back two chapters`() {
+        // Just read chapter 5 with keep-last-2 → chapter 3 gets deleted
+        val target = selectChapterToDeleteAfterRead(chapters, justReadChapterId = 50L, slots = 2)
+        assertEquals(30L, target?.id)
+    }
+
+    @Test
+    fun `returns null when not enough earlier chapters exist`() {
+        // Just read chapter 2 with keep-last-3 → nothing far enough back to delete
+        assertNull(selectChapterToDeleteAfterRead(chapters, justReadChapterId = 20L, slots = 3))
+    }
+
+    @Test
+    fun `returns null when just-read chapter is first in reading order`() {
+        assertNull(selectChapterToDeleteAfterRead(chapters, justReadChapterId = 10L, slots = 1))
+    }
+
+    @Test
+    fun `returns null when just-read chapter is not in the list`() {
+        assertNull(selectChapterToDeleteAfterRead(chapters, justReadChapterId = 999L, slots = 1))
+    }
+
+    @Test
+    fun `slots zero returns null when just-read chapter is not in the list`() {
+        assertNull(selectChapterToDeleteAfterRead(chapters, justReadChapterId = 999L, slots = 0))
+    }
+
+    @Test
+    fun `empty chapter list returns null`() {
+        assertNull(selectChapterToDeleteAfterRead(emptyList(), justReadChapterId = 10L, slots = 1))
+    }
+}

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDeleteAfterReadDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDeleteAfterReadDelegate.kt
@@ -3,6 +3,7 @@ package app.otakureader.feature.reader.viewmodel.delegate
 import app.otakureader.core.preferences.DeleteAfterReadMode
 import app.otakureader.core.preferences.DownloadPreferences
 import app.otakureader.core.preferences.resolveShouldDeleteAfterRead
+import app.otakureader.domain.download.selectChapterToDeleteAfterRead
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.MangaRepository
@@ -36,12 +37,22 @@ class ReaderDeleteAfterReadDelegate @Inject constructor(
         if (!shouldDelete) return
 
         val manga = mangaRepository.getMangaById(mangaId) ?: return
-        val chapter = chapterRepository.getChapterById(chapterId) ?: return
+        // slots > 0 keeps the last N read chapters downloaded and deletes the one N back instead.
+        val slots = downloadPreferences.removeAfterReadSlots.first()
+        val chapter = if (slots <= 0) {
+            chapterRepository.getChapterById(chapterId)
+        } else {
+            selectChapterToDeleteAfterRead(
+                chapters = chapterRepository.getChaptersByMangaIdSync(mangaId),
+                justReadChapterId = chapterId,
+                slots = slots,
+            )
+        } ?: return
         val downloadFolderName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
         if (!downloadRepository.isChapterDownloaded(downloadFolderName, manga.title, chapter.name)) return
 
         downloadRepository.deleteChapterDownload(
-            chapterId = chapterId,
+            chapterId = chapter.id,
             sourceName = downloadFolderName,
             mangaTitle = manga.title,
             chapterTitle = chapter.name,

--- a/feature/reader/src/test/java/app/otakureader/feature/reader/ReaderViewModelTest.kt
+++ b/feature/reader/src/test/java/app/otakureader/feature/reader/ReaderViewModelTest.kt
@@ -166,6 +166,7 @@ class ReaderViewModelTest {
         every { downloadPreferences.downloadAheadOnlyOnWifi } returns flowOf(false)
         every { downloadPreferences.deleteAfterReading } returns flowOf(false)
         every { downloadPreferences.perMangaOverrides } returns flowOf(emptyMap())
+        every { downloadPreferences.removeAfterReadSlots } returns flowOf(0)
         every { downloadRepository.observeDownloads() } returns flowOf(emptyList())
         coEvery { downloadRepository.enqueueChapter(any(), any(), any(), any(), any(), any(), any()) } just runs
         coEvery { downloadRepository.isChapterDownloaded(any(), any(), any()) } returns false

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/DownloadSettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/DownloadSettingsMvi.kt
@@ -6,6 +6,8 @@ import app.otakureader.domain.model.Category
 
 data class DownloadSettingsState(
     val deleteAfterReading: Boolean = false,
+    /** Keep the last N read chapters downloaded (0 = delete the just-read chapter immediately). */
+    val removeAfterReadSlots: Int = 0,
     val saveAsCbz: Boolean = false,
     val autoDownloadEnabled: Boolean = false,
     val downloadOnlyOnWifi: Boolean = true,

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsDownloadsScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsDownloadsScreen.kt
@@ -330,6 +330,39 @@ private fun DownloadsContent(state: SettingsState, onEvent: (SettingsEvent) -> U
         },
     )
 
+    if (state.deleteAfterReading) {
+        var slotsSlider by remember(state.removeAfterReadSlots) {
+            mutableFloatStateOf(state.removeAfterReadSlots.toFloat())
+        }
+        val slots = slotsSlider.roundToInt()
+        ListItem(
+            headlineContent = {
+                Text(
+                    if (slots == 0) {
+                        stringResource(R.string.settings_remove_after_read_immediately)
+                    } else {
+                        stringResource(R.string.settings_remove_after_read_keep_last, slots)
+                    },
+                )
+            },
+            supportingContent = {
+                Column {
+                    Text(stringResource(R.string.settings_remove_after_read_description))
+                    Slider(
+                        value = slotsSlider,
+                        onValueChange = { slotsSlider = it },
+                        onValueChangeFinished = {
+                            onEvent(SettingsEvent.SetRemoveAfterReadSlots(slotsSlider.roundToInt()))
+                        },
+                        valueRange = 0f..4f,
+                        steps = 3,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            },
+        )
+    }
+
     ListItem(
         headlineContent = { Text(stringResource(R.string.settings_save_as_cbz)) },
         supportingContent = { Text(stringResource(R.string.settings_save_as_cbz_description)) },

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
@@ -134,6 +134,7 @@ data class SettingsState(
 
     // --- Downloads ---
     val deleteAfterReading get() = downloads.deleteAfterReading
+    val removeAfterReadSlots get() = downloads.removeAfterReadSlots
     val saveAsCbz get() = downloads.saveAsCbz
     val autoDownloadEnabled get() = downloads.autoDownloadEnabled
     val downloadOnlyOnWifi get() = downloads.downloadOnlyOnWifi
@@ -270,6 +271,7 @@ sealed interface SettingsEvent : UiEvent {
 
     // Downloads
     data class SetDeleteAfterReading(val enabled: Boolean) : SettingsEvent
+    data class SetRemoveAfterReadSlots(val slots: Int) : SettingsEvent
     data class SetSaveAsCbz(val enabled: Boolean) : SettingsEvent
     data class SetAutoDownloadEnabled(val enabled: Boolean) : SettingsEvent
     data class SetDownloadOnlyOnWifi(val enabled: Boolean) : SettingsEvent

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/DownloadSettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/DownloadSettingsDelegate.kt
@@ -98,6 +98,11 @@ class DownloadSettingsDelegate @Inject constructor(
                 updateState { it.copy(downloads = it.downloads.copy(cbzEncryptionEnabled = enabled)) }
             }
         }
+        scope.launch {
+            downloadPreferences.removeAfterReadSlots.collect { slots ->
+                updateState { it.copy(downloads = it.downloads.copy(removeAfterReadSlots = slots)) }
+            }
+        }
     }
 
     @Suppress("CyclomaticComplexMethod")
@@ -106,6 +111,7 @@ class DownloadSettingsDelegate @Inject constructor(
         sendEffect: suspend (SettingsEffect) -> Unit,
     ): Boolean = when (event) {
         is SettingsEvent.SetDeleteAfterReading -> { downloadPreferences.setDeleteAfterReading(event.enabled); true }
+        is SettingsEvent.SetRemoveAfterReadSlots -> { downloadPreferences.setRemoveAfterReadSlots(event.slots); true }
         is SettingsEvent.SetSaveAsCbz -> { downloadPreferences.setSaveAsCbz(event.enabled); true }
         is SettingsEvent.SetAutoDownloadEnabled -> { downloadPreferences.setAutoDownloadEnabled(event.enabled); true }
         is SettingsEvent.SetDownloadOnlyOnWifi -> { downloadPreferences.setDownloadOnlyOnWifi(event.enabled); true }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -547,6 +547,9 @@
     <string name="settings_smart_download_min_storage">Require %1$d MB free</string>
     <string name="settings_delete_after_reading">Delete After Reading</string>
     <string name="settings_delete_after_reading_description">Remove downloaded chapters once finished</string>
+    <string name="settings_remove_after_read_immediately">Delete the chapter just read</string>
+    <string name="settings_remove_after_read_keep_last">Keep the last %1$d read chapters</string>
+    <string name="settings_remove_after_read_description">Choose how many recently read chapters stay downloaded before older ones are removed</string>
 
     <!-- Cloud Sync removed: cloud sync (Google Drive / Dropbox / WebDAV / self-hosted)
          was extracted to a sibling repository. Local backup/restore strings live in


### PR DESCRIPTION
## 📋 Description

Third PR of the #1192 deferred-gaps pass: Komikku's `removeAfterReadSlots` equivalent. Delete-after-reading previously always deleted the chapter you just finished; now it can keep the last N read chapters downloaded (N = 0–4, default 0 = existing behavior, so nothing changes until a user opts in).

**Semantics** (Komikku-compatible): with N > 0, finishing a chapter deletes the chapter N positions *earlier* in reading order — so the N most recently read chapters stay on disk for back-reference. If nothing is that far back (early in a series), nothing is deleted.

- `DownloadPreferences.removeAfterReadSlots` — int pref, setter coerces to 0..`MAX_REMOVE_AFTER_READ_SLOTS` (4).
- `selectChapterToDeleteAfterRead()` — pure domain function; sorts by ascending `chapterNumber` (the app's established reading order; the domain `Chapter` has no sourceOrder field) and returns the chapter at `justReadIndex - slots`, or null. slots = 0 returns the just-read chapter itself.
- Both delete paths honor it: `ReaderDeleteAfterReadDelegate` (live in-session path) and `RecordReadingHistoryWorker.deleteDownloadIfEligible` (the durable exit-time counterpart). Both now delete the resolved target chapter's id/name instead of the just-read chapter's. Enable/disable stays governed by the existing delete-after-reading toggle + per-manga override — slots only choose *which* chapter goes.
- UI: Settings → Downloads gains a slider directly under the delete-after-reading toggle (only visible while the toggle is on, matching the CBZ-encryption conditional row): "Delete the chapter just read" at 0, "Keep the last N read chapters" for 1–4.

## 🔄 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 🧪 Testing

- `SelectChapterToDeleteAfterReadTest` (new, domain): out-of-order input proves sorting; slots 0/1/2 targets; null when not enough earlier chapters, when the just-read chapter is first or missing, and for an empty list.
- `RecordReadingHistoryWorkerTest`: two new cases — slots-based deletion targets the chapter N back (verifies the *other* chapter's id/name is passed to `deleteChapterDownload`), and no deletion when nothing is far enough back. Existing tests get the slots=0 default stub and are otherwise unchanged.
- `ReaderViewModelTest`: slots=0 default stub added; existing delete-after-read cases still cover the immediate path.
- `detekt` + `ktlintCheck` pass locally. Compile, unit tests, coverage gate, and screenshot tests run in CI (no local Android SDK in this environment).

## 📸 Screenshots

UI changes cannot be visually verified in this sandbox (no emulator). The slider row clones the existing download-ahead slider pattern in the same file.

## ✅ Checklist

- [x] My code follows the project's style guidelines (MVI, Compose-only, no hardcoded strings)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (static checks locally; unit tests in CI)

## 🔗 Related Issues

Part of #1192 (deferred gaps — Reader: `removeAfterReadSlots`).

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

## Summary by Sourcery

Add configurable delete-after-reading behavior that can keep the last N read chapters downloaded and delete older ones instead of always deleting the just-read chapter.

New Features:
- Introduce a remove-after-read slots preference that controls how many recently read chapters are kept downloaded when delete-after-reading is enabled.
- Add a settings slider UI under the delete-after-reading option to let users choose how many last-read chapters to keep (0–4).

Enhancements:
- Centralize chapter selection logic for delete-after-reading into a domain function that chooses the chapter N positions earlier in reading order.
- Update reader and history workers to honor the slots preference and delete the selected earlier chapter rather than the one just read.

Tests:
- Add unit tests for the chapter selection logic covering ordering, slot offsets, and edge cases when no chapter should be deleted.
- Extend reader and history worker tests to cover slots-based deletion behavior and the case where nothing is deleted when no chapter is far enough back.