### PR TITLE
Add dedicated Update Errors screen (#1192)

### DIFF
--- a/app/src/main/java/app/otakureader/OtakuReaderBottomBar.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderBottomBar.kt
@@ -84,7 +84,7 @@ fun OtakuReaderBottomBar(
             )
             val route: Route = when (tab) {
                 NavTab.LIBRARY -> Route.Library
-                NavTab.UPDATES -> Route.Updates()
+                NavTab.UPDATES -> Route.Updates
                 NavTab.BROWSE -> Route.Browse
                 NavTab.HISTORY -> Route.History
                 NavTab.MORE -> Route.More

--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -82,7 +82,7 @@ fun OtakuReaderNavHost(
                 onDeepLinkConsumed()
             }
             is DeepLinkResult.NavigateToUpdates -> {
-                navController.navigate(Route.Updates()) {
+                navController.navigate(Route.Updates) {
                     launchSingleTop = true
                 }
                 onDeepLinkConsumed()
@@ -205,6 +205,16 @@ fun OtakuReaderNavHost(
             onNavigateToDownloads = {
                 navController.navigate(Route.Downloads)
             },
+            onNavigateToUpdateErrors = {
+                navController.navigate(Route.UpdateErrors)
+            },
+        )
+
+        // Dedicated Update Errors screen (replaces the old in-dialog error list)
+        updateErrorsScreen(
+            onNavigateBack = { navController.popBackStack() },
+            onNavigateToManga = { mangaId -> navController.navigate(Route.MangaDetails(mangaId)) },
+            onNavigateToMigration = { mangaIds -> navController.navigate(Route.Migration(mangaIds)) },
         )
 
         // Browse - sources catalog
@@ -549,7 +559,7 @@ fun OtakuReaderNavHost(
                 navController.navigate(Route.ScanLibrary)
             },
             onNavigateToUpdateErrors = {
-                navController.navigate(Route.Updates(openErrors = true))
+                navController.navigate(Route.UpdateErrors)
             },
             onNavigateToBackup = {
                 navController.navigate(Route.SettingsBackup)

--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -48,6 +48,7 @@ import app.otakureader.feature.tracking.navigation.trackingScreen
 import app.otakureader.core.webview.webViewScreen
 import app.otakureader.feature.webview.navigation.webViewFallbackScreen
 import app.otakureader.feature.updates.navigation.downloadsScreen
+import app.otakureader.feature.updates.navigation.updateErrorsScreen
 import app.otakureader.feature.updates.navigation.updatesScreen
 import app.otakureader.util.DeepLinkResult
 

--- a/core/navigation/src/main/java/app/otakureader/core/navigation/OtakuReaderNavigator.kt
+++ b/core/navigation/src/main/java/app/otakureader/core/navigation/OtakuReaderNavigator.kt
@@ -37,7 +37,7 @@ class OtakuReaderNavigator(
         Route.Library,
         Route.Browse,
         Route.History,
-        Route.Updates(),
+        Route.Updates,
         Route.More,
     )
 

--- a/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
+++ b/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
@@ -35,16 +35,15 @@ sealed interface Route {
     @Serializable
     data object History : Route
 
-    /**
-     * @param openErrors When true, the Updates screen auto-opens the update-errors dialog on
-     * launch (used by the More tab's "Update Errors" entry). Defaults to false for normal
-     * bottom-nav tab navigation.
-     */
     @Serializable
-    data class Updates(val openErrors: Boolean = false) : Route
+    data object Updates : Route
 
     @Serializable
     data object More : Route
+
+    /** Dedicated Update Errors screen — replaces the old in-dialog error list (see #1192). */
+    @Serializable
+    data object UpdateErrors : Route
 
     @Serializable
     data object Bookmarks : Route

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesMvi.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesMvi.kt
@@ -43,17 +43,6 @@ data class MangaUpdateGroup(
 enum class UpdatesDisplayMode { GROUPED_BY_MANGA, GROUPED_BY_DATE }
 
 /**
- * Represents a failed update entry for the error screen.
- */
-data class UpdateErrorEntry(
-    val mangaId: Long,
-    val mangaTitle: String,
-    val thumbnailUrl: String?,
-    val errorMessage: String,
-    val timestamp: Long
-)
-
-/**
  * Represents a manga that will be checked during the next library update.
  */
 data class PendingUpdateManga(
@@ -73,10 +62,8 @@ data class UpdatesState(
     val selectedItems: Set<Long> = emptySet(),
     /** Manga IDs whose chapter groups are expanded in GROUPED_BY_MANGA mode. */
     val expandedMangaGroups: Set<Long> = emptySet(),
-    /** List of failed updates for the Update Error Screen. */
-    val updateErrors: List<UpdateErrorEntry> = emptyList(),
-    /** Whether the update error screen is visible. */
-    val showUpdateErrors: Boolean = false,
+    /** Count of unresolved library-update failures, for the top-bar badge (see Route.UpdateErrors). */
+    val updateErrorCount: Int = 0,
     /** List of manga that will be checked in the next update. */
     val pendingUpdates: List<PendingUpdateManga> = emptyList(),
     /** Whether the To-Be-Updated screen is visible. */
@@ -111,12 +98,6 @@ sealed interface UpdatesEvent : UiEvent {
     data object MarkSelectedAsRead : UpdatesEvent
     data object MarkSelectedAsUnread : UpdatesEvent
     data class MarkChapterAsRead(val chapterId: Long) : UpdatesEvent
-
-    // Update Error Screen events
-    data object ShowUpdateErrors : UpdatesEvent
-    data object HideUpdateErrors : UpdatesEvent
-    data class ClearUpdateError(val mangaId: Long) : UpdatesEvent
-    data object ClearAllUpdateErrors : UpdatesEvent
 
     // To-Be-Updated Screen events
     data object ShowPendingUpdates : UpdatesEvent

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
@@ -115,8 +115,8 @@ fun UpdatesScreen(
     onMangaClick: (Long) -> Unit,
     onNavigateBack: () -> Unit,
     onNavigateToDownloads: () -> Unit,
+    onNavigateToUpdateErrors: () -> Unit = {},
     modifier: Modifier = Modifier,
-    openErrorsOnLaunch: Boolean = false,
     viewModel: UpdatesViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -127,19 +127,6 @@ fun UpdatesScreen(
 
     BackHandler(enabled = state.selectedItems.isNotEmpty()) {
         viewModel.onEvent(UpdatesEvent.ClearSelection)
-    }
-
-    // Auto-open the update-errors dialog when navigated here from the More tab's
-    // "Update Errors" entry — otherwise there's no way to reach the error view from there.
-    // rememberSaveable guards against re-firing: the openErrors route arg is restored with the
-    // back stack entry, so without this the dialog would reopen every time the user navigated
-    // away from Updates and back.
-    var hasAutoOpenedErrors by rememberSaveable { mutableStateOf(false) }
-    LaunchedEffect(openErrorsOnLaunch) {
-        if (openErrorsOnLaunch && !hasAutoOpenedErrors) {
-            hasAutoOpenedErrors = true
-            viewModel.onEvent(UpdatesEvent.ShowUpdateErrors)
-        }
     }
 
     LaunchedEffect(viewModel.effect) {
@@ -234,12 +221,12 @@ fun UpdatesScreen(
                                 contentDescription = stringResource(R.string.updates_refresh_now)
                             )
                         }
-                        // Update errors badge (Otaku-exclusive)
-                        if (state.updateErrors.isNotEmpty()) {
-                            IconButton(onClick = { viewModel.onEvent(UpdatesEvent.ShowUpdateErrors) }) {
+                        // Update errors badge (Otaku-exclusive) — opens the dedicated Update Errors screen
+                        if (state.updateErrorCount > 0) {
+                            IconButton(onClick = onNavigateToUpdateErrors) {
                                 BadgedBox(
                                     badge = {
-                                        Badge { Text("${state.updateErrors.size}") }
+                                        Badge { Text("${state.updateErrorCount}") }
                                     }
                                 ) {
                                     Icon(
@@ -436,16 +423,6 @@ fun UpdatesScreen(
                 onSetFilter = { start, end -> viewModel.onEvent(UpdatesEvent.SetDateFilter(start, end)) },
                 onClearFilter = { viewModel.onEvent(UpdatesEvent.ClearDateFilter) },
                 onDismiss = { viewModel.onEvent(UpdatesEvent.HideFilterDialog) },
-            )
-        }
-
-        // Update Error Dialog
-        if (state.showUpdateErrors) {
-            UpdateErrorDialog(
-                errors = state.updateErrors,
-                onDismiss = { viewModel.onEvent(UpdatesEvent.HideUpdateErrors) },
-                onClearError = { viewModel.onEvent(UpdatesEvent.ClearUpdateError(it)) },
-                onClearAll = { viewModel.onEvent(UpdatesEvent.ClearAllUpdateErrors) }
             )
         }
 
@@ -1112,92 +1089,6 @@ private fun formatFetchDate(epochMs: Long): String = runCatching {
         .atZone(ZoneId.systemDefault())
         .format(dateFormatter)
 }.getOrDefault("Unknown date")
-
-@Composable
-private fun UpdateErrorDialog(
-    errors: List<UpdateErrorEntry>,
-    onDismiss: () -> Unit,
-    onClearError: (Long) -> Unit,
-    onClearAll: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.updates_error_title)) },
-        text = {
-            if (errors.isEmpty()) {
-                Text(stringResource(R.string.updates_error_empty))
-            } else {
-                LazyColumn(modifier = modifier.fillMaxWidth()) {
-                    items(errors, key = { it.mangaId }) { error ->
-                        UpdateErrorItem(
-                            error = error,
-                            onClear = { onClearError(error.mangaId) }
-                        )
-                        HorizontalDivider()
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.updates_error_close))
-            }
-        },
-        dismissButton = {
-            if (errors.isNotEmpty()) {
-                TextButton(onClick = onClearAll) {
-                    Text(stringResource(R.string.updates_error_clear_all))
-                }
-            }
-        }
-    )
-}
-
-@Composable
-private fun UpdateErrorItem(
-    error: UpdateErrorEntry,
-    onClear: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = error.mangaTitle,
-                style = MaterialTheme.typography.bodyMedium,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            Text(
-                text = error.errorMessage,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.error,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
-            if (error.timestamp > 0L) {
-                Text(
-                    text = formatFetchDate(error.timestamp),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-        IconButton(onClick = onClear) {
-            Icon(
-                imageVector = Icons.Default.ErrorOutline,
-                contentDescription = stringResource(R.string.updates_error_clear),
-                tint = MaterialTheme.colorScheme.error
-            )
-        }
-    }
-}
 
 @Composable
 private fun PendingUpdatesDialog(

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
@@ -90,12 +90,8 @@ class UpdatesViewModel @Inject constructor(
                 }
                 state.copy(displayMode = next)
             }
-            UpdatesEvent.ShowUpdateErrors,
-            UpdatesEvent.HideUpdateErrors,
-            UpdatesEvent.ClearAllUpdateErrors,
             UpdatesEvent.ShowPendingUpdates,
             UpdatesEvent.HidePendingUpdates -> handleOverlayEvent(event)
-            is UpdatesEvent.ClearUpdateError -> handleOverlayEvent(event)
             is UpdatesEvent.ToggleMangaGroupExpansion -> _state.update { state ->
                 val expanded = state.expandedMangaGroups
                 state.copy(
@@ -116,14 +112,6 @@ class UpdatesViewModel @Inject constructor(
 
     private fun handleOverlayEvent(event: UpdatesEvent) {
         when (event) {
-            UpdatesEvent.ShowUpdateErrors -> _state.update { it.copy(showUpdateErrors = true) }
-            UpdatesEvent.HideUpdateErrors -> _state.update { it.copy(showUpdateErrors = false) }
-            is UpdatesEvent.ClearUpdateError -> viewModelScope.launch {
-                updateErrorRepository.clearError(event.mangaId)
-            }
-            UpdatesEvent.ClearAllUpdateErrors -> viewModelScope.launch {
-                updateErrorRepository.clearAllErrors()
-            }
             UpdatesEvent.ShowPendingUpdates -> {
                 _state.update { it.copy(showPendingUpdates = true) }
                 loadPendingUpdates()
@@ -381,24 +369,10 @@ class UpdatesViewModel @Inject constructor(
             .launchIn(viewModelScope)
     }
 
-    /** Observe unresolved library-update failures for the top-bar badge and error dialog. */
+    /** Observe unresolved library-update failures for the top-bar badge (see Route.UpdateErrors). */
     private fun observeUpdateErrors() {
         updateErrorRepository.observeErrors()
-            .onEach { errors ->
-                _state.update {
-                    it.copy(
-                        updateErrors = errors.map { error ->
-                            UpdateErrorEntry(
-                                mangaId = error.mangaId,
-                                mangaTitle = error.mangaTitle,
-                                thumbnailUrl = error.thumbnailUrl,
-                                errorMessage = error.errorMessage,
-                                timestamp = error.timestamp,
-                            )
-                        }
-                    )
-                }
-            }
+            .onEach { errors -> _state.update { it.copy(updateErrorCount = errors.size) } }
             .catch { /* error-tracking failure should not affect the main updates list */ }
             .launchIn(viewModelScope)
     }

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/errors/UpdateErrorsMvi.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/errors/UpdateErrorsMvi.kt
@@ -1,0 +1,37 @@
+package app.otakureader.feature.updates.errors
+
+import app.otakureader.core.common.mvi.UiEffect
+import app.otakureader.core.common.mvi.UiEvent
+import app.otakureader.core.common.mvi.UiState
+import app.otakureader.domain.model.UpdateError
+
+data class UpdateErrorsState(
+    val isLoading: Boolean = true,
+    /** Unresolved update failures grouped by their raw error message (sticky-header key). */
+    val errorsByMessage: Map<String, List<UpdateError>> = emptyMap(),
+    /** Manga IDs currently selected for bulk actions; non-empty means selection mode is active. */
+    val selectedMangaIds: Set<Long> = emptySet(),
+) : UiState {
+    val isSelectionMode: Boolean get() = selectedMangaIds.isNotEmpty()
+    val isEmpty: Boolean get() = errorsByMessage.isEmpty()
+}
+
+sealed interface UpdateErrorsEvent : UiEvent {
+    /** Tap on a card: navigates when not selecting, toggles selection when selection mode is active. */
+    data class CardClick(val mangaId: Long) : UpdateErrorsEvent
+    /** Long-press on a card: always toggles selection (enters selection mode if not already active). */
+    data class ToggleSelection(val mangaId: Long) : UpdateErrorsEvent
+    data object SelectAll : UpdateErrorsEvent
+    data object InvertSelection : UpdateErrorsEvent
+    data object ClearSelection : UpdateErrorsEvent
+    /** Swipe-to-dismiss a single card, regardless of selection state. */
+    data class DeleteError(val mangaId: Long) : UpdateErrorsEvent
+    data object DeleteSelected : UpdateErrorsEvent
+    data object ClearAll : UpdateErrorsEvent
+    data object MigrateSelected : UpdateErrorsEvent
+}
+
+sealed interface UpdateErrorsEffect : UiEffect {
+    data class NavigateToManga(val mangaId: Long) : UpdateErrorsEffect
+    data class NavigateToMigration(val mangaIds: List<Long>) : UpdateErrorsEffect
+}

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/errors/UpdateErrorsScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/errors/UpdateErrorsScreen.kt
@@ -1,6 +1,7 @@
 package app.otakureader.feature.updates.errors
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
@@ -15,7 +16,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.stickyHeader
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -75,7 +75,7 @@ private fun formatErrorTimestamp(epochMs: Long): String = runCatching {
     Instant.ofEpochMilli(epochMs).atZone(ZoneId.systemDefault()).format(errorDateFormatter)
 }.getOrDefault("Unknown date")
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun UpdateErrorsScreen(
     onNavigateBack: () -> Unit,

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/errors/UpdateErrorsScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/errors/UpdateErrorsScreen.kt
@@ -1,0 +1,378 @@
+package app.otakureader.feature.updates.errors
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.stickyHeader
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.CompareArrows
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.FlipToBack
+import androidx.compose.material.icons.filled.SelectAll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.otakureader.domain.model.UpdateError
+import app.otakureader.feature.updates.R
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import kotlinx.coroutines.flow.collectLatest
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+private val errorDateFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
+
+private fun formatErrorTimestamp(epochMs: Long): String = runCatching {
+    Instant.ofEpochMilli(epochMs).atZone(ZoneId.systemDefault()).format(errorDateFormatter)
+}.getOrDefault("Unknown date")
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UpdateErrorsScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToManga: (Long) -> Unit,
+    onNavigateToMigration: (List<Long>) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: UpdateErrorsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val haptic = LocalHapticFeedback.current
+    var showClearAllConfirm by remember { mutableStateOf(false) }
+
+    BackHandler(enabled = state.isSelectionMode) {
+        viewModel.onEvent(UpdateErrorsEvent.ClearSelection)
+    }
+
+    LaunchedEffect(viewModel.effect) {
+        viewModel.effect.collectLatest { effect ->
+            when (effect) {
+                is UpdateErrorsEffect.NavigateToManga -> onNavigateToManga(effect.mangaId)
+                is UpdateErrorsEffect.NavigateToMigration -> onNavigateToMigration(effect.mangaIds)
+            }
+        }
+    }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            if (state.isSelectionMode) {
+                TopAppBar(
+                    title = { Text(stringResource(R.string.updates_selected_count, state.selectedMangaIds.size)) },
+                    navigationIcon = {
+                        IconButton(onClick = { viewModel.onEvent(UpdateErrorsEvent.ClearSelection) }) {
+                            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.updates_clear_selection))
+                        }
+                    },
+                    actions = {
+                        IconButton(onClick = { viewModel.onEvent(UpdateErrorsEvent.SelectAll) }) {
+                            Icon(Icons.Default.SelectAll, contentDescription = stringResource(R.string.updates_select_all))
+                        }
+                        IconButton(onClick = { viewModel.onEvent(UpdateErrorsEvent.InvertSelection) }) {
+                            Icon(Icons.Default.FlipToBack, contentDescription = stringResource(R.string.updates_invert_selection))
+                        }
+                    }
+                )
+            } else {
+                TopAppBar(
+                    title = { Text(stringResource(R.string.updates_error_title)) },
+                    navigationIcon = {
+                        IconButton(onClick = onNavigateBack) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.updates_back))
+                        }
+                    },
+                    actions = {
+                        if (!state.isEmpty) {
+                            TextButton(onClick = { showClearAllConfirm = true }) {
+                                Text(stringResource(R.string.updates_error_clear_all))
+                            }
+                        }
+                    }
+                )
+            }
+        },
+        bottomBar = {
+            if (state.isSelectionMode) {
+                UpdateErrorsSelectionBar(
+                    onMigrate = { viewModel.onEvent(UpdateErrorsEvent.MigrateSelected) },
+                    onDelete = { viewModel.onEvent(UpdateErrorsEvent.DeleteSelected) },
+                )
+            }
+        }
+    ) { paddingValues ->
+        if (state.isEmpty) {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(paddingValues),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(R.string.updates_error_empty),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+                state.errorsByMessage.forEach { (message, errors) ->
+                    stickyHeader(key = "header_$message") {
+                        UpdateErrorGroupHeader(message = message, count = errors.size)
+                    }
+                    items(errors, key = { it.mangaId }) { error ->
+                        UpdateErrorCard(
+                            error = error,
+                            isSelected = error.mangaId in state.selectedMangaIds,
+                            isSelectionMode = state.isSelectionMode,
+                            onClick = { viewModel.onEvent(UpdateErrorsEvent.CardClick(error.mangaId)) },
+                            onLongClick = {
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                viewModel.onEvent(UpdateErrorsEvent.ToggleSelection(error.mangaId))
+                            },
+                            onDismiss = { viewModel.onEvent(UpdateErrorsEvent.DeleteError(error.mangaId)) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (showClearAllConfirm) {
+        AlertDialog(
+            onDismissRequest = { showClearAllConfirm = false },
+            title = { Text(stringResource(R.string.updates_error_clear_all)) },
+            text = { Text(stringResource(R.string.update_errors_clear_all_confirm)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showClearAllConfirm = false
+                    viewModel.onEvent(UpdateErrorsEvent.ClearAll)
+                }) {
+                    Text(stringResource(R.string.updates_error_clear_all))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearAllConfirm = false }) {
+                    Text(stringResource(R.string.downloads_cancel))
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun UpdateErrorGroupHeader(message: String, count: Int, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.error,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = count.toString(),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun UpdateErrorCard(
+    error: UpdateError,
+    isSelected: Boolean,
+    isSelectionMode: Boolean,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { value ->
+            if (value == SwipeToDismissBoxValue.EndToStart) {
+                onDismiss()
+                true
+            } else {
+                false
+            }
+        }
+    )
+    SwipeToDismissBox(
+        state = dismissState,
+        enableDismissFromStartToEnd = false,
+        modifier = modifier,
+        backgroundContent = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.errorContainer),
+                contentAlignment = Alignment.CenterEnd,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = stringResource(R.string.updates_error_clear),
+                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                    modifier = Modifier.padding(end = 16.dp),
+                )
+            }
+        }
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    if (isSelected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
+                )
+                .combinedClickable(onClick = onClick, onLongClick = onLongClick)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (isSelectionMode) {
+                Checkbox(checked = isSelected, onCheckedChange = { onClick() })
+            }
+            Surface(
+                shape = MaterialTheme.shapes.small,
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                modifier = Modifier.size(width = 48.dp, height = 64.dp),
+            ) {
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(error.thumbnailUrl)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = error.mangaTitle,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize().clip(MaterialTheme.shapes.small),
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = error.mangaTitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (error.timestamp > 0L) {
+                    Text(
+                        text = formatErrorTimestamp(error.timestamp),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            if (!isSelectionMode) {
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Default.ErrorOutline,
+                        contentDescription = stringResource(R.string.updates_error_clear),
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun UpdateErrorsSelectionBar(
+    onMigrate: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        tonalElevation = 3.dp,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            SelectionBarAction(
+                icon = Icons.AutoMirrored.Filled.CompareArrows,
+                label = stringResource(R.string.update_errors_migrate_selected),
+                onClick = onMigrate,
+            )
+            SelectionBarAction(
+                icon = Icons.Default.Delete,
+                label = stringResource(R.string.update_errors_delete_selected),
+                onClick = onDelete,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SelectionBarAction(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.combinedClickable(onClick = onClick, onLongClick = {}).padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(imageVector = icon, contentDescription = label)
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(text = label, style = MaterialTheme.typography.labelSmall)
+    }
+}

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/errors/UpdateErrorsViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/errors/UpdateErrorsViewModel.kt
@@ -1,0 +1,112 @@
+package app.otakureader.feature.updates.errors
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.otakureader.domain.repository.UpdateErrorRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class UpdateErrorsViewModel @Inject constructor(
+    private val updateErrorRepository: UpdateErrorRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(UpdateErrorsState())
+    val state: StateFlow<UpdateErrorsState> = _state.asStateFlow()
+
+    private val _effect = Channel<UpdateErrorsEffect>(Channel.BUFFERED)
+    val effect = _effect.receiveAsFlow()
+
+    init {
+        updateErrorRepository.observeErrors()
+            .onEach { errors ->
+                val stillErroredIds = errors.map { it.mangaId }.toSet()
+                _state.update {
+                    it.copy(
+                        isLoading = false,
+                        errorsByMessage = errors.groupBy { error -> error.errorMessage },
+                        // Drop selections for manga whose error was resolved elsewhere (e.g. a
+                        // background update succeeding) so selection never references a stale id.
+                        selectedMangaIds = it.selectedMangaIds intersect stillErroredIds,
+                    )
+                }
+            }
+            .catch { _state.update { it.copy(isLoading = false) } }
+            .launchIn(viewModelScope)
+    }
+
+    fun onEvent(event: UpdateErrorsEvent) {
+        when (event) {
+            is UpdateErrorsEvent.CardClick -> onCardClick(event.mangaId)
+            is UpdateErrorsEvent.ToggleSelection -> toggleSelection(event.mangaId)
+            UpdateErrorsEvent.SelectAll -> selectAll()
+            UpdateErrorsEvent.InvertSelection -> invertSelection()
+            UpdateErrorsEvent.ClearSelection -> _state.update { it.copy(selectedMangaIds = emptySet()) }
+            is UpdateErrorsEvent.DeleteError -> deleteError(event.mangaId)
+            UpdateErrorsEvent.DeleteSelected -> deleteSelected()
+            UpdateErrorsEvent.ClearAll -> clearAll()
+            UpdateErrorsEvent.MigrateSelected -> migrateSelected()
+        }
+    }
+
+    private fun allMangaIds(): Set<Long> =
+        _state.value.errorsByMessage.values.flatten().map { it.mangaId }.toSet()
+
+    private fun onCardClick(mangaId: Long) {
+        if (_state.value.isSelectionMode) {
+            toggleSelection(mangaId)
+        } else {
+            viewModelScope.launch { _effect.send(UpdateErrorsEffect.NavigateToManga(mangaId)) }
+        }
+    }
+
+    private fun toggleSelection(mangaId: Long) {
+        _state.update { st ->
+            val sel = st.selectedMangaIds
+            st.copy(selectedMangaIds = if (mangaId in sel) sel - mangaId else sel + mangaId)
+        }
+    }
+
+    private fun selectAll() {
+        _state.update { it.copy(selectedMangaIds = allMangaIds()) }
+    }
+
+    private fun invertSelection() {
+        _state.update { it.copy(selectedMangaIds = allMangaIds() - it.selectedMangaIds) }
+    }
+
+    private fun deleteError(mangaId: Long) {
+        viewModelScope.launch { updateErrorRepository.clearError(mangaId) }
+    }
+
+    private fun deleteSelected() {
+        val ids = _state.value.selectedMangaIds
+        if (ids.isEmpty()) return
+        _state.update { it.copy(selectedMangaIds = emptySet()) }
+        viewModelScope.launch {
+            ids.forEach { updateErrorRepository.clearError(it) }
+        }
+    }
+
+    private fun clearAll() {
+        _state.update { it.copy(selectedMangaIds = emptySet()) }
+        viewModelScope.launch { updateErrorRepository.clearAllErrors() }
+    }
+
+    private fun migrateSelected() {
+        val ids = _state.value.selectedMangaIds.toList()
+        if (ids.isEmpty()) return
+        _state.update { it.copy(selectedMangaIds = emptySet()) }
+        viewModelScope.launch { _effect.send(UpdateErrorsEffect.NavigateToMigration(ids)) }
+    }
+}

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/navigation/UpdatesNavigation.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/navigation/UpdatesNavigation.kt
@@ -2,23 +2,23 @@ package app.otakureader.feature.updates.navigation
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import androidx.navigation.toRoute
 import app.otakureader.core.navigation.Route
 import app.otakureader.feature.updates.DownloadsScreen
 import app.otakureader.feature.updates.UpdatesScreen
+import app.otakureader.feature.updates.errors.UpdateErrorsScreen
 
 fun NavGraphBuilder.updatesScreen(
     onMangaClick: (Long) -> Unit,
     onNavigateBack: () -> Unit,
-    onNavigateToDownloads: () -> Unit
+    onNavigateToDownloads: () -> Unit,
+    onNavigateToUpdateErrors: () -> Unit = {},
 ) {
-    composable<Route.Updates> { backStackEntry ->
-        val route = backStackEntry.toRoute<Route.Updates>()
+    composable<Route.Updates> {
         UpdatesScreen(
             onMangaClick = onMangaClick,
             onNavigateBack = onNavigateBack,
             onNavigateToDownloads = onNavigateToDownloads,
-            openErrorsOnLaunch = route.openErrors,
+            onNavigateToUpdateErrors = onNavigateToUpdateErrors,
         )
     }
 }
@@ -29,6 +29,20 @@ fun NavGraphBuilder.downloadsScreen(
     composable<Route.Downloads> {
         DownloadsScreen(
             onNavigateBack = onNavigateBack
+        )
+    }
+}
+
+fun NavGraphBuilder.updateErrorsScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToManga: (Long) -> Unit,
+    onNavigateToMigration: (List<Long>) -> Unit,
+) {
+    composable<Route.UpdateErrors> {
+        UpdateErrorsScreen(
+            onNavigateBack = onNavigateBack,
+            onNavigateToManga = onNavigateToManga,
+            onNavigateToMigration = onNavigateToMigration,
         )
     }
 }

--- a/feature/updates/src/main/res/values/strings.xml
+++ b/feature/updates/src/main/res/values/strings.xml
@@ -40,14 +40,16 @@
     <string name="downloads_status_failed">Failed</string>
     <string name="downloads_status_canceled">Canceled</string>
     
-    <!-- Update Error Screen -->
+    <!-- Update Errors screen -->
     <string name="updates_view_errors">View update errors</string>
     <string name="updates_error_title">Update Errors</string>
     <string name="updates_error_empty">No update errors</string>
-    <string name="updates_error_close">Close</string>
     <string name="updates_error_clear">Clear error</string>
     <string name="updates_error_clear_all">Clear all</string>
-    
+    <string name="update_errors_clear_all_confirm">Clear every recorded update error? This can\'t be undone.</string>
+    <string name="update_errors_migrate_selected">Migrate selected</string>
+    <string name="update_errors_delete_selected">Delete selected</string>
+
     <string name="updates_refresh_now">Update library now</string>
 
     <!-- To-Be-Updated Screen -->

--- a/feature/updates/src/test/java/app/otakureader/feature/updates/UpdatesViewModelTest.kt
+++ b/feature/updates/src/test/java/app/otakureader/feature/updates/UpdatesViewModelTest.kt
@@ -266,7 +266,7 @@ class UpdatesViewModelTest {
     }
 
     @Test
-    fun init_populatesUpdateErrorsFromRepository() = runTest {
+    fun init_populatesUpdateErrorCountFromRepository() = runTest {
         every { getRecentUpdatesUseCase() } returns flowOf(emptyList())
         val sampleError = app.otakureader.domain.model.UpdateError(
             mangaId = 1L,
@@ -280,35 +280,6 @@ class UpdatesViewModelTest {
         val viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
 
-        val errors = viewModel.state.value.updateErrors
-        assertEquals(1, errors.size)
-        assertEquals(1L, errors.first().mangaId)
-        assertEquals("HTTP 404", errors.first().errorMessage)
-    }
-
-    @Test
-    fun onEvent_ClearUpdateError_delegatesToRepository() = runTest {
-        every { getRecentUpdatesUseCase() } returns flowOf(emptyList())
-
-        val viewModel = createViewModel()
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        viewModel.onEvent(UpdatesEvent.ClearUpdateError(mangaId = 1L))
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        coVerify(exactly = 1) { updateErrorRepository.clearError(1L) }
-    }
-
-    @Test
-    fun onEvent_ClearAllUpdateErrors_delegatesToRepository() = runTest {
-        every { getRecentUpdatesUseCase() } returns flowOf(emptyList())
-
-        val viewModel = createViewModel()
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        viewModel.onEvent(UpdatesEvent.ClearAllUpdateErrors)
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        coVerify(exactly = 1) { updateErrorRepository.clearAllErrors() }
+        assertEquals(1, viewModel.state.value.updateErrorCount)
     }
 }

--- a/feature/updates/src/test/java/app/otakureader/feature/updates/errors/UpdateErrorsViewModelTest.kt
+++ b/feature/updates/src/test/java/app/otakureader/feature/updates/errors/UpdateErrorsViewModelTest.kt
@@ -1,0 +1,287 @@
+package app.otakureader.feature.updates.errors
+
+import app.otakureader.domain.model.UpdateError
+import app.otakureader.domain.repository.UpdateErrorRepository
+import app.cash.turbine.test
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpdateErrorsViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var updateErrorRepository: UpdateErrorRepository
+
+    private val errorNaruto = UpdateError(
+        mangaId = 1L,
+        mangaTitle = "Naruto",
+        thumbnailUrl = null,
+        errorMessage = "HTTP 404",
+        timestamp = 5_000L,
+    )
+    private val errorBleach = UpdateError(
+        mangaId = 2L,
+        mangaTitle = "Bleach",
+        thumbnailUrl = null,
+        errorMessage = "HTTP 404",
+        timestamp = 6_000L,
+    )
+    private val errorOnePiece = UpdateError(
+        mangaId = 3L,
+        mangaTitle = "One Piece",
+        thumbnailUrl = null,
+        errorMessage = "Connection timed out",
+        timestamp = 7_000L,
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        updateErrorRepository = mockk(relaxed = true)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(): UpdateErrorsViewModel =
+        UpdateErrorsViewModel(updateErrorRepository)
+
+    @Test
+    fun init_groupsErrorsByMessage() = runTest {
+        every { updateErrorRepository.observeErrors() } returns
+            flowOf(listOf(errorNaruto, errorBleach, errorOnePiece))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertFalse(state.isLoading)
+        assertEquals(2, state.errorsByMessage.size)
+        assertEquals(2, state.errorsByMessage.getValue("HTTP 404").size)
+        assertEquals(1, state.errorsByMessage.getValue("Connection timed out").size)
+    }
+
+    @Test
+    fun init_withNoErrors_isEmpty() = runTest {
+        every { updateErrorRepository.observeErrors() } returns flowOf(emptyList())
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(viewModel.state.value.isEmpty)
+    }
+
+    @Test
+    fun toggleSelection_addsAndRemovesMangaId() = runTest {
+        every { updateErrorRepository.observeErrors() } returns flowOf(listOf(errorNaruto))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(UpdateErrorsEvent.ToggleSelection(1L))
+        assertTrue(viewModel.state.value.isSelectionMode)
+        assertTrue(1L in viewModel.state.value.selectedMangaIds)
+
+        viewModel.onEvent(UpdateErrorsEvent.ToggleSelection(1L))
+        assertFalse(viewModel.state.value.isSelectionMode)
+    }
+
+    @Test
+    fun cardClick_whenNotInSelectionMode_emitsNavigateToManga() = runTest {
+        every { updateErrorRepository.observeErrors() } returns flowOf(listOf(errorNaruto))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.effect.test {
+            viewModel.onEvent(UpdateErrorsEvent.CardClick(1L))
+            val effect = awaitItem()
+            assertTrue(effect is UpdateErrorsEffect.NavigateToManga)
+            assertEquals(1L, (effect as UpdateErrorsEffect.NavigateToManga).mangaId)
+        }
+    }
+
+    @Test
+    fun cardClick_whenInSelectionMode_togglesSelectionInstead() = runTest {
+        every { updateErrorRepository.observeErrors() } returns flowOf(listOf(errorNaruto, errorBleach))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(UpdateErrorsEvent.ToggleSelection(1L))
+        viewModel.onEvent(UpdateErrorsEvent.CardClick(2L))
+
+        assertEquals(setOf(1L, 2L), viewModel.state.value.selectedMangaIds)
+    }
+
+    @Test
+    fun selectAll_selectsEveryMangaId() = runTest {
+        every { updateErrorRepository.observeErrors() } returns
+            flowOf(listOf(errorNaruto, errorBleach, errorOnePiece))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(UpdateErrorsEvent.SelectAll)
+
+        assertEquals(setOf(1L, 2L, 3L), viewModel.state.value.selectedMangaIds)
+    }
+
+    @Test
+    fun invertSelection_flipsSelectedSet() = runTest {
+        every { updateErrorRepository.observeErrors() } returns
+            flowOf(listOf(errorNaruto, errorBleach, errorOnePiece))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(UpdateErrorsEvent.ToggleSelection(1L))
+        viewModel.onEvent(UpdateErrorsEvent.InvertSelection)
+
+        assertEquals(setOf(2L, 3L), viewModel.state.value.selectedMangaIds)
+    }
+
+    @Test
+    fun clearSelection_emptiesSelectedSet() = runTest {
+        every { updateErrorRepository.observeErrors() } returns flowOf(listOf(errorNaruto))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(UpdateErrorsEvent.ToggleSelection(1L))
+        viewModel.onEvent(UpdateErrorsEvent.ClearSelection)
+
+        assertTrue(viewModel.state.value.selectedMangaIds.isEmpty())
+    }
+
+    @Test
+    fun deleteError_delegatesToRepositoryForSingleManga() = runTest {
+        every { updateErrorRepository.observeErrors() } returns flowOf(listOf(errorNaruto))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(UpdateErrorsEvent.DeleteError(1L))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { updateErrorRepository.clearError(1L) }
+    }
+
+    @Test
+    fun deleteSelected_clearsEachSelectedMangaAndSelection() = runTest {
+        every { updateErrorRepository.observeErrors() } returns flowOf(listOf(errorNaruto, errorBleach))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(UpdateErrorsEvent.ToggleSelection(1L))
+        viewModel.onEvent(UpdateErrorsEvent.ToggleSelection(2L))
+        viewModel.onEvent(UpdateErrorsEvent.DeleteSelected)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { updateErrorRepository.clearError(1L) }
+        coVerify(exactly = 1) { updateErrorRepository.clearError(2L) }
+        assertTrue(viewModel.state.value.selectedMangaIds.isEmpty())
+    }
+
+    @Test
+    fun deleteSelected_withNoSelection_doesNothing() = runTest {
+        every { updateErrorRepository.observeErrors() } returns flowOf(listOf(errorNaruto))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(UpdateErrorsEvent.DeleteSelected)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 0) { updateErrorRepository.clearError(any()) }
+    }
+
+    @Test
+    fun clearAll_delegatesToRepositoryAndClearsSelection() = runTest {
+        every { updateErrorRepository.observeErrors() } returns flowOf(listOf(errorNaruto, errorBleach))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(UpdateErrorsEvent.ToggleSelection(1L))
+        viewModel.onEvent(UpdateErrorsEvent.ClearAll)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { updateErrorRepository.clearAllErrors() }
+        assertTrue(viewModel.state.value.selectedMangaIds.isEmpty())
+    }
+
+    @Test
+    fun migrateSelected_emitsNavigateToMigrationAndClearsSelection() = runTest {
+        every { updateErrorRepository.observeErrors() } returns flowOf(listOf(errorNaruto, errorBleach))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(UpdateErrorsEvent.ToggleSelection(1L))
+        viewModel.onEvent(UpdateErrorsEvent.ToggleSelection(2L))
+
+        viewModel.effect.test {
+            viewModel.onEvent(UpdateErrorsEvent.MigrateSelected)
+            val effect = awaitItem()
+            assertTrue(effect is UpdateErrorsEffect.NavigateToMigration)
+            assertEquals(setOf(1L, 2L), (effect as UpdateErrorsEffect.NavigateToMigration).mangaIds.toSet())
+        }
+        assertTrue(viewModel.state.value.selectedMangaIds.isEmpty())
+    }
+
+    @Test
+    fun migrateSelected_withNoSelection_doesNotEmitEffect() = runTest {
+        every { updateErrorRepository.observeErrors() } returns flowOf(listOf(errorNaruto))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(UpdateErrorsEvent.MigrateSelected)
+        testDispatcher.scheduler.advanceUntilIdle()
+        // No effect should be pending; a subsequent CardClick's own effect proves the channel wasn't
+        // already occupied by a stray MigrateSelected effect.
+        viewModel.effect.test {
+            viewModel.onEvent(UpdateErrorsEvent.CardClick(1L))
+            val effect = awaitItem()
+            assertTrue(effect is UpdateErrorsEffect.NavigateToManga)
+        }
+    }
+
+    @Test
+    fun selectionResolvedElsewhere_isDroppedFromSelection() = runTest {
+        val errorsFlow = kotlinx.coroutines.flow.MutableStateFlow(listOf(errorNaruto, errorBleach))
+        every { updateErrorRepository.observeErrors() } returns errorsFlow
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(UpdateErrorsEvent.ToggleSelection(1L))
+        viewModel.onEvent(UpdateErrorsEvent.ToggleSelection(2L))
+        assertEquals(setOf(1L, 2L), viewModel.state.value.selectedMangaIds)
+
+        // Manga 1's error resolves elsewhere (e.g. a background update succeeded).
+        errorsFlow.value = listOf(errorBleach)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(setOf(2L), viewModel.state.value.selectedMangaIds)
+    }
+}


### PR DESCRIPTION
## 📋 Description
Replaces the in-dialog Update Errors list (PR #1119) with a dedicated `Route.UpdateErrors` screen, per the PR 5 item in the #1192 deferred-gaps backlog.

- New `feature/updates/errors/` package: `UpdateErrorsMvi.kt`, `UpdateErrorsViewModel.kt`, `UpdateErrorsScreen.kt`.
- Errors are grouped under sticky headers by their raw `errorMessage` string (no DB/schema change — `UpdateErrorRepository`/`UpdateErrorDao` are untouched).
- Tap a card to open the manga; long-press to enter multi-select (select-all / invert / clear); selection bottom bar offers **Migrate selected** (→ `Route.Migration`) and **Delete selected**.
- Per-item swipe-to-dismiss to clear a single error, cloned from `UpdatesScreen`'s existing swipe pattern. `BackHandler` exits selection mode first, also matching `UpdatesScreen` precedent.
- The Updates screen's top-bar error badge and the More-tab "Update Errors" entry both now navigate to `Route.UpdateErrors` instead of opening a dialog.
- Removed the now-dead `UpdateErrorDialog`/`UpdateErrorItem` composables, the `ShowUpdateErrors`/`HideUpdateErrors`/`ClearUpdateError`/`ClearAllUpdateErrors` events, and the `showUpdateErrors`/`updateErrors: List<UpdateErrorEntry>` state — replaced with a single `updateErrorCount: Int` used only for the badge.
- `Route.Updates` reverts to a plain `data object` now that the `openErrors` auto-open flag is no longer needed.

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📖 Documentation
- [x] 🎨 UI/UX
- [x] ♻️ Refactoring
- [ ] 🚀 Performance
- [ ] 🧪 Tests

## 🧪 Testing
- Added `UpdateErrorsViewModelTest` covering grouping by message, selection toggling/select-all/invert/clear, card-click navigate-vs-toggle behavior, delete-single/delete-selected/clear-all repository delegation, migrate-selected effect + selection clearing, and dropping stale selections when an error resolves elsewhere.
- Updated `UpdatesViewModelTest` to assert the new `updateErrorCount` field instead of the removed dialog-list state/events.
- `./gradlew detekt` passes locally. Ktlint's Gradle task in this project only covers root-level `.kts` build scripts, not module Kotlin sources, so it was not run per-module; module compilation and full ktlint/unit-test/coverage/screenshot gates run in CI (no local Android SDK in this environment).
- UI was not visually verified in this sandbox — no way to run the app here. Please check the sticky headers, swipe-to-dismiss, and selection bar visually before merging.

## 📸 Screenshots
Not available — no local Android runtime/emulator in this environment.

## ✅ Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code (none needed)
- [ ] Documentation updated
- [x] No new warnings (detekt clean)
- [x] Tests pass (new/updated unit tests included; full suite runs in CI)

## 🔗 Related Issues
Part of #1192 (PR 5 of 7 in the deferred-gaps backlog).


---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

## Summary by Sourcery

Introduce a dedicated Update Errors screen and route, and rework update error handling to use it instead of the previous dialog-based flow.

New Features:
- Add a standalone Update Errors screen with grouped error lists, sticky headers, swipe-to-dismiss cards, and bulk selection actions for migration and deletion.

Enhancements:
- Change the Updates screen error badge to display a simple unresolved error count and navigate to the new Update Errors screen.
- Simplify the Updates route and navigation by removing the open-errors flag and adding a dedicated UpdateErrors route.

Tests:
- Add unit tests for the new UpdateErrorsViewModel covering error grouping, selection behavior, deletion, migration, and selection cleanup.
- Update UpdatesViewModel tests to assert the new updateErrorCount field instead of the removed dialog-based error state.