### PR TITLE
Attach Referer and source headers to page-image requests

### DIFF
--- a/app/src/main/java/app/otakureader/OtakuReaderApplication.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderApplication.kt
@@ -5,6 +5,7 @@ import android.content.ComponentCallbacks2
 import android.content.Context
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import app.otakureader.core.common.network.PageImageHeaders
 import app.otakureader.core.preferences.CrashReportingStore
 import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.crash.CrashHandler
@@ -54,6 +55,9 @@ class OtakuReaderApplication : Application(), Configuration.Provider, SingletonI
 
     @Inject
     lateinit var okHttpClient: OkHttpClient
+
+    @Inject
+    lateinit var pageImageHeaders: PageImageHeaders
 
     @Inject
     lateinit var generalPreferences: GeneralPreferences
@@ -197,11 +201,29 @@ class OtakuReaderApplication : Application(), Configuration.Provider, SingletonI
                 add(OkHttpNetworkFetcherFactory(callFactory = {
                     okHttpClient.newBuilder()
                         .addInterceptor { chain ->
-                            chain.proceed(
-                                chain.request().newBuilder()
-                                    .tag(RequestCategory::class.java, RequestCategory.IMAGE_CACHE)
-                                    .build()
-                            )
+                            val request = chain.request()
+                            val builder = request.newBuilder()
+                                .tag(RequestCategory::class.java, RequestCategory.IMAGE_CACHE)
+
+                            // Attach the headers recorded when this page list was fetched.
+                            //
+                            // Done here rather than at the call sites because page images are
+                            // requested from six of them, and a host that hotlink-protects its
+                            // images answers a missing Referer with 403 — which surfaces as a
+                            // blank page indistinguishable from a dead link. One interceptor
+                            // covers every call site including the prefetchers, so a new one
+                            // cannot forget.
+                            //
+                            // Only headers the caller has not already set are added, so an
+                            // explicit header at a call site still wins.
+                            pageImageHeaders.headersFor(request.url.toString())
+                                .forEach { (name, value) ->
+                                    if (request.header(name) == null) {
+                                        builder.header(name, value)
+                                    }
+                                }
+
+                            chain.proceed(builder.build())
                         }
                         .build()
                 }))

--- a/app/src/main/java/app/otakureader/OtakuReaderApplication.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderApplication.kt
@@ -20,6 +20,7 @@ import coil3.SingletonImageLoader
 import coil3.disk.DiskCache
 import coil3.memory.MemoryCache
 import app.otakureader.core.network.RequestCategory
+import app.otakureader.core.network.di.PageImageOkHttp
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.allowRgb565
 import coil3.request.crossfade
@@ -54,6 +55,17 @@ class OtakuReaderApplication : Application(), Configuration.Provider, SingletonI
 
     @Inject
     lateinit var okHttpClient: OkHttpClient
+
+    /**
+     * The page-image client, used only for Coil.
+     *
+     * Kept distinct from [okHttpClient], which is what extensions get through Injekt below.
+     * This one attaches source-supplied page headers, and handing that to extension code would
+     * let one source obtain another's credentials by requesting its image URLs.
+     */
+    @Inject
+    @PageImageOkHttp
+    lateinit var pageImageOkHttpClient: OkHttpClient
 
 
     @Inject
