### PR TITLE
Add selective backup/restore (#1192 PR 7)

### DIFF
--- a/data/src/main/java/app/otakureader/data/backup/BackupCreator.kt
+++ b/data/src/main/java/app/otakureader/data/backup/BackupCreator.kt
@@ -72,7 +72,12 @@ class BackupCreator @Inject constructor(
 
             if (options.libraryEntries) {
                 // Load history map once — it's ID+timestamps, compact even for large libraries.
-                val historyByChapterId = readingHistoryDao.observeHistory().first().associateBy { it.chapterId }
+                // Skipped entirely when chapters are excluded, since history is per-chapter.
+                val historyByChapterId = if (options.effectiveChapters) {
+                    readingHistoryDao.observeHistory().first().associateBy { it.chapterId }
+                } else {
+                    emptyMap()
+                }
                 val favoriteManga = mangaDao.getFavoriteManga().first()
 
                 favoriteManga.forEachIndexed { index, mangaEntity ->

--- a/data/src/main/java/app/otakureader/data/backup/BackupCreator.kt
+++ b/data/src/main/java/app/otakureader/data/backup/BackupCreator.kt
@@ -22,6 +22,8 @@ import app.otakureader.data.backup.mapper.toBackupSyncConfiguration
 import app.otakureader.data.backup.mapper.toBackupTrackerSyncState
 import app.otakureader.data.backup.model.BackupData
 import app.otakureader.data.backup.model.BackupManga
+import app.otakureader.data.backup.model.BackupPreferences
+import app.otakureader.domain.model.BackupOptions
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -56,52 +58,73 @@ class BackupCreator @Inject constructor(
      * holding the entire library + chapters + JSON string in RAM simultaneously.
      * Callers should wrap [output] in a [java.io.BufferedOutputStream] if the underlying
      * stream is not already buffered.
+     *
+     * Sections deselected via [options] are written as empty arrays (or `null` for
+     * preferences) rather than omitted — the JSON envelope/decoder is unchanged, no version
+     * bump needed. See [BackupOptions] for the dependency gating rules (chapters/tracking
+     * require libraryEntries).
      */
-    suspend fun createBackupToStream(output: OutputStream) = withContext(Dispatchers.IO) {
-        val writer = output.bufferedWriter(Charsets.UTF_8)
-        writer.write("""{"version":${BackupData.CURRENT_VERSION},"createdAt":${System.currentTimeMillis()},"manga":[""")
+    @Suppress("LongMethod", "CognitiveComplexMethod")
+    suspend fun createBackupToStream(output: OutputStream, options: BackupOptions = BackupOptions.ALL) =
+        withContext(Dispatchers.IO) {
+            val writer = output.bufferedWriter(Charsets.UTF_8)
+            writer.write("""{"version":${BackupData.CURRENT_VERSION},"createdAt":${System.currentTimeMillis()},"manga":[""")
 
-        // Load history map once — it's ID+timestamps, compact even for large libraries.
-        val historyByChapterId = readingHistoryDao.observeHistory().first().associateBy { it.chapterId }
-        val favoriteManga = mangaDao.getFavoriteManga().first()
+            if (options.libraryEntries) {
+                // Load history map once — it's ID+timestamps, compact even for large libraries.
+                val historyByChapterId = readingHistoryDao.observeHistory().first().associateBy { it.chapterId }
+                val favoriteManga = mangaDao.getFavoriteManga().first()
 
-        favoriteManga.forEachIndexed { index, mangaEntity ->
-            if (index > 0) writer.write(",")
-            val chapters = chapterDao.getChaptersByMangaId(mangaEntity.id).first()
-            val backupChapters = chapters.map { chapterEntity ->
-                chapterEntity.toBackupChapter(readingHistory = historyByChapterId[chapterEntity.id]?.toBackupReadingHistory())
+                favoriteManga.forEachIndexed { index, mangaEntity ->
+                    if (index > 0) writer.write(",")
+                    val backupChapters = if (options.effectiveChapters) {
+                        chapterDao.getChaptersByMangaId(mangaEntity.id).first().map { chapterEntity ->
+                            chapterEntity.toBackupChapter(
+                                readingHistory = historyByChapterId[chapterEntity.id]?.toBackupReadingHistory()
+                            )
+                        }
+                    } else {
+                        emptyList()
+                    }
+                    val categoryIds = if (options.categories) {
+                        categoryDao.getCategoryIdsForManga(mangaEntity.id).first()
+                    } else {
+                        emptyList()
+                    }
+                    writer.write(json.encodeToString(mangaEntity.toBackupManga(chapters = backupChapters, categoryIds = categoryIds)))
+                    // Flush every 50 manga so buffered bytes don't accumulate unbounded.
+                    if (index % 50 == 49) writer.flush()
+                }
             }
-            val categoryIds = categoryDao.getCategoryIdsForManga(mangaEntity.id).first()
-            writer.write(json.encodeToString(mangaEntity.toBackupManga(chapters = backupChapters, categoryIds = categoryIds)))
-            // Flush every 50 manga so buffered bytes don't accumulate unbounded.
-            if (index % 50 == 49) writer.flush()
-        }
 
-        writer.write("""],"categories":""")
-        writer.write(json.encodeToString(createCategoryBackup()))
-        writer.write(""","preferences":""")
-        writer.write(json.encodeToString(createPreferencesBackup()))
-        writer.write(""","opdsServers":""")
-        writer.write(json.encodeToString(createOpdsBackup()))
-        writer.write(""","feedSources":""")
-        writer.write(json.encodeToString(createFeedSourceBackup()))
-        writer.write(""","feedSavedSearches":""")
-        writer.write(json.encodeToString(createFeedSavedSearchBackup()))
-        writer.write(""","trackerSyncStates":""")
-        writer.write(json.encodeToString(createTrackerSyncStateBackup()))
-        writer.write(""","syncConfigurations":""")
-        writer.write(json.encodeToString(createSyncConfigBackup()))
-        writer.write("}")
-        writer.flush()
-    }
+            val preferencesBackup: BackupPreferences? =
+                if (options.preferences) createPreferencesBackup() else null
+
+            writer.write("""],"categories":""")
+            writer.write(json.encodeToString(if (options.categories) createCategoryBackup() else emptyList()))
+            writer.write(""","preferences":""")
+            writer.write(json.encodeToString(preferencesBackup))
+            writer.write(""","opdsServers":""")
+            writer.write(json.encodeToString(if (options.opdsServers) createOpdsBackup() else emptyList()))
+            writer.write(""","feedSources":""")
+            writer.write(json.encodeToString(if (options.feed) createFeedSourceBackup() else emptyList()))
+            writer.write(""","feedSavedSearches":""")
+            writer.write(json.encodeToString(if (options.feed) createFeedSavedSearchBackup() else emptyList()))
+            writer.write(""","trackerSyncStates":""")
+            writer.write(json.encodeToString(if (options.effectiveTracking) createTrackerSyncStateBackup() else emptyList()))
+            writer.write(""","syncConfigurations":""")
+            writer.write(json.encodeToString(if (options.syncConfigurations) createSyncConfigBackup() else emptyList()))
+            writer.write("}")
+            writer.flush()
+        }
 
     /**
      * Creates a full backup of all app data.
      * For large libraries, prefer [createBackupToStream] to avoid a large intermediate String.
      */
-    suspend fun createBackup(): String {
+    suspend fun createBackup(options: BackupOptions = BackupOptions.ALL): String {
         val baos = java.io.ByteArrayOutputStream()
-        createBackupToStream(baos)
+        createBackupToStream(baos, options)
         return baos.toString(Charsets.UTF_8.name())
     }
 

--- a/data/src/main/java/app/otakureader/data/backup/BackupRestorer.kt
+++ b/data/src/main/java/app/otakureader/data/backup/BackupRestorer.kt
@@ -23,6 +23,7 @@ import app.otakureader.data.backup.mapper.toOpdsServerEntity
 import app.otakureader.data.backup.mapper.toSyncConfigurationEntity
 import app.otakureader.data.backup.mapper.toTrackerSyncStateEntity
 import app.otakureader.data.backup.model.BackupData
+import app.otakureader.domain.model.BackupOptions
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
@@ -58,22 +59,26 @@ class BackupRestorer @Inject constructor(
      * participate in a Room transaction.
      *
      * @param backupJson JSON string containing the backup data
+     * @param options Which data categories to restore. Defaults to everything (pre-#1192-PR-7
+     *   behavior). Sections outside [options] are skipped even if present in the backup file.
      * @throws Exception if the backup cannot be parsed or restored
      */
-    suspend fun restoreBackup(backupJson: String) {
+    suspend fun restoreBackup(backupJson: String, options: BackupOptions = BackupOptions.ALL) {
         val backupData = json.decodeFromString<BackupData>(backupJson)
 
         database.withTransaction {
-            restoreCategories(backupData)
-            restoreManga(backupData)
-            restoreOpdsServers(backupData)
-            restoreFeedSources(backupData)
-            restoreFeedSavedSearches(backupData)
-            restoreSyncConfigurations(backupData)
-            restoreTrackerSyncStates(backupData)
+            if (options.categories) restoreCategories(backupData)
+            if (options.libraryEntries) restoreManga(backupData, options)
+            if (options.opdsServers) restoreOpdsServers(backupData)
+            if (options.feed) {
+                restoreFeedSources(backupData)
+                restoreFeedSavedSearches(backupData)
+            }
+            if (options.syncConfigurations) restoreSyncConfigurations(backupData)
+            if (options.effectiveTracking) restoreTrackerSyncStates(backupData)
         }
 
-        restorePreferences(backupData)
+        if (options.preferences) restorePreferences(backupData)
     }
 
     /**
@@ -90,7 +95,7 @@ class BackupRestorer @Inject constructor(
     /**
      * Restores manga, chapters, and reading history from backup.
      */
-    private suspend fun restoreManga(backupData: BackupData) {
+    private suspend fun restoreManga(backupData: BackupData, options: BackupOptions) {
         backupData.manga.forEach { backupManga ->
             // Check if manga already exists by source and URL
             val existingManga = mangaDao.getMangaBySourceAndUrl(
@@ -109,10 +114,10 @@ class BackupRestorer @Inject constructor(
             }
 
             // Restore chapters for this manga
-            restoreChapters(mangaId, backupManga)
+            if (options.chapters) restoreChapters(mangaId, backupManga)
 
             // Restore category associations
-            restoreMangaCategories(mangaId, backupManga.categoryIds)
+            if (options.categories) restoreMangaCategories(mangaId, backupManga.categoryIds)
         }
     }
 

--- a/data/src/main/java/app/otakureader/data/backup/repository/BackupRepository.kt
+++ b/data/src/main/java/app/otakureader/data/backup/repository/BackupRepository.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import app.otakureader.data.backup.AesBackupCipher
 import app.otakureader.data.backup.BackupCreator
 import app.otakureader.data.backup.BackupRestorer
+import app.otakureader.domain.model.BackupOptions
 import app.otakureader.domain.backup.BackupRepository as BackupRepositoryInterface
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -23,29 +24,29 @@ class BackupRepository @Inject constructor(
     private val backupRestorer: BackupRestorer
 ) : BackupRepositoryInterface {
 
-    override suspend fun createBackup(uriString: String) = withContext(Dispatchers.IO) {
+    override suspend fun createBackup(uriString: String, options: BackupOptions) = withContext(Dispatchers.IO) {
         val uri = Uri.parse(uriString)
-        context.contentResolver.openOutputStream(uri)?.use { backupCreator.createBackupToStream(it) }
+        context.contentResolver.openOutputStream(uri)?.use { backupCreator.createBackupToStream(it, options) }
             ?: error("Failed to open output stream for URI: $uriString")
     }
 
-    override suspend fun restoreBackup(uriString: String) = withContext(Dispatchers.IO) {
+    override suspend fun restoreBackup(uriString: String, options: BackupOptions) = withContext(Dispatchers.IO) {
         val uri = Uri.parse(uriString)
         val backupJson = context.contentResolver.openInputStream(uri)?.use { it.readBytes().decodeToString() }
             ?: error("Failed to open input stream for URI: $uriString")
-        backupRestorer.restoreBackup(backupJson)
+        backupRestorer.restoreBackup(backupJson, options)
     }
 
-    override suspend fun createLocalBackup(): File = withContext(Dispatchers.IO) {
+    override suspend fun createLocalBackup(options: BackupOptions): File = withContext(Dispatchers.IO) {
         val dir = getLocalBackupDir()
         val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
         val file = File(dir, "otakureader_backup_$timestamp.json")
-        file.outputStream().use { backupCreator.createBackupToStream(it) }
+        file.outputStream().use { backupCreator.createBackupToStream(it, options) }
         file
     }
 
-    override suspend fun restoreLocalBackup(file: File) = withContext(Dispatchers.IO) {
-        backupRestorer.restoreBackup(file.readText())
+    override suspend fun restoreLocalBackup(file: File, options: BackupOptions) = withContext(Dispatchers.IO) {
+        backupRestorer.restoreBackup(file.readText(), options)
     }
 
     override suspend fun listLocalBackups(): List<File> = withContext(Dispatchers.IO) {
@@ -63,21 +64,23 @@ class BackupRepository @Inject constructor(
         }
     }
 
-    override suspend fun createEncryptedBackup(uriString: String, password: CharArray) = withContext(Dispatchers.IO) {
-        val uri = Uri.parse(uriString)
-        val backupJson = backupCreator.createBackup()
-        val encrypted = AesBackupCipher.encrypt(backupJson.toByteArray(Charsets.UTF_8), password)
-        context.contentResolver.openOutputStream(uri)?.use { it.write(encrypted) }
-            ?: error("Failed to open output stream for URI: $uriString")
-    }
+    override suspend fun createEncryptedBackup(uriString: String, password: CharArray, options: BackupOptions) =
+        withContext(Dispatchers.IO) {
+            val uri = Uri.parse(uriString)
+            val backupJson = backupCreator.createBackup(options)
+            val encrypted = AesBackupCipher.encrypt(backupJson.toByteArray(Charsets.UTF_8), password)
+            context.contentResolver.openOutputStream(uri)?.use { it.write(encrypted) }
+                ?: error("Failed to open output stream for URI: $uriString")
+        }
 
-    override suspend fun restoreEncryptedBackup(uriString: String, password: CharArray) = withContext(Dispatchers.IO) {
-        val uri = Uri.parse(uriString)
-        val data = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
-            ?: error("Failed to open input stream for URI: $uriString")
-        val decrypted = AesBackupCipher.decrypt(data, password)
-        backupRestorer.restoreBackup(decrypted.decodeToString())
-    }
+    override suspend fun restoreEncryptedBackup(uriString: String, password: CharArray, options: BackupOptions) =
+        withContext(Dispatchers.IO) {
+            val uri = Uri.parse(uriString)
+            val data = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                ?: error("Failed to open input stream for URI: $uriString")
+            val decrypted = AesBackupCipher.decrypt(data, password)
+            backupRestorer.restoreBackup(decrypted.decodeToString(), options)
+        }
 
     override suspend fun isBackupEncrypted(uriString: String): Boolean = withContext(Dispatchers.IO) {
         val uri = Uri.parse(uriString)

--- a/data/src/test/java/app/otakureader/data/backup/BackupCreatorTest.kt
+++ b/data/src/test/java/app/otakureader/data/backup/BackupCreatorTest.kt
@@ -1,0 +1,193 @@
+package app.otakureader.data.backup
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.otakureader.core.database.OtakuReaderDatabase
+import app.otakureader.core.database.entity.CategoryEntity
+import app.otakureader.core.database.entity.ChapterEntity
+import app.otakureader.core.database.entity.MangaCategoryEntity
+import app.otakureader.core.database.entity.MangaEntity
+import app.otakureader.core.database.entity.OpdsServerEntity
+import app.otakureader.core.preferences.GeneralPreferences
+import app.otakureader.core.preferences.LibraryPreferences
+import app.otakureader.core.preferences.ReaderPreferences
+import app.otakureader.data.backup.model.BackupData
+import app.otakureader.domain.model.BackupOptions
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.ByteArrayOutputStream
+
+/**
+ * Round-trip tests for [BackupCreator] with [BackupOptions] sections toggled off — verifies
+ * deselected sections are written as empty arrays (or null for preferences) rather than
+ * omitted, per #1192 PR 7.
+ */
+@RunWith(AndroidJUnit4::class)
+class BackupCreatorTest {
+
+    private lateinit var database: OtakuReaderDatabase
+    private lateinit var creator: BackupCreator
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            OtakuReaderDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        val generalPreferences = mockk<GeneralPreferences>(relaxed = true) {
+            every { themeMode } returns flowOf(0)
+            every { useDynamicColor } returns flowOf(true)
+            every { locale } returns flowOf("")
+            every { updateCheckInterval } returns flowOf(12)
+            every { notificationsEnabled } returns flowOf(true)
+        }
+        val libraryPreferences = mockk<LibraryPreferences>(relaxed = true) {
+            every { gridSize } returns flowOf(3)
+            every { showBadges } returns flowOf(true)
+        }
+        val readerPreferences = mockk<ReaderPreferences>(relaxed = true) {
+            every { readerMode } returns flowOf(0)
+            every { keepScreenOn } returns flowOf(true)
+            every { volumeKeysEnabled } returns flowOf(false)
+            every { volumeKeysInverted } returns flowOf(false)
+        }
+
+        creator = BackupCreator(
+            mangaDao = database.mangaDao(),
+            chapterDao = database.chapterDao(),
+            categoryDao = database.categoryDao(),
+            readingHistoryDao = database.readingHistoryDao(),
+            trackerSyncDao = database.trackerSyncDao(),
+            opdsServerDao = database.opdsServerDao(),
+            feedDao = database.feedDao(),
+            generalPreferences = generalPreferences,
+            libraryPreferences = libraryPreferences,
+            readerPreferences = readerPreferences,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    private suspend fun seedFavoriteMangaWithChapterAndCategory(): Long {
+        val mangaId = database.mangaDao().insert(
+            MangaEntity(sourceId = 1L, url = "/m/1", title = "Test Manga", favorite = true)
+        )
+        database.chapterDao().insert(
+            ChapterEntity(mangaId = mangaId, url = "/c/1", name = "Chapter 1", chapterNumber = 1f)
+        )
+        database.categoryDao().insert(CategoryEntity(id = 1L, name = "Reading", order = 0))
+        database.mangaCategoryDao().upsert(MangaCategoryEntity(mangaId = mangaId, categoryId = 1L))
+        return mangaId
+    }
+
+    private suspend fun createAndDecode(options: BackupOptions): BackupData {
+        val output = ByteArrayOutputStream()
+        creator.createBackupToStream(output, options)
+        return json.decodeFromString(output.toString(Charsets.UTF_8.name()))
+    }
+
+    @Test
+    fun `default options include manga with its chapters and categories`() = runBlocking {
+        seedFavoriteMangaWithChapterAndCategory()
+
+        val backup = createAndDecode(BackupOptions.ALL)
+
+        assertEquals(1, backup.manga.size)
+        assertEquals(1, backup.manga[0].chapters.size)
+        assertEquals(listOf(1L), backup.manga[0].categoryIds)
+    }
+
+    @Test
+    fun `libraryEntries off emits an empty manga array`() = runBlocking {
+        seedFavoriteMangaWithChapterAndCategory()
+
+        val backup = createAndDecode(BackupOptions.ALL.copy(libraryEntries = false))
+
+        assertTrue(backup.manga.isEmpty())
+    }
+
+    @Test
+    fun `chapters off keeps the manga entry but empties its chapter list`() = runBlocking {
+        seedFavoriteMangaWithChapterAndCategory()
+
+        val backup = createAndDecode(BackupOptions.ALL.copy(chapters = false))
+
+        assertEquals(1, backup.manga.size)
+        assertTrue(backup.manga[0].chapters.isEmpty())
+    }
+
+    @Test
+    fun `categories off empties both the categories list and manga categoryIds`() = runBlocking {
+        seedFavoriteMangaWithChapterAndCategory()
+
+        val backup = createAndDecode(BackupOptions.ALL.copy(categories = false))
+
+        assertTrue(backup.categories.isEmpty())
+        assertTrue(backup.manga[0].categoryIds.isEmpty())
+    }
+
+    @Test
+    fun `preferences off writes null preferences`() = runBlocking {
+        val backup = createAndDecode(BackupOptions.ALL.copy(preferences = false))
+
+        assertNull(backup.preferences)
+    }
+
+    @Test
+    fun `preferences on writes non-null preferences`() = runBlocking {
+        val backup = createAndDecode(BackupOptions.ALL)
+
+        assertNotNull(backup.preferences)
+    }
+
+    @Test
+    fun `opdsServers off empties the opds server list`() = runBlocking {
+        database.opdsServerDao().insertAll(listOf(OpdsServerEntity(id = 1L, name = "Server", url = "https://example.com")))
+
+        val backup = createAndDecode(BackupOptions.ALL.copy(opdsServers = false))
+
+        assertTrue(backup.opdsServers.isEmpty())
+    }
+
+    @Test
+    fun `opdsServers on includes opds servers`() = runBlocking {
+        database.opdsServerDao().insertAll(listOf(OpdsServerEntity(id = 1L, name = "Server", url = "https://example.com")))
+
+        val backup = createAndDecode(BackupOptions.ALL)
+
+        assertEquals(1, backup.opdsServers.size)
+    }
+
+    @Test
+    fun `tracking off empties trackerSyncStates even with libraryEntries on`() = runBlocking {
+        seedFavoriteMangaWithChapterAndCategory()
+
+        val backup = createAndDecode(BackupOptions.ALL.copy(tracking = false))
+
+        assertTrue(backup.trackerSyncStates.isEmpty())
+    }
+
+    @Test
+    fun `syncConfigurations off empties the syncConfigurations list`() = runBlocking {
+        val backup = createAndDecode(BackupOptions.ALL.copy(syncConfigurations = false))
+
+        assertTrue(backup.syncConfigurations.isEmpty())
+    }
+}

--- a/data/src/test/java/app/otakureader/data/backup/BackupRestorerTest.kt
+++ b/data/src/test/java/app/otakureader/data/backup/BackupRestorerTest.kt
@@ -1,0 +1,193 @@
+package app.otakureader.data.backup
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.otakureader.core.database.OtakuReaderDatabase
+import app.otakureader.core.preferences.GeneralPreferences
+import app.otakureader.core.preferences.LibraryPreferences
+import app.otakureader.core.preferences.ReaderPreferences
+import app.otakureader.data.backup.model.BackupCategory
+import app.otakureader.data.backup.model.BackupChapter
+import app.otakureader.data.backup.model.BackupData
+import app.otakureader.data.backup.model.BackupFeedSavedSearch
+import app.otakureader.data.backup.model.BackupFeedSource
+import app.otakureader.data.backup.model.BackupManga
+import app.otakureader.data.backup.model.BackupOpdsServer
+import app.otakureader.data.backup.model.BackupPreferences
+import app.otakureader.data.backup.model.BackupSyncConfiguration
+import app.otakureader.data.backup.model.BackupTrackerSyncState
+import app.otakureader.domain.model.BackupOptions
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Round-trip tests for [BackupRestorer] with [BackupOptions] sections toggled off — verifies
+ * each restore step is skipped when its section is deselected, even when the backup JSON
+ * still contains data for it, per #1192 PR 7.
+ */
+@RunWith(AndroidJUnit4::class)
+class BackupRestorerTest {
+
+    private lateinit var database: OtakuReaderDatabase
+    private lateinit var restorer: BackupRestorer
+    private lateinit var generalPreferences: GeneralPreferences
+    private lateinit var libraryPreferences: LibraryPreferences
+    private lateinit var readerPreferences: ReaderPreferences
+    private val json = Json { encodeDefaults = true }
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            OtakuReaderDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        generalPreferences = mockk(relaxed = true)
+        libraryPreferences = mockk(relaxed = true)
+        readerPreferences = mockk(relaxed = true)
+
+        restorer = BackupRestorer(
+            database = database,
+            mangaDao = database.mangaDao(),
+            chapterDao = database.chapterDao(),
+            categoryDao = database.categoryDao(),
+            mangaCategoryDao = database.mangaCategoryDao(),
+            readingHistoryDao = database.readingHistoryDao(),
+            trackerSyncDao = database.trackerSyncDao(),
+            opdsServerDao = database.opdsServerDao(),
+            feedDao = database.feedDao(),
+            generalPreferences = generalPreferences,
+            libraryPreferences = libraryPreferences,
+            readerPreferences = readerPreferences,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    private val fullBackup = BackupData(
+        manga = listOf(
+            BackupManga(
+                sourceId = 1L,
+                url = "/m/1",
+                title = "Test Manga",
+                favorite = true,
+                chapters = listOf(
+                    BackupChapter(url = "/c/1", name = "Chapter 1", chapterNumber = 1f)
+                ),
+                categoryIds = listOf(1L),
+            )
+        ),
+        categories = listOf(BackupCategory(id = 1L, name = "Reading")),
+        preferences = BackupPreferences(),
+        opdsServers = listOf(BackupOpdsServer(id = 1L, name = "Server", url = "https://example.com")),
+        feedSources = listOf(BackupFeedSource(id = 1L, sourceId = 1L, sourceName = "Source")),
+        feedSavedSearches = listOf(BackupFeedSavedSearch(id = 1L, sourceId = 1L, sourceName = "Source", query = "q")),
+        trackerSyncStates = listOf(
+            BackupTrackerSyncState(
+                mangaId = 1L, trackerId = 1, remoteId = "r1",
+                localLastChapterRead = 1f, localTotalChapters = 10, localStatus = 0,
+                localLastModifiedEpochMilli = 0L, remoteLastChapterRead = 1f,
+                remoteTotalChapters = 10, remoteStatus = 0, syncStatus = 0,
+            )
+        ),
+        syncConfigurations = listOf(BackupSyncConfiguration(trackerId = 1, syncDirection = 0, conflictResolution = 0)),
+    )
+
+    private fun backupJson(data: BackupData = fullBackup) = json.encodeToString(data)
+
+    @Test
+    fun `default options restores every section`() = runBlocking {
+        restorer.restoreBackup(backupJson(), BackupOptions.ALL)
+
+        assertEquals(1, database.mangaDao().getFavoriteManga().first().size)
+        assertEquals(1, database.categoryDao().getCategories().first().size)
+        assertEquals(1, database.opdsServerDao().getAll().first().size)
+        assertEquals(1, database.feedDao().getFeedSources().first().size)
+        assertEquals(1, database.feedDao().getSavedSearches().first().size)
+        assertEquals(1, database.trackerSyncDao().getSyncConfigurations().first().size)
+        assertEquals(1, database.trackerSyncDao().getAllSyncStates().first().size)
+    }
+
+    @Test
+    fun `libraryEntries off skips manga restore entirely`() = runBlocking {
+        restorer.restoreBackup(backupJson(), BackupOptions.ALL.copy(libraryEntries = false))
+
+        assertTrue(database.mangaDao().getFavoriteManga().first().isEmpty())
+    }
+
+    @Test
+    fun `chapters off restores manga but not its chapters`() = runBlocking {
+        restorer.restoreBackup(backupJson(), BackupOptions.ALL.copy(chapters = false))
+
+        val manga = database.mangaDao().getFavoriteManga().first().single()
+        assertTrue(database.chapterDao().getChaptersByMangaIdOnce(manga.id).isEmpty())
+    }
+
+    @Test
+    fun `categories off restores manga without category rows or associations`() = runBlocking {
+        restorer.restoreBackup(backupJson(), BackupOptions.ALL.copy(categories = false))
+
+        assertTrue(database.categoryDao().getCategories().first().isEmpty())
+        val manga = database.mangaDao().getFavoriteManga().first().single()
+        assertTrue(database.categoryDao().getCategoryIdsForManga(manga.id).first().isEmpty())
+    }
+
+    @Test
+    fun `preferences off never calls any preference setter`() = runBlocking {
+        restorer.restoreBackup(backupJson(), BackupOptions.ALL.copy(preferences = false))
+
+        coVerify(exactly = 0) { generalPreferences.setThemeMode(any()) }
+        coVerify(exactly = 0) { libraryPreferences.setGridSize(any()) }
+        coVerify(exactly = 0) { readerPreferences.setReaderMode(any()) }
+    }
+
+    @Test
+    fun `preferences on calls the preference setters`() = runBlocking {
+        restorer.restoreBackup(backupJson(), BackupOptions.ALL)
+
+        coVerify(exactly = 1) { generalPreferences.setThemeMode(any()) }
+    }
+
+    @Test
+    fun `opdsServers off skips opds server restore`() = runBlocking {
+        restorer.restoreBackup(backupJson(), BackupOptions.ALL.copy(opdsServers = false))
+
+        assertTrue(database.opdsServerDao().getAll().first().isEmpty())
+    }
+
+    @Test
+    fun `feed off skips both feed sources and saved searches`() = runBlocking {
+        restorer.restoreBackup(backupJson(), BackupOptions.ALL.copy(feed = false))
+
+        assertTrue(database.feedDao().getFeedSources().first().isEmpty())
+        assertTrue(database.feedDao().getSavedSearches().first().isEmpty())
+    }
+
+    @Test
+    fun `syncConfigurations off skips sync configuration restore`() = runBlocking {
+        restorer.restoreBackup(backupJson(), BackupOptions.ALL.copy(syncConfigurations = false))
+
+        assertTrue(database.trackerSyncDao().getSyncConfigurations().first().isEmpty())
+    }
+
+    @Test
+    fun `tracking off skips tracker sync state restore even with libraryEntries on`() = runBlocking {
+        restorer.restoreBackup(backupJson(), BackupOptions.ALL.copy(tracking = false))
+
+        assertTrue(database.trackerSyncDao().getAllSyncStates().first().isEmpty())
+    }
+}

--- a/domain/src/main/java/app/otakureader/domain/backup/BackupRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/backup/BackupRepository.kt
@@ -1,20 +1,21 @@
 package app.otakureader.domain.backup
 
+import app.otakureader.domain.model.BackupOptions
 import java.io.File
 
 /** Repository for managing backup and restore operations. */
 interface BackupRepository {
     /** Creates a backup and writes it to the provided URI. */
-    suspend fun createBackup(uriString: String)
+    suspend fun createBackup(uriString: String, options: BackupOptions = BackupOptions.ALL)
 
     /** Restores a backup from the provided URI. */
-    suspend fun restoreBackup(uriString: String)
+    suspend fun restoreBackup(uriString: String, options: BackupOptions = BackupOptions.ALL)
 
     /** Creates an automatic backup and saves it to the app's private backup directory. */
-    suspend fun createLocalBackup(): File
+    suspend fun createLocalBackup(options: BackupOptions = BackupOptions.ALL): File
 
     /** Restores a backup from a local file. */
-    suspend fun restoreLocalBackup(file: File)
+    suspend fun restoreLocalBackup(file: File, options: BackupOptions = BackupOptions.ALL)
 
     /** Returns a list of automatic backup files stored locally, sorted newest first. */
     suspend fun listLocalBackups(): List<File>
@@ -26,10 +27,10 @@ interface BackupRepository {
     suspend fun pruneLocalBackups(maxCount: Int)
 
     /** Creates an AES-256-GCM encrypted backup and writes it to the provided URI. */
-    suspend fun createEncryptedBackup(uriString: String, password: CharArray)
+    suspend fun createEncryptedBackup(uriString: String, password: CharArray, options: BackupOptions = BackupOptions.ALL)
 
     /** Decrypts and restores a backup from the provided URI. */
-    suspend fun restoreEncryptedBackup(uriString: String, password: CharArray)
+    suspend fun restoreEncryptedBackup(uriString: String, password: CharArray, options: BackupOptions = BackupOptions.ALL)
 
     /** Returns true if the file at [uriString] begins with the encrypted-backup magic bytes. */
     suspend fun isBackupEncrypted(uriString: String): Boolean

--- a/domain/src/main/java/app/otakureader/domain/model/BackupOptions.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/BackupOptions.kt
@@ -1,0 +1,32 @@
+package app.otakureader.domain.model
+
+/**
+ * Which data categories to include when creating a backup, or apply when restoring one.
+ * Threaded through [app.otakureader.domain.backup.BackupRepository] at the point of use — this
+ * carries no persisted state itself. Default ([ALL]) preserves the pre-#1192-PR-7
+ * unconditional backup/restore behavior.
+ */
+data class BackupOptions(
+    val libraryEntries: Boolean = true,
+    val chapters: Boolean = true,
+    val categories: Boolean = true,
+    val tracking: Boolean = true,
+    val preferences: Boolean = true,
+    val opdsServers: Boolean = true,
+    val feed: Boolean = true,
+    val syncConfigurations: Boolean = true,
+) {
+    /** Chapters are per-manga data — meaningless without [libraryEntries]. */
+    val effectiveChapters: Boolean get() = libraryEntries && chapters
+
+    /** Tracker sync state is per-manga data — meaningless without [libraryEntries]. */
+    val effectiveTracking: Boolean get() = libraryEntries && tracking
+
+    /** At least one section must be selected for a backup to be worth creating. */
+    fun canCreate(): Boolean =
+        libraryEntries || categories || preferences || opdsServers || feed || syncConfigurations
+
+    companion object {
+        val ALL = BackupOptions()
+    }
+}

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/BackupSettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/BackupSettingsMvi.kt
@@ -2,6 +2,7 @@
 
 package app.otakureader.feature.settings
 
+import app.otakureader.domain.model.BackupOptions
 import app.otakureader.domain.model.TachiyomiBackupPreview
 
 data class BackupSettingsState(
@@ -26,9 +27,15 @@ data class BackupSettingsState(
     val showBackupChecklist: Boolean = false,
     val backupChecklistMangaCount: Int = 0,
     val backupChecklistCategoryCount: Int = 0,
-    val backupChecklistTrackingCount: Int = 0,
+    val backupChecklistOpdsCount: Int = 0,
+    val backupChecklistFeedCount: Int = 0,
+    val backupChecklistSyncConfigCount: Int = 0,
+    /** Which data categories the user has selected to include in the next backup. */
+    val backupOptions: BackupOptions = BackupOptions.ALL,
     // Pre-restore preflight dialog
     val showRestoreConfirm: Boolean = false,
     val pendingRestoreUri: String? = null,
     val pendingRestoreFileName: String = "",
+    /** Which data categories the user has selected to apply from the pending restore. */
+    val restoreOptions: BackupOptions = BackupOptions.ALL,
 )

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsBackupScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsBackupScreen.kt
@@ -467,7 +467,15 @@ private fun BackupOptionCheckboxRow(
             .padding(vertical = 4.dp),
     ) {
         Checkbox(checked = checked, onCheckedChange = null, enabled = enabled)
-        Text(text = label, modifier = Modifier.padding(start = 8.dp))
+        Text(
+            text = label,
+            color = if (enabled) {
+                MaterialTheme.colorScheme.onSurface
+            } else {
+                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+            },
+            modifier = Modifier.padding(start = 8.dp),
+        )
     }
 }
 

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsBackupScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsBackupScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -55,6 +56,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import app.otakureader.core.navigation.Route
+import app.otakureader.domain.model.BackupOptions
 import app.otakureader.feature.settings.viewmodel.BackupSyncViewModel
 
 /**
@@ -182,7 +184,11 @@ fun SettingsBackupScreen(
         BackupChecklistDialog(
             mangaCount = state.backupChecklistMangaCount,
             categoryCount = state.backupChecklistCategoryCount,
-            trackingCount = state.backupChecklistTrackingCount,
+            opdsCount = state.backupChecklistOpdsCount,
+            feedCount = state.backupChecklistFeedCount,
+            syncConfigCount = state.backupChecklistSyncConfigCount,
+            options = state.backupOptions,
+            onOptionsChange = { viewModel.onEvent(SettingsEvent.SetBackupOptions(it)) },
             onConfirm = { viewModel.onEvent(SettingsEvent.ConfirmCreateBackup) },
             onDismiss = { viewModel.onEvent(SettingsEvent.DismissBackupChecklist) },
         )
@@ -192,6 +198,8 @@ fun SettingsBackupScreen(
     if (state.showRestoreConfirm) {
         RestorePreflightDialog(
             fileName = state.pendingRestoreFileName,
+            options = state.restoreOptions,
+            onOptionsChange = { viewModel.onEvent(SettingsEvent.SetRestoreOptions(it)) },
             onConfirm = {
                 val uri = state.pendingRestoreUri
                 if (uri != null) {
@@ -258,14 +266,19 @@ fun SettingsBackupScreen(
 
 /**
  * Pre-backup checklist dialog.
- * Shows the user what will be included in the backup (manga count, categories, tracking
- * entries, history, and settings) before the file-save picker opens.
+ * Lets the user pick which data categories to include before the file-save picker opens.
+ * Each checkbox label shows the current count for that section (see [BackupOptionCheckboxRow]);
+ * chapters/tracking are per-manga data, so they're disabled while libraryEntries is off.
  */
 @Composable
 private fun BackupChecklistDialog(
     mangaCount: Int,
     categoryCount: Int,
-    trackingCount: Int,
+    opdsCount: Int,
+    feedCount: Int,
+    syncConfigCount: Int,
+    options: BackupOptions,
+    onOptionsChange: (BackupOptions) -> Unit,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -274,14 +287,72 @@ private fun BackupChecklistDialog(
         title = { Text(stringResource(R.string.backup_checklist_title)) },
         text = {
             Column {
-                Text(stringResource(R.string.backup_checklist_summary, mangaCount, categoryCount, trackingCount))
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(stringResource(R.string.backup_checklist_history_included))
-                Text(stringResource(R.string.backup_checklist_settings_included))
+                BackupOptionCheckboxRow(
+                    checked = options.libraryEntries,
+                    onCheckedChange = { onOptionsChange(options.copy(libraryEntries = it)) },
+                    label = stringResource(
+                        R.string.backup_option_with_count,
+                        stringResource(R.string.backup_option_library_entries),
+                        mangaCount,
+                    ),
+                )
+                BackupOptionCheckboxRow(
+                    checked = options.chapters,
+                    enabled = options.libraryEntries,
+                    onCheckedChange = { onOptionsChange(options.copy(chapters = it)) },
+                    label = stringResource(R.string.backup_option_chapters),
+                )
+                BackupOptionCheckboxRow(
+                    checked = options.categories,
+                    onCheckedChange = { onOptionsChange(options.copy(categories = it)) },
+                    label = stringResource(
+                        R.string.backup_option_with_count,
+                        stringResource(R.string.backup_option_categories),
+                        categoryCount,
+                    ),
+                )
+                BackupOptionCheckboxRow(
+                    checked = options.tracking,
+                    enabled = options.libraryEntries,
+                    onCheckedChange = { onOptionsChange(options.copy(tracking = it)) },
+                    label = stringResource(R.string.backup_option_tracking),
+                )
+                BackupOptionCheckboxRow(
+                    checked = options.preferences,
+                    onCheckedChange = { onOptionsChange(options.copy(preferences = it)) },
+                    label = stringResource(R.string.backup_option_preferences),
+                )
+                BackupOptionCheckboxRow(
+                    checked = options.opdsServers,
+                    onCheckedChange = { onOptionsChange(options.copy(opdsServers = it)) },
+                    label = stringResource(
+                        R.string.backup_option_with_count,
+                        stringResource(R.string.backup_option_opds_servers),
+                        opdsCount,
+                    ),
+                )
+                BackupOptionCheckboxRow(
+                    checked = options.feed,
+                    onCheckedChange = { onOptionsChange(options.copy(feed = it)) },
+                    label = stringResource(
+                        R.string.backup_option_with_count,
+                        stringResource(R.string.backup_option_feed),
+                        feedCount,
+                    ),
+                )
+                BackupOptionCheckboxRow(
+                    checked = options.syncConfigurations,
+                    onCheckedChange = { onOptionsChange(options.copy(syncConfigurations = it)) },
+                    label = stringResource(
+                        R.string.backup_option_with_count,
+                        stringResource(R.string.backup_option_sync_configurations),
+                        syncConfigCount,
+                    ),
+                )
             }
         },
         confirmButton = {
-            TextButton(onClick = onConfirm) {
+            TextButton(onClick = onConfirm, enabled = options.canCreate()) {
                 Text(stringResource(R.string.backup_checklist_create))
             }
         },
@@ -295,12 +366,15 @@ private fun BackupChecklistDialog(
 
 /**
  * Pre-restore preflight dialog.
- * Shown after the user selects a backup file but before the restore begins, so they can
- * confirm they understand the operation will replace their current library.
+ * Shown after the user selects a backup file but before the restore begins. Lets them pick
+ * which sections to apply and confirms they understand the operation will overwrite matching
+ * data in their current library.
  */
 @Composable
 private fun RestorePreflightDialog(
     fileName: String,
+    options: BackupOptions,
+    onOptionsChange: (BackupOptions) -> Unit,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -314,10 +388,53 @@ private fun RestorePreflightDialog(
                     Spacer(modifier = Modifier.height(8.dp))
                 }
                 Text(stringResource(R.string.restore_preflight_message))
+                Spacer(modifier = Modifier.height(8.dp))
+                BackupOptionCheckboxRow(
+                    checked = options.libraryEntries,
+                    onCheckedChange = { onOptionsChange(options.copy(libraryEntries = it)) },
+                    label = stringResource(R.string.backup_option_library_entries),
+                )
+                BackupOptionCheckboxRow(
+                    checked = options.chapters,
+                    enabled = options.libraryEntries,
+                    onCheckedChange = { onOptionsChange(options.copy(chapters = it)) },
+                    label = stringResource(R.string.backup_option_chapters),
+                )
+                BackupOptionCheckboxRow(
+                    checked = options.categories,
+                    onCheckedChange = { onOptionsChange(options.copy(categories = it)) },
+                    label = stringResource(R.string.backup_option_categories),
+                )
+                BackupOptionCheckboxRow(
+                    checked = options.tracking,
+                    enabled = options.libraryEntries,
+                    onCheckedChange = { onOptionsChange(options.copy(tracking = it)) },
+                    label = stringResource(R.string.backup_option_tracking),
+                )
+                BackupOptionCheckboxRow(
+                    checked = options.preferences,
+                    onCheckedChange = { onOptionsChange(options.copy(preferences = it)) },
+                    label = stringResource(R.string.backup_option_preferences),
+                )
+                BackupOptionCheckboxRow(
+                    checked = options.opdsServers,
+                    onCheckedChange = { onOptionsChange(options.copy(opdsServers = it)) },
+                    label = stringResource(R.string.backup_option_opds_servers),
+                )
+                BackupOptionCheckboxRow(
+                    checked = options.feed,
+                    onCheckedChange = { onOptionsChange(options.copy(feed = it)) },
+                    label = stringResource(R.string.backup_option_feed),
+                )
+                BackupOptionCheckboxRow(
+                    checked = options.syncConfigurations,
+                    onCheckedChange = { onOptionsChange(options.copy(syncConfigurations = it)) },
+                    label = stringResource(R.string.backup_option_sync_configurations),
+                )
             }
         },
         confirmButton = {
-            TextButton(onClick = onConfirm) {
+            TextButton(onClick = onConfirm, enabled = options.canCreate()) {
                 Text(stringResource(R.string.restore_preflight_proceed))
             }
         },
@@ -327,6 +444,31 @@ private fun RestorePreflightDialog(
             }
         },
     )
+}
+
+/** A single checkbox row for a [BackupOptions] section, used by both backup/restore dialogs. */
+@Composable
+private fun BackupOptionCheckboxRow(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    label: String,
+    enabled: Boolean = true,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = checked,
+                onClick = { onCheckedChange(!checked) },
+                role = Role.Checkbox,
+                enabled = enabled,
+            )
+            .padding(vertical = 4.dp),
+    ) {
+        Checkbox(checked = checked, onCheckedChange = null, enabled = enabled)
+        Text(text = label, modifier = Modifier.padding(start = 8.dp))
+    }
 }
 
 @Composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsMvi.kt
@@ -5,6 +5,7 @@ import app.otakureader.core.common.mvi.UiEffect
 import app.otakureader.core.common.mvi.UiEvent
 import app.otakureader.core.common.mvi.UiState
 import app.otakureader.core.preferences.LocalSourcePreferences
+import app.otakureader.domain.model.BackupOptions
 
 data class TrackerInfo(
     val id: Int,
@@ -174,10 +175,14 @@ data class SettingsState(
     val showBackupChecklist get() = backup.showBackupChecklist
     val backupChecklistMangaCount get() = backup.backupChecklistMangaCount
     val backupChecklistCategoryCount get() = backup.backupChecklistCategoryCount
-    val backupChecklistTrackingCount get() = backup.backupChecklistTrackingCount
+    val backupChecklistOpdsCount get() = backup.backupChecklistOpdsCount
+    val backupChecklistFeedCount get() = backup.backupChecklistFeedCount
+    val backupChecklistSyncConfigCount get() = backup.backupChecklistSyncConfigCount
+    val backupOptions get() = backup.backupOptions
     val showRestoreConfirm get() = backup.showRestoreConfirm
     val pendingRestoreUri get() = backup.pendingRestoreUri
     val pendingRestoreFileName get() = backup.pendingRestoreFileName
+    val restoreOptions get() = backup.restoreOptions
 
     // --- Tracking ---
     val trackers get() = tracking.trackers
@@ -314,6 +319,10 @@ sealed interface SettingsEvent : UiEvent {
     data class ConfirmRestore(val uri: Uri) : SettingsEvent
     /** User cancelled the restore preflight dialog. */
     data object DismissRestoreConfirm : SettingsEvent
+    /** User toggled a section checkbox in the pre-backup checklist dialog. */
+    data class SetBackupOptions(val options: BackupOptions) : SettingsEvent
+    /** User toggled a section checkbox in the pre-restore preflight dialog. */
+    data class SetRestoreOptions(val options: BackupOptions) : SettingsEvent
     data class CreateBackupWithUri(val uri: Uri) : SettingsEvent
     data class RestoreBackupFromUri(val uri: Uri) : SettingsEvent
     data class ImportTachiyomiBackupFromUri(val uri: Uri) : SettingsEvent

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/BackupSettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/BackupSettingsDelegate.kt
@@ -6,8 +6,11 @@ import app.otakureader.core.preferences.BackupPreferences
 import app.otakureader.domain.backup.BackupRepository
 import app.otakureader.domain.backup.BackupScheduler
 import app.otakureader.domain.backup.TachiyomiBackupImporter
+import app.otakureader.domain.model.BackupOptions
 import app.otakureader.domain.repository.CategoryRepository
+import app.otakureader.domain.repository.FeedRepository
 import app.otakureader.domain.repository.MangaRepository
+import app.otakureader.domain.repository.OpdsRepository
 import app.otakureader.domain.repository.TrackerSyncRepository
 import app.otakureader.feature.settings.SettingsEffect
 import app.otakureader.feature.settings.SettingsEvent
@@ -31,12 +34,22 @@ class BackupSettingsDelegate @Inject constructor(
     private val mangaRepository: MangaRepository,
     private val categoryRepository: CategoryRepository,
     private val trackerSyncRepository: TrackerSyncRepository,
+    private val opdsRepository: OpdsRepository,
+    private val feedRepository: FeedRepository,
 ) {
 
     private var updateState: ((SettingsState) -> SettingsState) -> Unit = {}
 
     /** URI of the backup the user is previewing, awaiting import confirmation. */
     private var pendingImportUri: String? = null
+
+    /**
+     * Mirrors of the checklist/preflight dialogs' current option selections. `updateState` only
+     * writes to the UI state, so these give `ConfirmCreateBackup`/`RestoreBackupFromUri`/etc. a
+     * way to read back what the user picked — same technique as [pendingImportUri] above.
+     */
+    private var pendingBackupOptions: BackupOptions = BackupOptions.ALL
+    private var pendingRestoreOptions: BackupOptions = BackupOptions.ALL
 
     private fun readBytes(uri: Uri): ByteArray =
         context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
@@ -89,22 +102,36 @@ class BackupSettingsDelegate @Inject constructor(
         SettingsEvent.ShowBackupChecklist -> {
             val mangaCount = mangaRepository.getLibraryManga().first().size
             val categoryCount = categoryRepository.getCategories().first().size
-            // Count distinct tracker sync configurations (one per tracked manga/tracker pair).
-            val trackingCount = trackerSyncRepository.getSyncConfigurations().first().size
+            val syncConfigCount = trackerSyncRepository.getSyncConfigurations().first().size
+            val opdsCount = opdsRepository.getServers().first().size
+            val feedCount = feedRepository.getFeedSources().first().size + feedRepository.getSavedSearches().first().size
+            pendingBackupOptions = BackupOptions.ALL
             updateState {
                 it.copy(backup = it.backup.copy(
                     showBackupChecklist = true,
                     backupChecklistMangaCount = mangaCount,
                     backupChecklistCategoryCount = categoryCount,
-                    backupChecklistTrackingCount = trackingCount,
+                    backupChecklistSyncConfigCount = syncConfigCount,
+                    backupChecklistOpdsCount = opdsCount,
+                    backupChecklistFeedCount = feedCount,
+                    backupOptions = BackupOptions.ALL,
                 ))
             }
             true
         }
+        is SettingsEvent.SetBackupOptions -> {
+            pendingBackupOptions = event.options
+            updateState { it.copy(backup = it.backup.copy(backupOptions = event.options)) }
+            true
+        }
         SettingsEvent.ConfirmCreateBackup -> {
-            // Dismiss checklist, then open the file-save picker.
-            updateState { it.copy(backup = it.backup.copy(showBackupChecklist = false)) }
-            sendEffect(SettingsEffect.ShowBackupPicker)
+            if (!pendingBackupOptions.canCreate()) {
+                sendEffect(SettingsEffect.ShowSnackbar("Select at least one item to back up"))
+            } else {
+                // Dismiss checklist, then open the file-save picker.
+                updateState { it.copy(backup = it.backup.copy(showBackupChecklist = false)) }
+                sendEffect(SettingsEffect.ShowBackupPicker)
+            }
             true
         }
         SettingsEvent.DismissBackupChecklist -> {
@@ -117,13 +144,20 @@ class BackupSettingsDelegate @Inject constructor(
         // carries the URI directly so no state-stored side-effect is needed.
         is SettingsEvent.ShowRestoreConfirm -> {
             val fileName = event.uri.lastPathSegment ?: event.uri.toString()
+            pendingRestoreOptions = BackupOptions.ALL
             updateState {
                 it.copy(backup = it.backup.copy(
                     showRestoreConfirm = true,
                     pendingRestoreUri = event.uri.toString(),
                     pendingRestoreFileName = fileName,
+                    restoreOptions = BackupOptions.ALL,
                 ))
             }
+            true
+        }
+        is SettingsEvent.SetRestoreOptions -> {
+            pendingRestoreOptions = event.options
+            updateState { it.copy(backup = it.backup.copy(restoreOptions = event.options)) }
             true
         }
         is SettingsEvent.ConfirmRestore -> {
@@ -232,7 +266,7 @@ class BackupSettingsDelegate @Inject constructor(
             } else {
                 updateState { it.copy(backup = it.backup.copy(isBackupInProgress = true)) }
                 try {
-                    backupRepository.createBackup(event.uri.toString())
+                    backupRepository.createBackup(event.uri.toString(), pendingBackupOptions)
                     sendEffect(SettingsEffect.ShowSnackbar("Backup created successfully"))
                 } catch (e: CancellationException) {
                     throw e
@@ -247,7 +281,7 @@ class BackupSettingsDelegate @Inject constructor(
         is SettingsEvent.CreateEncryptedBackupWithUri -> {
             updateState { it.copy(backup = it.backup.copy(isBackupInProgress = true)) }
             try {
-                backupRepository.createEncryptedBackup(event.uri.toString(), event.password.toCharArray())
+                backupRepository.createEncryptedBackup(event.uri.toString(), event.password.toCharArray(), pendingBackupOptions)
                 sendEffect(SettingsEffect.ShowSnackbar("Encrypted backup created successfully"))
             } catch (e: CancellationException) {
                 throw e
@@ -267,7 +301,7 @@ class BackupSettingsDelegate @Inject constructor(
                     it.copy(backup = it.backup.copy(isRestoreInProgress = true, tachiyomiImportTotal = 0, tachiyomiImportProgress = 0))
                 }
                 try {
-                    backupRepository.restoreBackup(event.uri.toString())
+                    backupRepository.restoreBackup(event.uri.toString(), pendingRestoreOptions)
                     sendEffect(SettingsEffect.ShowSnackbar("Backup restored successfully"))
                 } catch (e: CancellationException) {
                     throw e
@@ -284,7 +318,7 @@ class BackupSettingsDelegate @Inject constructor(
                 it.copy(backup = it.backup.copy(isRestoreInProgress = true, tachiyomiImportTotal = 0, tachiyomiImportProgress = 0))
             }
             try {
-                backupRepository.restoreEncryptedBackup(event.uri.toString(), event.password.toCharArray())
+                backupRepository.restoreEncryptedBackup(event.uri.toString(), event.password.toCharArray(), pendingRestoreOptions)
                 sendEffect(SettingsEffect.ShowSnackbar("Backup restored successfully"))
             } catch (e: CancellationException) {
                 throw e

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -179,15 +179,22 @@
     <string name="settings_restore_button">Restore</string>
     <!-- Pre-backup checklist dialog -->
     <string name="backup_checklist_title">Backup contents</string>
-    <string name="backup_checklist_summary">%1$d manga · %2$d categories · %3$d tracking entries</string>
-    <string name="backup_checklist_history_included">History: included</string>
-    <string name="backup_checklist_settings_included">Settings: included</string>
     <string name="backup_checklist_create">Create backup</string>
     <!-- Pre-restore preflight dialog -->
     <string name="restore_preflight_title">Restore backup?</string>
     <string name="restore_preflight_filename">Restore from: %1$s</string>
-    <string name="restore_preflight_message">This will replace your current library with the selected backup. This cannot be undone.</string>
+    <string name="restore_preflight_message">This will replace matching data in your current library with the selected backup. This cannot be undone.</string>
     <string name="restore_preflight_proceed">Restore</string>
+    <!-- Selective backup/restore options (#1192 PR 7) -->
+    <string name="backup_option_library_entries">Library entries</string>
+    <string name="backup_option_chapters">Chapters &amp; reading history</string>
+    <string name="backup_option_categories">Categories</string>
+    <string name="backup_option_tracking">Tracker sync state</string>
+    <string name="backup_option_preferences">App preferences</string>
+    <string name="backup_option_opds_servers">OPDS servers</string>
+    <string name="backup_option_feed">Feed sources &amp; saved searches</string>
+    <string name="backup_option_sync_configurations">Tracker sync settings</string>
+    <string name="backup_option_with_count">%1$s (%2$d)</string>
     <string name="settings_import_tachiyomi">Import from Tachiyomi/Mihon</string>
     <string name="settings_import_tachiyomi_description">Bring your library from another manga reader app</string>
     <string name="settings_import_button">Import</string>


### PR DESCRIPTION
## 📋 Description
Implements PR 7 — the final PR of the #1192 deferred-gaps backlog: selective backup/restore, replacing the previous all-or-nothing behavior.

- New `BackupOptions` domain model (`domain/model/BackupOptions.kt`): `libraryEntries` (master toggle), `chapters`, `categories`, `tracking`, `preferences`, `opdsServers`, `feed`, `syncConfigurations`. `chapters`/`tracking` are gated by `libraryEntries` (per-manga data is meaningless without the manga itself); `canCreate()` requires at least one section selected. Default `ALL` preserves prior unconditional-backup behavior.
- `BackupCreator.createBackupToStream`/`createBackup` thread an `options` param through — deselected sections are written as empty arrays (or `null` for preferences) rather than omitted, so the JSON envelope/decoder and format version (v4) are completely unchanged. Only the one truly-streamed section (manga+chapters) needed real branching; the other 7 sections were already built as complete in-memory lists, so gating them is just skipping the DAO query.
- `BackupRestorer.restoreBackup` gates each restore step (still inside the existing single `withTransaction`, in the same order) behind the matching `options` flag; `restorePreferences` (which runs outside the transaction, since DataStore can't participate in one) is gated the same way.
- `domain.backup.BackupRepository` (+ data impl) gains the same `options: BackupOptions = BackupOptions.ALL` parameter on every create/restore method. `AutoBackupWorker` and `BackupWorker` call sites are untouched — they rely on the default, so scheduled/automatic backups keep full-backup behavior unchanged, per the plan.
- UI: the pre-backup checklist dialog (previously a single "142 manga · 12 categories · 3 tracking entries" sentence) and the pre-restore preflight dialog (previously no options at all) both become checkbox lists sharing one `BackupOptionCheckboxRow` composable. Counts are shown as labels where cheaply available (library entries, categories, OPDS servers, feed sources+searches, tracker sync configs — the existing "trackingCount" was actually counting sync *configurations*, not per-manga sync *state*, so it's now correctly labeled). `chapters`/`tracking` checkboxes are disabled while `libraryEntries` is off; the confirm button is disabled until `canCreate()` is true.

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🎨 UI/UX
- [ ] 📖 Documentation
- [ ] ♻️ Refactoring
- [ ] 🚀 Performance
- [ ] 🧪 Tests

## 🧪 Testing
- New `BackupCreatorTest` (in-memory Room DB): each section toggled off individually, asserting the decoded `BackupData` has that section empty (or `null` for preferences) while everything else stays intact; also confirms `categories = false` blanks manga entries' `categoryIds` too.
- New `BackupRestorerTest` (in-memory Room DB, mocked preference classes): each section toggled off, asserting the corresponding DB rows/preference setters are never written, using a full-coverage `BackupData` fixture so every section has something to (not) restore.
- `./gradlew detekt` passes locally (fixed one `CognitiveComplexMethod` violation in the gated `createBackupToStream` and a few long lines in the dialog composables along the way). Ktlint's Gradle task in this project only covers root-level `.kts` build scripts, not module Kotlin sources, so per-module lint/compile/full-unit-test/coverage-gate runs in CI only — no local Android SDK in this sandbox.
- UI (the new checkbox-list dialogs) was not visually verified — no way to run the app in this sandbox. Please eyeball both dialogs on a device/emulator before merging, and double check the disabled-checkbox visual state when `libraryEntries` is unchecked.

## 📸 Screenshots
Not available — no local Android runtime/emulator in this environment.

## ✅ Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code (none needed beyond inline rationale already present)
- [ ] Documentation updated
- [x] No new warnings (detekt clean)
- [x] Tests pass (new unit tests included; full suite runs in CI)

## 🔗 Related Issues
Closes the last open item in #1192 (PR 7 of 7 — only the Advanced settings screen and the reading-history-migration follow-up noted in #1206 remain after this merges).


---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

## Summary by Sourcery

Introduce configurable backup and restore options so users can selectively include or apply different data categories while preserving existing full-backup defaults.

New Features:
- Add BackupOptions domain model to represent selectable backup and restore sections with a default full-backup configuration.
- Expose selective backup and restore controls in the settings UI via checkbox dialogs for both backup creation and restore preflight.
- Extend backup repository and workers to accept BackupOptions for regular, local, and encrypted backups and restores without changing the JSON format.

Enhancements:
- Update backup creation and restore logic to gate each data section (library entries, chapters, categories, tracking, preferences, OPDS, feed, sync configurations) based on user-selected options.
- Improve pre-backup and pre-restore messaging to clarify that restores overwrite matching data and to show per-section counts where available.
- Add shared composable UI for backup/restore option rows to keep the dialogs consistent.

Tests:
- Add BackupCreatorTest to verify that deselected backup sections are serialized as empty arrays or null while other sections remain intact.
- Add BackupRestorerTest to ensure deselected sections are skipped during restore even when the backup JSON contains data for them.