### PR TITLE
Fix N+1 queries: library tracking/downloads, bulk mark-read, download reorder

### DIFF
--- a/core/database/src/main/java/app/otakureader/core/database/dao/ChapterDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/ChapterDao.kt
@@ -19,6 +19,9 @@ interface ChapterDao {
     @Query("SELECT * FROM chapters WHERE mangaId = :mangaId ORDER BY sourceOrder DESC")
     suspend fun getChaptersByMangaIdOnce(mangaId: Long): List<ChapterEntity>
 
+    @Query("SELECT * FROM chapters WHERE mangaId IN (:mangaIds) ORDER BY sourceOrder DESC")
+    suspend fun getChaptersByMangaIdsOnce(mangaIds: Collection<Long>): List<ChapterEntity>
+
     @Query("SELECT * FROM chapters")
     suspend fun getAllChaptersOnce(): List<ChapterEntity>
 

--- a/core/database/src/main/java/app/otakureader/core/database/dao/DownloadQueueDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/DownloadQueueDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import app.otakureader.core.database.entity.DownloadQueueEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -27,6 +28,14 @@ interface DownloadQueueDao {
 
     @Query("UPDATE download_queue SET priority = :priority WHERE chapter_id = :chapterId")
     suspend fun updatePriority(chapterId: Long, priority: Int)
+
+    /** Batched variant of [updatePriority] for reordering the whole queue in one transaction. */
+    @Transaction
+    suspend fun updatePriorities(updates: Map<Long, Int>) {
+        for ((chapterId, priority) in updates) {
+            updatePriority(chapterId, priority)
+        }
+    }
 
     @Query("UPDATE download_queue SET page_urls_json = :pageUrlsJson WHERE chapter_id = :chapterId")
     suspend fun updatePageUrls(chapterId: Long, pageUrlsJson: String)

--- a/core/database/src/main/java/app/otakureader/core/database/dao/TrackEntryDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/TrackEntryDao.kt
@@ -23,6 +23,14 @@ interface TrackEntryDao {
     suspend fun deleteByMangaAndTracker(mangaId: Long, trackerId: Int)
 
     /**
+     * Distinct manga IDs that have at least one tracker entry, for the Library screen's
+     * tracked-badge lookup — one query for the whole library instead of a per-manga
+     * [getByMangaId] check.
+     */
+    @Query("SELECT DISTINCT manga_id FROM track_entries")
+    fun getMangaIdsWithTrackEntries(): Flow<Set<Long>>
+
+    /**
      * Aggregated tracker statistics for the Statistics screen, computed in a single query:
      * distinct tracked manga, mean of non-zero scores (normalized 0–10 across every tracker
      * service; 0 = unscored, excluded via the CASE so it can't drag the mean down — null when

--- a/core/database/src/main/java/app/otakureader/core/database/dao/TrackEntryDao.kt
+++ b/core/database/src/main/java/app/otakureader/core/database/dao/TrackEntryDao.kt
@@ -28,7 +28,7 @@ interface TrackEntryDao {
      * [getByMangaId] check.
      */
     @Query("SELECT DISTINCT manga_id FROM track_entries")
-    fun getMangaIdsWithTrackEntries(): Flow<Set<Long>>
+    fun getMangaIdsWithTrackEntries(): Flow<List<Long>>
 
     /**
      * Aggregated tracker statistics for the Statistics screen, computed in a single query:

--- a/data/src/main/java/app/otakureader/data/download/DownloadManager.kt
+++ b/data/src/main/java/app/otakureader/data/download/DownloadManager.kt
@@ -416,9 +416,7 @@ class DownloadManager @Inject constructor(
 
             refreshDownloadsList()
         }
-        for ((id, priority) in priorityUpdates) {
-            downloadQueueDao.updatePriority(id, priority)
-        }
+        downloadQueueDao.updatePriorities(priorityUpdates)
     }
 
     // -------------------------------------------------------------------------

--- a/data/src/main/java/app/otakureader/data/download/DownloadProvider.kt
+++ b/data/src/main/java/app/otakureader/data/download/DownloadProvider.kt
@@ -258,6 +258,35 @@ object DownloadProvider {
         }
     }
 
+    /**
+     * Returns the set of (sanitized sourceName, sanitized mangaTitle) pairs for every manga
+     * directory under [root] containing at least one chapter with a downloaded page or CBZ
+     * archive. One filesystem walk instead of repeating [hasMangaDownloads]'s per-manga
+     * directory listing for every manga in the library.
+     */
+    fun getMangaDirsWithDownloads(root: File): Set<Pair<String, String>> {
+        val rootDir = File(root, ROOT_DIR)
+        val sourceDirs = rootDir.listFiles { file -> file.isDirectory } ?: return emptySet()
+        val result = mutableSetOf<Pair<String, String>>()
+        for (sourceDir in sourceDirs) {
+            val mangaDirs = sourceDir.listFiles { file -> file.isDirectory } ?: continue
+            for (mangaDir in mangaDirs) {
+                val chapterDirs = mangaDir.listFiles { file -> file.isDirectory } ?: continue
+                val hasDownloads = chapterDirs.any { chapterDir ->
+                    val fileList = chapterDir.list() ?: return@any false
+                    fileList.any { filename ->
+                        filename == CbzCreator.CBZ_FILE_NAME ||
+                            filename.substringAfterLast('.', "").lowercase() in PAGE_EXTENSIONS
+                    }
+                }
+                if (hasDownloads) {
+                    result.add(sourceDir.name to mangaDir.name)
+                }
+            }
+        }
+        return result
+    }
+
     fun getDownloadedPageUris(
         root: File,
         sourceName: String,

--- a/data/src/main/java/app/otakureader/data/repository/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/ChapterRepositoryImpl.kt
@@ -148,6 +148,13 @@ class ChapterRepositoryImpl @Inject constructor(
         }.first()
     }
 
+    override suspend fun getChaptersByMangaIdsSync(mangaIds: Collection<Long>): List<Chapter> {
+        // Same bound-parameter-limit chunking as updateChapterProgress(Collection<Long>, ...).
+        return mangaIds.chunked(SQLITE_MAX_BIND_PARAMETERS).flatMap { chunk ->
+            chapterDao.getChaptersByMangaIdsOnce(chunk).map { it.toDomain() }
+        }
+    }
+
     private fun ChapterEntity.toDomain() = Chapter(
         id = id,
         mangaId = mangaId,

--- a/data/src/main/java/app/otakureader/data/repository/DownloadRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/DownloadRepositoryImpl.kt
@@ -130,6 +130,16 @@ class DownloadRepositoryImpl @Inject constructor(
         DownloadProvider.hasMangaDownloads(context, sourceName, mangaTitle)
     }
 
+    override suspend fun getMangaIdsWithDownloads(
+        mangaKeys: Map<Long, Pair<String, String>>
+    ): Set<Long> = withContext(Dispatchers.IO) {
+        val root = context.getExternalFilesDir(null) ?: context.filesDir
+        val downloadedDirKeys = DownloadProvider.getMangaDirsWithDownloads(root)
+        mangaKeys.filterValues { (sourceName, mangaTitle) ->
+            (DownloadProvider.sanitize(sourceName) to DownloadProvider.sanitize(mangaTitle)) in downloadedDirKeys
+        }.keys
+    }
+
     override suspend fun exportChapterAsCbz(
         sourceName: String,
         mangaTitle: String,

--- a/data/src/main/java/app/otakureader/data/tracking/repository/TrackRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/repository/TrackRepositoryImpl.kt
@@ -17,7 +17,7 @@ class TrackRepositoryImpl @Inject constructor(
         dao.getByMangaId(mangaId).map { entities -> entities.map { it.toDomain() } }
 
     override fun observeMangaIdsWithTrackEntries(): Flow<Set<Long>> =
-        dao.getMangaIdsWithTrackEntries()
+        dao.getMangaIdsWithTrackEntries().map { it.toSet() }
 
     override suspend fun getEntry(mangaId: Long, trackerId: Int): TrackEntry? =
         dao.getByMangaAndTracker(mangaId, trackerId)?.toDomain()

--- a/data/src/main/java/app/otakureader/data/tracking/repository/TrackRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/repository/TrackRepositoryImpl.kt
@@ -16,6 +16,9 @@ class TrackRepositoryImpl @Inject constructor(
     override fun observeEntriesForManga(mangaId: Long): Flow<List<TrackEntry>> =
         dao.getByMangaId(mangaId).map { entities -> entities.map { it.toDomain() } }
 
+    override fun observeMangaIdsWithTrackEntries(): Flow<Set<Long>> =
+        dao.getMangaIdsWithTrackEntries()
+
     override suspend fun getEntry(mangaId: Long, trackerId: Int): TrackEntry? =
         dao.getByMangaAndTracker(mangaId, trackerId)?.toDomain()
 

--- a/domain/src/main/java/app/otakureader/domain/repository/ChapterRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/ChapterRepository.kt
@@ -28,4 +28,7 @@ interface ChapterRepository {
 
     /** Migration-specific methods */
     suspend fun getChaptersByMangaIdSync(mangaId: Long): List<Chapter>
+
+    /** Batched variant of [getChaptersByMangaIdSync] for bulk actions across multiple manga. */
+    suspend fun getChaptersByMangaIdsSync(mangaIds: Collection<Long>): List<Chapter>
 }

--- a/domain/src/main/java/app/otakureader/domain/repository/DownloadRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/DownloadRepository.kt
@@ -98,6 +98,13 @@ interface DownloadRepository {
     suspend fun hasMangaDownloads(sourceName: String, mangaTitle: String): Boolean
 
     /**
+     * Returns the subset of [mangaKeys] (mangaId -> (sourceName, mangaTitle)) that have at
+     * least one downloaded chapter. One filesystem walk for the whole batch instead of calling
+     * [hasMangaDownloads] once per manga in the library.
+     */
+    suspend fun getMangaIdsWithDownloads(mangaKeys: Map<Long, Pair<String, String>>): Set<Long>
+
+    /**
      * Creates a CBZ archive from the downloaded pages (if any) of the given chapter.
      *
      * The archive is placed inside the chapter's download directory. This operation

--- a/domain/src/main/java/app/otakureader/domain/tracking/TrackRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/tracking/TrackRepository.kt
@@ -11,6 +11,9 @@ interface TrackRepository {
     /** Observe all entries for a given local manga. */
     fun observeEntriesForManga(mangaId: Long): Flow<List<TrackEntry>>
 
+    /** Observe the set of manga IDs that have at least one tracker entry across all trackers. */
+    fun observeMangaIdsWithTrackEntries(): Flow<Set<Long>>
+
     /** Retrieve a single entry by the unique (manga, tracker) key. */
     suspend fun getEntry(mangaId: Long, trackerId: Int): TrackEntry?
 

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -603,30 +603,25 @@ class LibraryViewModel @Inject constructor(
 
                     val sourceIconUrlDeferred = async { buildSourceIconUrlMap() }
 
-                    // Build tracking lookup in parallel
-                    val trackingDeferred = mangaList.map { manga ->
-                        async {
-                            val hasEntries = trackRepository.observeEntriesForManga(manga.id)
-                                .first().isNotEmpty()
-                            if (hasEntries) manga.id else null
-                        }
+                    // One query for the whole library instead of a per-manga tracking check
+                    val globalTrackedIdsDeferred = async {
+                        trackRepository.observeMangaIdsWithTrackEntries().first()
                     }
 
-                    // Build download lookup in parallel
-                    val downloadDeferred = mangaList.map { manga ->
-                        async {
-                            val hasDownloads = downloadRepository.hasMangaDownloads(
-                                sourceName = sourceRepository.resolveDownloadFolderName(manga.sourceId),
-                                mangaTitle = manga.title
-                            )
-                            if (hasDownloads) manga.id else null
+                    // Resolve each manga's download-folder key in parallel, then one
+                    // filesystem walk for the whole library instead of a per-manga check
+                    val mangaKeysDeferred = async {
+                        mangaList.associate { manga ->
+                            manga.id to (sourceRepository.resolveDownloadFolderName(manga.sourceId) to manga.title)
                         }
                     }
 
                     val sourceMeta = sourceMetaDeferred.await()
                     val sourceIconUrls = sourceIconUrlDeferred.await()
-                    val trackedMangaIds = trackingDeferred.awaitAll().filterNotNull().toSet()
-                    val downloadedMangaIds = downloadDeferred.awaitAll().filterNotNull().toSet()
+                    val globalTrackedIds = globalTrackedIdsDeferred.await()
+                    val mangaKeys = mangaKeysDeferred.await()
+                    val trackedMangaIds = mangaList.map { it.id }.filter { it in globalTrackedIds }.toSet()
+                    val downloadedMangaIds = downloadRepository.getMangaIdsWithDownloads(mangaKeys)
 
                     mangaList.map { manga ->
                         val meta = sourceMeta[manga.sourceId]
@@ -816,9 +811,7 @@ class LibraryViewModel @Inject constructor(
         val mangaIds = selection.snapshotAndClear()
         if (mangaIds.isEmpty()) return
         viewModelScope.launch {
-            val chapterIds = mangaIds.flatMap { mangaId ->
-                chapterRepository.getChaptersByMangaIdSync(mangaId).map { it.id }
-            }
+            val chapterIds = chapterRepository.getChaptersByMangaIdsSync(mangaIds).map { it.id }
             if (chapterIds.isNotEmpty()) {
                 chapterRepository.updateChapterProgress(chapterIds, read = read, lastPageRead = 0)
             }

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -39,6 +39,7 @@ import app.otakureader.domain.scheduler.LibraryUpdateScheduler
 import app.cash.turbine.test
 import io.mockk.Awaits
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -126,6 +127,7 @@ class LibraryViewModelTest {
         mangaRepository = mockk(relaxed = true)
         downloadRepository = mockk {
             coEvery { hasMangaDownloads(any(), any()) } returns false
+            coEvery { getMangaIdsWithDownloads(any()) } returns emptySet()
             every { observeDownloads() } returns flowOf(emptyList())
         }
         settingsRepository = mockk {
@@ -133,6 +135,7 @@ class LibraryViewModelTest {
         }
         trackRepository = mockk {
             every { observeEntriesForManga(any()) } returns flowOf(emptyList())
+            every { observeMangaIdsWithTrackEntries() } returns flowOf(emptySet())
         }
         getCategories = mockk(relaxed = true) {
             every { this@mockk.invoke() } returns flowOf(emptyList())
@@ -272,6 +275,24 @@ class LibraryViewModelTest {
     }
 
     @Test
+    fun loadLibrary_marksTrackedAndDownloadedMangaFromBatchedLookups() = runTest {
+        every { getLibraryManga() } returns flowOf(sampleMangas)
+        every { trackRepository.observeMangaIdsWithTrackEntries() } returns flowOf(setOf(2L))
+        coEvery { downloadRepository.getMangaIdsWithDownloads(any()) } returns setOf(1L)
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val byId = viewModel.state.value.mangaList.associateBy { it.id }
+        assertTrue(byId.getValue(1L).isDownloaded)
+        assertFalse(byId.getValue(1L).hasTracking)
+        assertFalse(byId.getValue(2L).isDownloaded)
+        assertTrue(byId.getValue(2L).hasTracking)
+        assertFalse(byId.getValue(3L).isDownloaded)
+        assertFalse(byId.getValue(3L).hasTracking)
+    }
+
+    @Test
     fun init_setsLoadingFalseAfterLoad() = runTest {
         every { getLibraryManga() } returns flowOf(sampleMangas)
 
@@ -385,6 +406,28 @@ class LibraryViewModelTest {
             sampleMangas.map { it.id }.toSet(),
             viewModel.state.value.selectedManga
         )
+    }
+
+    @Test
+    fun onEvent_MarkSelectedAsRead_batchesChapterLookupAcrossSelectedManga() = runTest {
+        every { getLibraryManga() } returns flowOf(sampleMangas)
+        val chapters = listOf(
+            Chapter(id = 100L, mangaId = 1L, url = "/c/100", name = "Ch. 1"),
+            Chapter(id = 200L, mangaId = 2L, url = "/c/200", name = "Ch. 1"),
+        )
+        coEvery { chapterRepository.getChaptersByMangaIdsSync(setOf(1L, 2L)) } returns chapters
+        coEvery { chapterRepository.updateChapterProgress(any<Collection<Long>>(), any(), any()) } just Awaits
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onEvent(LibraryEvent.OnMangaLongClick(1L))
+        viewModel.onEvent(LibraryEvent.OnMangaLongClick(2L))
+        viewModel.onEvent(LibraryEvent.MarkSelectedAsRead)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { chapterRepository.getChaptersByMangaIdsSync(setOf(1L, 2L)) }
+        coVerify { chapterRepository.updateChapterProgress(listOf(100L, 200L), read = true, lastPageRead = 0) }
     }
 
     @Test


### PR DESCRIPTION
## 📋 Description
Third and final PR in the maintenance/cleanup pass (#1210 mechanical cleanup, #1211 test dispatcher migration). This one is the only PR with actual behavior changes — three N+1 query/IO fixes:

- **`LibraryViewModel.loadLibrary()`** ran one tracking-entry query and one filesystem stat per manga on every library load (parallelized with `async`, but still O(N)). Replaced with:
  - One `SELECT DISTINCT manga_id` query (`TrackEntryDao.getMangaIdsWithTrackEntries` → `TrackRepository.observeMangaIdsWithTrackEntries()`) instead of a per-manga `observeEntriesForManga(id).first().isNotEmpty()` check.
  - One filesystem walk (`DownloadProvider.getMangaDirsWithDownloads`) instead of a per-manga `hasMangaDownloads(...)` directory listing.

  **Deviation from the original plan sketch worth flagging**: the plan had the ViewModel importing `DownloadProvider` (a `data`-layer object) directly and calling `DownloadProvider.sanitize()`. `feature/library` has no Gradle dependency on `data` at all, and Clean Architecture (per this repo's CLAUDE.md) forbids feature-layer code from depending on data directly — that would neither compile nor pass review. Instead, `DownloadRepository.getMangaIdsWithDownloads(mangaKeys: Map<Long, Pair<String, String>>): Set<Long>` keeps the sanitize/directory-matching logic entirely inside `DownloadRepositoryImpl`; the ViewModel only ever sees manga IDs.

- **`LibraryViewModel.markChaptersForSelectedManga()`** (bulk mark-read/unread) ran one chapter query per selected manga. Added `ChapterDao.getChaptersByMangaIdsOnce` (chunked at the existing `SQLITE_MAX_BIND_PARAMETERS` constant, mirroring the established `updateChapterProgress(Collection<Long>, ...)` chunking pattern) → `ChapterRepository.getChaptersByMangaIdsSync(mangaIds)`, replacing the per-manga `flatMap`.

- **`DownloadManager.prioritizeAll()`** issued one `UPDATE` per reordered chapter. Added `DownloadQueueDao.updatePriorities()` as a `@Transaction` default method — same pattern as the existing `ReadingHistoryDao.upsert`/`replaceHistory` — for one atomic batch instead of N individual statements.

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation
- [ ] 🎨 UI/UX
- [ ] ♻️ Refactoring
- [x] 🚀 Performance
- [x] 🧪 Tests

## 🧪 Testing
No local Android SDK/emulator in this environment. Verified locally with `./gradlew detekt` and `./gradlew ktlintCheck` (both pass — detekt initially flagged `DownloadProvider` for exceeding the `TooManyFunctions` threshold after adding a `Context`-based convenience wrapper, so that wrapper was dropped and the repository resolves the root `File` directly instead).

Added/extended unit tests:
- `LibraryViewModelTest`: new test asserting tracked/downloaded status is computed correctly per-manga from the batched lookups (previously untested).
- `LibraryViewModelTest`: new test asserting the chapter query for bulk mark-read is batched (one call) across all selected manga.
- `DownloadManagerTest`'s existing `prioritizeAll` test suite needed no changes — those tests assert against the in-memory `downloads` StateFlow, and `downloadQueueDao` is a relaxed mock, so the DAO-layer batching change is transparent to them.

CI (Unit Tests, Coverage Gate) is the actual verification gate for the new/changed test coverage in this sandbox.

## 📸 Screenshots
N/A — no UI changes.

## ✅ Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings
- [ ] Tests pass (CI-only in this environment)

## 🔗 Related Issues
Final PR in the 3-PR maintenance/cleanup pass started in #1210 and continued in #1211. No tracking issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_012L63YECCrNMzsAgiEf64ya)_

## Summary by Sourcery

Optimize library tracking, downloads detection, and bulk mark-read operations to remove N+1 query and filesystem patterns, and batch download queue priority updates.

Enhancements:
- Batch library tracking badge resolution via a single tracked-manga ID stream rather than per-manga lookups.
- Batch library download status detection via a single filesystem walk and repository-level key matching.
- Add batched chapter retrieval across multiple manga for bulk mark-read/unread actions.
- Add DAO-level batched download queue priority updates wrapped in a single transaction.

Tests:
- Extend LibraryViewModel tests to cover tracked/downloaded flags derived from batched lookups and verify batched chapter queries for bulk mark-read.