@@ -196,10 +208,10 @@ class OtakuReaderApplication : Application(), Configuration.Provider, SingletonI
             }
             .components {
                 add(OkHttpNetworkFetcherFactory(callFactory = {
-                    // Tags image traffic for the Data Usage dashboard. Page-image headers are
-                    // NOT attached here — they live on the shared client in NetworkModule, so
-                    // that Downloader gets them too rather than only the reader.
-                    okHttpClient.newBuilder()
+                    // Tags image traffic for the Data Usage dashboard. The page-image headers
+                    // themselves come from the injected client, which Downloader also uses, so
+                    // display and offline saving behave identically.
+                    pageImageOkHttpClient.newBuilder()
                         .addInterceptor { chain ->
                             chain.proceed(
                                 chain.request().newBuilder()

--- a/app/src/main/java/app/otakureader/OtakuReaderApplication.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderApplication.kt
@@ -5,7 +5,6 @@ import android.content.ComponentCallbacks2
 import android.content.Context
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
-import app.otakureader.core.common.network.PageImageHeaders
 import app.otakureader.core.preferences.CrashReportingStore
 import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.crash.CrashHandler
@@ -56,8 +55,6 @@ class OtakuReaderApplication : Application(), Configuration.Provider, SingletonI
     @Inject
     lateinit var okHttpClient: OkHttpClient
 
-    @Inject
-    lateinit var pageImageHeaders: PageImageHeaders
 
     @Inject
     lateinit var generalPreferences: GeneralPreferences
@@ -199,31 +196,16 @@ class OtakuReaderApplication : Application(), Configuration.Provider, SingletonI
             }
             .components {
                 add(OkHttpNetworkFetcherFactory(callFactory = {
+                    // Tags image traffic for the Data Usage dashboard. Page-image headers are
+                    // NOT attached here — they live on the shared client in NetworkModule, so
+                    // that Downloader gets them too rather than only the reader.
                     okHttpClient.newBuilder()
                         .addInterceptor { chain ->
-                            val request = chain.request()
-                            val builder = request.newBuilder()
-                                .tag(RequestCategory::class.java, RequestCategory.IMAGE_CACHE)
-
-                            // Attach the headers recorded when this page list was fetched.
-                            //
-                            // Done here rather than at the call sites because page images are
-                            // requested from six of them, and a host that hotlink-protects its
-                            // images answers a missing Referer with 403 — which surfaces as a
-                            // blank page indistinguishable from a dead link. One interceptor
-                            // covers every call site including the prefetchers, so a new one
-                            // cannot forget.
-                            //
-                            // Only headers the caller has not already set are added, so an
-                            // explicit header at a call site still wins.
-                            pageImageHeaders.headersFor(request.url.toString())
-                                .forEach { (name, value) ->
-                                    if (request.header(name) == null) {
-                                        builder.header(name, value)
-                                    }
-                                }
-
-                            chain.proceed(builder.build())
+                            chain.proceed(
+                                chain.request().newBuilder()
+                                    .tag(RequestCategory::class.java, RequestCategory.IMAGE_CACHE)
+                                    .build()
+                            )
                         }
                         .build()
                 }))

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -17,4 +17,6 @@ dependencies {
     api(libs.kotlinx.coroutines.core)
     implementation(libs.lifecycle.viewmodel.ktx)
     implementation(libs.zxing.core)
+
+    testImplementation(libs.junit)
 }

--- a/core/common/src/main/java/app/otakureader/core/common/network/PageImageHeaders.kt
+++ b/core/common/src/main/java/app/otakureader/core/common/network/PageImageHeaders.kt
@@ -1,0 +1,115 @@
+package app.otakureader.core.common.network
+
+import java.net.URI
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Headers to attach when fetching a page image, looked up by image URL.
+ *
+ * ### Why a registry rather than parameters
+ *
+ * Page images are requested from **six** places — the zoomable page, the full-page gallery, the
+ * thumbnail strip, two prefetchers and the reader's own warm-up. Threading headers through all
+ * of them means every future call site has to remember, and the failure when one forgets is
+ * near-undiagnosable: the host returns 403, the page renders blank, and nothing distinguishes it
+ * from a dead link. Registering once where the page list is produced, and reading here inside
+ * the image pipeline's interceptor, makes omission structurally impossible and gets the
+ * prefetchers right for free.
+ *
+ * ### Why headers are needed at all
+ *
+ * Many hosts refuse an image request that arrives without a `Referer` naming the site it was
+ * linked from — hotlink protection. A reader fetching the image directly looks exactly like a
+ * hotlinker unless it says where it came from. Some sources also supply their own per-page
+ * headers (a signed token, a session header), which must be preserved rather than replaced.
+ *
+ * ### Lookup order
+ *
+ * Exact URL first, then the URL's host. The host fallback matters because an image URL is not
+ * always byte-identical to the one the source handed us — CDNs append cache-busting query
+ * parameters, and redirects land on a sibling host. Falling back to the host keeps the `Referer`
+ * attached through those, where an exact-match-only registry would silently stop working.
+ *
+ * ### Known limitation
+ *
+ * The host fallback is last-writer-wins, so if two sources serve images from the *same* CDN host
+ * the second to fetch a page list overwrites the first's `Referer`. Entries are refreshed on
+ * every page-list fetch, so this self-corrects as soon as the affected source is read again, and
+ * per-page headers — which sources with real hotlink requirements supply — are unaffected. Stated
+ * rather than papered over: there is no clear() here, because clearing on a source-list refresh
+ * would strip the headers from the chapter the user is reading at that moment, which is a worse
+ * failure than the one it would be trying to avoid.
+ *
+ * Thread-safe: registration happens on IO while lookups happen on OkHttp's dispatcher threads.
+ */
+@Singleton
+class PageImageHeaders @Inject constructor() {
+
+    private companion object {
+        /**
+         * Bounds on retained entries.
+         *
+         * A chapter is tens to a couple of hundred pages and a long session spans many chapters,
+         * so an unbounded map would grow for as long as the reader is open. Eviction is
+         * least-recently-used, which matches how pages are read: the chapter in front of the
+         * user stays warm and old ones fall out.
+         */
+        const val MAX_PAGE_ENTRIES = 2_000
+        const val MAX_HOST_ENTRIES = 64
+
+        const val REFERER = "Referer"
+    }
+
+    private val perPage = lruMap<String, Map<String, String>>(MAX_PAGE_ENTRIES)
+    private val perHost = lruMap<String, Map<String, String>>(MAX_HOST_ENTRIES)
+
+    /**
+     * Register the fallback `Referer` for every host in [pageUrls], derived from [sourceBaseUrl].
+     *
+     * Applies to every backend — an APK-backed source needs this exactly as much as a JavaScript
+     * one, so it is registered from the shared repository path rather than inside either backend.
+     */
+    fun registerReferer(sourceBaseUrl: String, pageUrls: List<String>) {
+        val referer = sourceBaseUrl.takeIf { it.isNotBlank() } ?: return
+        val headers = mapOf(REFERER to referer)
+        synchronized(perHost) {
+            pageUrls.mapNotNull { it.hostOrNull() }.distinct().forEach { perHost[it] = headers }
+        }
+    }
+
+    /**
+     * Register headers a source supplied for specific pages.
+     *
+     * Merged over the host fallback at lookup time rather than replacing it, so a source that
+     * supplies only an auth header still gets a `Referer`, and one that supplies its own
+     * `Referer` overrides ours.
+     */
+    fun registerPageHeaders(headersByUrl: Map<String, Map<String, String>>) {
+        if (headersByUrl.isEmpty()) return
+        synchronized(perPage) { perPage.putAll(headersByUrl) }
+    }
+
+    /** Headers for [url], or empty when nothing was registered for it. */
+    fun headersFor(url: String): Map<String, String> {
+        val host = url.hostOrNull()
+        val hostHeaders = host?.let { synchronized(perHost) { perHost[it] } }.orEmpty()
+        val pageHeaders = synchronized(perPage) { perPage[url] }.orEmpty()
+        return hostHeaders + pageHeaders
+    }
+
+    private fun String.hostOrNull(): String? =
+        runCatching { URI(this).host }.getOrNull()?.takeIf { it.isNotBlank() }
+}
+
+/**
+ * Access-ordered map that evicts the least recently used entry past [maxEntries].
+ *
+ * `accessOrder = true` is the point: with insertion order, the pages a reader is actually
+ * looking at would be evicted on the same schedule as ones they left behind an hour ago.
+ */
+private fun <K, V> lruMap(maxEntries: Int): LinkedHashMap<K, V> =
+    object : LinkedHashMap<K, V>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, V>?): Boolean =
+            size > maxEntries
+    }

--- a/core/common/src/test/java/app/otakureader/core/common/network/PageImageHeadersTest.kt
+++ b/core/common/src/test/java/app/otakureader/core/common/network/PageImageHeadersTest.kt
@@ -1,0 +1,147 @@
+package app.otakureader.core.common.network
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Covers the lookup rules for page-image headers.
+ *
+ * The behaviour that matters is what a *missing* header costs: a host with hotlink protection
+ * answers a `Referer`-less request with 403, which the reader renders as a blank page
+ * indistinguishable from a dead link. So these tests are mostly about the paths where a naive
+ * implementation quietly returns nothing.
+ */
+class PageImageHeadersTest {
+
+    private lateinit var headers: PageImageHeaders
+
+    @Before
+    fun setUp() {
+        headers = PageImageHeaders()
+    }
+
+    @Test
+    fun `a registered host supplies the referer for its images`() {
+        headers.registerReferer(
+            sourceBaseUrl = "https://example.test",
+            pageUrls = listOf("https://cdn.example.test/1.jpg"),
+        )
+
+        assertEquals(
+            mapOf("Referer" to "https://example.test"),
+            headers.headersFor("https://cdn.example.test/1.jpg"),
+        )
+    }
+
+    /**
+     * The reason the fallback is keyed by host and not by exact URL. CDNs append cache-busting
+     * query parameters and redirects land on sibling paths, so an exact-match-only registry
+     * would attach the Referer to the first request and silently drop it from the rest.
+     */
+    @Test
+    fun `the referer survives a url the source never handed us verbatim`() {
+        headers.registerReferer("https://example.test", listOf("https://cdn.example.test/1.jpg"))
+
+        val withQuery = headers.headersFor("https://cdn.example.test/1.jpg?token=abc&v=2")
+        val otherPath = headers.headersFor("https://cdn.example.test/deep/9.jpg")
+
+        assertEquals("https://example.test", withQuery["Referer"])
+        assertEquals("https://example.test", otherPath["Referer"])
+    }
+
+    @Test
+    fun `an unregistered host contributes nothing`() {
+        headers.registerReferer("https://example.test", listOf("https://cdn.example.test/1.jpg"))
+
+        assertTrue(headers.headersFor("https://elsewhere.test/1.jpg").isEmpty())
+    }
+
+    /**
+     * A source supplying an auth header must still get the Referer — replacing rather than
+     * merging would trade one 403 for another.
+     */
+    @Test
+    fun `source headers merge over the host referer rather than replacing it`() {
+        headers.registerReferer("https://example.test", listOf("https://cdn.example.test/1.jpg"))
+        headers.registerPageHeaders(
+            mapOf("https://cdn.example.test/1.jpg" to mapOf("Authorization" to "Bearer x")),
+        )
+
+        val result = headers.headersFor("https://cdn.example.test/1.jpg")
+
+        assertEquals("https://example.test", result["Referer"])
+        assertEquals("Bearer x", result["Authorization"])
+    }
+
+    /** A source that knows its own Referer requirement must be able to override ours. */
+    @Test
+    fun `a source supplied referer wins over the derived one`() {
+        headers.registerReferer("https://example.test", listOf("https://cdn.example.test/1.jpg"))
+        headers.registerPageHeaders(
+            mapOf("https://cdn.example.test/1.jpg" to mapOf("Referer" to "https://override.test")),
+        )
+
+        assertEquals(
+            "https://override.test",
+            headers.headersFor("https://cdn.example.test/1.jpg")["Referer"],
+        )
+    }
+
+    @Test
+    fun `per page headers apply only to their own page`() {
+        headers.registerPageHeaders(
+            mapOf("https://cdn.example.test/1.jpg" to mapOf("Authorization" to "Bearer x")),
+        )
+
+        assertNull(headers.headersFor("https://cdn.example.test/2.jpg")["Authorization"])
+    }
+
+    /** A malformed URL must return empty rather than throwing into the image pipeline. */
+    @Test
+    fun `a malformed url yields no headers instead of failing`() {
+        headers.registerReferer("https://example.test", listOf("not a url at all"))
+
+        assertTrue(headers.headersFor("also not a url").isEmpty())
+    }
+
+    /** A source with no baseUrl has no Referer to give; registering an empty one is worse. */
+    @Test
+    fun `a blank base url registers nothing`() {
+        headers.registerReferer("", listOf("https://cdn.example.test/1.jpg"))
+
+        assertTrue(headers.headersFor("https://cdn.example.test/1.jpg").isEmpty())
+    }
+
+    /**
+     * The registry lives for the life of the app, so it has to be bounded — a long reading
+     * session would otherwise accumulate an entry per page forever.
+     */
+    @Test
+    fun `page entries are bounded`() {
+        val overflow = 2_500
+        headers.registerPageHeaders(
+            (1..overflow).associate { "https://cdn.example.test/$it.jpg" to mapOf("K" to "$it") },
+        )
+
+        // The most recent entry survives; the oldest is evicted.
+        assertEquals("$overflow", headers.headersFor("https://cdn.example.test/$overflow.jpg")["K"])
+        assertNull(headers.headersFor("https://cdn.example.test/1.jpg")["K"])
+    }
+
+    /**
+     * Hosts are bounded too, and separately — one host covers a whole source, so the ceiling is
+     * much lower and must not be consumed by page-level churn.
+     */
+    @Test
+    fun `host entries are bounded independently of page entries`() {
+        repeat(100) { i ->
+            headers.registerReferer("https://source$i.test", listOf("https://cdn$i.test/1.jpg"))
+        }
+
+        assertEquals("https://source99.test", headers.headersFor("https://cdn99.test/1.jpg")["Referer"])
+        assertTrue(headers.headersFor("https://cdn0.test/1.jpg").isEmpty())
+    }
+}

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/client/JsSource.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/client/JsSource.kt
@@ -7,6 +7,7 @@ import app.otakureader.core.js.protocol.JsMangaListDto
 import app.otakureader.core.js.protocol.JsPageDto
 import app.otakureader.core.js.protocol.JsProtocol
 import app.otakureader.core.js.protocol.JsSourceConfig
+import app.otakureader.core.common.network.PageImageHeaders
 import app.otakureader.sourceapi.FilterList
 import app.otakureader.sourceapi.MangaPage
 import app.otakureader.sourceapi.MangaSource
@@ -29,6 +30,7 @@ import app.otakureader.sourceapi.SourceManga
 class JsSource(
     private val config: JsSourceConfig,
     private val connection: JsEngineConnection,
+    private val pageImageHeaders: PageImageHeaders,
 ) : MangaSource {
 
     override val id: String = config.id
@@ -92,31 +94,23 @@ class JsSource(
             JsProtocol.Method.PAGE_LIST,
             JsCallArgs(url = chapter.url),
         )
+
+        // Per-page headers cannot travel on Page — it carries only an index and two URLs — so
+        // they are handed to the image pipeline here instead. Registering during the same call
+        // that produced the pages is deliberate: the earlier design exposed a separate
+        // pageHeaders() accessor, which would have re-run getPageList in the engine a second
+        // time for data this call already had, doubling the work and the network traffic behind
+        // it for every chapter opened.
+        pages.filter { it.headers.isNotEmpty() }
+            .associate { it.url to it.headers }
+            .let(pageImageHeaders::registerPageHeaders)
+
         return pages.mapIndexed { index, page ->
             // Both fields carry the image URL. Page.url means "this page's remote URL", not
             // the chapter's; downstream code falls back to it when imageUrl is blank, so
             // putting the chapter URL there would make that fallback fetch the wrong thing.
             Page(index = index, url = page.url, imageUrl = page.url)
         }
-    }
-
-    /**
-     * Per-page request headers supplied by the source, keyed by image URL.
-     *
-     * These cannot travel on [Page] — it carries only an index and two URLs — but they matter:
-     * many hosts 403 an image request that arrives without the right `Referer`, so dropping
-     * them silently would mean protected images simply fail to load with no explanation.
-     *
-     * Stage 4 wires this into the image pipeline alongside the baseUrl-derived Referer
-     * fallback for sources that supply no headers at all. It is exposed here rather than
-     * discarded so that the data survives until there is somewhere to apply it.
-     */
-    suspend fun pageHeaders(chapter: SourceChapter): Map<String, Map<String, String>> {
-        val pages = decode<List<JsPageDto>>(
-            JsProtocol.Method.PAGE_LIST,
-            JsCallArgs(url = chapter.url),
-        )
-        return pages.filter { it.headers.isNotEmpty() }.associate { it.url to it.headers }
     }
 
     private suspend fun mangaList(method: String, args: JsCallArgs): MangaPage {

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/client/JsSourceProvider.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/client/JsSourceProvider.kt
@@ -3,6 +3,7 @@ package app.otakureader.core.js.client
 import app.otakureader.core.js.protocol.JsSourceConfig
 import app.otakureader.core.js.store.JsSourcePreferencesStore
 import app.otakureader.core.js.store.JsSourceStore
+import app.otakureader.core.common.network.PageImageHeaders
 import app.otakureader.sourceapi.MangaSource
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -21,6 +22,7 @@ class JsSourceProvider @Inject constructor(
     private val store: JsSourceStore,
     private val preferencesStore: JsSourcePreferencesStore,
     private val connection: JsEngineConnection,
+    private val pageImageHeaders: PageImageHeaders,
 ) {
 
     /**
@@ -46,7 +48,7 @@ class JsSourceProvider @Inject constructor(
             // stored settings in here is what stops an update from wiping them.
             val withPreferences = config.copy(preferences = preferencesStore.get(config.id))
             connection.register(withPreferences, script)
-            JsSource(withPreferences, connection)
+            JsSource(withPreferences, connection, pageImageHeaders)
         }
     }
 

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -23,3 +23,8 @@ dependencies {
     implementation(libs.retrofit.kotlinx.serialization)
     api(libs.kotlinx.serialization.json)
 }
+
+dependencies {
+    testImplementation(libs.junit)
+    testImplementation(libs.okhttp.mockwebserver)
+}

--- a/core/network/src/main/java/app/otakureader/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/app/otakureader/core/network/di/NetworkModule.kt
@@ -121,7 +121,21 @@ object NetworkModule {
             // need it — installing it on the image loader alone left downloads hitting
             // hotlink-protected hosts without a Referer, so a chapter read fine and then failed
             // to save, with the 403 surfacing later as a broken offline page.
-            .addInterceptor { chain ->
+            //
+            // A NETWORK interceptor, not an application one, and that distinction is the
+            // security control. An application interceptor runs once, above OkHttp's redirect
+            // handling, so whatever it adds is carried to every subsequent hop — and OkHttp
+            // strips only `Authorization` on a host change, not a source-supplied `X-Api-Key`.
+            // An image host that redirects cross-origin, whether compromised or simply
+            // misconfigured, would then receive credentials meant for somewhere else, and the
+            // source has no say in where its own CDN points.
+            //
+            // Running per hop makes that unreachable rather than merely mitigated: each hop is
+            // looked up on its own URL, so a redirect to an unregistered host gets nothing and
+            // one to a registered host gets exactly the headers belonging to it. Headers added
+            // here do not propagate either, because OkHttp builds a redirect from the request
+            // as it stood *above* the network interceptors.
+            .addNetworkInterceptor { chain ->
                 val request = chain.request()
                 val extra = pageImageHeaders.headersFor(request.url.toString())
                 if (extra.isEmpty()) {

--- a/core/network/src/main/java/app/otakureader/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/app/otakureader/core/network/di/NetworkModule.kt
@@ -26,6 +26,16 @@ import javax.inject.Singleton
 @Retention(AnnotationRetention.BINARY)
 annotation class TrackerOkHttp
 
+/**
+ * Qualifier for the page-image client, which attaches source-supplied request headers.
+ *
+ * Deliberately not the shared client: untrusted source code derives its own client from that
+ * one and would inherit the header injection. See [NetworkModule.providePageImageOkHttpClient].
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class PageImageOkHttp
+
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
@@ -42,39 +52,8 @@ object NetworkModule {
     @Singleton
     fun provideOkHttpClient(
         bytesRecorder: BytesRecorder,
-        pageImageHeaders: PageImageHeaders,
     ): OkHttpClient {
         val builder = OkHttpClient.Builder()
-            // Attach the headers recorded when a page list was fetched — a Referer naming the
-            // source, plus anything the source supplied for that specific page.
-            //
-            // This belongs on the SHARED client, not on the image loader. Page images are
-            // fetched by two entirely separate consumers: Coil, for display, and Downloader,
-            // for saving chapters offline. Installing it on Coil alone leaves downloads
-            // hitting hotlink-protected hosts without a Referer, so a chapter reads fine and
-            // then fails to download — with the 403 surfacing much later as a broken saved
-            // page. Here, every consumer of this client is covered, including ones not yet
-            // written.
-            //
-            // Not gated on RequestCategory: Coil sets its tag through newBuilder(), which
-            // appends its interceptor *after* these, so the tag is not yet present when this
-            // runs. Scoping instead comes from the registry itself, which only ever holds
-            // hosts that served a page list — a request to any other host finds nothing and is
-            // left untouched.
-            .addInterceptor { chain ->
-                val request = chain.request()
-                val extra = pageImageHeaders.headersFor(request.url.toString())
-                if (extra.isEmpty()) {
-                    chain.proceed(request)
-                } else {
-                    val builder = request.newBuilder()
-                    // Never overwrite a header the caller set deliberately.
-                    extra.forEach { (name, value) ->
-                        if (request.header(name) == null) builder.header(name, value)
-                    }
-                    chain.proceed(builder.build())
-                }
-            }
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
@@ -111,6 +90,52 @@ object NetworkModule {
 
         return builder.build()
     }
+
+    /**
+     * Client for fetching page images — the reader's display path and the offline downloader.
+     *
+     * A **derived** client rather than the shared one, and that is a security boundary rather
+     * than tidiness. `JsHttpBridge` builds its client from the shared one with `newBuilder()`,
+     * so anything installed there is inherited by every request a JavaScript source makes.
+     * Injecting page headers at that level would let a hostile source request another source's
+     * registered image URL and have that source's credentials attached for it — routing straight
+     * around the per-source scoping that keeps one source from reading another's stored login.
+     * Deriving here instead means untrusted code never sees the interceptor.
+     *
+     * The derivation order also keeps injected headers out of the debug log. Application
+     * interceptors run in the order added, and `HttpLoggingInterceptor` is already on the base
+     * client, so it runs *before* this one and never observes what this adds — which matters
+     * because the logger redacts a fixed list of header names and cannot know about a
+     * source-supplied `X-Api-Key`.
+     */
+    @Provides
+    @Singleton
+    @PageImageOkHttp
+    fun providePageImageOkHttpClient(
+        okHttpClient: OkHttpClient,
+        pageImageHeaders: PageImageHeaders,
+    ): OkHttpClient =
+        okHttpClient.newBuilder()
+            // Attach what was recorded when the page list was fetched: a Referer naming the
+            // source, plus anything the source supplied for that specific page. Both consumers
+            // need it — installing it on the image loader alone left downloads hitting
+            // hotlink-protected hosts without a Referer, so a chapter read fine and then failed
+            // to save, with the 403 surfacing later as a broken offline page.
+            .addInterceptor { chain ->
+                val request = chain.request()
+                val extra = pageImageHeaders.headersFor(request.url.toString())
+                if (extra.isEmpty()) {
+                    chain.proceed(request)
+                } else {
+                    val withHeaders = request.newBuilder()
+                    // Never overwrite a header the caller set deliberately.
+                    extra.forEach { (name, value) ->
+                        if (request.header(name) == null) withHeaders.header(name, value)
+                    }
+                    chain.proceed(withHeaders.build())
+                }
+            }
+            .build()
 
     @Provides
     @Singleton

--- a/core/network/src/main/java/app/otakureader/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/app/otakureader/core/network/di/NetworkModule.kt
@@ -1,5 +1,6 @@
 package app.otakureader.core.network.di
 
+import app.otakureader.core.common.network.PageImageHeaders
 import app.otakureader.core.network.BuildConfig
 import app.otakureader.core.network.BytesEventListener
 import app.otakureader.core.network.BytesRecorder
@@ -41,8 +42,39 @@ object NetworkModule {
     @Singleton
     fun provideOkHttpClient(
         bytesRecorder: BytesRecorder,
+        pageImageHeaders: PageImageHeaders,
     ): OkHttpClient {
         val builder = OkHttpClient.Builder()
+            // Attach the headers recorded when a page list was fetched — a Referer naming the
+            // source, plus anything the source supplied for that specific page.
+            //
+            // This belongs on the SHARED client, not on the image loader. Page images are
+            // fetched by two entirely separate consumers: Coil, for display, and Downloader,
+            // for saving chapters offline. Installing it on Coil alone leaves downloads
+            // hitting hotlink-protected hosts without a Referer, so a chapter reads fine and
+            // then fails to download — with the 403 surfacing much later as a broken saved
+            // page. Here, every consumer of this client is covered, including ones not yet
+            // written.
+            //
+            // Not gated on RequestCategory: Coil sets its tag through newBuilder(), which
+            // appends its interceptor *after* these, so the tag is not yet present when this
+            // runs. Scoping instead comes from the registry itself, which only ever holds
+            // hosts that served a page list — a request to any other host finds nothing and is
+            // left untouched.
+            .addInterceptor { chain ->
+                val request = chain.request()
+                val extra = pageImageHeaders.headersFor(request.url.toString())
+                if (extra.isEmpty()) {
+                    chain.proceed(request)
+                } else {
+                    val builder = request.newBuilder()
+                    // Never overwrite a header the caller set deliberately.
+                    extra.forEach { (name, value) ->
+                        if (request.header(name) == null) builder.header(name, value)
+                    }
+                    chain.proceed(builder.build())
+                }
+            }
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)

--- a/core/network/src/test/java/app/otakureader/core/network/RedirectHeaderPropagationTest.kt
+++ b/core/network/src/test/java/app/otakureader/core/network/RedirectHeaderPropagationTest.kt
@@ -1,0 +1,80 @@
+package app.otakureader.core.network
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Establishes, by experiment rather than by reading, what OkHttp actually does with a header a
+ * NETWORK interceptor adds when the response is a cross-host redirect.
+ *
+ * This is the load-bearing assumption behind injecting page-image headers per hop
+ * (`NetworkModule.providePageImageOkHttpClient`). If a header added on hop 1 survived into
+ * hop 2, a source-supplied credential would ride to whatever host a CDN redirects to and
+ * per-hop lookup would be no containment at all — the header would already be on the request
+ * before the lookup ran.
+ *
+ * **It does not survive**, and the mechanism is specific: `RetryAndFollowUpInterceptor` sits
+ * above the network interceptors and rebuilds the response with *its own* request
+ * (`response.newBuilder().request(request)`) before deriving the follow-up. So the redirect is
+ * built from the request as it stood before any network interceptor touched it. An
+ * *application* interceptor would be above that boundary and its headers would propagate —
+ * which is the bug this design exists to avoid.
+ *
+ * Kept as a test rather than a comment because it is an assertion about a third-party library's
+ * internals: it holds for the OkHttp version in the catalog and an upgrade could change it
+ * silently. A comment claiming this would rot invisibly; a failing test would not.
+ */
+class RedirectHeaderPropagationTest {
+
+    @Test
+    fun `a header added by a network interceptor is carried across a cross-host redirect`() {
+        val target = MockWebServer().apply {
+            enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+            start()
+        }
+        val origin = MockWebServer().apply {
+            enqueue(
+                MockResponse()
+                    .setResponseCode(302)
+                    .setHeader("Location", target.url("/image.jpg").toString()),
+            )
+            start()
+        }
+
+        // Inject only on the first host, exactly as the page-image client does.
+        val client = OkHttpClient.Builder()
+            .addNetworkInterceptor { chain ->
+                val request = chain.request()
+                val builder = request.newBuilder()
+                if (request.url.port == origin.port && request.header("X-Api-Key") == null) {
+                    builder.header("X-Api-Key", "secret")
+                }
+                chain.proceed(builder.build())
+            }
+            .build()
+
+        val body = client.newCall(Request.Builder().url(origin.url("/image.jpg")).build())
+            .execute().use { it.body?.string() }
+
+        // Guards against the assertion below passing vacuously: prove the redirect was actually
+        // followed and the target actually served the request, so "no header" means "the header
+        // was dropped", not "no request happened".
+        assertEquals("the redirect must have been followed", "ok", body)
+        assertEquals(1, target.requestCount)
+        assertEquals("secret", origin.takeRequest().getHeader("X-Api-Key"))
+        // The assertion that decides the design. If this is non-null, per-hop lookup alone is
+        // not a containment boundary and the previous hop's header has to be removed explicitly.
+        assertNull(
+            "a credential injected for the origin must not reach the redirect target",
+            target.takeRequest().getHeader("X-Api-Key"),
+        )
+
+        origin.shutdown()
+        target.shutdown()
+    }
+}

--- a/data/src/main/java/app/otakureader/data/download/Downloader.kt
+++ b/data/src/main/java/app/otakureader/data/download/Downloader.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import app.otakureader.core.network.RequestCategory
+import app.otakureader.core.network.di.PageImageOkHttp
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
@@ -19,7 +20,11 @@ import okhttp3.Request
  */
 @Singleton
 class Downloader @Inject constructor(
-    private val okHttpClient: OkHttpClient
+    // The page-image client, not the shared one: it attaches the Referer and any source-supplied
+    // headers recorded when the page list was fetched. Without them a hotlink-protected host
+    // answers 403 and the chapter saves as unopenable files — a failure that only shows up
+    // offline, long after the download reported success.
+    @param:PageImageOkHttp private val okHttpClient: OkHttpClient
 ) {
 
     /**

--- a/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
@@ -18,6 +18,7 @@ import app.otakureader.sourceapi.MangaSource
 import app.otakureader.sourceapi.SourceChapter
 import app.otakureader.sourceapi.SourceManga
 import app.otakureader.core.common.di.ApplicationScope
+import app.otakureader.core.common.network.PageImageHeaders
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -53,6 +54,7 @@ class SourceRepositoryImpl @Inject constructor(
     private val extensionLoader: ExtensionLoader,
     private val extensionRepository: ExtensionRepository,
     private val jsSourceProvider: JsSourceProvider,
+    private val pageImageHeaders: PageImageHeaders,
     @param:ApplicationScope private val scope: CoroutineScope,
 ) : SourceRepository, ExtensionManagementRepository {
 
@@ -76,16 +78,20 @@ class SourceRepositoryImpl @Inject constructor(
         extensionLoader: ExtensionLoader,
         extensionRepository: ExtensionRepository,
         jsSourceProvider: JsSourceProvider,
+        pageImageHeaders: PageImageHeaders,
         scope: CoroutineScope,
     ) : this(
-        context,
-        LocalSourcePreferences.ofDirectory(localDirectory),
-        healthMonitor,
-        httpClient,
-        extensionLoader,
-        extensionRepository,
-        jsSourceProvider,
-        scope,
+        // Named rather than positional: this delegation silently mis-bound when a parameter was
+        // inserted into the primary constructor, and the next insertion would do it again.
+        context = context,
+        localSourcePreferences = LocalSourcePreferences.ofDirectory(localDirectory),
+        healthMonitor = healthMonitor,
+        httpClient = httpClient,
+        extensionLoader = extensionLoader,
+        extensionRepository = extensionRepository,
+        jsSourceProvider = jsSourceProvider,
+        pageImageHeaders = pageImageHeaders,
+        scope = scope,
     )
 
     /**
@@ -363,6 +369,17 @@ class SourceRepositoryImpl @Inject constructor(
                     )
 
                 val pages = source.fetchPageList(chapter)
+
+                // Record the Referer for these images while we still know which source produced
+                // them. This is the only place that knows both, and registering here rather than
+                // at the six places that request page images means a new call site cannot forget
+                // — including the prefetchers, which would otherwise fetch without it and poison
+                // the cache with 403s the reader then displays as blank pages.
+                pageImageHeaders.registerReferer(
+                    sourceBaseUrl = source.baseUrl,
+                    pageUrls = pages.mapNotNull { it.imageUrl?.takeIf(String::isNotBlank) ?: it.url },
+                )
+
                 healthMonitor.recordSuccess(sourceId)
                 Result.success(pages)
             } catch (e: CancellationException) {

--- a/data/src/test/java/app/otakureader/data/repository/SourceRepositoryImplTest.kt
+++ b/data/src/test/java/app/otakureader/data/repository/SourceRepositoryImplTest.kt
@@ -5,6 +5,7 @@ import app.otakureader.core.extension.domain.model.Extension
 import app.otakureader.core.extension.domain.model.InstallStatus
 import app.otakureader.core.extension.domain.repository.ExtensionRepository
 import app.otakureader.core.extension.loader.ExtensionLoader
+import app.otakureader.core.common.network.PageImageHeaders
 import app.otakureader.core.js.client.JsSourceProvider
 import app.otakureader.core.extension.loader.ExtensionLoadResult
 import app.otakureader.core.preferences.LocalSourcePreferences
@@ -69,6 +70,7 @@ class SourceRepositoryImplTest {
     private lateinit var extensionLoader: ExtensionLoader
     private lateinit var extensionRepository: ExtensionRepository
     private lateinit var jsSourceProvider: JsSourceProvider
+    private lateinit var pageImageHeaders: PageImageHeaders
 
     private lateinit var repository: SourceRepositoryImpl
 
@@ -84,6 +86,7 @@ class SourceRepositoryImplTest {
         extensionLoader = mockk(relaxed = true)
         extensionRepository = mockk(relaxed = true)
         jsSourceProvider = mockk(relaxed = true)
+        pageImageHeaders = mockk(relaxed = true)
 
         // Default: no JavaScript sources installed
         coEvery { jsSourceProvider.loadSources() } returns emptyList()
@@ -108,6 +111,7 @@ class SourceRepositoryImplTest {
             extensionLoader = extensionLoader,
             extensionRepository = extensionRepository,
             jsSourceProvider = jsSourceProvider,
+            pageImageHeaders = pageImageHeaders,
             scope = testScope.backgroundScope,
         )
     }


### PR DESCRIPTION
## **User description**
## 📋 Description

Stage 4b. Many hosts refuse an image request that arrives without a `Referer` naming the site it was linked from — hotlink protection. A reader fetching the image directly looks exactly like a hotlinker unless it says where it came from.

This is a **correctness fix, not polish**: without it a large fraction of sources render blank pages, and the failure is a 403 the user experiences as a page that won't load — indistinguishable from a dead link, with nothing anywhere explaining it.

## 🎯 The design question is *where*, not *what*

Page images are requested from **six** call sites:

| File | |
|---|---|
| `ZoomableImage.kt:208` | the page itself |
| `FullPageGallery.kt:170` | full-page gallery |
| `PageThumbnailStrip.kt:158` | thumbnail strip |
| `AdaptiveChapterPrefetcher.kt` | :212 and :235 |
| `SmartPrefetchManager.kt:127` | prefetch |
| `ReaderViewModel.kt` | warm-up |

(The plan predicted three, extrapolating from AnymeX. This codebase has six.)

Threading headers through all of them means every *future* call site has to remember too — and the one that forgets produces exactly the undiagnosable blank page above. So instead:

- **`PageImageHeaders`**, a bounded registry in `core:common`
- **Written once** at `SourceRepositoryImpl.getPageList` — the single point that knows both the pages and the source that produced them
- **Read in the interceptor already present** in `newImageLoader`, which every image request passes through regardless of call site

Omission becomes structurally impossible, and the prefetchers get correct headers for free — they would otherwise fetch without them and **poison the disk cache with 403s** that the reader later displays as failures.

## 🔍 Lookup: exact URL, then host

The host fallback is not redundancy. CDNs append cache-busting query parameters and redirects land on sibling paths, so an exact-match-only registry would attach the `Referer` to the first request and silently drop it from the rest — working in a test, failing in the field.

Source-supplied headers **merge over** the derived `Referer` rather than replacing it, so a source sending only an auth header still gets a `Referer`, and a source that knows its own requirement can override ours.

## ⚡ A hidden second engine call, removed

`JsSource` now registers per-page headers during `fetchPageList`, and the separate `pageHeaders()` accessor is **gone**. That accessor re-ran `getPageList` inside the engine for data the original call already had — doubling the work *and the network traffic behind it* on every chapter opened. It was written in Stage 3 as a placeholder for "somewhere to put this later", and the cost only became visible at the moment something actually called it.

## 🔄 Type of Change
- [x] 🐛 Bug fix (protected images currently fail to load)
- [x] ✨ New feature (source-supplied per-page headers are now honoured)

## 🧪 Testing

| Check | Result |
|---|---|
| `:app:assembleDebug` | ✅ |
| `testDebugUnitTest` (all modules) | ✅ |
| `detekt` | ✅ |
| `ktlintCheck` | ✅ |

Ten tests on the lookup rules, weighted toward the paths where a naive implementation quietly returns nothing rather than failing loudly:

- A registered host supplies the `Referer`; an unregistered one contributes nothing
- **The `Referer` survives a URL the source never handed us verbatim** — query params, sibling paths
- Source headers merge over the host `Referer`; a source-supplied `Referer` wins
- Per-page headers apply only to their own page
- A malformed URL yields empty rather than throwing into the image pipeline
- A blank base URL registers nothing
- **Both bounds are enforced** — page entries and host entries, independently

`core:common` had no test dependency; JUnit added.

## 🧹 Deliberate omissions, stated rather than hidden

**No `clear()`.** Clearing on a source-list refresh would strip headers from the chapter the user is reading *at that moment* — a worse failure than the stale entry it would avoid. I wrote one, found nothing that could call it correctly, and removed it rather than leaving unused API.

**Shared-CDN limitation.** The host fallback is last-writer-wins, so two sources serving images from the same CDN host will overwrite each other's `Referer`. It self-corrects on the next page-list fetch and does not affect per-page headers, which is what sources with real hotlink requirements supply. Documented in the class rather than papered over.

## ✅ Checklist
- [x] Code follows style guidelines
- [x] Self-review completed (against the checklist added in #1225)
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings
- [x] Tests pass

## 📸 Screenshots
N/A — no UI change.

## 🔗 Related Issues

Part of the source-system rebuild. Follows #1225.

**Not verified on a device.** There is still no way to install a JS source, so the JS path here is exercised by tests rather than by use. Stage 4c builds the install path; Stage 8 is the device pass.

**Also of note:** the secondary `SourceRepositoryImpl` constructor now delegates **by name**. It silently mis-bound when this PR inserted a parameter into the primary constructor — positional delegation would do it again on the next one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoEui2mCCcqArdhyQyFwnR)_

## Summary by Sourcery

Attach source-derived Referer and per-page headers to all page image requests via a shared registry and image pipeline interceptor to prevent hotlink-protected images from failing to load.

New Features:
- Introduce a PageImageHeaders registry to store per-page and per-host headers for page images, including derived Referer values.
- Support JS sources supplying per-page headers by registering them during page list fetching so they are honored by the image pipeline.

Bug Fixes:
- Ensure page image requests consistently include appropriate Referer headers, preventing hotlink-protected images from returning 403s and rendering as blank pages.
- Fix a mis-bound secondary SourceRepositoryImpl constructor by switching to named parameter delegation when calling the primary constructor.

Enhancements:
- Wire the PageImageHeaders registry into SourceRepositoryImpl and the global OkHttp image interceptor so all image requests, including prefetchers, automatically receive the correct headers.
- Remove the redundant JsSource.pageHeaders() engine call by capturing and registering per-page headers in fetchPageList, avoiding duplicate work and network traffic.

Build:
- Add JUnit as a test dependency to the core:common module.

Tests:
- Add unit tests for PageImageHeaders covering host and URL lookup behavior, header merging and overriding rules, malformed URL handling, and independent LRU bounds for page and host entries.


___

## **CodeAnt-AI Description**
Prevent protected page images from appearing as blank pages

### What Changed
- Page-image requests now automatically include the source site's `Referer` across reading, thumbnails, galleries, warm-up, and prefetching.
- Source-provided page headers, such as authorization tokens, are preserved and can override the derived `Referer`.
- The header lookup works for changed image URLs on the same host, while retaining only a bounded set of recent entries.
- Added tests for header fallback, merging, overrides, malformed URLs, and registry limits.

### Impact
`✅ Fewer blank pages from hotlink-protected image hosts`
`✅ Fewer cached 403 image failures during prefetching`
`✅ Protected sources retain authorization and custom Referer headers`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach `Referer` and source-provided headers to all page-image requests via a central registry and a dedicated `@PageImageOkHttp` client used by Coil and the `Downloader`, injected per hop to block redirect leaks. This prevents 403s/blank pages and avoids credential leakage to untrusted sources.

- **Bug Fixes**
  - Central `PageImageHeaders` registry (in `core:common`) + a network interceptor on `@PageImageOkHttp` (in `core:network`) attaches headers to every image request from Coil and the `Downloader`, per hop so off-origin redirects can’t carry headers; prevents cache poisoning, blank pages, and broken saved pages.
  - Registered once at `SourceRepositoryImpl.getPageList`; lookup is exact URL then host; source headers merge over the derived `Referer` without overwriting caller-set headers.
  - Security: header injection is isolated from the shared client so JS sources cannot inherit it; logging runs before injection so sensitive headers aren’t printed.
  - Added `RedirectHeaderPropagationTest` in `core:network` using `okhttp3.mockwebserver` to prove per-hop injection does not propagate across cross-host redirects; test deps added.

- **Refactors**
  - `JsSource` registers per-page headers during `fetchPageList`; removed `pageHeaders()` to avoid a second engine call and extra network traffic.
  - Image loader now uses `pageImageOkHttpClient`; `Downloader` receives `@PageImageOkHttp` via DI.
  - Added bounded LRU caches and tests; added `junit` test dependency; secondary `SourceRepositoryImpl` constructor now delegates by name to avoid mis-binding.

<sup>Written for commit 82328192f5c72792f66fe872c675ad4daf309c13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HeartlessVeteran2/Otaku-Reader/pull/1226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

