### PR TITLE
Maintenance pass: mechanical cleanup (deprecations, dead code, unused strings)

### DIFF
--- a/app/src/main/java/app/otakureader/shortcut/AppShortcutManager.kt
+++ b/app/src/main/java/app/otakureader/shortcut/AppShortcutManager.kt
@@ -27,9 +27,9 @@ import javax.inject.Singleton
  */
 @Singleton
 class AppShortcutManager @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val readingHistoryDao: ReadingHistoryDao,
-    @ApplicationScope private val scope: CoroutineScope
+    @param:ApplicationScope private val scope: CoroutineScope
 ) {
 
     /**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.room) apply false
-    alias(libs.plugins.license.report) apply false
     alias(libs.plugins.cyclonedx.bom) apply false
     // R-4: detekt static analysis applied to all subprojects
     alias(libs.plugins.detekt)

--- a/core/common/src/main/java/app/otakureader/core/common/network/NetworkMonitor.kt
+++ b/core/common/src/main/java/app/otakureader/core/common/network/NetworkMonitor.kt
@@ -17,7 +17,7 @@ enum class NetworkType { WIFI, MOBILE, OFFLINE }
 
 @Singleton
 class NetworkMonitor @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) {
     private val connectivityManager =
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager

--- a/core/discord/src/main/java/app/otakureader/core/discord/DiscordRpcService.kt
+++ b/core/discord/src/main/java/app/otakureader/core/discord/DiscordRpcService.kt
@@ -28,8 +28,8 @@ import javax.inject.Singleton
  */
 @Singleton
 class DiscordRpcService @Inject constructor(
-    @ApplicationContext private val context: Context,
-    @ApplicationScope private val scope: CoroutineScope
+    @param:ApplicationContext private val context: Context,
+    @param:ApplicationScope private val scope: CoroutineScope
 ) {
 
     private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected)

--- a/core/extension/src/main/java/app/otakureader/core/extension/loader/ExtensionApkParser.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/loader/ExtensionApkParser.kt
@@ -24,7 +24,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class ExtensionApkParser @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
 ) {
 
     private val packageManager: PackageManager = context.packageManager

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/CbzEncryptionStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/CbzEncryptionStore.kt
@@ -14,7 +14,7 @@ import javax.inject.Singleton
  * if a strict threading policy is required.
  */
 @Singleton
-class CbzEncryptionStore @Inject constructor(@ApplicationContext private val context: Context) {
+class CbzEncryptionStore @Inject constructor(@param:ApplicationContext private val context: Context) {
 
 
     // Created via EncryptedPrefsFactory so Keystore corruption recovers instead of

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/EhSessionStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/EhSessionStore.kt
@@ -15,7 +15,7 @@ import javax.inject.Singleton
  * to fetch the favorites page without re-prompting for credentials.
  */
 @Singleton
-class EhSessionStore @Inject constructor(@ApplicationContext private val context: Context) {
+class EhSessionStore @Inject constructor(@param:ApplicationContext private val context: Context) {
 
 
     // Created via EncryptedPrefsFactory so Keystore corruption recovers instead of

--- a/core/ui/src/main/java/app/otakureader/core/ui/theme/Color.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/theme/Color.kt
@@ -4,15 +4,6 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 
-// Default Material 3 colors (kept for backwards compatibility)
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
-
-val Purple40 = Color(0xFF6650A4)
-val PurpleGrey40 = Color(0xFF625B71)
-val Pink40 = Color(0xFF7D5260)
-
 // Pure Black for AMOLED mode
 val PureBlack = Color(0xFF000000)
 

--- a/core/ui/src/main/java/app/otakureader/core/ui/theme/ThemeExtractor.kt
+++ b/core/ui/src/main/java/app/otakureader/core/ui/theme/ThemeExtractor.kt
@@ -34,7 +34,7 @@ data class DynamicThemeColors(
  */
 @Singleton
 class ThemeExtractor @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) {
 
     /**

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewScreen.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/data/src/main/java/app/otakureader/data/backup/BackupCreator.kt
+++ b/data/src/main/java/app/otakureader/data/backup/BackupCreator.kt
@@ -134,40 +134,6 @@ class BackupCreator @Inject constructor(
     }
 
     /**
-     * Creates backup data for all favorite manga with their chapters and reading history.
-     */
-    @Suppress("UnusedPrivateMember")
-    private suspend fun createMangaBackup(): List<BackupManga> {
-        // Get all favorite manga
-        val favoriteManga = mangaDao.getFavoriteManga().first()
-
-        // Load full reading history once and index by chapterId for fast lookups
-        val historyByChapterId = readingHistoryDao.observeHistory().first()
-            .associateBy { it.chapterId }
-
-        return favoriteManga.map { mangaEntity ->
-            // Get chapters for this manga
-            val chapters = chapterDao.getChaptersByMangaId(mangaEntity.id).first()
-
-            // Get reading history for each chapter
-            val backupChapters = chapters.map { chapterEntity ->
-                val history = historyByChapterId[chapterEntity.id]
-                    ?.toBackupReadingHistory()
-
-                chapterEntity.toBackupChapter(readingHistory = history)
-            }
-
-            // Get category associations for this manga
-            val categoryIds = categoryDao.getCategoryIdsForManga(mangaEntity.id).first()
-
-            mangaEntity.toBackupManga(
-                chapters = backupChapters,
-                categoryIds = categoryIds
-            )
-        }
-    }
-
-    /**
      * Creates backup data for all categories.
      */
     private suspend fun createCategoryBackup() =

--- a/data/src/main/java/app/otakureader/data/backup/BackupScheduler.kt
+++ b/data/src/main/java/app/otakureader/data/backup/BackupScheduler.kt
@@ -20,7 +20,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class BackupScheduler @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) : BackupSchedulerInterface {
 
     /**

--- a/data/src/main/java/app/otakureader/data/backup/repository/BackupRepository.kt
+++ b/data/src/main/java/app/otakureader/data/backup/repository/BackupRepository.kt
@@ -19,7 +19,7 @@ import javax.inject.Singleton
 
 @Singleton
 class BackupRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val backupCreator: BackupCreator,
     private val backupRestorer: BackupRestorer
 ) : BackupRepositoryInterface {

--- a/data/src/main/java/app/otakureader/data/download/DownloadManager.kt
+++ b/data/src/main/java/app/otakureader/data/download/DownloadManager.kt
@@ -69,7 +69,7 @@ data class ChapterDownloadRequest(
  */
 @Singleton
 class DownloadManager @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val downloader: Downloader,
     private val downloadPreferences: DownloadPreferences,
     private val cbzEncryptionStore: CbzEncryptionStore,
@@ -77,7 +77,7 @@ class DownloadManager @Inject constructor(
     private val downloadQueueDao: DownloadQueueDao,
     private val chapterRepository: ChapterRepository,
     private val sourceRepository: SourceRepository,
-    @ApplicationScope private val scope: CoroutineScope
+    @param:ApplicationScope private val scope: CoroutineScope
 ) {
     private val mutex = Mutex()
 

--- a/data/src/main/java/app/otakureader/data/history/WorkManagerHistoryScheduler.kt
+++ b/data/src/main/java/app/otakureader/data/history/WorkManagerHistoryScheduler.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 @Singleton
 class WorkManagerHistoryScheduler @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) : ReadingHistoryScheduler {
 
     override fun scheduleExit(

--- a/data/src/main/java/app/otakureader/data/loader/PageLoader.kt
+++ b/data/src/main/java/app/otakureader/data/loader/PageLoader.kt
@@ -18,7 +18,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class PageLoader @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val cbzEncryptionStore: CbzEncryptionStore,
 ) : PageLoaderInterface {
 

--- a/data/src/main/java/app/otakureader/data/repository/DownloadRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/DownloadRepositoryImpl.kt
@@ -27,12 +27,12 @@ import kotlinx.coroutines.withContext
 
 @Singleton
 class DownloadRepositoryImpl @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val downloadManager: DownloadManager,
     private val mangaDao: MangaDao,
     private val chapterDao: ChapterDao,
     private val sourceRepository: SourceRepository,
-    @ApplicationScope private val scope: CoroutineScope
+    @param:ApplicationScope private val scope: CoroutineScope
 ) : DownloadRepository {
 
     private val notifier = DownloadNotifier(context)

--- a/data/src/main/java/app/otakureader/data/repository/FeedRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/FeedRepositoryImpl.kt
@@ -22,7 +22,7 @@ private const val KV_SEP = "\u001F"    // ASCII Unit Separator (US)
 
 @Singleton
 class FeedRepositoryImpl @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val feedDao: FeedDao
 ) : FeedRepository {
 

--- a/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
@@ -27,7 +27,7 @@ import javax.inject.Singleton
 
 @Singleton
 class MangaRepositoryImpl @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val mangaDao: MangaDao,
     private val chapterDao: ChapterDao,
     private val mangaCategoryDao: MangaCategoryDao,

--- a/data/src/main/java/app/otakureader/data/repository/ReaderSettingsRepository.kt
+++ b/data/src/main/java/app/otakureader/data/repository/ReaderSettingsRepository.kt
@@ -34,7 +34,7 @@ import javax.inject.Singleton
 @Singleton
 class ReaderSettingsRepository @Inject constructor(
     private val dataStore: DataStore<Preferences>,
-    @ApplicationScope private val scope: CoroutineScope,
+    @param:ApplicationScope private val scope: CoroutineScope,
 ) : ReaderSettingsRepositoryInterface {
     /**
      * Emits an event whenever a DataStore write fails due to disk I/O.

--- a/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
@@ -45,13 +45,13 @@ import javax.inject.Singleton
  */
 @Singleton
 class SourceRepositoryImpl @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val localSourcePreferences: LocalSourcePreferences,
     private val healthMonitor: SourceHealthMonitor,
     private val httpClient: OkHttpClient,
     private val extensionLoader: ExtensionLoader,
     private val extensionRepository: ExtensionRepository,
-    @ApplicationScope private val scope: CoroutineScope,
+    @param:ApplicationScope private val scope: CoroutineScope,
 ) : SourceRepository, ExtensionManagementRepository {
 
     private companion object {

--- a/data/src/main/java/app/otakureader/data/updater/AppUpdateChecker.kt
+++ b/data/src/main/java/app/otakureader/data/updater/AppUpdateChecker.kt
@@ -125,7 +125,7 @@ class AppUpdateWorker @AssistedInject constructor(
  */
 @Singleton
 class AppUpdateChecker @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val generalPreferences: GeneralPreferences,
     private val okHttpClient: OkHttpClient
 ) : AppUpdateCheckerInterface {

--- a/data/src/main/java/app/otakureader/data/worker/CoverRefreshSchedulerImpl.kt
+++ b/data/src/main/java/app/otakureader/data/worker/CoverRefreshSchedulerImpl.kt
@@ -8,7 +8,7 @@ import javax.inject.Singleton
 
 @Singleton
 class CoverRefreshSchedulerImpl @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) : CoverRefreshScheduler {
     override fun schedule() {
         CoverRefreshWorker.enqueue(context)

--- a/data/src/main/java/app/otakureader/data/worker/DownloadFolderMigrationSchedulerImpl.kt
+++ b/data/src/main/java/app/otakureader/data/worker/DownloadFolderMigrationSchedulerImpl.kt
@@ -8,7 +8,7 @@ import javax.inject.Singleton
 
 @Singleton
 class DownloadFolderMigrationSchedulerImpl @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) : DownloadFolderMigrationScheduler {
     override fun schedule() {
         DownloadFolderMigrationWorker.enqueue(context)

--- a/data/src/main/java/app/otakureader/data/worker/ExtensionUpdateSchedulerImpl.kt
+++ b/data/src/main/java/app/otakureader/data/worker/ExtensionUpdateSchedulerImpl.kt
@@ -8,7 +8,7 @@ import javax.inject.Singleton
 
 @Singleton
 class ExtensionUpdateSchedulerImpl @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
 ) : ExtensionUpdateScheduler {
 
     override fun schedule(intervalHours: Int, wifiOnly: Boolean) {

--- a/data/src/main/java/app/otakureader/data/worker/GoalCompletionNotifier.kt
+++ b/data/src/main/java/app/otakureader/data/worker/GoalCompletionNotifier.kt
@@ -37,7 +37,7 @@ private const val ACHIEVEMENT_NOTIFICATION_ID = 4003
  */
 @Singleton
 class GoalCompletionNotifier @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val readingGoalPreferences: ReadingGoalPreferences,
     private val readingHistoryDao: ReadingHistoryDao,
 ) {

--- a/data/src/main/java/app/otakureader/data/worker/LibraryUpdateScheduler.kt
+++ b/data/src/main/java/app/otakureader/data/worker/LibraryUpdateScheduler.kt
@@ -15,7 +15,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class LibraryUpdateScheduler @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) : LibraryUpdateSchedulerInterface {
 
     override fun schedule(intervalHours: Int, wifiOnly: Boolean, requireCharging: Boolean) {

--- a/data/src/main/java/app/otakureader/data/worker/ReadingReminderScheduler.kt
+++ b/data/src/main/java/app/otakureader/data/worker/ReadingReminderScheduler.kt
@@ -19,7 +19,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class ReadingReminderScheduler @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) : ReminderScheduler {
 
     /**

--- a/data/src/main/java/app/otakureader/data/worker/SyncSchedulerImpl.kt
+++ b/data/src/main/java/app/otakureader/data/worker/SyncSchedulerImpl.kt
@@ -15,7 +15,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class SyncSchedulerImpl @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
 ) : SyncScheduler {
 
     override fun schedulePeriodicSync() {

--- a/data/src/main/java/app/otakureader/data/worker/TrackerSyncSchedulerImpl.kt
+++ b/data/src/main/java/app/otakureader/data/worker/TrackerSyncSchedulerImpl.kt
@@ -8,7 +8,7 @@ import javax.inject.Singleton
 
 @Singleton
 class TrackerSyncSchedulerImpl @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) : TrackerSyncScheduler {
 
     override fun schedule(intervalHours: Int) {

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -100,7 +100,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.core.ui.theme.LocalOtakuColors
 import app.otakureader.feature.feed.FeedContent
@@ -825,7 +825,7 @@ private fun SourceListContent(
                         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        items(state.searchHistory) { query ->
+                        items(state.searchHistory, key = { it }) { query ->
                             FilterChip(
                                 selected = false,
                                 onClick = {

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseViewModel.kt
@@ -505,16 +505,6 @@ class BrowseViewModel @Inject constructor(
     }
 
     /**
-     * Helper to get the currently selected source.
-     * Kept for future refactoring opportunities.
-     */
-    @Suppress("UnusedPrivateMember")
-    private fun getCurrentSource(): MangaSource? {
-        val sourceId = _state.value.currentSourceId ?: return null
-        return _sources.value.find { it.id == sourceId }
-    }
-
-    /**
      * Toggles selection of a manga for bulk favorite.
      * Enables bulk selection mode when first manga is selected.
      */

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/ExtensionsBottomSheet.kt
@@ -65,7 +65,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.core.extension.domain.model.Extension
 import app.otakureader.core.extension.domain.model.InstallStatus

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 /**

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailViewModel.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaDetailViewModel.kt
@@ -10,12 +10,9 @@ import app.otakureader.domain.repository.MangaRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
@@ -39,14 +36,9 @@ sealed class RedirectState {
     data class Error(val message: String) : RedirectState()
 }
 
-sealed interface SourceMangaDetailEffect {
-    data class NavigateToMangaDetail(val mangaId: Long) : SourceMangaDetailEffect
-}
-
 /**
  * Resolves a source manga (identified by [sourceId] + [mangaUrl]) to a database
- * entry and emits [SourceMangaDetailEffect.NavigateToMangaDetail] so the UI can
- * forward to the full [Route.MangaDetails] screen.
+ * entry so the UI can forward to the full [Route.MangaDetails] screen.
  *
  * If the manga is already in the database (previously browsed or in library) its
  * existing ID is reused. Otherwise a stub entry is inserted so the details screen
@@ -63,10 +55,6 @@ class SourceMangaDetailViewModel @Inject constructor(
 
     private val _redirectState = MutableStateFlow<RedirectState>(RedirectState.Loading)
     val redirectState: StateFlow<RedirectState> = _redirectState.asStateFlow()
-
-    // Kept for backwards-compatibility with any observers still using the effect channel.
-    private val _effect = Channel<SourceMangaDetailEffect>()
-    val effect: Flow<SourceMangaDetailEffect> = _effect.receiveAsFlow()
 
     init {
         val route = savedStateHandle.toRoute<Route.SourceMangaDetail>()
@@ -101,9 +89,6 @@ class SourceMangaDetailViewModel @Inject constructor(
 
                 if (mangaId > 0L) {
                     _redirectState.value = RedirectState.Success(mangaId)
-                    // Also emit on the legacy effect channel so existing nav-host collectors
-                    // are not broken by this change.
-                    _effect.send(SourceMangaDetailEffect.NavigateToMangaDetail(mangaId))
                 } else {
                     _redirectState.value = RedirectState.NotFound
                 }

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/SourceMangaScreen.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.core.ui.component.ErrorScreen
 import app.otakureader.core.ui.component.LoadingScreen

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/extension/ExtensionDetailScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/extension/ExtensionDetailScreen.kt
@@ -56,7 +56,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/extension/ExtensionInstallScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/extension/ExtensionInstallScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.otakureader.core.ui.theme.LocalOtakuColors
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import app.otakureader.domain.repository.ExtensionManagementRepository
 import app.otakureader.feature.browse.R

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/navigation/BrowseNavigation.kt
@@ -1,6 +1,6 @@
 package app.otakureader.feature.browse.navigation
 
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/repos/ExtensionRepositoriesScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/repos/ExtensionRepositoriesScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.feature.browse.R
 import kotlinx.coroutines.flow.collectLatest

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsScreen.kt
@@ -99,7 +99,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.core.ui.adaptive.isExpanded
 import app.otakureader.core.ui.adaptive.rememberWindowWidthSizeClass

--- a/feature/feed/src/main/java/app/otakureader/feature/feed/FeedScreen.kt
+++ b/feature/feed/src/main/java/app/otakureader/feature/feed/FeedScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.domain.model.FeedItem
 import kotlinx.coroutines.flow.collectLatest

--- a/feature/feed/src/main/java/app/otakureader/feature/feed/SavedFeedScreen.kt
+++ b/feature/feed/src/main/java/app/otakureader/feature/feed/SavedFeedScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch

--- a/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/app/otakureader/feature/history/HistoryScreen.kt
@@ -81,7 +81,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.domain.model.ChapterWithHistory
 import app.otakureader.feature.history.R

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryBottomSheet.kt
@@ -36,7 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
+import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -66,7 +66,7 @@ internal fun LibraryBottomSheet(
                 .padding(bottom = 32.dp),
         ) {
             // Tabs
-            TabRow(
+            SecondaryTabRow(
                 selectedTabIndex = state.bottomSheetTab.ordinal,
                 modifier = Modifier.fillMaxWidth(),
             ) {

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -40,7 +40,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
+import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -247,7 +247,7 @@ internal fun MangaGrid(
         }
 
         // Content-type filter tabs (All / Manga / Manhwa)
-        TabRow(
+        SecondaryTabRow(
             selectedTabIndex = selectedContentFilter,
             containerColor = Color.Transparent,
             contentColor = MaterialTheme.colorScheme.onSurface,

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -40,7 +40,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
-import androidx.compose.material3.SecondaryTabRow
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -247,7 +247,11 @@ internal fun MangaGrid(
         }
 
         // Content-type filter tabs (All / Manga / Manhwa)
-        SecondaryTabRow(
+        // Kept on the deprecated TabRow: the custom per-index indicator color below uses
+        // TabRow's (tabPositions: List<TabPosition>) -> Unit indicator signature, which
+        // SecondaryTabRow's TabIndicatorScope-based indicator does not support.
+        @Suppress("DEPRECATION")
+        TabRow(
             selectedTabIndex = selectedContentFilter,
             containerColor = Color.Transparent,
             contentColor = MaterialTheme.colorScheme.onSurface,

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryScreen.kt
@@ -83,7 +83,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.core.ui.components.IncognitoBanner
 import app.otakureader.core.ui.adaptive.WindowWidthSizeClass

--- a/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesScreen.kt
@@ -50,7 +50,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import kotlinx.coroutines.flow.collectLatest

--- a/feature/library/src/main/java/app/otakureader/feature/library/category/CategoryManagementScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/category/CategoryManagementScreen.kt
@@ -71,7 +71,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.feature.library.R
 import kotlinx.coroutines.flow.collectLatest

--- a/feature/library/src/main/java/app/otakureader/feature/library/maintenance/LibraryMaintenanceScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/maintenance/LibraryMaintenanceScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.feature.library.R
 import kotlinx.coroutines.flow.collectLatest

--- a/feature/library/src/main/java/app/otakureader/feature/library/readinglist/ReadingListDetailScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/readinglist/ReadingListDetailScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import android.content.Intent
 import androidx.core.content.FileProvider

--- a/feature/library/src/main/java/app/otakureader/feature/library/readinglist/ReadingListsScreen.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/readinglist/ReadingListsScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.domain.model.ReadingList
 import app.otakureader.feature.library.R

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -22,24 +22,11 @@
     <string name="library_content_tab_all">All</string>
     <string name="library_content_tab_manga">Manga</string>
     <string name="library_content_tab_manhwa">Manhwa</string>
-    <!-- Bottom navigation -->
-    <string name="library_nav_library">Library</string>
-    <string name="library_nav_updates">Updates</string>
-    <string name="library_nav_browse">Browse</string>
-    <string name="library_nav_history">History</string>
-    <string name="library_nav_stats">Stats</string>
-    <string name="library_nav_settings">Settings</string>
     <!-- Accessibility -->
     <string name="library_empty_icon_description">Empty library</string>
     <!-- Recommendations -->
     <string name="library_for_you_title">For You</string>
-    <string name="library_recommendations_refresh">Refresh recommendations</string>
-    <string name="library_recommendations_loading">Loading recommendations…</string>
-    <string name="library_recommendations_not_enough_manga">Add at least 3 manga to your library to get AI-powered recommendations</string>
-    <string name="library_recommendations_error_retry">Retry</string>
     <string name="library_recommendations_dismiss">Dismiss recommendation</string>
-    <string name="library_recommendations_thumbnail">Recommendation thumbnail for %1$s</string>
-    <string name="library_recommendations_reason_prefix">Why: %1$s</string>
     <!-- Category filter -->
     <string name="library_category_all">All</string>
     <!-- Category Management -->
@@ -68,7 +55,6 @@
     <string name="category_empty_message">Create categories to organize your library</string>
     <string name="category_mark_nsfw">Mark as NSFW</string>
     <string name="category_remove_nsfw">Remove NSFW</string>
-    <string name="category_nsfw_toggled">NSFW status updated</string>
     <string name="category_update_frequency_label">Update frequency</string>
     <string name="category_update_freq_label">Update: %1$s</string>
     <string name="category_freq_never">Never</string>
@@ -161,9 +147,6 @@
     <string name="category_updates_skipped">Excluded from library updates</string>
     <string name="category_skip_updates">Skip library updates</string>
     <string name="category_include_in_updates">Include in library updates</string>
-    <string name="category_make_dynamic">Make dynamic</string>
-    <string name="category_remove_dynamic">Remove dynamic</string>
-    <string name="category_unlock_prompt">Unlock to view hidden category</string>
     <!-- Smart rules editor -->
     <string name="category_edit_smart_rules">Smart rules…</string>
     <string name="category_smart_rules_title">Smart rules: %1$s</string>
@@ -370,12 +353,7 @@
     <!-- Bulk delete feedback (L8) -->
     <string name="library_removed_count">Removed %1$d manga from library</string>
     <!-- Long-press context menu (L2/L3) -->
-    <string name="library_context_menu_open">Open</string>
-    <string name="library_context_menu_resume">Resume reading</string>
-    <string name="library_context_menu_mark_read">Mark as read</string>
-    <string name="library_context_menu_share">Share</string>
     <string name="library_context_menu_migrate">Migrate</string>
-    <string name="library_context_menu_select">Select</string>
     <!-- Filter-active empty state (Komikku parity: error_no_match) -->
     <string name="library_filter_no_results_title">No manga match</string>
     <string name="library_filter_no_results_message">No manga in your library match the active filters</string>

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryScreen.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryScreen.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import kotlinx.coroutines.flow.collectLatest

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationScreen.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationScreen.kt
@@ -58,7 +58,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.model.MigrationCandidate

--- a/feature/more/src/main/java/app/otakureader/feature/more/MoreScreen.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/MoreScreen.kt
@@ -61,7 +61,7 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.core.ui.R as CoreUiR
 import app.otakureader.core.ui.components.GlassCard

--- a/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksScreen.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksScreen.kt
@@ -69,7 +69,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksViewModel.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/bookmarks/BookmarksViewModel.kt
@@ -32,7 +32,7 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class BookmarksViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val pageBookmarkRepository: PageBookmarkRepository,
     private val bookmarkCollectionRepository: BookmarkCollectionRepository,
     private val mangaRepository: MangaRepository,

--- a/feature/more/src/main/java/app/otakureader/feature/more/qr/ScanLibraryScreen.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/qr/ScanLibraryScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext

--- a/feature/more/src/main/java/app/otakureader/feature/more/qr/ShareLibraryScreen.kt
+++ b/feature/more/src/main/java/app/otakureader/feature/more/qr/ShareLibraryScreen.kt
@@ -43,7 +43,7 @@ import app.otakureader.feature.more.R
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 /**

--- a/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/app/otakureader/feature/onboarding/OnboardingScreen.kt
@@ -62,7 +62,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.foundation.clickable
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 

--- a/feature/opds/src/main/java/app/otakureader/feature/opds/OpdsScreen.kt
+++ b/feature/opds/src/main/java/app/otakureader/feature/opds/OpdsScreen.kt
@@ -58,7 +58,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.domain.model.OpdsEntry
 import app.otakureader.domain.model.OpdsServer

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderScreen.kt
@@ -65,7 +65,7 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.core.ui.component.EmptyScreen
 import app.otakureader.core.ui.component.LoadingScreen

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ReaderViewModel.kt
@@ -90,7 +90,7 @@ import javax.inject.Inject
 @HiltViewModel
 @Suppress("LargeClass")
 class ReaderViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val mangaRepository: MangaRepository,
     private val chapterRepository: ChapterRepository,
     private val pageBookmarkRepository: PageBookmarkRepository,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/SmartDownloadTrigger.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/SmartDownloadTrigger.kt
@@ -35,7 +35,7 @@ class SmartDownloadTrigger @Inject constructor(
     private val downloadRepository: DownloadRepository,
     private val sourceRepository: SourceRepository,
     private val networkMonitor: NetworkMonitor,
-    @ApplicationScope private val scope: CoroutineScope,
+    @param:ApplicationScope private val scope: CoroutineScope,
 ) {
 
     /**

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/prefetch/AdaptiveChapterPrefetcher.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/prefetch/AdaptiveChapterPrefetcher.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.CancellationException
  */
 @Singleton
 class AdaptiveChapterPrefetcher @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val imageLoader: ImageLoader,
     private val chapterRepository: ChapterRepository,
     private val sourceRepository: app.otakureader.domain.repository.SourceRepository

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/prefetch/SmartPrefetchManager.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/prefetch/SmartPrefetchManager.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.CancellationException
  */
 @Singleton
 class SmartPrefetchManager @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val imageLoader: ImageLoader,
     private val networkMonitor: NetworkMonitor,
 ) {

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/services/PanelCacheService.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/services/PanelCacheService.kt
@@ -46,7 +46,7 @@ import kotlinx.coroutines.CancellationException
  */
 @Singleton
 class PanelCacheService @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) {
     private val cacheDir = File(context.cacheDir, CACHE_DIR_NAME)
     private val resultsDir = File(cacheDir, "results")
@@ -416,7 +416,7 @@ private data class CacheMetadata(
             val count = extractInt(json, "count") ?: 0
             val size = extractLong(json, "size") ?: 0
 
-            CacheMetadata(hash, time, access, count.toInt(), size)
+            CacheMetadata(hash, time, access, count, size)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderBottomBar.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderBottomBar.kt
@@ -18,7 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.NavigateNext
 import androidx.compose.material.icons.filled.FitScreen
 import androidx.compose.material.icons.filled.GridView
-import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.ScreenRotation
 import androidx.compose.material.icons.outlined.BurstMode
 import androidx.compose.material.icons.outlined.Crop
@@ -52,7 +52,7 @@ private val readerBarSlide = tween<IntOffset>(READER_BAR_SLIDE_MS)
 private val readerBarFade = tween<Float>(READER_BAR_FADE_MS)
 
 private val ReaderMode.icon: ImageVector get() = when (this) {
-    ReaderMode.SINGLE_PAGE -> Icons.Default.MenuBook
+    ReaderMode.SINGLE_PAGE -> Icons.AutoMirrored.Filled.MenuBook
     ReaderMode.DUAL_PAGE -> Icons.AutoMirrored.Filled.NavigateNext
     ReaderMode.WEBTOON -> Icons.Default.FitScreen
     ReaderMode.SMART_PANELS -> Icons.Default.GridView
@@ -155,7 +155,7 @@ fun ReaderBottomBar(
             if (onPageLayout != null) {
                 IconButton(onClick = onPageLayout) {
                     Icon(
-                        imageVector = Icons.Default.MenuBook,
+                        imageVector = Icons.AutoMirrored.Filled.MenuBook,
                         contentDescription = stringResource(R.string.reader_page_layout),
                         tint = iconColor,
                     )

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderCommentsOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderCommentsOverlay.kt
@@ -22,7 +22,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
+import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -80,7 +80,7 @@ fun ReaderCommentsOverlay(
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             )
-            TabRow(selectedTabIndex = selectedTab) {
+            SecondaryTabRow(selectedTabIndex = selectedTab) {
                 Tab(
                     selected = selectedTab == TAB_CHAPTER,
                     onClick = { selectedTab = TAB_CHAPTER },

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderMenuOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderMenuOverlay.kt
@@ -32,9 +32,9 @@ import androidx.compose.material.icons.filled.FitScreen
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.GridView
-import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.RotateRight
+import androidx.compose.material.icons.automirrored.filled.RotateRight
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.ZoomIn
 import androidx.compose.material.icons.filled.ZoomOut
@@ -160,7 +160,10 @@ fun ReaderMenuOverlay(
                     }
                     if (onToggleChapterList != null) {
                         IconButton(onClick = onToggleChapterList) {
-                            Icon(Icons.Default.MenuBook, contentDescription = stringResource(R.string.reader_chapter_list_title))
+                            Icon(
+                                Icons.AutoMirrored.Filled.MenuBook,
+                                contentDescription = stringResource(R.string.reader_chapter_list_title),
+                            )
                         }
                     }
                     if (onToggleComments != null) {
@@ -245,7 +248,7 @@ fun ReaderMenuOverlay(
                         }
                         IconButton(onClick = onRotateCW) {
                             Icon(
-                                Icons.Default.RotateRight,
+                                Icons.AutoMirrored.Filled.RotateRight,
                                 contentDescription = stringResource(R.string.reader_rotate_cw),
                                 tint = if (pageRotation != PageRotation.NONE) {
                                     MaterialTheme.colorScheme.primary
@@ -322,7 +325,7 @@ private fun ModeButton(
     modifier: Modifier = Modifier
 ) {
     val (icon, label) = when (mode) {
-        ReaderMode.SINGLE_PAGE -> Icons.Default.MenuBook to stringResource(R.string.reader_mode_single)
+        ReaderMode.SINGLE_PAGE -> Icons.AutoMirrored.Filled.MenuBook to stringResource(R.string.reader_mode_single)
         ReaderMode.DUAL_PAGE -> Icons.AutoMirrored.Filled.NavigateNext to stringResource(R.string.reader_mode_dual)
         ReaderMode.WEBTOON -> Icons.Default.FitScreen to stringResource(R.string.reader_mode_webtoon)
         ReaderMode.SMART_PANELS -> Icons.Default.Settings to stringResource(R.string.reader_mode_smart)
@@ -452,7 +455,7 @@ fun RotationControl(
 
         IconButton(onClick = onRotateCW) {
             Icon(
-                Icons.Default.RotateRight,
+                Icons.AutoMirrored.Filled.RotateRight,
                 contentDescription = stringResource(R.string.reader_rotate_cw)
             )
         }

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderSettingsOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/ReaderSettingsOverlay.kt
@@ -22,7 +22,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
+import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -64,7 +64,7 @@ fun ReaderSettingsOverlay(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
     ) {
-        TabRow(selectedTabIndex = pagerState.currentPage) {
+        SecondaryTabRow(selectedTabIndex = pagerState.currentPage) {
             tabs.forEachIndexed { index, title ->
                 Tab(
                     selected = pagerState.currentPage == index,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/ui/TapZoneOverlay.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/ui/TapZoneOverlay.kt
@@ -186,26 +186,3 @@ fun NavigationOverlay(
         )
     }
 }
-
-/**
- * Legacy simple tap-zone overlay kept for backward compatibility.
- * Long-pressing the center zone triggers [onCenterLongPress].
- */
-@Composable
-fun SimpleTapZoneOverlay(
-    onLeftTap: () -> Unit,
-    onCenterTap: () -> Unit,
-    onRightTap: () -> Unit,
-    onCenterLongPress: (() -> Unit)? = null,
-    isRtl: Boolean = false,
-    modifier: Modifier = Modifier,
-) {
-    NavigationOverlay(
-        onPrev = if (isRtl) onRightTap else onLeftTap,
-        onNext = if (isRtl) onLeftTap else onRightTap,
-        onToggleMenu = onCenterTap,
-        onLongPress = onCenterLongPress,
-        navigationMode = 0,
-        modifier = modifier,
-    )
-}

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDownloadAheadDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDownloadAheadDelegate.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class ReaderDownloadAheadDelegate @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val downloadPreferences: DownloadPreferences,
     private val downloadRepository: DownloadRepository,
     private val sourceRepository: SourceRepository,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderPrefetchDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderPrefetchDelegate.kt
@@ -19,7 +19,7 @@ import kotlin.coroutines.cancellation.CancellationException
 import javax.inject.Inject
 
 class ReaderPrefetchDelegate @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val smartPrefetchManager: SmartPrefetchManager,
     private val behaviorTracker: ReadingBehaviorTracker,
     private val chapterPrefetcher: AdaptiveChapterPrefetcher,

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/LocalSourceBrowserScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/LocalSourceBrowserScreen.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsAppearanceScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsAppearanceScreen.kt
@@ -54,7 +54,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsBackupScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsBackupScreen.kt
@@ -51,7 +51,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsBrowseScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsBrowseScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsDiscordScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsDiscordScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsDownloadsScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsDownloadsScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsLibraryScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsLibraryScreen.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsNotificationsScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsNotificationsScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsReaderScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsReaderScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsScreen.kt
@@ -60,7 +60,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlin.math.roundToInt
 

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsSecurityScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsSecurityScreen.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsTrackingScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsTrackingScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/SettingsViewModel.kt
@@ -45,7 +45,7 @@ class SettingsViewModel @Inject constructor(
     private val readingReminderScheduler: ReminderScheduler,
     private val coverRefreshScheduler: CoverRefreshScheduler,
     private val chapterRepository: ChapterRepository,
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(SettingsState())

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/WidgetConfigurationScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/WidgetConfigurationScreen.kt
@@ -53,7 +53,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/cloudbackup/CloudBackupSettingsScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/cloudbackup/CloudBackupSettingsScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/datausage/DataUsageScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/datausage/DataUsageScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
+import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -34,7 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.otakureader.feature.settings.R
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -107,7 +107,7 @@ fun DataUsageScreen(
 
             // --- Period tabs ---
             val tabs = DataUsageTab.entries
-            TabRow(selectedTabIndex = state.selectedTab.ordinal) {
+            SecondaryTabRow(selectedTabIndex = state.selectedTab.ordinal) {
                 tabs.forEach { tab ->
                     Tab(
                         selected = state.selectedTab == tab,
@@ -132,7 +132,7 @@ fun DataUsageScreen(
 
                 // --- Per-period category breakdown ---
                 val grouped = entries.groupBy { it.category }
-                items(grouped.entries.toList()) { (category, rows) ->
+                items(grouped.entries.toList(), key = { it.key }) { (category, rows) ->
                     DataUsageRow(category = category, bytes = rows.sumOf { it.bytes })
                 }
 
@@ -168,7 +168,7 @@ fun DataUsageScreen(
                         )
                     }
                 } else {
-                    items(state.sourceBreakdown) { entry ->
+                    items(state.sourceBreakdown, key = { it.sourceName }) { entry ->
                         DataUsageRow(
                             category = entry.sourceName,
                             bytes = entry.bytesThisMonth,

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/BackupSettingsDelegate.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/delegate/BackupSettingsDelegate.kt
@@ -26,7 +26,7 @@ import javax.inject.Singleton
 
 @Singleton
 class BackupSettingsDelegate @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val backupPreferences: BackupPreferences,
     private val backupRepository: BackupRepository,
     private val backupScheduler: BackupScheduler,

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/navorder/SettingsNavOrderScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/navorder/SettingsNavOrderScreen.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/readerpresets/ReaderPresetsScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/readerpresets/ReaderPresetsScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/storage/StorageAnalyticsScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/storage/StorageAnalyticsScreen.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -121,7 +121,7 @@ fun StorageAnalyticsScreen(
                     )
                     HorizontalDivider()
                 }
-                items(state.sources) { source ->
+                items(state.sources, key = { it.sourceName }) { source ->
                     SourceRow(
                         entry = source,
                         totalBytes = state.totalBytes,

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/storage/StorageAnalyticsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/storage/StorageAnalyticsViewModel.kt
@@ -19,7 +19,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class StorageAnalyticsViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(StorageAnalyticsState())

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsScreen.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsViewModel.kt
+++ b/feature/settings/src/main/java/app/otakureader/feature/settings/sync/SyncSettingsViewModel.kt
@@ -35,7 +35,7 @@ import javax.inject.Inject
  */
 @HiltViewModel
 class SyncSettingsViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val syncSettingsStore: SyncSettingsStore,
     private val syncRepository: SyncRepository,
     private val syncScheduler: SyncScheduler,

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -84,8 +84,6 @@
 
     <!-- Downloads (settings section) -->
     <string name="settings_downloads">Downloads</string>
-    <string name="settings_remove_after_reading">Remove chapter after reading</string>
-    <string name="settings_remove_after_reading_description">Automatically delete downloaded chapters once finished</string>
     <string name="settings_save_as_cbz">Save as CBZ</string>
     <string name="settings_save_as_cbz_description">Compress downloaded chapters into CBZ archives</string>
     <string name="settings_cbz_encryption">Encrypt CBZ archives</string>
@@ -98,9 +96,7 @@
     <string name="settings_download_only_wifi_description">Restrict downloads to Wi-Fi connections only</string>
     <string name="settings_auto_download_limit">Auto-Download Limit: %1$d chapter(s)</string>
     <string name="settings_auto_download_category_include">Include categories</string>
-    <string name="settings_auto_download_category_include_description">Auto-download only for these categories (empty = all)</string>
     <string name="settings_auto_download_category_exclude">Exclude categories</string>
-    <string name="settings_auto_download_category_exclude_description">Skip auto-download for these categories</string>
     <string name="settings_auto_download_category_all">All categories</string>
     <string name="settings_auto_download_category_count">%1$d selected</string>
     <string name="settings_auto_download_category_none_excluded">None excluded</string>
@@ -356,59 +352,6 @@
     <string name="day_sat">Sat</string>
     <string name="settings_discord_rich_presence">Rich Presence</string>
     <string name="settings_discord_rich_presence_description">Show current reading activity as your Discord status</string>
-
-    <!-- AI Features -->
-    <string name="settings_ai_features">AI Features</string>
-    <string name="settings_ai_not_available_title">AI Features Not Available</string>
-    <string name="settings_ai_not_available_desc">AI features require the full build of Otaku Reader. This FOSS build does not include Gemini or any proprietary AI SDK.</string>
-    <string name="settings_ai_enable">Enable AI Features</string>
-    <string name="settings_ai_enable_description">Powered by Gemini. Requires an API key.</string>
-    <string name="settings_ai_gemini_api_key">Gemini API Key</string>
-    <string name="settings_ai_api_key_set">API key is set. Enter a new key to replace it.</string>
-    <string name="settings_ai_api_key_label">API Key</string>
-    <string name="settings_ai_hide_key">Hide key</string>
-    <string name="settings_ai_show_key">Show key</string>
-    <string name="settings_ai_save_api_key">Save API Key</string>
-    <string name="settings_ai_service_tier">Service Tier</string>
-    <string name="settings_ai_tier_free">Free</string>
-    <string name="settings_ai_tier_standard">Standard</string>
-    <string name="settings_ai_tier_pro">Pro</string>
-    <string name="settings_ai_feature_toggles">Feature Toggles</string>
-    <string name="settings_ai_reading_insights">Reading Insights</string>
-    <string name="settings_ai_reading_insights_desc">AI-powered reading statistics</string>
-    <string name="settings_ai_smart_search">Smart Search</string>
-    <string name="settings_ai_smart_search_desc">Natural language search queries</string>
-    <string name="settings_ai_recommendations">Recommendations</string>
-    <string name="settings_ai_recommendations_desc">Personalised manga suggestions</string>
-    <string name="settings_ai_panel_reader">Panel-Aware Reader</string>
-    <string name="settings_ai_panel_reader_desc">Gemini Vision panel detection</string>
-    <string name="settings_ai_sfx_translation">SFX Translation</string>
-    <string name="settings_ai_sfx_translation_desc">Translate sound effects in pages</string>
-    <string name="settings_ai_summary_translation">Summary Translation</string>
-    <string name="settings_ai_summary_translation_desc">Auto-translate chapter summaries</string>
-    <string name="settings_ai_source_intelligence">Source Intelligence</string>
-    <string name="settings_ai_source_intelligence_desc">Score and rank sources automatically</string>
-    <string name="settings_ai_smart_notifications">Smart Notifications</string>
-    <string name="settings_ai_smart_notifications_desc">Context-aware update summaries</string>
-    <string name="settings_ai_auto_categorization">Auto-Categorization</string>
-    <string name="settings_ai_auto_categorization_desc">Categorise new manga automatically</string>
-    <string name="settings_ai_ocr_translation">OCR Translation</string>
-    <string name="settings_ai_ocr_translation_desc">Translate page text with Gemini Vision (free tier: ~15 pages/min)</string>
-    <string name="settings_ai_usage">Usage</string>
-    <string name="settings_ai_monthly_token_usage">Monthly Token Usage</string>
-    <string name="settings_ai_tokens_used_period">%1$d tokens used (%2$s)</string>
-    <string name="settings_ai_tokens_used_month">%1$d tokens used this month</string>
-    <string name="settings_ai_clear_cache">Clear AI Cache</string>
-    <string name="settings_ai_clear_cache_description">Remove cached AI responses to free up space</string>
-    <string name="settings_ai_clear">Clear</string>
-    <string name="settings_ai_remove_key">Remove API Key</string>
-    <string name="settings_ai_remove_key_dialog_title">Remove API Key?</string>
-    <string name="settings_ai_remove_key_dialog_text">This will clear your saved Gemini API key. AI features will be disabled until a new key is added.</string>
-    <string name="settings_ai_remove_key_confirm">Remove</string>
-    <string name="settings_ai_remove_key_cancel">Cancel</string>
-    <string name="settings_ai_api_key_invalid_format">Invalid key format. Gemini API keys should start with &quot;AIza&quot; and be at least 20 characters.</string>
-    <string name="settings_ai_load_failed">Failed to load AI settings. You may need to re-enter your API key.</string>
-
     <!-- Reader Display -->
     <string name="settings_reader_display">Reader Display</string>
     <string name="settings_fullscreen">Fullscreen</string>
@@ -470,10 +413,6 @@
 
     <!-- Reader Interaction -->
     <string name="settings_reader_interaction">Interaction</string>
-    <string name="settings_double_tap_speed">Double-Tap Animation Speed</string>
-    <string name="settings_speed_slow">Slow</string>
-    <string name="settings_speed_normal">Normal</string>
-    <string name="settings_speed_fast">Fast</string>
     <string name="settings_long_tap_actions">Long-Tap Actions</string>
     <string name="settings_long_tap_actions_description">Show menu on long press</string>
     <string name="settings_save_separate_folders">Save Pages to Separate Folders</string>
@@ -587,9 +526,6 @@
     <string name="widget_config_all_categories">All categories</string>
     <string name="widget_config_show_thumbnails">Show thumbnails</string>
     <string name="widget_config_preview_label">Preview</string>
-    <string name="widget_config_preview_item_placeholder">Manga title</string>
-    <string name="widget_config_preview_subtitle_placeholder">Chapter info</string>
-    <string name="widget_config_settings_saved">Widget settings saved</string>
     <string name="settings_local_source_supported_formats">Supported local library formats</string>
     <string name="settings_local_source_archives">Archives</string>
     <string name="settings_local_source_archives_description">CBZ, ZIP, and EPUB files can be scanned directly from the configured local-source directory.</string>
@@ -686,7 +622,6 @@
 
     <!-- Nav tab order (#Komikku) -->
     <string name="nav_order_title">Tab Order</string>
-    <string name="nav_order_subtitle">Reorder the bottom navigation tabs</string>
     <string name="nav_order_reset">Reset to default</string>
     <string name="nav_order_move_up">Move up</string>
     <string name="nav_order_move_down">Move down</string>

--- a/feature/statistics/src/main/java/app/otakureader/feature/statistics/StatisticsScreen.kt
+++ b/feature/statistics/src/main/java/app/otakureader/feature/statistics/StatisticsScreen.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.core.ui.components.MonoLabel
 import app.otakureader.core.ui.theme.LocalOtakuColors

--- a/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackerOAuthScreen.kt
+++ b/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackerOAuthScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 /**

--- a/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingScreen.kt
+++ b/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingScreen.kt
@@ -64,7 +64,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.domain.model.SyncStatus
 import app.otakureader.domain.model.TrackerType

--- a/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingViewModel.kt
+++ b/feature/tracking/src/main/java/app/otakureader/feature/tracking/TrackingViewModel.kt
@@ -33,7 +33,7 @@ class TrackingViewModel @Inject constructor(
     private val trackRepository: TrackRepository,
     private val trackerSyncRepository: TrackerSyncRepository,
     private val pendingOAuthStore: PendingOAuthStore,
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) : ViewModel() {
 
     private val trackerMap: Map<Int, Tracker> = trackers.associateBy { it.id }

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/DownloadsScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/DownloadsScreen.kt
@@ -55,7 +55,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.domain.model.DownloadItem
 import app.otakureader.domain.model.DownloadPriority

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesScreen.kt
@@ -88,7 +88,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.domain.model.DownloadItem
 import app.otakureader.domain.model.DownloadStatus

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.delay
 
 @HiltViewModel
 class UpdatesViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val getRecentUpdatesUseCase: GetRecentUpdatesUseCase,
     private val getLibraryMangaUseCase: GetLibraryMangaUseCase,
     private val getLastUpdateRunSummaryUseCase: GetLastUpdateRunSummaryUseCase,

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/errors/UpdateErrorsScreen.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/errors/UpdateErrorsScreen.kt
@@ -57,7 +57,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.otakureader.domain.model.UpdateError
 import app.otakureader.feature.updates.R

--- a/feature/updates/src/main/res/values/strings.xml
+++ b/feature/updates/src/main/res/values/strings.xml
@@ -3,7 +3,6 @@
     <!-- Updates screen -->
     <string name="updates_title">Updates</string>
     <string name="updates_back">Back</string>
-    <string name="updates_downloads">Downloads</string>
     <string name="updates_empty">No updates yet. Library chapters will appear here after an update check.</string>
 
     <!-- Downloads screen -->
@@ -53,7 +52,6 @@
     <string name="updates_refresh_now">Update library now</string>
 
     <!-- To-Be-Updated Screen -->
-    <string name="updates_view_pending">Preview next update</string>
     <string name="updates_pending_title">To Be Updated</string>
     <string name="updates_pending_empty">No manga scheduled for update</string>
     <string name="updates_pending_hint">Manga in your library will appear here before the next update check</string>
@@ -95,12 +93,6 @@
     <string name="updates_last_run_skipped">Skipped</string>
     <string name="updates_last_run_failed">Failed</string>
     <string name="updates_last_run_meta">%1$s · took %2$s</string>
-    <!-- Date group headers -->
-    <string name="updates_date_today">Today</string>
-    <string name="updates_date_yesterday">Yesterday</string>
-    <string name="updates_date_this_week">This week</string>
-    <string name="updates_date_this_month">This month</string>
-    <string name="updates_date_older">Older</string>
     <string name="updates_unknown_error">Something went wrong while loading updates</string>
     <!-- Date filter chips (U1) -->
     <string name="updates_filter_last_7_days">Last 7 days</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,9 +92,6 @@ androidx-preference = "1.2.1"
 # Desugaring
 desugar-jdk-libs = "2.1.5"
 
-# License reporting
-license-report = "2.8"
-
 # SBOM generation
 cyclonedx-bom = "1.9.0"
 
@@ -118,7 +115,6 @@ kover = "0.9.8"
 [libraries]
 # Kotlin
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
-kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
@@ -300,7 +296,6 @@ otakureader-android-feature = { id = "otakureader.android.feature", version = "u
 otakureader-android-hilt = { id = "otakureader.android.hilt", version = "unspecified" }
 otakureader-android-room = { id = "otakureader.android.room", version = "unspecified" }
 otakureader-kotlin-library = { id = "otakureader.kotlin.library", version = "unspecified" }
-license-report = { id = "com.github.jk1.dependency-license-report", version.ref = "license-report" }
 cyclonedx-bom = { id = "org.cyclonedx.bom", version.ref = "cyclonedx-bom" }
 
 # Extra Android plugins for baselineprofile module


### PR DESCRIPTION
## 📋 Description
First of three PRs in a general maintenance/cleanup pass (dead code, deprecations, performance). This one bundles every fix that is zero-behavior-change and compiler/CI-verified, so one CI run covers all of it:

- **`hiltViewModel()` import migration** — `androidx.hilt.navigation.compose.hiltViewModel` → `androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel` (call syntax unchanged), confirmed via `hilt-navigation-compose = "1.3.0"` in `gradle/libs.versions.toml`. 53 files.
- **KT-73255 `@param:` use-site target fix** — `@ApplicationContext`/`@ApplicationScope` on primary-constructor `val` params now carry an explicit `@param:` prefix to resolve the annotation-target ambiguity warning. 40 files / 45 occurrences. `@Provides`-function parameters (no backing property, no ambiguity) were correctly left untouched.
- **Compose/Material3 mechanical fixes** — `Icons.Filled.MenuBook`/`RotateRight` → `Icons.AutoMirrored.Filled.*` (RTL-correct) in the reader overlay/bottom bar; `TabRow` → `SecondaryTabRow` at 5 nested/contextual tab sites; a redundant `.toInt()` removed in `PanelCacheService`; missing `key = {}` added to 4 lists with real recomposition-identity churn (`BrowseScreen` search history, `StorageAnalyticsScreen` sources, `DataUsageScreen` category/source breakdown).
- **Dead code removal** — `BackupCreator.createMangaBackup()`, `BrowseViewModel.getCurrentSource()`, `TapZoneOverlay.SimpleTapZoneOverlay()`, unused legacy `Color.kt` values, and `SourceMangaDetailViewModel`'s unused effect channel (the screen navigates via `RedirectState` instead) — all verified zero-call-site via repo-wide grep. Also removed the unused `kotlin-test` version-catalog alias and the vestigial `license-report` Gradle plugin declaration (superseded by `app/build.gradle.kts`'s own custom license-report task).
- **Unused string-resource cleanup** — `feature/updates` (7 strings), `feature/settings` (63 strings, including a ~50-entry dead AI-settings block left over from a removed feature), `feature/library` (20 strings). Each key was individually verified dead via a repo-wide grep for both the `R.string` reference and the raw string literal (covering `getIdentifier()`-style reflection lookups) before removal; live siblings sitting right next to dead keys (e.g. `library_context_menu_migrate`, `library_recommendations_dismiss`) were double-checked and kept.

Locale-translated `strings.xml` copies are intentionally left untouched (orphaned translated keys are inert, not broken; pruning them is a separate low-value cleanup).

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation
- [ ] 🎨 UI/UX
- [x] ♻️ Refactoring
- [ ] 🚀 Performance
- [ ] 🧪 Tests

## 🧪 Testing
No local Android SDK/emulator in this environment. Verified locally with `./gradlew detekt` (source-level lint gate — passes clean) and `./gradlew ktlintCheck` (passes; note this task only covers root-level Kotlin build scripts, not module sources, in this repo's current Gradle wiring — a pre-existing quirk, out of scope here). Full compile, KSP/Hilt annotation processing, unit tests, and screenshot tests are confirmed by CI. UI-affecting sections (icon swaps, TabRow) could not be visually verified in this sandbox.

## 📸 Screenshots
N/A — no visual changes intended (Material3 component swaps preserve existing appearance); could not screenshot-verify locally.

## ✅ Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings
- [ ] Tests pass (CI-only in this environment)

## 🔗 Related Issues
Part of a 3-PR maintenance/cleanup pass (mechanical cleanup → test dispatcher migration → N+1 performance fixes). No tracking issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

## Summary by Sourcery

Perform a zero-behavior-change maintenance pass across the app, cleaning up dead code, unused resources, and deprecated APIs while aligning with current Hilt and Material3 guidance.

Enhancements:
- Update Hilt Compose integrations to use the new androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel API and resolve @ApplicationContext/@ApplicationScope annotation target warnings via explicit @param: usage.
- Switch several tabbed UI surfaces from TabRow to SecondaryTabRow and adopt AutoMirrored Material icons for reader actions to improve RTL correctness and Material3 consistency.
- Remove unused helper code such as legacy backup and tap-zone overlay implementations and an unused effect channel now superseded by RedirectState-driven navigation.
- Streamline storage- and reader-related Compose lists by adding stable keys and cleaning up an unnecessary numeric conversion in panel cache metadata parsing.
- Delete obsolete color constants, unused string resources across settings, library, and updates modules, and unused Gradle catalog entries including a redundant license-report plugin and kotlin-test alias.

Build:
- Remove unused kotlin-test library alias and the obsolete license-report Gradle plugin from the version catalog and root build script.

Documentation:
- Prune unused, user-facing settings copy such as legacy AI feature descriptions and other now-unreferenced strings in settings, library, and updates modules.

Chores:
- Apply project-wide mechanical cleanup of deprecations, unused APIs, and dead resources verified by compiler and CI.