### PR TITLE
Onboarding: storage-location step, drop Name page; simplify splash to three-chibi art

### DIFF
--- a/app/src/main/java/app/otakureader/MainActivity.kt
+++ b/app/src/main/java/app/otakureader/MainActivity.kt
@@ -90,9 +90,11 @@ class MainActivity : FragmentActivity() {
         const val THEME_MODE_LIGHT = 1
         const val THEME_MODE_DARK = 2
 
-        // Minimum time (ms) the cold-start splash is held on screen. Startup got fast enough
-        // after the crash fixes that the system splash could flash for <100ms and the mascot
-        // logo was never visible. This is a short, always-released hold — see onCreate.
+        // Minimum time (ms) the cold-start system splash is held on screen before the
+        // three-chibi SplashArtOverlay takes over. Startup got fast enough after the crash
+        // fixes that the system splash could flash for <100ms, cutting straight to the app UI
+        // before the overlay had a moment to mount. This is a short, always-released hold —
+        // see onCreate.
         private const val SPLASH_MIN_DISPLAY_MS = 650L
     }
 

--- a/app/src/main/res/drawable/splash_icon_none.xml
+++ b/app/src/main/res/drawable/splash_icon_none.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Intentionally empty. The system cold-start splash (SplashScreen API) requires an
+    animated-icon drawable, but the app's actual splash art is the three-chibi overlay
+    (splash_art_1, shown by SplashArtOverlay in MainActivity) rather than a single-character
+    icon. Pointing windowSplashScreenAnimatedIcon here leaves just the navy background
+    visible during the brief system-splash stage, so the three-chibi art reads as the splash.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -7,17 +7,13 @@
 
     <!-- SplashScreen theme for cold start -->
     <style name="Theme.OtakuReaderSplash" parent="Theme.SplashScreen">
-        <!-- Window background: dark navy matching the mascot icon set's backdrop -->
+        <!-- Window background: dark navy matching the three-chibi splash art's backdrop -->
         <item name="windowSplashScreenBackground">#2B2F3A</item>
 
-        <!-- Animated icon: the launcher foreground (mascot hugging a manga stack) -->
-        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
-
-        <!-- Circle behind the icon: same navy so the mascot floats on the splash -->
-        <item name="windowSplashScreenIconBackgroundColor">#2B2F3A</item>
-
-        <!-- Animation duration (max 1000ms per Android guidelines) -->
-        <item name="windowSplashScreenAnimationDuration">300</item>
+        <!-- No icon here by design — the app's splash art is the three-chibi overlay
+             (SplashArtOverlay in MainActivity), not a single-character icon. The system
+             splash stage briefly shows just the navy background instead. -->
+        <item name="windowSplashScreenAnimatedIcon">@drawable/splash_icon_none</item>
 
         <!-- Keep splash on screen until content is ready -->
         <item name="postSplashScreenTheme">@style/Theme.OtakuReaderBase</item>

--- a/feature/onboarding/build.gradle.kts
+++ b/feature/onboarding/build.gradle.kts
@@ -11,4 +11,9 @@ dependencies {
     implementation(projects.core.common)
     implementation(projects.core.preferences)
     implementation(libs.kotlinx.serialization.json)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.turbine)
 }

--- a/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.MenuBook
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Palette
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.PowerSettingsNew
 import androidx.compose.material3.Button
