### PR TITLE
Add migration options + custom-cover migration (#1192 PR 6)

### DIFF
--- a/core/preferences/src/main/java/app/otakureader/core/preferences/AppPreferences.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/AppPreferences.kt
@@ -6,6 +6,8 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import app.otakureader.domain.model.MigrationFlag
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -39,9 +41,22 @@ class AppPreferences(private val dataStore: DataStore<Preferences>) {
     suspend fun setMigrationMinChapterCount(value: Int) =
         dataStore.edit { it[Keys.MIGRATION_MIN_CHAPTER_COUNT] = value }
 
+    /** Which data categories to carry over during migration. Default: every flag (all data). */
+    val migrationFlags: Flow<Set<MigrationFlag>> = dataStore.data.map { prefs ->
+        val raw = prefs[Keys.MIGRATION_FLAGS]
+        if (raw == null) {
+            MigrationFlag.entries.toSet()
+        } else {
+            raw.mapNotNull { name -> runCatching { MigrationFlag.valueOf(name) }.getOrNull() }.toSet()
+        }
+    }
+    suspend fun setMigrationFlags(flags: Set<MigrationFlag>) =
+        dataStore.edit { it[Keys.MIGRATION_FLAGS] = flags.map { flag -> flag.name }.toSet() }
+
     private object Keys {
         val MIGRATION_SIMILARITY_THRESHOLD = floatPreferencesKey("migration_similarity_threshold")
         val MIGRATION_ALWAYS_CONFIRM = booleanPreferencesKey("migration_always_confirm")
         val MIGRATION_MIN_CHAPTER_COUNT = intPreferencesKey("migration_min_chapter_count")
+        val MIGRATION_FLAGS = stringSetPreferencesKey("migration_flags")
     }
 }

--- a/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
@@ -273,6 +273,20 @@ class MangaRepositoryImpl @Inject constructor(
         deleteCustomCoverFiles(id)
     }
 
+    override suspend fun copyCustomCover(fromMangaId: Long, toMangaId: Long) = withContext(Dispatchers.IO) {
+        val sourcePath = mangaDao.getMangaById(fromMangaId)?.userThumbnailUrl?.removePrefix("file://")
+        val sourceFile = sourcePath?.let { File(it) }
+        if (sourceFile == null || !sourceFile.exists()) return@withContext
+
+        val coversDir = File(context.filesDir, CUSTOM_COVERS_DIR).apply { mkdirs() }
+        val newFile = File(coversDir, "${toMangaId}_${System.currentTimeMillis()}.img")
+        sourceFile.copyTo(newFile, overwrite = true)
+
+        // DB first for the same crash-safety reason as setCustomCover.
+        mangaDao.updateUserThumbnail(toMangaId, "file://${newFile.absolutePath}")
+        deleteCustomCoverFiles(toMangaId, except = newFile)
+    }
+
     /** Deletes stored custom cover files for [id], optionally keeping [except]. */
     private fun deleteCustomCoverFiles(id: Long, except: File? = null) {
         File(context.filesDir, CUSTOM_COVERS_DIR)

--- a/domain/src/main/java/app/otakureader/domain/model/MigrationModels.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/MigrationModels.kt
@@ -57,3 +57,17 @@ data class MigrationResult(
     val status: MigrationStatus,
     val error: String? = null
 )
+
+/**
+ * Which categories of data to carry over during a migration. Persisted as a string-set
+ * preference; default is every flag enabled (matches the pre-existing unconditional-copy
+ * behavior of [app.otakureader.domain.usecase.migration.MigrateMangaUseCase]).
+ */
+enum class MigrationFlag {
+    CHAPTERS,
+    CATEGORIES,
+    TRACKING,
+    NOTES,
+    DOWNLOADS,
+    CUSTOM_COVER
+}

--- a/domain/src/main/java/app/otakureader/domain/repository/MangaRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/MangaRepository.kt
@@ -83,6 +83,13 @@ interface MangaRepository {
     /** Deletes the stored custom cover file (if any) and reverts to the source cover. */
     suspend fun removeCustomCover(id: Long)
 
+    /**
+     * Copies [fromMangaId]'s custom cover file (if it has one) to a new file and points
+     * [toMangaId] at it. No-op if [fromMangaId] has no custom cover. Used by migration
+     * (#1192 PR 6) to carry a user-set cover over to the migrated manga.
+     */
+    suspend fun copyCustomCover(fromMangaId: Long, toMangaId: Long)
+
     // Duplicate detection (#997)
     /** Groups of library manga sharing the same normalised title (≥2 entries per group). */
     fun findDuplicates(): Flow<List<List<Manga>>>

--- a/domain/src/main/java/app/otakureader/domain/usecase/migration/MigrateMangaUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/migration/MigrateMangaUseCase.kt
@@ -3,6 +3,7 @@ package app.otakureader.domain.usecase.migration
 import app.otakureader.domain.model.Chapter
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MigrationCandidate
+import app.otakureader.domain.model.MigrationFlag
 import app.otakureader.domain.model.MigrationMode
 import app.otakureader.domain.model.MigrationResult
 import app.otakureader.domain.model.MigrationStatus
@@ -37,13 +38,15 @@ class MigrateMangaUseCase @Inject constructor(
      * @param sourceManga The manga to migrate
      * @param targetCandidate The target manga candidate from the new source
      * @param mode Migration mode (MOVE or COPY)
+     * @param flags Which data categories to carry over. Defaults to all (pre-#1192-PR-6 behavior).
      * @return Result with MigrationResult containing status and details
      */
     @Suppress("ThrowsCount", "LongMethod", "CyclomaticComplexMethod", "CognitiveComplexMethod")
     suspend operator fun invoke(
         sourceManga: Manga,
         targetCandidate: MigrationCandidate,
-        mode: MigrationMode
+        mode: MigrationMode,
+        flags: Set<MigrationFlag> = MigrationFlag.entries.toSet()
     ): Result<MigrationResult> {
         return try {
             // Check if target manga already exists in library
@@ -62,7 +65,7 @@ class MigrateMangaUseCase @Inject constructor(
                 val newManga = targetCandidate.toManga(
                     favorite = sourceManga.favorite,
                     autoDownload = sourceManga.autoDownload,
-                    notes = sourceManga.notes
+                    notes = if (MigrationFlag.NOTES in flags) sourceManga.notes else null
                 )
                 mangaRepository.insertManga(newManga)
             }
@@ -102,7 +105,8 @@ class MigrateMangaUseCase @Inject constructor(
                 targetManga = targetCandidate,
                 targetMangaId = targetMangaId,
                 targetChapters = targetChapters,
-                mode = mode
+                mode = mode,
+                flags = flags
             )
 
             // A newly-created target already got its notes set at insert time above. An
@@ -112,7 +116,7 @@ class MigrateMangaUseCase @Inject constructor(
             // snapshot taken before this point: several suspending calls (source detail/chapter
             // fetches, chapter matching, download migration) run in between, and a note the user
             // added during that window would otherwise be silently overwritten.
-            if (existingTarget != null && !sourceManga.notes.isNullOrBlank()) {
+            if (MigrationFlag.NOTES in flags && existingTarget != null && !sourceManga.notes.isNullOrBlank()) {
                 try {
                     val currentNotes = mangaRepository.getMangaById(targetMangaId)?.notes
                     if (currentNotes.isNullOrBlank()) {
@@ -125,8 +129,19 @@ class MigrateMangaUseCase @Inject constructor(
                 }
             }
 
+            // Migrate custom cover art (Otaku-exclusive user-set cover override).
+            if (MigrationFlag.CUSTOM_COVER in flags && sourceManga.hasCustomCover) {
+                try {
+                    mangaRepository.copyCustomCover(sourceManga.id, targetMangaId)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // Custom cover is a non-critical field; a failure here shouldn't abort migration.
+                }
+            }
+
             // Migrate categories
-            if (sourceManga.categoryIds.isNotEmpty()) {
+            if (MigrationFlag.CATEGORIES in flags && sourceManga.categoryIds.isNotEmpty()) {
                 sourceManga.categoryIds.forEach { categoryId ->
                     try {
                         categoryRepository.addMangaToCategory(targetMangaId, categoryId)
@@ -141,26 +156,28 @@ class MigrateMangaUseCase @Inject constructor(
 
             // Migrate tracker links – per-entry error handling so a single
             // tracker failure does not abort an otherwise-successful migration.
-            val trackerEntries = trackRepository.observeEntriesForManga(sourceManga.id).first()
-            var failedTrackers = 0
-            trackerEntries.forEach { entry ->
-                try {
-                    val migratedEntry = entry.copy(mangaId = targetMangaId)
-                    trackRepository.upsertEntry(migratedEntry)
-                } catch (e: CancellationException) {
-                    // Propagate cancellation immediately
-                    throw e
-                } catch (e: Exception) {
-                    // Individual tracker migration failure is non-fatal; continue
-                    // with the remaining entries so partial progress is preserved.
-                    failedTrackers++
-                    // Domain layer uses System.err.println (not android.util.Log) as it's pure Kotlin
-                    // System.err.println("Failed to migrate tracker entry for tracker ${entry.trackerId}: ${e.message}")
+            if (MigrationFlag.TRACKING in flags) {
+                val trackerEntries = trackRepository.observeEntriesForManga(sourceManga.id).first()
+                var failedTrackers = 0
+                trackerEntries.forEach { entry ->
+                    try {
+                        val migratedEntry = entry.copy(mangaId = targetMangaId)
+                        trackRepository.upsertEntry(migratedEntry)
+                    } catch (e: CancellationException) {
+                        // Propagate cancellation immediately
+                        throw e
+                    } catch (e: Exception) {
+                        // Individual tracker migration failure is non-fatal; continue
+                        // with the remaining entries so partial progress is preserved.
+                        failedTrackers++
+                        // Domain layer uses System.err.println (not android.util.Log) as it's pure Kotlin
+                        // System.err.println("Failed to migrate tracker entry for tracker ${entry.trackerId}: ${e.message}")
+                    }
                 }
-            }
-            if (failedTrackers > 0) {
-                // Domain layer uses System.err.println (not android.util.Log) as it's pure Kotlin
-                // System.err.println("Migration completed with $failedTrackers tracker failure(s) out of ${trackerEntries.size} total")
+                if (failedTrackers > 0) {
+                    // Domain layer uses System.err.println (not android.util.Log) as it's pure Kotlin
+                    // System.err.println("Migration completed with $failedTrackers tracker failure(s) out of ${trackerEntries.size} total")
+                }
             }
 
             // Handle MOVE vs COPY mode.
@@ -173,7 +190,7 @@ class MigrateMangaUseCase @Inject constructor(
             when (mode) {
                 MigrationMode.MOVE -> {
                     // Remove category associations from old manga
-                    if (sourceManga.categoryIds.isNotEmpty()) {
+                    if (MigrationFlag.CATEGORIES in flags && sourceManga.categoryIds.isNotEmpty()) {
                         sourceManga.categoryIds.forEach { categoryId ->
                             try {
                                 categoryRepository.removeMangaFromCategory(sourceManga.id, categoryId)
@@ -221,7 +238,8 @@ class MigrateMangaUseCase @Inject constructor(
         targetManga: MigrationCandidate,
         targetMangaId: Long,
         targetChapters: List<SourceChapter>,
-        mode: MigrationMode
+        mode: MigrationMode,
+        flags: Set<MigrationFlag>
     ): Int {
         var matchedCount = 0
 
@@ -244,26 +262,33 @@ class MigrateMangaUseCase @Inject constructor(
             if (sourceChapter != null) {
                 matchedCount++
 
-                // Migrate downloaded chapters if they exist
-                val isDownloaded = downloadRepository.isChapterDownloaded(
-                    sourceName = fromSourceName,
-                    mangaTitle = fromMangaTitle,
-                    chapterTitle = sourceChapter.name
-                )
-
-                if (isDownloaded) {
-                    // Migrate downloads: copy for COPY mode, move for MOVE mode
-                    downloadRepository.migrateChapterDownload(
-                        fromSourceName = fromSourceName,
-                        fromMangaTitle = fromMangaTitle,
-                        fromChapterName = sourceChapter.name,
-                        toSourceName = toSourceName,
-                        toMangaTitle = toMangaTitle,
-                        toChapterName = targetChapter.name,
-                        copy = mode == MigrationMode.COPY
+                if (MigrationFlag.DOWNLOADS in flags) {
+                    // Migrate downloaded chapters if they exist
+                    val isDownloaded = downloadRepository.isChapterDownloaded(
+                        sourceName = fromSourceName,
+                        mangaTitle = fromMangaTitle,
+                        chapterTitle = sourceChapter.name
                     )
+
+                    if (isDownloaded) {
+                        // Migrate downloads: copy for COPY mode, move for MOVE mode
+                        downloadRepository.migrateChapterDownload(
+                            fromSourceName = fromSourceName,
+                            fromMangaTitle = fromMangaTitle,
+                            fromChapterName = sourceChapter.name,
+                            toSourceName = toSourceName,
+                            toMangaTitle = toMangaTitle,
+                            toChapterName = targetChapter.name,
+                            copy = mode == MigrationMode.COPY
+                        )
+                    }
                 }
             }
+
+            // Reading progress (read/lastPageRead) is only carried over under the CHAPTERS
+            // flag; chapter matching itself always happens so downloads above can still find
+            // their corresponding source chapter regardless of this flag.
+            val carryProgress = MigrationFlag.CHAPTERS in flags && sourceChapter != null
 
             Chapter(
                 id = 0L, // Auto-generate
@@ -271,8 +296,8 @@ class MigrateMangaUseCase @Inject constructor(
                 url = targetChapter.url,
                 name = targetChapter.name,
                 scanlator = targetChapter.scanlator,
-                read = sourceChapter?.read ?: false,
-                lastPageRead = sourceChapter?.lastPageRead ?: 0,
+                read = if (carryProgress) sourceChapter?.read ?: false else false,
+                lastPageRead = if (carryProgress) sourceChapter?.lastPageRead ?: 0 else 0,
                 chapterNumber = targetChapter.chapterNumber,
                 dateUpload = targetChapter.dateUpload
             )

--- a/domain/src/test/java/app/otakureader/domain/usecase/migration/MigrateMangaUseCaseTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/usecase/migration/MigrateMangaUseCaseTest.kt
@@ -3,6 +3,7 @@ package app.otakureader.domain.usecase.migration
 import app.otakureader.domain.model.Chapter
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MigrationCandidate
+import app.otakureader.domain.model.MigrationFlag
 import app.otakureader.domain.model.MigrationMode
 import app.otakureader.domain.model.MigrationStatus
 import app.otakureader.domain.model.TrackEntry
@@ -23,6 +24,7 @@ import io.mockk.slot
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -479,6 +481,185 @@ class MigrateMangaUseCaseTest {
 
         assertTrue(result.isSuccess)
         coVerify(exactly = 0) { mangaRepository.updateMangaNote(any(), any()) }
+    }
+
+    // ── MigrationFlag gating tests (#1192 PR 6) ──────────────────────────
+
+    @Test
+    fun `CATEGORIES flag off skips category migration and cleanup`() = runTest {
+        val sourceMangaId = 1L
+        val targetMangaId = 2L
+        val sourceManga = createTestManga(id = sourceMangaId, title = "Test Manga", categoryIds = listOf(10L, 20L))
+        val targetCandidate = createTestCandidate(title = "Test Manga (New Source)")
+
+        coEvery { mangaRepository.getMangaBySourceAndUrl(any(), any()) } returns null
+        coEvery { mangaRepository.insertManga(any()) } returns targetMangaId
+        coEvery { sourceRepository.getMangaDetails(any(), any()) } returns Result.success(mockk())
+        coEvery { sourceRepository.getChapterList(any(), any()) } returns Result.success(emptyList())
+        coEvery { chapterRepository.getChaptersByMangaIdSync(sourceMangaId) } returns emptyList()
+
+        val result = useCase(
+            sourceManga, targetCandidate, MigrationMode.MOVE,
+            flags = MigrationFlag.entries.toSet() - MigrationFlag.CATEGORIES
+        )
+
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 0) { categoryRepository.addMangaToCategory(any(), any()) }
+        coVerify(exactly = 0) { categoryRepository.removeMangaFromCategory(any(), any()) }
+    }
+
+    @Test
+    fun `TRACKING flag off skips tracker migration entirely`() = runTest {
+        val sourceMangaId = 1L
+        val targetMangaId = 2L
+        val sourceManga = createTestManga(id = sourceMangaId, title = "Test Manga")
+        val targetCandidate = createTestCandidate(title = "Test Manga (New Source)")
+
+        coEvery { mangaRepository.getMangaBySourceAndUrl(any(), any()) } returns null
+        coEvery { mangaRepository.insertManga(any()) } returns targetMangaId
+        coEvery { sourceRepository.getMangaDetails(any(), any()) } returns Result.success(mockk())
+        coEvery { sourceRepository.getChapterList(any(), any()) } returns Result.success(emptyList())
+        coEvery { chapterRepository.getChaptersByMangaIdSync(sourceMangaId) } returns emptyList()
+
+        val result = useCase(
+            sourceManga, targetCandidate, MigrationMode.MOVE,
+            flags = MigrationFlag.entries.toSet() - MigrationFlag.TRACKING
+        )
+
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 0) { trackRepository.observeEntriesForManga(any()) }
+        coVerify(exactly = 0) { trackRepository.upsertEntry(any()) }
+    }
+
+    @Test
+    fun `NOTES flag off does not carry notes to a newly created target`() = runTest {
+        val sourceMangaId = 1L
+        val targetMangaId = 2L
+        val sourceManga = createTestManga(id = sourceMangaId, title = "Test Manga", notes = "Great art style")
+        val targetCandidate = createTestCandidate(title = "Test Manga (New Source)")
+
+        coEvery { mangaRepository.getMangaBySourceAndUrl(any(), any()) } returns null
+        coEvery { mangaRepository.insertManga(any()) } returns targetMangaId
+        coEvery { sourceRepository.getMangaDetails(any(), any()) } returns Result.success(mockk())
+        coEvery { sourceRepository.getChapterList(any(), any()) } returns Result.success(emptyList())
+        coEvery { chapterRepository.getChaptersByMangaIdSync(sourceMangaId) } returns emptyList()
+        coEvery { trackRepository.observeEntriesForManga(sourceMangaId) } returns flowOf(emptyList())
+
+        val result = useCase(
+            sourceManga, targetCandidate, MigrationMode.MOVE,
+            flags = MigrationFlag.entries.toSet() - MigrationFlag.NOTES
+        )
+
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 1) { mangaRepository.insertManga(match { it.notes == null }) }
+    }
+
+    @Test
+    fun `CUSTOM_COVER flag copies cover only when source has one`() = runTest {
+        val sourceMangaId = 1L
+        val targetMangaId = 2L
+        val sourceManga = createTestManga(id = sourceMangaId, title = "Test Manga").copy(hasCustomCover = true)
+        val targetCandidate = createTestCandidate(title = "Test Manga (New Source)")
+
+        coEvery { mangaRepository.getMangaBySourceAndUrl(any(), any()) } returns null
+        coEvery { mangaRepository.insertManga(any()) } returns targetMangaId
+        coEvery { sourceRepository.getMangaDetails(any(), any()) } returns Result.success(mockk())
+        coEvery { sourceRepository.getChapterList(any(), any()) } returns Result.success(emptyList())
+        coEvery { chapterRepository.getChaptersByMangaIdSync(sourceMangaId) } returns emptyList()
+        coEvery { trackRepository.observeEntriesForManga(sourceMangaId) } returns flowOf(emptyList())
+
+        val result = useCase(sourceManga, targetCandidate, MigrationMode.MOVE)
+
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 1) { mangaRepository.copyCustomCover(sourceMangaId, targetMangaId) }
+    }
+
+    @Test
+    fun `CUSTOM_COVER flag off skips cover copy even when source has one`() = runTest {
+        val sourceMangaId = 1L
+        val targetMangaId = 2L
+        val sourceManga = createTestManga(id = sourceMangaId, title = "Test Manga").copy(hasCustomCover = true)
+        val targetCandidate = createTestCandidate(title = "Test Manga (New Source)")
+
+        coEvery { mangaRepository.getMangaBySourceAndUrl(any(), any()) } returns null
+        coEvery { mangaRepository.insertManga(any()) } returns targetMangaId
+        coEvery { sourceRepository.getMangaDetails(any(), any()) } returns Result.success(mockk())
+        coEvery { sourceRepository.getChapterList(any(), any()) } returns Result.success(emptyList())
+        coEvery { chapterRepository.getChaptersByMangaIdSync(sourceMangaId) } returns emptyList()
+        coEvery { trackRepository.observeEntriesForManga(sourceMangaId) } returns flowOf(emptyList())
+
+        val result = useCase(
+            sourceManga, targetCandidate, MigrationMode.MOVE,
+            flags = MigrationFlag.entries.toSet() - MigrationFlag.CUSTOM_COVER
+        )
+
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 0) { mangaRepository.copyCustomCover(any(), any()) }
+    }
+
+    @Test
+    fun `DOWNLOADS flag off skips download migration for matched chapters`() = runTest {
+        val sourceMangaId = 1L
+        val targetMangaId = 2L
+        val sourceManga = createTestManga(id = sourceMangaId, title = "Test Manga")
+        val targetCandidate = createTestCandidate(title = "Test Manga (New Source)")
+        val sourceChapter = Chapter(
+            id = 100L, mangaId = sourceMangaId, url = "/c/1", name = "Chapter 1",
+            chapterNumber = 1f, read = true, lastPageRead = 5
+        )
+        val targetChapter = SourceChapter(url = "/new/c/1", name = "Chapter 1", chapterNumber = 1f)
+
+        coEvery { mangaRepository.getMangaBySourceAndUrl(any(), any()) } returns null
+        coEvery { mangaRepository.insertManga(any()) } returns targetMangaId
+        coEvery { sourceRepository.getMangaDetails(any(), any()) } returns Result.success(mockk())
+        coEvery { sourceRepository.getChapterList(any(), any()) } returns Result.success(listOf(targetChapter))
+        coEvery { chapterRepository.getChaptersByMangaIdSync(sourceMangaId) } returns listOf(sourceChapter)
+        coEvery { trackRepository.observeEntriesForManga(sourceMangaId) } returns flowOf(emptyList())
+
+        val result = useCase(
+            sourceManga, targetCandidate, MigrationMode.MOVE,
+            flags = MigrationFlag.entries.toSet() - MigrationFlag.DOWNLOADS
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, result.getOrNull()?.chaptersMatched) // matching still happens
+        coVerify(exactly = 0) { downloadRepository.isChapterDownloaded(any(), any(), any()) }
+        coVerify(exactly = 0) { downloadRepository.migrateChapterDownload(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `CHAPTERS flag off matches chapters but does not carry reading progress`() = runTest {
+        val sourceMangaId = 1L
+        val targetMangaId = 2L
+        val sourceManga = createTestManga(id = sourceMangaId, title = "Test Manga")
+        val targetCandidate = createTestCandidate(title = "Test Manga (New Source)")
+        val sourceChapter = Chapter(
+            id = 100L, mangaId = sourceMangaId, url = "/c/1", name = "Chapter 1",
+            chapterNumber = 1f, read = true, lastPageRead = 5
+        )
+        val targetChapter = SourceChapter(url = "/new/c/1", name = "Chapter 1", chapterNumber = 1f)
+
+        coEvery { mangaRepository.getMangaBySourceAndUrl(any(), any()) } returns null
+        coEvery { mangaRepository.insertManga(any()) } returns targetMangaId
+        coEvery { sourceRepository.getMangaDetails(any(), any()) } returns Result.success(mockk())
+        coEvery { sourceRepository.getChapterList(any(), any()) } returns Result.success(listOf(targetChapter))
+        coEvery { chapterRepository.getChaptersByMangaIdSync(sourceMangaId) } returns listOf(sourceChapter)
+        coEvery { trackRepository.observeEntriesForManga(sourceMangaId) } returns flowOf(emptyList())
+        coEvery { downloadRepository.isChapterDownloaded(any(), any(), any()) } returns false
+
+        val insertedSlot = slot<List<Chapter>>()
+        coEvery { chapterRepository.insertChapters(capture(insertedSlot)) } returns Unit
+
+        val result = useCase(
+            sourceManga, targetCandidate, MigrationMode.MOVE,
+            flags = MigrationFlag.entries.toSet() - MigrationFlag.CHAPTERS
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, result.getOrNull()?.chaptersMatched) // matching still happens
+        val insertedChapter = insertedSlot.captured.single()
+        assertFalse(insertedChapter.read)
+        assertEquals(0, insertedChapter.lastPageRead)
     }
 
     // Helper functions

--- a/domain/src/test/java/app/otakureader/domain/usecase/migration/MigrateMangaUseCaseTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/usecase/migration/MigrateMangaUseCaseTest.kt
@@ -497,6 +497,7 @@ class MigrateMangaUseCaseTest {
         coEvery { sourceRepository.getMangaDetails(any(), any()) } returns Result.success(mockk())
         coEvery { sourceRepository.getChapterList(any(), any()) } returns Result.success(emptyList())
         coEvery { chapterRepository.getChaptersByMangaIdSync(sourceMangaId) } returns emptyList()
+        coEvery { trackRepository.observeEntriesForManga(sourceMangaId) } returns flowOf(emptyList())
 
         val result = useCase(
             sourceManga, targetCandidate, MigrationMode.MOVE,

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationMvi.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationMvi.kt
@@ -2,6 +2,7 @@ package app.otakureader.feature.migration
 
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MigrationCandidate
+import app.otakureader.domain.model.MigrationFlag
 import app.otakureader.domain.model.MigrationMode
 import app.otakureader.domain.model.MigrationStatus
 
@@ -27,7 +28,9 @@ data class MigrationState(
     /** Number of failed migrations (populated when showCompletionSummary = true). */
     val failedCount: Int = 0,
     /** Number of skipped migrations (populated when showCompletionSummary = true). */
-    val skippedCount: Int = 0
+    val skippedCount: Int = 0,
+    /** Which data categories to carry over during migration. Default: everything. */
+    val migrationFlags: Set<MigrationFlag> = MigrationFlag.entries.toSet()
 )
 
 /**
@@ -70,6 +73,8 @@ sealed class MigrationEvent {
     data object RetryFailed : MigrationEvent()
     /** Dismisses the completion summary dialog. */
     data object DismissCompletionSummary : MigrationEvent()
+    /** Toggles [flag] in or out of the persisted migration-flags set. */
+    data class ToggleMigrationFlag(val flag: MigrationFlag) : MigrationEvent()
 }
 
 /**

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationScreen.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -29,6 +31,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -59,6 +62,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.model.MigrationCandidate
+import app.otakureader.domain.model.MigrationFlag
 import app.otakureader.domain.model.MigrationMode
 import app.otakureader.domain.model.MigrationStatus
 import coil3.compose.AsyncImage
@@ -68,7 +72,18 @@ import kotlinx.coroutines.flow.collectLatest
 private fun MangaStatus.toDisplayString(): String =
     name.replace("_", " ").lowercase().replaceFirstChar { it.uppercase() }
 
-@OptIn(ExperimentalMaterial3Api::class)
+/** Human-readable label for a migration flag chip. */
+@Composable
+private fun MigrationFlag.displayLabel(): String = when (this) {
+    MigrationFlag.CHAPTERS -> stringResource(R.string.migration_flag_chapters)
+    MigrationFlag.CATEGORIES -> stringResource(R.string.migration_flag_categories)
+    MigrationFlag.TRACKING -> stringResource(R.string.migration_flag_tracking)
+    MigrationFlag.NOTES -> stringResource(R.string.migration_flag_notes)
+    MigrationFlag.DOWNLOADS -> stringResource(R.string.migration_flag_downloads)
+    MigrationFlag.CUSTOM_COVER -> stringResource(R.string.migration_flag_custom_cover)
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun MigrationScreen(
     selectedMangaIds: List<Long>,
@@ -189,6 +204,27 @@ fun MigrationScreen(
                             }
                         )
                         Text(stringResource(R.string.migration_mode_copy))
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Migration flags: which data categories to carry over
+                Text(
+                    text = stringResource(R.string.migration_flags_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    MigrationFlag.entries.forEach { flag ->
+                        FilterChip(
+                            selected = flag in state.migrationFlags,
+                            onClick = { viewModel.onEvent(MigrationEvent.ToggleMigrationFlag(flag)) },
+                            label = { Text(flag.displayLabel()) }
+                        )
                     }
                 }
 

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationViewModel.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationViewModel.kt
@@ -3,6 +3,7 @@ package app.otakureader.feature.migration
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.otakureader.core.preferences.AppPreferences
+import app.otakureader.domain.model.MigrationFlag
 import app.otakureader.domain.model.MigrationMode
 import app.otakureader.domain.model.MigrationStatus
 import app.otakureader.domain.repository.MangaRepository
@@ -51,6 +52,7 @@ class MigrationViewModel @Inject constructor(
             is MigrationEvent.DismissConfirmationDialog -> dismissConfirmationDialog()
             is MigrationEvent.RetryFailed -> retryFailed()
             is MigrationEvent.DismissCompletionSummary -> dismissCompletionSummary()
+            is MigrationEvent.ToggleMigrationFlag -> toggleMigrationFlag(event.flag)
         }
     }
 
@@ -80,12 +82,15 @@ class MigrationViewModel @Inject constructor(
                     )
                 }
 
+                val migrationFlags = appPreferences.migrationFlags.first()
+
                 _state.update {
                     it.copy(
                         isLoading = false,
                         selectedManga = manga,
                         migrationTasks = tasks,
-                        availableSources = sources
+                        availableSources = sources,
+                        migrationFlags = migrationFlags
                     )
                 }
             } catch (e: CancellationException) {
@@ -188,7 +193,8 @@ class MigrationViewModel @Inject constructor(
                     val migrationResult = migrateManga(
                         sourceManga = task.manga,
                         targetCandidate = bestMatch,
-                        mode = _state.value.migrationMode
+                        mode = _state.value.migrationMode,
+                        flags = _state.value.migrationFlags
                     )
 
                     if (migrationResult.isSuccess) {
@@ -312,7 +318,8 @@ class MigrationViewModel @Inject constructor(
             val migrationResult = migrateManga(
                 sourceManga = tasks[taskIndex].manga,
                 targetCandidate = candidate,
-                mode = _state.value.migrationMode
+                mode = _state.value.migrationMode,
+                flags = _state.value.migrationFlags
             )
 
             if (migrationResult.isSuccess) {
@@ -400,5 +407,13 @@ class MigrationViewModel @Inject constructor(
 
     private fun dismissCompletionSummary() {
         _state.update { it.copy(showCompletionSummary = false) }
+    }
+
+    private fun toggleMigrationFlag(flag: MigrationFlag) {
+        val updated = _state.value.migrationFlags.let { current ->
+            if (flag in current) current - flag else current + flag
+        }
+        _state.update { it.copy(migrationFlags = updated) }
+        viewModelScope.launch { appPreferences.setMigrationFlags(updated) }
     }
 }

--- a/feature/migration/src/main/res/values/strings.xml
+++ b/feature/migration/src/main/res/values/strings.xml
@@ -12,6 +12,15 @@
     <string name="migration_migrating">Migrating…</string>
     <string name="migration_start">Start Migration</string>
 
+    <!-- Migration flags (#1192 PR 6) -->
+    <string name="migration_flags_title">What to migrate</string>
+    <string name="migration_flag_chapters">Reading progress</string>
+    <string name="migration_flag_categories">Categories</string>
+    <string name="migration_flag_tracking">Tracking</string>
+    <string name="migration_flag_notes">Notes</string>
+    <string name="migration_flag_downloads">Downloads</string>
+    <string name="migration_flag_custom_cover">Custom cover</string>
+
     <!-- Error dialog -->
     <string name="migration_error_title">Error</string>
     <string name="migration_ok">OK</string>

--- a/feature/migration/src/test/java/app/otakureader/feature/migration/MigrationViewModelTest.kt
+++ b/feature/migration/src/test/java/app/otakureader/feature/migration/MigrationViewModelTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import app.otakureader.core.preferences.AppPreferences
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MigrationCandidate
+import app.otakureader.domain.model.MigrationFlag
 import app.otakureader.domain.model.MigrationMode
 import app.otakureader.domain.model.MigrationResult
 import app.otakureader.domain.model.MigrationStatus
@@ -13,6 +14,7 @@ import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.usecase.migration.MigrateMangaUseCase
 import app.otakureader.domain.usecase.migration.SearchMigrationTargetsUseCase
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -70,6 +72,7 @@ class MigrationViewModelTest {
             every { migrationSimilarityThreshold } returns flowOf(0.8f)
             every { migrationAlwaysConfirm } returns flowOf(false)
             every { migrationMinChapterCount } returns flowOf(0)
+            every { migrationFlags } returns flowOf(MigrationFlag.entries.toSet())
         }
     }
 
@@ -231,5 +234,50 @@ class MigrationViewModelTest {
 
         assertEquals(1, viewModel.state.value.currentCandidates.size)
         assertTrue(viewModel.state.value.showConfirmationDialog)
+    }
+
+    @Test
+    fun onEvent_Initialize_loadsMigrationFlagsFromPreferences() = runTest {
+        coEvery { appPreferences.migrationFlags } returns flowOf(setOf(MigrationFlag.CHAPTERS, MigrationFlag.CATEGORIES))
+        coEvery { mangaRepository.getMangaByIds(listOf(1L)) } returns listOf(sampleManga[0])
+
+        val viewModel = createViewModel()
+        viewModel.onEvent(MigrationEvent.Initialize(listOf(1L)))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(setOf(MigrationFlag.CHAPTERS, MigrationFlag.CATEGORIES), viewModel.state.value.migrationFlags)
+    }
+
+    @Test
+    fun onEvent_ToggleMigrationFlag_removesFlagAndPersists() = runTest {
+        coEvery { appPreferences.setMigrationFlags(any()) } returns Unit
+        coEvery { mangaRepository.getMangaByIds(listOf(1L)) } returns listOf(sampleManga[0])
+
+        val viewModel = createViewModel()
+        viewModel.onEvent(MigrationEvent.Initialize(listOf(1L)))
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(MigrationFlag.TRACKING in viewModel.state.value.migrationFlags)
+
+        viewModel.onEvent(MigrationEvent.ToggleMigrationFlag(MigrationFlag.TRACKING))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(MigrationFlag.TRACKING in viewModel.state.value.migrationFlags)
+        coVerify { appPreferences.setMigrationFlags(match { MigrationFlag.TRACKING !in it }) }
+    }
+
+    @Test
+    fun onEvent_ToggleMigrationFlag_reAddsFlagWhenToggledTwice() = runTest {
+        coEvery { appPreferences.setMigrationFlags(any()) } returns Unit
+        coEvery { mangaRepository.getMangaByIds(listOf(1L)) } returns listOf(sampleManga[0])
+
+        val viewModel = createViewModel()
+        viewModel.onEvent(MigrationEvent.Initialize(listOf(1L)))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(MigrationEvent.ToggleMigrationFlag(MigrationFlag.NOTES))
+        viewModel.onEvent(MigrationEvent.ToggleMigrationFlag(MigrationFlag.NOTES))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(MigrationFlag.NOTES in viewModel.state.value.migrationFlags)
     }
 }

--- a/feature/migration/src/test/java/app/otakureader/feature/migration/MigrationViewModelTest.kt
+++ b/feature/migration/src/test/java/app/otakureader/feature/migration/MigrationViewModelTest.kt
@@ -250,7 +250,7 @@ class MigrationViewModelTest {
 
     @Test
     fun onEvent_ToggleMigrationFlag_removesFlagAndPersists() = runTest {
-        coEvery { appPreferences.setMigrationFlags(any()) } returns Unit
+        coEvery { appPreferences.setMigrationFlags(any()) } returns mockk()
         coEvery { mangaRepository.getMangaByIds(listOf(1L)) } returns listOf(sampleManga[0])
 
         val viewModel = createViewModel()
@@ -267,7 +267,7 @@ class MigrationViewModelTest {
 
     @Test
     fun onEvent_ToggleMigrationFlag_reAddsFlagWhenToggledTwice() = runTest {
-        coEvery { appPreferences.setMigrationFlags(any()) } returns Unit
+        coEvery { appPreferences.setMigrationFlags(any()) } returns mockk()
         coEvery { mangaRepository.getMangaByIds(listOf(1L)) } returns listOf(sampleManga[0])
 
         val viewModel = createViewModel()

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/errors/UpdateErrorsScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/errors/UpdateErrorsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -256,6 +257,7 @@ private fun UpdateErrorCard(
     SwipeToDismissBox(
         state = dismissState,
         enableDismissFromStartToEnd = false,
+        enableDismissFromEndToStart = !isSelectionMode,
         modifier = modifier,
         backgroundContent = {
             Box(
@@ -343,7 +345,10 @@ private fun UpdateErrorsSelectionBar(
         tonalElevation = 3.dp,
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(vertical = 8.dp),
             horizontalArrangement = Arrangement.SpaceEvenly,
         ) {
             SelectionBarAction(


### PR DESCRIPTION
## 📋 Description
Implements PR 6 of the #1192 deferred-gaps backlog: per-category migration options plus custom-cover migration.

- New `MigrationFlag` enum (domain): `CHAPTERS, CATEGORIES, TRACKING, NOTES, DOWNLOADS, CUSTOM_COVER`.
- `AppPreferences.migrationFlags: Flow<Set<MigrationFlag>>` (+ setter) — persisted as a string set, default = every flag (preserves pre-existing unconditional-copy behavior).
- `MigrateMangaUseCase` gains a `flags: Set<MigrationFlag> = MigrationFlag.entries.toSet()` parameter; every previously-unconditional copy block is now gated: notes (insert-time + existing-target update), category add/remove, tracker link migration, downloaded-chapter migration, and reading-progress (read/lastPageRead) carry-over. Chapter *matching* itself is never gated — it's needed regardless of which flags are on so downloads/progress can still find their corresponding source chapter.
- New `MangaRepository.copyCustomCover(fromMangaId, toMangaId)` (+ `MangaRepositoryImpl` implementation mirroring `setCustomCover`'s file-copy internals) — an Otaku-exclusive feature Komikku has no equivalent flag for, so this is genuinely new plumbing rather than a reused method. Gated behind `CUSTOM_COVER` + `sourceManga.hasCustomCover`.
- UI: a `FilterChip` row on the migration screen (Komikku's `MigrationConfigScreenSheet` pattern) below the mode selector, reading/writing the pref via a new `MigrationEvent.ToggleMigrationFlag`.
- **Skipped** (documented per the plan): reading-history timestamps (readAt/duration). `ChapterRepository` only exposes a global, unscoped `observeHistory()` — there's no per-manga/per-chapter read API to select just the migrating manga's history without scanning the entire app's history table. Wiring this under `CHAPTERS` needs new repository plumbing; left as a follow-up note for #1192 rather than growing this PR.

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🎨 UI/UX
- [ ] 📖 Documentation
- [ ] ♻️ Refactoring
- [ ] 🚀 Performance
- [ ] 🧪 Tests

## 🧪 Testing
- `MigrateMangaUseCaseTest`: new gating tests per flag — `CATEGORIES`/`TRACKING`/`NOTES`/`CUSTOM_COVER`/`DOWNLOADS`/`CHAPTERS` off each verify the corresponding repository calls don't happen (or, for `CHAPTERS`, that progress isn't carried while matching still occurs). All pre-existing tests are unaffected since `flags` defaults to "everything" and none of them pass it explicitly.
- `MigrationViewModelTest`: added tests for loading `migrationFlags` from preferences on `Initialize`, and toggling a flag on/off (including persistence via `setMigrationFlags`).
- `./gradlew detekt` passes locally. Ktlint's Gradle task in this project only covers root-level `.kts` build scripts, not module Kotlin sources (confirmed in the prior PR), so per-module lint runs in CI only.
- No local Android SDK in this sandbox, so `:app`/module compilation, the full unit-test suite, and coverage gates could only be verified in CI, not locally.
- UI (the new FilterChip row) was not visually verified — no way to run the app in this sandbox. Please eyeball it on a device/emulator before merging.

## 📸 Screenshots
Not available — no local Android runtime/emulator in this environment.

## ✅ Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code (none needed beyond inline rationale already present)
- [ ] Documentation updated
- [x] No new warnings (detekt clean)
- [x] Tests pass (new/updated unit tests included; full suite runs in CI)

## 🔗 Related Issues
Part of #1192 (PR 6 of 7 in the deferred-gaps backlog).


---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

## Summary by Sourcery

Introduce per-category migration flags and custom cover migration, with UI controls and persistence, plus minor update errors screen UX improvements.

New Features:
- Add MigrationFlag enum and preference-backed migrationFlags to control which data categories are migrated per operation.
- Support migrating custom cover art between manga entries when the source has a user-set cover.
- Expose migration flags in the migration screen via filter chips, allowing users to toggle data categories before running migrations.

Enhancements:
- Gate migration behavior (notes, categories, tracking, downloads, reading progress) behind configurable MigrationFlag checks while preserving previous default behavior.
- Persist and restore migration flag selections through AppPreferences so user choices are remembered across sessions.
- Adjust update errors list swipe-to-dismiss and selection bar layout for better behavior in selection mode and improved insets handling.

Tests:
- Extend MigrateMangaUseCaseTest with coverage for each MigrationFlag to ensure the corresponding migrations are skipped or applied as configured.
- Update MigrationViewModelTest to verify migrationFlags are loaded from preferences and toggling flags updates state and persistence correctly.