### PR TITLE
Migrate to createComposeRule v2 in Compose UI/screenshot tests

### DIFF
--- a/feature/library/src/test/java/app/otakureader/feature/library/screenshot/LibraryScreenshotTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/screenshot/LibraryScreenshotTest.kt
@@ -14,7 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.dp
 import com.github.takahirom.roborazzi.captureRoboImage

--- a/feature/library/src/test/java/app/otakureader/feature/library/ui/LibraryUiTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/ui/LibraryUiTest.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/feature/reader/src/test/java/app/otakureader/feature/reader/screenshot/ReaderScreenshotTest.kt
+++ b/feature/reader/src/test/java/app/otakureader/feature/reader/screenshot/ReaderScreenshotTest.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.dp
 import com.github.takahirom.roborazzi.captureRoboImage

--- a/feature/reader/src/test/java/app/otakureader/feature/reader/ui/ReaderUiTest.kt
+++ b/feature/reader/src/test/java/app/otakureader/feature/reader/ui/ReaderUiTest.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick


### PR DESCRIPTION
## 📋 Description
Second of three PRs in the general maintenance/cleanup pass (see #1210 for the first). This one is test-only: `androidx.compose.ui.test.junit4.createComposeRule` is deprecated in favor of the v2 entry point at `androidx.compose.ui.test.junit4.v2.createComposeRule`, in:

- `feature/library/src/test/java/app/otakureader/feature/library/ui/LibraryUiTest.kt`
- `feature/library/src/test/java/app/otakureader/feature/library/screenshot/LibraryScreenshotTest.kt`
- `feature/reader/src/test/java/app/otakureader/feature/reader/ui/ReaderUiTest.kt`
- `feature/reader/src/test/java/app/otakureader/feature/reader/screenshot/ReaderScreenshotTest.kt`

**Not purely mechanical** — the v2 rule runs on `StandardTestDispatcher` instead of `UnconfinedTestDispatcher`, which can change assertion timing relative to recomposition. This PR only makes the import swap, no speculative `awaitIdle()`/`advanceUntilIdle()` additions. If CI's Unit Tests or Screenshot Tests jobs surface a timing-related failure from the dispatcher change, I'll add the minimal synchronization fix as a follow-up commit on this same branch/PR rather than opening a new one.

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation
- [ ] 🎨 UI/UX
- [ ] ♻️ Refactoring
- [ ] 🚀 Performance
- [x] 🧪 Tests

## 🧪 Testing
No local Android SDK/Robolectric in this environment. Verified locally with `./gradlew detekt` and `./gradlew ktlintCheck` (both pass). CI's Unit Tests and Screenshot Tests (Roborazzi) jobs are the only environments that can actually exercise the new dispatcher — watching those closely.

## 📸 Screenshots
N/A — test-only change.

## ✅ Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings
- [ ] Tests pass (CI-only in this environment — this is the actual verification for this PR)

## 🔗 Related Issues
Part of the 3-PR maintenance/cleanup pass started in #1210. No tracking issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

## Summary by Sourcery

Tests:
- Migrate library and reader UI and screenshot tests from the deprecated createComposeRule to androidx.compose.ui.test.junit4.v2.createComposeRule.