@@ -46,7 +45,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -71,7 +69,6 @@ import kotlinx.coroutines.launch
 /** Type of each onboarding page — drives which permission UI (if any) is shown. */
 enum class OnboardingPageType {
     WELCOME,
-    NAME,           // Display name entry
     STORAGE,        // Optional download-location picker (non-blocking, unlike Komikku)
     NOTIFICATIONS,  // Android 13+ only
     BATTERY,        // Battery optimisation exclusion
@@ -90,10 +87,11 @@ data class OnboardingPage(
  * Onboarding screen that mirrors the setup-focused flow used by Mihon and Komikku:
  *
  *  1. Welcome
- *  2. [Android 13+] Notifications permission
- *  3. Battery-optimisation exclusion
- *  4. Appearance (theme — applies live)
- *  5. Install extensions (with quick-start hints)
+ *  2. Storage location (optional — never blocks completion)
+ *  3. [Android 13+] Notifications permission
+ *  4. Battery-optimisation exclusion
+ *  5. Appearance (theme — applies live)
+ *  6. Install extensions (with quick-start hints)
  *
  * Each permission page shows a live status icon and an action button that is
  * disabled once the permission has been granted.
@@ -109,7 +107,6 @@ fun OnboardingScreen(
 ) {
     val context = LocalContext.current
     val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
-    val displayName by viewModel.displayName.collectAsStateWithLifecycle()
     val downloadLocation by viewModel.downloadLocation.collectAsStateWithLifecycle()
 
     // Build page list dynamically; notifications page is Android 13+ only
@@ -121,14 +118,6 @@ fun OnboardingScreen(
                     titleRes = R.string.onboarding_title_welcome,
                     descriptionRes = R.string.onboarding_desc_welcome,
                     icon = Icons.Default.MenuBook,
-                ),
-            )
-            add(
-                OnboardingPage(
-                    type = OnboardingPageType.NAME,
-                    titleRes = R.string.onboarding_title_name,
-                    descriptionRes = R.string.onboarding_desc_name,
-                    icon = Icons.Default.Person,
                 ),
             )
             add(
@@ -252,10 +241,8 @@ fun OnboardingScreen(
                 notificationsGranted = notificationsGranted,
                 batteryOptimizationIgnored = batteryOptimizationIgnored,
                 themeMode = themeMode,
-                displayName = displayName,
                 downloadLocation = downloadLocation,
                 onThemeModeSelected = viewModel::setThemeMode,
-                onDisplayNameChange = viewModel::setDisplayName,
                 onRequestNotifications = {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                         notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
@@ -284,10 +271,8 @@ private fun OnboardingPageContent(
     notificationsGranted: Boolean,
     batteryOptimizationIgnored: Boolean,
     themeMode: Int,
-    displayName: String,
     downloadLocation: String?,
     onThemeModeSelected: (Int) -> Unit,
-    onDisplayNameChange: (String) -> Unit,
     onRequestNotifications: () -> Unit,
     onRequestBatteryOptimization: () -> Unit,
     onRequestStorageLocation: () -> Unit,
@@ -352,18 +337,6 @@ private fun OnboardingPageContent(
         )
 
         // ── Per-page action buttons ───────────────────────────────────────────
-
-        if (page.type == OnboardingPageType.NAME) {
-            Spacer(modifier = Modifier.height(32.dp))
-            OutlinedTextField(
-                value = displayName,
-                onValueChange = onDisplayNameChange,
-                label = { Text(stringResource(R.string.onboarding_name_label)) },
-                placeholder = { Text(stringResource(R.string.onboarding_name_placeholder)) },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
 
         if (page.type == OnboardingPageType.STORAGE) {
             Spacer(modifier = Modifier.height(32.dp))

--- a/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.BatteryFull
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Extension
+import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.MenuBook
 import androidx.compose.material.icons.filled.Notifications
@@ -71,6 +72,7 @@ import kotlinx.coroutines.launch
 enum class OnboardingPageType {
     WELCOME,
     NAME,           // Display name entry
+    STORAGE,        // Optional download-location picker (non-blocking, unlike Komikku)
     NOTIFICATIONS,  // Android 13+ only
     BATTERY,        // Battery optimisation exclusion
     APPEARANCE,     // Theme selection (applies live)
@@ -108,6 +110,7 @@ fun OnboardingScreen(
     val context = LocalContext.current
     val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
     val displayName by viewModel.displayName.collectAsStateWithLifecycle()
+    val downloadLocation by viewModel.downloadLocation.collectAsStateWithLifecycle()
 
     // Build page list dynamically; notifications page is Android 13+ only
     val pages = remember {
@@ -126,6 +129,14 @@ fun OnboardingScreen(
                     titleRes = R.string.onboarding_title_name,
                     descriptionRes = R.string.onboarding_desc_name,
                     icon = Icons.Default.Person,
+                ),
+            )
+            add(
+                OnboardingPage(
+                    type = OnboardingPageType.STORAGE,
+                    titleRes = R.string.onboarding_title_storage,
+                    descriptionRes = R.string.onboarding_desc_storage,
+                    icon = Icons.Default.Folder,
                 ),
             )
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -193,6 +204,22 @@ fun OnboardingScreen(
         ActivityResultContracts.StartActivityForResult(),
     ) { batteryOptimizationIgnored = isBatteryOptimizationIgnored() }
 
+    // ── Storage location (optional — see OnboardingPageType.STORAGE) ─────────
+    val storageLocationLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocumentTree(),
+    ) { uri: Uri? ->
+        if (uri != null) {
+            // Without this the grant is lost on reboot.
+            runCatching {
+                context.contentResolver.takePersistableUriPermission(
+                    uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+                )
+            }
+            viewModel.setDownloadLocation(uri.toString())
+        }
+    }
+
     Scaffold(
         modifier = modifier.fillMaxSize(),
         bottomBar = {
@@ -226,6 +253,7 @@ fun OnboardingScreen(
                 batteryOptimizationIgnored = batteryOptimizationIgnored,
                 themeMode = themeMode,
                 displayName = displayName,
+                downloadLocation = downloadLocation,
                 onThemeModeSelected = viewModel::setThemeMode,
                 onDisplayNameChange = viewModel::setDisplayName,
                 onRequestNotifications = {
@@ -239,6 +267,7 @@ fun OnboardingScreen(
                     }
                     batteryOptimizationLauncher.launch(intent)
                 },
+                onRequestStorageLocation = { storageLocationLauncher.launch(null) },
                 modifier = Modifier.fillMaxSize(),
             )
         }
@@ -256,15 +285,18 @@ private fun OnboardingPageContent(
     batteryOptimizationIgnored: Boolean,
     themeMode: Int,
     displayName: String,
+    downloadLocation: String?,
     onThemeModeSelected: (Int) -> Unit,
     onDisplayNameChange: (String) -> Unit,
     onRequestNotifications: () -> Unit,
     onRequestBatteryOptimization: () -> Unit,
+    onRequestStorageLocation: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val isPermissionGranted = when (page.type) {
         OnboardingPageType.NOTIFICATIONS -> notificationsGranted
         OnboardingPageType.BATTERY -> batteryOptimizationIgnored
+        OnboardingPageType.STORAGE -> downloadLocation != null
         else -> false
     }
 
@@ -331,6 +363,30 @@ private fun OnboardingPageContent(
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )
+        }
+
+        if (page.type == OnboardingPageType.STORAGE) {
+            Spacer(modifier = Modifier.height(32.dp))
+            Button(
+                onClick = onRequestStorageLocation,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(
+                    imageVector = if (downloadLocation != null) Icons.Default.Check else Icons.Default.Folder,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    stringResource(
+                        if (downloadLocation != null) {
+                            R.string.onboarding_storage_selected
+                        } else {
+                            R.string.onboarding_btn_select_folder
+                        },
+                    ),
+                )
+            }
         }
 
         if (page.type == OnboardingPageType.NOTIFICATIONS) {

--- a/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingViewModel.kt
@@ -31,14 +31,6 @@ class OnboardingViewModel @Inject constructor(
         viewModelScope.launch { generalPreferences.setThemeMode(mode) }
     }
 
-    /** Display name entered by the user on the Name onboarding page. */
-    val displayName: StateFlow<String> = generalPreferences.displayName
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
-
-    fun setDisplayName(name: String) {
-        viewModelScope.launch { generalPreferences.setDisplayName(name) }
-    }
-
     /**
      * Persisted download-location URI (as a string), or null when the user hasn't picked one —
      * in which case downloads use the app's default internal storage. Surfaced on the Storage

--- a/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingViewModel.kt
@@ -2,6 +2,7 @@ package app.otakureader.feature.onboarding
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import app.otakureader.core.preferences.DownloadPreferences
 import app.otakureader.core.preferences.GeneralPreferences
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
@@ -11,7 +12,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
- * ViewModel for the onboarding wizard's Appearance step.
+ * ViewModel for the onboarding wizard's Appearance and Storage steps.
  *
  * Exposes the persisted theme mode reactively so the selection survives process death
  * and the app re-themes live as the user taps an option.
@@ -19,6 +20,7 @@ import javax.inject.Inject
 @HiltViewModel
 class OnboardingViewModel @Inject constructor(
     private val generalPreferences: GeneralPreferences,
+    private val downloadPreferences: DownloadPreferences,
 ) : ViewModel() {
 
     /** Theme mode: 0 = system default, 1 = light, 2 = dark. */
@@ -35,5 +37,18 @@ class OnboardingViewModel @Inject constructor(
 
     fun setDisplayName(name: String) {
         viewModelScope.launch { generalPreferences.setDisplayName(name) }
+    }
+
+    /**
+     * Persisted download-location URI (as a string), or null when the user hasn't picked one —
+     * in which case downloads use the app's default internal storage. Surfaced on the Storage
+     * onboarding page purely so users know the choice exists; picking a folder here is optional
+     * (onboarding never blocks on it, unlike Komikku).
+     */
+    val downloadLocation: StateFlow<String?> = downloadPreferences.downloadLocation
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    fun setDownloadLocation(location: String) {
+        viewModelScope.launch { downloadPreferences.setDownloadLocation(location) }
     }
 }

--- a/feature/onboarding/src/main/res/values/strings.xml
+++ b/feature/onboarding/src/main/res/values/strings.xml
@@ -49,9 +49,4 @@
     <!-- Accessibility -->
     <string name="onboarding_page_icon">Onboarding illustration</string>
 
-    <!-- Name page -->
-    <string name="onboarding_title_name">What should we call you?</string>
-    <string name="onboarding_desc_name">We\'ll use your name for the greeting in your Library. You can change it later in Settings.</string>
-    <string name="onboarding_name_label">Your name</string>
-    <string name="onboarding_name_placeholder">e.g. Manny</string>
 </resources>

--- a/feature/onboarding/src/main/res/values/strings.xml
+++ b/feature/onboarding/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="onboarding_title_notifications">Notifications</string>
     <string name="onboarding_title_battery">Background Updates</string>
     <string name="onboarding_title_appearance">Make It Yours</string>
+    <string name="onboarding_title_storage">Choose Download Location</string>
 
     <!-- Page descriptions -->
     <string name="onboarding_desc_welcome">Your personal manga library. Track your reading, discover new series, and enjoy your favorite manga offline.</string>
@@ -19,6 +20,7 @@
     <string name="onboarding_desc_notifications">Get notified when new chapters of your favorite manga become available.</string>
     <string name="onboarding_desc_battery">Disable battery optimization so Otaku Reader can fetch updates reliably in the background.</string>
     <string name="onboarding_desc_appearance">Pick a theme — it applies instantly. You can change this anytime in Settings.</string>
+    <string name="onboarding_desc_storage">Optionally pick a folder for downloaded chapters. Otaku Reader works fine without this — you can set or change it anytime in Settings → Downloads.</string>
 
     <!-- Appearance page theme options -->
     <string name="onboarding_theme_system">System default</string>
@@ -37,10 +39,12 @@
     <string name="onboarding_btn_install_extensions">Install Extensions</string>
     <string name="onboarding_btn_grant_permission">Grant Permission</string>
     <string name="onboarding_btn_disable_battery">Disable Battery Optimization</string>
+    <string name="onboarding_btn_select_folder">Select Folder</string>
 
     <!-- Status labels (shown when permission is already granted) -->
     <string name="onboarding_notifications_granted">Permission Granted</string>
     <string name="onboarding_battery_unrestricted">Unrestricted</string>
+    <string name="onboarding_storage_selected">Folder Selected</string>
 
     <!-- Accessibility -->
     <string name="onboarding_page_icon">Onboarding illustration</string>

--- a/feature/onboarding/src/test/java/app/otakureader/feature/onboarding/OnboardingViewModelTest.kt
+++ b/feature/onboarding/src/test/java/app/otakureader/feature/onboarding/OnboardingViewModelTest.kt
@@ -1,0 +1,80 @@
+package app.otakureader.feature.onboarding
+
+import app.cash.turbine.test
+import app.otakureader.core.preferences.DownloadPreferences
+import app.otakureader.core.preferences.GeneralPreferences
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OnboardingViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var generalPreferences: GeneralPreferences
+    private lateinit var downloadPreferences: DownloadPreferences
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        generalPreferences = mockk()
+        downloadPreferences = mockk()
+
+        every { generalPreferences.themeMode } returns flowOf(0)
+        every { generalPreferences.displayName } returns flowOf("")
+        coEvery { generalPreferences.setThemeMode(any()) } returns Unit
+        coEvery { generalPreferences.setDisplayName(any()) } returns Unit
+        every { downloadPreferences.downloadLocation } returns flowOf(null)
+        coEvery { downloadPreferences.setDownloadLocation(any()) } returns Unit
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = OnboardingViewModel(generalPreferences, downloadPreferences)
+
+    @Test
+    fun `downloadLocation defaults to null when nothing is picked yet`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.downloadLocation.test {
+            assertNull(awaitItem())
+        }
+    }
+
+    @Test
+    fun `downloadLocation reflects the persisted value`() = runTest {
+        every { downloadPreferences.downloadLocation } returns flowOf("content://tree/downloads")
+        val viewModel = createViewModel()
+
+        viewModel.downloadLocation.test {
+            assertEquals("content://tree/downloads", awaitItem())
+        }
+    }
+
+    @Test
+    fun `setDownloadLocation writes through to preferences`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.setDownloadLocation("content://tree/newpath")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { downloadPreferences.setDownloadLocation("content://tree/newpath") }
+    }
+}

--- a/feature/onboarding/src/test/java/app/otakureader/feature/onboarding/OnboardingViewModelTest.kt
+++ b/feature/onboarding/src/test/java/app/otakureader/feature/onboarding/OnboardingViewModelTest.kt
@@ -35,9 +35,7 @@ class OnboardingViewModelTest {
         downloadPreferences = mockk()
 
         every { generalPreferences.themeMode } returns flowOf(0)
-        every { generalPreferences.displayName } returns flowOf("")
         coEvery { generalPreferences.setThemeMode(any()) } returns Unit
-        coEvery { generalPreferences.setDisplayName(any()) } returns Unit
         every { downloadPreferences.downloadLocation } returns flowOf(null)
         coEvery { downloadPreferences.setDownloadLocation(any()) } returns Unit
     }

--- a/feature/onboarding/src/test/java/app/otakureader/feature/onboarding/OnboardingViewModelTest.kt
+++ b/feature/onboarding/src/test/java/app/otakureader/feature/onboarding/OnboardingViewModelTest.kt
@@ -35,9 +35,11 @@ class OnboardingViewModelTest {
         downloadPreferences = mockk()
 
         every { generalPreferences.themeMode } returns flowOf(0)
-        coEvery { generalPreferences.setThemeMode(any()) } returns Unit
+        // setThemeMode/setDownloadLocation both return DataStore.edit {}'s Preferences result,
+        // not Unit — stub with a mock instance rather than the wrong return type.
+        coEvery { generalPreferences.setThemeMode(any()) } returns mockk()
         every { downloadPreferences.downloadLocation } returns flowOf(null)
-        coEvery { downloadPreferences.setDownloadLocation(any()) } returns Unit
+        coEvery { downloadPreferences.setDownloadLocation(any()) } returns mockk()
     }
 
     @After

--- a/feature/onboarding/src/test/java/app/otakureader/feature/onboarding/OnboardingViewModelTest.kt
+++ b/feature/onboarding/src/test/java/app/otakureader/feature/onboarding/OnboardingViewModelTest.kt
@@ -64,6 +64,11 @@ class OnboardingViewModelTest {
         val viewModel = createViewModel()
 
         viewModel.downloadLocation.test {
+            // stateIn(WhileSubscribed) only starts collecting the upstream once this test
+            // subscribes, so the first emission is the seeded initial value (null); the real
+            // value follows once the upstream collector coroutine gets to run.
+            assertNull(awaitItem())
+            testDispatcher.scheduler.advanceUntilIdle()
             assertEquals("content://tree/downloads", awaitItem())
         }
     }

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsDownloadsScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsDownloadsScreen.kt
@@ -1,5 +1,6 @@
 package app.otakureader.feature.settings
 
+import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -70,10 +71,21 @@ fun SettingsDownloadsScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     var showCbzPasswordDialog by remember { mutableStateOf(false) }
 
+    val downloadLocationContext = androidx.compose.ui.platform.LocalContext.current
     val downloadLocationLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocumentTree(),
     ) { uri: Uri? ->
-        uri?.let { viewModel.onEvent(SettingsEvent.SetDownloadLocation(it.toString())) }
+        if (uri != null) {
+            // Without this the grant is lost on reboot, silently reverting the download
+            // location the next time WorkManager/downloads run after a restart.
+            runCatching {
+                downloadLocationContext.contentResolver.takePersistableUriPermission(
+                    uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+                )
+            }
+            viewModel.onEvent(SettingsEvent.SetDownloadLocation(uri.toString()))
+        }
     }
 
     LaunchedEffect(Unit) {


### PR DESCRIPTION
## 📋 Description

**Part of #1192 (deferred gaps):** adds a Storage page to the onboarding pager (after Welcome, before Notifications) letting users optionally pick a download folder up front, instead of only discovering the picker later in Settings → Downloads.

- `OnboardingPageType.STORAGE`: `OpenDocumentTree` launcher + `takePersistableUriPermission` (read+write) so the grant survives a reboot — mirrors the one place in the codebase that already does this correctly (`LocalSourceBrowserScreen`'s folder picker). Shows the same "granted" check-icon treatment as the Notifications/Battery pages.
- `OnboardingViewModel` now also injects `DownloadPreferences`, exposing `downloadLocation: StateFlow<String?>` and `setDownloadLocation()` — same pattern as the existing `themeMode` property.
- **Non-blocking by design**, unlike Komikku's Storage step which gates onboarding completion: Otaku's onboarding is skippable end-to-end already, and downloads work fine from internal storage without ever picking a location, so this is purely additive.
- **Deliberately skips** Komikku's "install unknown apps" permission checklist item (also tracked in #1192): Otaku's `ExtensionInstaller` is a private installer — it copies APKs into the app's own `exts/` directory and classloads them directly, and never launches the system package installer — so `canRequestPackageInstalls` is never needed here.

**Bonus fix**: `SettingsDownloadsScreen`'s existing `OpenDocumentTree` launcher never called `takePersistableUriPermission` either, so a location picked from Settings also silently lost its grant on the next reboot. Same fix applied there.

**Two additional ad-hoc requests folded in** (unrelated to #1192):
- **Removed the onboarding Name page.** Display-name entry is no longer part of onboarding. The underlying `GeneralPreferences.displayName` and the Library greeting stay intact — the greeting already degrades gracefully with no name set (e.g. "Good morning 👋" with no dangling comma) — only the onboarding step and its now-dead `OnboardingViewModel.displayName`/`setDisplayName` are removed.
- **Simplified the cold-start splash to just the three-chibi art.** The system splash previously showed a single-character mascot icon (`ic_launcher_foreground`) via `windowSplashScreenAnimatedIcon` before the app's own `SplashArtOverlay` (the three-chibi-poses image) faded in on top. Now `windowSplashScreenAnimatedIcon` points at a fully transparent drawable, so the brief system-splash stage is just the navy background, and the three-chibi overlay is the only splash art the user actually sees. The mascot drawable is untouched as the actual home-screen app icon (`mipmap/ic_launcher` still references it) — only its use as a *splash* icon is removed.

## 🔄 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (Settings → Downloads location grant not surviving reboot)
- [x] 🎨 UI/UX change (onboarding page removed, splash art simplified)

## 🧪 Testing

- `OnboardingViewModelTest` (new — the module had no tests before): `downloadLocation` defaults to null, reflects the persisted value, and `setDownloadLocation` writes through to `DownloadPreferences`. Added the module's test dependencies (junit, mockk, coroutines-test, turbine) to `build.gradle.kts` since none existed.
- `detekt` + `ktlintCheck` pass locally. Compile, unit tests, coverage gate, and screenshot tests run in CI (no local Android SDK in this environment).

## 📸 Screenshots

UI changes cannot be visually verified in this sandbox (no emulator). The Storage page reuses the exact icon/title/description/action-button layout of the existing Notifications and Battery pages; the splash change is a theme-attribute swap with no new layout.

## ✅ Checklist

- [x] My code follows the project's style guidelines (MVI, Compose-only, no hardcoded strings)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (static checks locally; unit tests in CI)

## 🔗 Related Issues

Part of #1192 (deferred gaps — onboarding storage-location step; install-unknown-apps step explicitly skipped as obsolete). Name-page removal and splash-art simplification are separate ad-hoc requests folded into this PR since they touch the same onboarding module already in review here.