### PR TITLE
Wire the Cloudflare challenge flow, which was entirely dead code

### DIFF
--- a/app/src/main/java/app/otakureader/ChallengeHostViewModel.kt
+++ b/app/src/main/java/app/otakureader/ChallengeHostViewModel.kt
@@ -1,0 +1,22 @@
+package app.otakureader
+
+import androidx.lifecycle.ViewModel
+import app.otakureader.core.webview.WebViewChallengeManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+/**
+ * Carries the singleton [WebViewChallengeManager] into the navigation host.
+ *
+ * The nav host is a composable, so it cannot take a constructor injection, and the challenge
+ * collector has to live there — it is the only place that can navigate. A one-field ViewModel is
+ * the smallest way to reach the singleton from composition without threading it through every
+ * caller of `OtakuReaderNavHost`.
+ *
+ * The manager itself is `@Singleton`; this holds a reference and owns nothing, so the ViewModel
+ * being recreated does not disturb an in-flight challenge.
+ */
+@HiltViewModel
+class ChallengeHostViewModel @Inject constructor(
+    val manager: WebViewChallengeManager,
+) : ViewModel()

--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -51,6 +51,10 @@ import app.otakureader.feature.updates.navigation.downloadsScreen
 import app.otakureader.feature.updates.navigation.updateErrorsScreen
 import app.otakureader.feature.updates.navigation.updatesScreen
 import app.otakureader.util.DeepLinkResult
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import app.otakureader.core.webview.WebViewPurpose
+import app.otakureader.core.webview.WebViewChallengeManager
+import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
 fun OtakuReaderNavHost(
@@ -60,9 +64,26 @@ fun OtakuReaderNavHost(
     deepLinkResult: DeepLinkResult? = null,
     onDeepLinkConsumed: () -> Unit = {},
     onOnboardingComplete: () -> Unit = {},
+    challengeManager: WebViewChallengeManager = hiltViewModel<ChallengeHostViewModel>().manager,
 ) {
     // Determine start destination based on onboarding status
     val startDestination: Route = if (onboardingCompleted) Route.Library else Route.Onboarding
+
+    // Open the WebView whenever a source hits a Cloudflare wall.
+    //
+    // This collector is the step that was missing: WebViewChallengeManager emitted on
+    // pendingChallenge and the KDoc said "the app's navigation layer observes it", but nothing
+    // did — so a blocked source simply failed with no way for the user to intervene.
+    LaunchedEffect(challengeManager) {
+        challengeManager.pendingChallenge.collect { request ->
+            navController.navigate(
+                Route.WebView(
+                    url = request.url,
+                    purpose = WebViewPurpose.CAPTCHA.name,
+                )
+            )
+        }
+    }
 
     // Handle deep link navigation - only trigger once when deepLinkResult changes
     LaunchedEffect(deepLinkResult) {
@@ -635,7 +656,14 @@ fun OtakuReaderNavHost(
 
         // WebView — embedded browser for CAPTCHA solving, OAuth, etc.
         webViewScreen(
-            onClose = { _, _, _ ->
+            onClose = { url, cookieString, userAgent ->
+                // Completing the challenge is what resumes the blocked request. The previous
+                // version discarded all three values and only popped the back stack, so the
+                // caller waiting on the challenge was never released — the WebView "worked"
+                // and nothing downstream ever knew.
+                url.toHttpUrlOrNull()?.host?.let { host ->
+                    challengeManager.completeChallenge(host, cookieString, userAgent)
+                }
                 navController.popBackStack()
             }
         )

--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -60,7 +60,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.toRoute
 
 @Composable
 fun OtakuReaderNavHost(
@@ -91,22 +91,35 @@ fun OtakuReaderNavHost(
     // other than its close button — a deep link that clears the back stack, for instance — and
     // a stale "still showing" would suppress every later challenge for the life of this nav
     // host, silently disabling the whole bypass. The NavController already knows the answer.
-    // The WHOLE back stack, not just the current entry. If the user navigates away from an open
-    // CAPTCHA without closing it — a notification tap, a deep link — the current destination is
-    // no longer the WebView, and gating on that alone would push a second CAPTCHA while the
-    // first sat stranded beneath it.
+    // Show a challenge that has no screen of its own yet — matched by challenge id, not by
+    // "is some WebView open".
+    //
+    // That distinction is the whole correctness of this block, and three narrower versions were
+    // each wrong in their own way: a remembered flag went stale when a deep link cleared the
+    // back stack and suppressed every later challenge; gating on the current destination missed
+    // a CAPTCHA the user had navigated away from and pushed a duplicate on top of it; gating on
+    // the bare route would let an unrelated general-purpose WebView mask pending challenges, and
+    // left a stranded CAPTCHA blocking the bypass permanently, since only its own close button
+    // can pop it.
+    //
+    // Matching on id makes all three vanish rather than being handled: a stranded screen whose
+    // challenge has completed no longer matches anything pending, and a WebView opened for any
+    // other purpose carries no id at all.
     val backStack by navController.currentBackStack.collectAsStateWithLifecycle()
-    val challengeShowing = backStack.any { it.destination.hasRoute(Route.WebView::class) }
+    val shownChallengeIds = backStack.mapNotNull { entry ->
+        runCatching { entry.toRoute<Route.WebView>() }.getOrNull()?.challengeId
+    }.toSet()
 
     val pendingChallenges by challengeManager.pendingChallenges.collectAsStateWithLifecycle()
-    val nextChallenge = pendingChallenges.firstOrNull()
+    val nextChallenge = pendingChallenges.firstOrNull { it.id !in shownChallengeIds }
 
-    LaunchedEffect(nextChallenge?.id, challengeShowing) {
-        if (nextChallenge != null && !challengeShowing) {
+    LaunchedEffect(nextChallenge?.id) {
+        if (nextChallenge != null) {
             navController.navigate(
                 Route.WebView(
                     url = nextChallenge.url,
                     purpose = WebViewPurpose.CAPTCHA.name,
+                    challengeId = nextChallenge.id,
                 )
             )
         }

--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -55,6 +55,11 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import app.otakureader.core.webview.WebViewPurpose
 import app.otakureader.core.webview.WebViewChallengeManager
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @Composable
 fun OtakuReaderNavHost(
@@ -69,16 +74,27 @@ fun OtakuReaderNavHost(
     // Determine start destination based on onboarding status
     val startDestination: Route = if (onboardingCompleted) Route.Library else Route.Onboarding
 
-    // Open the WebView whenever a source hits a Cloudflare wall.
+    // Open the WebView when a source hits a Cloudflare wall.
     //
-    // This collector is the step that was missing: WebViewChallengeManager emitted on
-    // pendingChallenge and the KDoc said "the app's navigation layer observes it", but nothing
-    // did — so a blocked source simply failed with no way for the user to intervene.
-    LaunchedEffect(challengeManager) {
-        challengeManager.pendingChallenge.collect { request ->
+    // This observer is the step that was missing entirely: the manager published pending
+    // challenges and the KDoc said "the app's navigation layer observes" them, but nothing did —
+    // so a blocked source simply failed with no way for the user to intervene.
+    //
+    // Exactly one challenge is shown at a time. Two hosts can be blocked at once (a chapter's
+    // pages and its cover, say), and navigating for each would push a stack of WebViews the user
+    // has to dismiss one by one — and a challenge arriving late would yank them off whatever
+    // screen they had moved on to. `showingChallengeHost` gates that: the next pending host is
+    // only shown once the current one closes.
+    val pendingChallenges by challengeManager.pendingChallenges.collectAsStateWithLifecycle()
+    var showingChallengeHost by rememberSaveable { mutableStateOf<String?>(null) }
+    val nextChallenge = pendingChallenges.firstOrNull { it.host != showingChallengeHost }
+
+    LaunchedEffect(nextChallenge?.host, showingChallengeHost) {
+        if (nextChallenge != null && showingChallengeHost == null) {
+            showingChallengeHost = nextChallenge.host
             navController.navigate(
                 Route.WebView(
-                    url = request.url,
+                    url = nextChallenge.url,
                     purpose = WebViewPurpose.CAPTCHA.name,
                 )
             )
@@ -664,6 +680,9 @@ fun OtakuReaderNavHost(
                 url.toHttpUrlOrNull()?.host?.let { host ->
                     challengeManager.completeChallenge(host, cookieString, userAgent)
                 }
+                // Releasing the gate here, rather than in the effect, is what lets a second
+                // blocked host be shown after this one is dealt with.
+                showingChallengeHost = null
                 navController.popBackStack()
             }
         )

--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -60,6 +60,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.NavDestination.Companion.hasRoute
 
 @Composable
 fun OtakuReaderNavHost(
@@ -85,13 +87,19 @@ fun OtakuReaderNavHost(
     // has to dismiss one by one — and a challenge arriving late would yank them off whatever
     // screen they had moved on to. `showingChallengeHost` gates that: the next pending host is
     // only shown once the current one closes.
-    val pendingChallenges by challengeManager.pendingChallenges.collectAsStateWithLifecycle()
-    var showingChallengeHost by rememberSaveable { mutableStateOf<String?>(null) }
-    val nextChallenge = pendingChallenges.firstOrNull { it.host != showingChallengeHost }
+    // Whether a challenge screen is up is read from the back stack, not tracked in a flag of
+    // our own. A remembered flag goes stale the moment the destination is removed by anything
+    // other than its close button — a deep link that clears the back stack, for instance — and
+    // a stale "still showing" would suppress every later challenge for the life of this nav
+    // host, silently disabling the whole bypass. The NavController already knows the answer.
+    val currentEntry by navController.currentBackStackEntryAsState()
+    val challengeShowing = currentEntry?.destination?.hasRoute(Route.WebView::class) == true
 
-    LaunchedEffect(nextChallenge?.host, showingChallengeHost) {
-        if (nextChallenge != null && showingChallengeHost == null) {
-            showingChallengeHost = nextChallenge.host
+    val pendingChallenges by challengeManager.pendingChallenges.collectAsStateWithLifecycle()
+    val nextChallenge = pendingChallenges.firstOrNull()
+
+    LaunchedEffect(nextChallenge?.id, challengeShowing) {
+        if (nextChallenge != null && !challengeShowing) {
             navController.navigate(
                 Route.WebView(
                     url = nextChallenge.url,
@@ -680,9 +688,6 @@ fun OtakuReaderNavHost(
                 url.toHttpUrlOrNull()?.host?.let { host ->
                     challengeManager.completeChallenge(host, cookieString, userAgent)
                 }
-                // Releasing the gate here, rather than in the effect, is what lets a second
-                // blocked host be shown after this one is dealt with.
-                showingChallengeHost = null
                 navController.popBackStack()
             }
         )

--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -60,7 +60,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.NavDestination.Companion.hasRoute
 
 @Composable
@@ -92,8 +91,12 @@ fun OtakuReaderNavHost(
     // other than its close button — a deep link that clears the back stack, for instance — and
     // a stale "still showing" would suppress every later challenge for the life of this nav
     // host, silently disabling the whole bypass. The NavController already knows the answer.
-    val currentEntry by navController.currentBackStackEntryAsState()
-    val challengeShowing = currentEntry?.destination?.hasRoute(Route.WebView::class) == true
+    // The WHOLE back stack, not just the current entry. If the user navigates away from an open
+    // CAPTCHA without closing it — a notification tap, a deep link — the current destination is
+    // no longer the WebView, and gating on that alone would push a second CAPTCHA while the
+    // first sat stranded beneath it.
+    val backStack by navController.currentBackStack.collectAsStateWithLifecycle()
+    val challengeShowing = backStack.any { it.destination.hasRoute(Route.WebView::class) }
 
     val pendingChallenges by challengeManager.pendingChallenges.collectAsStateWithLifecycle()
     val nextChallenge = pendingChallenges.firstOrNull()

--- a/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
+++ b/app/src/main/java/app/otakureader/OtakuReaderNavHost.kt
@@ -81,18 +81,10 @@ fun OtakuReaderNavHost(
     // challenges and the KDoc said "the app's navigation layer observes" them, but nothing did —
     // so a blocked source simply failed with no way for the user to intervene.
     //
-    // Exactly one challenge is shown at a time. Two hosts can be blocked at once (a chapter's
-    // pages and its cover, say), and navigating for each would push a stack of WebViews the user
-    // has to dismiss one by one — and a challenge arriving late would yank them off whatever
-    // screen they had moved on to. `showingChallengeHost` gates that: the next pending host is
-    // only shown once the current one closes.
-    // Whether a challenge screen is up is read from the back stack, not tracked in a flag of
-    // our own. A remembered flag goes stale the moment the destination is removed by anything
-    // other than its close button — a deep link that clears the back stack, for instance — and
-    // a stale "still showing" would suppress every later challenge for the life of this nav
-    // host, silently disabling the whole bypass. The NavController already knows the answer.
-    // Show a challenge that has no screen of its own yet — matched by challenge id, not by
-    // "is some WebView open".
+    // Show a challenge that has no screen of its own yet — matched by challenge **id**, not by
+    // "is some WebView open". Whether a screen exists is read from the back stack rather than
+    // tracked in a flag of our own, because the NavController already knows the answer and a
+    // flag of ours can disagree with it.
     //
     // That distinction is the whole correctness of this block, and three narrower versions were
     // each wrong in their own way: a remembered flag went stale when a deep link cleared the
@@ -102,16 +94,38 @@ fun OtakuReaderNavHost(
     // left a stranded CAPTCHA blocking the bypass permanently, since only its own close button
     // can pop it.
     //
-    // Matching on id makes all three vanish rather than being handled: a stranded screen whose
-    // challenge has completed no longer matches anything pending, and a WebView opened for any
-    // other purpose carries no id at all.
+    // The predicate has to satisfy FOUR properties at once, and every previous version got some
+    // subset. Listed so the next change can be checked against all of them rather than the one
+    // that happens to be under discussion:
+    //
+    //  1. One at a time. Two hosts can be blocked together; stacking their screens means the
+    //     user dismisses a pile of CAPTCHAs to get back to reading.
+    //  2. No duplicate for a live challenge, even after navigating away from its screen.
+    //  3. A stranded screen must not wedge the bypass. Only its own close button pops it, so a
+    //     CAPTCHA left behind by a deep link would otherwise block every later challenge for the
+    //     lifetime of the nav host.
+    //  4. An unrelated WebView — OAuth, the fallback viewer — must not mask a challenge.
+    //
+    // Matching on challenge id gives 2, 3 and 4: a stranded screen whose challenge completed
+    // matches nothing pending, and a WebView opened for another purpose carries no id. Property
+    // 1 needs the extra check below, because once a screen exists for A its id counts as shown
+    // and B would immediately become eligible — which is how an id-only filter reintroduced the
+    // stacking it was not trying to fix.
     val backStack by navController.currentBackStack.collectAsStateWithLifecycle()
     val shownChallengeIds = backStack.mapNotNull { entry ->
         runCatching { entry.toRoute<Route.WebView>() }.getOrNull()?.challengeId
     }.toSet()
 
     val pendingChallenges by challengeManager.pendingChallenges.collectAsStateWithLifecycle()
-    val nextChallenge = pendingChallenges.firstOrNull { it.id !in shownChallengeIds }
+
+    // A screen already exists for a challenge that is STILL pending — so the user is looking at
+    // (or has left open) live work, and nothing new should be pushed on top of it.
+    val liveChallengeOnStack = pendingChallenges.any { it.id in shownChallengeIds }
+
+    val nextChallenge = when {
+        liveChallengeOnStack -> null
+        else -> pendingChallenges.firstOrNull { it.id !in shownChallengeIds }
+    }
 
     LaunchedEffect(nextChallenge?.id) {
         if (nextChallenge != null) {

--- a/app/src/main/java/app/otakureader/di/CloudflareModule.kt
+++ b/app/src/main/java/app/otakureader/di/CloudflareModule.kt
@@ -1,0 +1,31 @@
+package app.otakureader.di
+
+import app.otakureader.core.network.cloudflare.CloudflareChallengeSolver
+import app.otakureader.core.webview.WebViewChallengeManager
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Binds the Cloudflare challenge solver to its WebView implementation.
+ *
+ * The binding lives in the app rather than in either module because solving a challenge means
+ * showing UI, and `:core:network` — where the interceptor runs — must not depend on a UI module.
+ * `:core:webview` implements the interface and the app is the only place that knows about both.
+ *
+ * The same pattern as `BytesRecorder` — a thin interface declared in `:core:network` and bound
+ * where the implementation lives — though that one is bound with `@Provides` in
+ * `:data`'s `NetworkRecorderModule`, since its implementation is a lambda rather than a class.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CloudflareModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindCloudflareChallengeSolver(
+        impl: WebViewChallengeManager,
+    ): CloudflareChallengeSolver
+}

--- a/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
+++ b/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
@@ -317,5 +317,18 @@ sealed interface Route {
     data class WebView(
         val url: String,
         val purpose: String = "GENERAL",
+        /**
+         * Identifies the Cloudflare challenge this screen was opened for, if any.
+         *
+         * Carried on the route so the navigation layer can ask the precise question — "is a
+         * WebView open for a challenge that is STILL pending?" — rather than the approximations
+         * that kept being subtly wrong: a remembered flag went stale, the current destination
+         * missed a screen the user had navigated away from, and the bare route matched a
+         * general-purpose WebView that has nothing to do with a challenge.
+         *
+         * Null for every non-challenge use, which is what keeps an OAuth or fallback WebView
+         * from masking a pending challenge.
+         */
+        val challengeId: Long? = null,
     ) : Route
 }

--- a/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
+++ b/core/navigation/src/main/java/app/otakureader/core/navigation/Route.kt
@@ -306,15 +306,15 @@ sealed interface Route {
     /**
      * Embedded WebView screen (e.g. CAPTCHA solving, OAuth).
      *
-     * @param sourceId Extension source ID this WebView is serving.
-     * @param url      URL to open.
+     * @param url      URL to open. The Cloudflare flow is keyed by this URL's host, since
+     *                 clearance is granted per domain and the network layer — which triggers
+     *                 the challenge — only ever knows a URL, never a source.
      * @param purpose  [app.otakureader.core.webview.WebViewPurpose] as a String to avoid
      *                 a cross-module enum reference in the navigation layer.
      *                 Defaults to "GENERAL".
      */
     @Serializable
     data class WebView(
-        val sourceId: Long,
         val url: String,
         val purpose: String = "GENERAL",
     ) : Route

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -14,6 +14,9 @@ android {
 
 dependencies {
     implementation(projects.core.common)
+    // ChallengeUserAgentStore lives here. Cycle-free: core:preferences depends only on
+    // core:common and domain, and domain depends only on source-api.
+    implementation(projects.core.preferences)
 
     implementation(platform(libs.okhttp.bom))
     api(libs.okhttp.core)

--- a/core/network/src/main/java/app/otakureader/core/network/cloudflare/ChallengeUserAgentInterceptor.kt
+++ b/core/network/src/main/java/app/otakureader/core/network/cloudflare/ChallengeUserAgentInterceptor.kt
@@ -1,0 +1,39 @@
+package app.otakureader.core.network.cloudflare
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Sends the User-Agent that solved a host's Cloudflare challenge, for requests to that host.
+ *
+ * Cloudflare binds clearance to the User-Agent that earned it. Replaying the cookie under a
+ * different one is treated as a stolen cookie and challenged again — so without this, solving a
+ * challenge appears to work and then the very next request is blocked exactly as before. The
+ * user is left tapping through a WebView repeatedly with nothing improving, which looks like the
+ * bypass being broken rather than a mismatched identity.
+ *
+ * The mismatch is guaranteed here rather than hypothetical: `NetworkHelper` sends a fixed
+ * `DEFAULT_USER_AGENT` for extension traffic, while the WebView reports the system WebView's own
+ * string. They are never the same.
+ *
+ * **Overrides an existing header**, unlike the page-image header injection, and deliberately so.
+ * Extensions set their own User-Agent, but for a challenged host the cookie only works with the
+ * solving one — deferring to the extension's preference would simply keep it blocked.
+ */
+@Singleton
+class ChallengeUserAgentInterceptor @Inject constructor(
+    private val solver: CloudflareChallengeSolver,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        // Null for every host that has never been challenged, which is nearly all of them —
+        // tracker APIs and unprotected sources keep whatever identity they chose.
+        val userAgent = solver.solvedUserAgent(request.url.host)
+            ?: return chain.proceed(request)
+
+        return chain.proceed(request.newBuilder().header("User-Agent", userAgent).build())
+    }
+}

--- a/core/network/src/main/java/app/otakureader/core/network/cloudflare/CloudflareChallengeSolver.kt
+++ b/core/network/src/main/java/app/otakureader/core/network/cloudflare/CloudflareChallengeSolver.kt
@@ -1,0 +1,36 @@
+package app.otakureader.core.network.cloudflare
+
+/**
+ * Solves a Cloudflare browser challenge for a host, by whatever means the app has available.
+ *
+ * An interface here rather than a direct call because solving one means showing a WebView, and
+ * `:core:network` must not depend on a UI module. `:core:webview` provides the implementation and
+ * the binding lives in the app — the same shape as [app.otakureader.core.network.BytesRecorder],
+ * which exists for exactly this reason.
+ */
+interface CloudflareChallengeSolver {
+
+    /**
+     * Present the challenge for [url] and suspend until it is resolved or abandoned.
+     *
+     * Implementations must **coalesce by host**: a blocked page triggers many parallel image
+     * requests, and every one of them will arrive here at once. Opening a WebView per request
+     * would bury the user under a stack of identical screens, all solving the same challenge.
+     *
+     * @return true when clearance was obtained, false when the user gave up or it timed out.
+     */
+    suspend fun solve(host: String, url: String): Boolean
+
+    /**
+     * The User-Agent that solved [host]'s challenge, or null if it has never been solved.
+     *
+     * Cloudflare binds clearance to the User-Agent that earned it, so a request replaying the
+     * cookie under a different one is challenged again. This lets the network layer send the
+     * same identity the WebView used.
+     *
+     * Non-suspending because it is read on every request from inside an interceptor, which is a
+     * blocking call on an OkHttp dispatcher thread — a suspending disk read there would put I/O
+     * on the hot path of every image in a chapter.
+     */
+    fun solvedUserAgent(host: String): String?
+}

--- a/core/network/src/main/java/app/otakureader/core/network/cloudflare/CloudflareInterceptor.kt
+++ b/core/network/src/main/java/app/otakureader/core/network/cloudflare/CloudflareInterceptor.kt
@@ -1,0 +1,87 @@
+package app.otakureader.core.network.cloudflare
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Detects a Cloudflare browser challenge and gives the user a way through it.
+ *
+ * Without this, a Cloudflare-protected source simply fails. The request comes back 403, the
+ * extension reports an error, and there is nothing the user can do about it — no prompt, no
+ * WebView, no explanation. Since a large share of manga hosts sit behind Cloudflare, that is a
+ * broad and completely silent class of "this source doesn't work".
+ *
+ * On detection this suspends the call, asks for the challenge to be solved, and — if it was —
+ * retries once. The retry carries the clearance cookie automatically, because the cookie jar and
+ * the WebView share Android's `CookieManager`.
+ */
+@Singleton
+class CloudflareInterceptor @Inject constructor(
+    private val solver: CloudflareChallengeSolver,
+) : Interceptor {
+
+    private companion object {
+        /**
+         * Ceiling on how long a blocked call waits for the user.
+         *
+         * This blocks an OkHttp dispatcher thread, so it cannot wait indefinitely: a handful of
+         * abandoned challenges would otherwise consume the pool and stall unrelated requests.
+         * Generous enough for a real CAPTCHA, short enough that a forgotten screen recovers.
+         */
+        const val SOLVE_TIMEOUT_MS = 3 * 60 * 1000L
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+        if (!response.isCloudflareChallenge()) return response
+
+        val url = response.request.url
+        // The body is never read, so it must be closed explicitly or the connection leaks while
+        // the user is off solving the challenge — potentially for minutes.
+        response.close()
+
+        // Blocking is correct: this call *is* the thing waiting on the user, and the timeout
+        // above bounds it. Solving is coalesced by host in the implementation, so the twenty
+        // parallel image requests behind a blocked page produce one WebView, not twenty.
+        val solved = runBlocking {
+            withTimeoutOrNull(SOLVE_TIMEOUT_MS) {
+                solver.solve(url.host, url.toString())
+            } ?: false
+        }
+
+        if (!solved) {
+            // Re-issue rather than fabricate a response, so the caller sees the site's real
+            // answer — an extension parsing an error page is easier to diagnose than one handed
+            // a synthetic failure that never came from the server.
+            return chain.proceed(chain.request())
+        }
+
+        // Retry once only. If clearance did not take, retrying again just re-opens the WebView
+        // in a loop the user cannot escape.
+        return chain.proceed(chain.request())
+    }
+}
+
+/**
+ * A challenge is a specific pairing of status code and `Server` header.
+ *
+ * Both are required, and that is the whole accuracy of the detector. The code alone catches
+ * every ordinary 403 on the internet and would pop a WebView at each one; the header alone
+ * catches every *successful* response from a Cloudflare-fronted site, which is most of them.
+ *
+ * A file-scope function rather than a method, so it can be tested against a constructed
+ * [Response] without building an interceptor chain.
+ */
+internal fun Response.isCloudflareChallenge(): Boolean =
+    code in CloudflareChallenge.CODES &&
+        header("Server")?.lowercase() in CloudflareChallenge.SERVERS
+
+internal object CloudflareChallenge {
+    /** 503 is the classic interstitial; 403 covers managed-challenge and block responses. */
+    val CODES = setOf(403, 503)
+    val SERVERS = setOf("cloudflare", "cloudflare-nginx")
+}

--- a/core/network/src/main/java/app/otakureader/core/network/cloudflare/CloudflareInterceptor.kt
+++ b/core/network/src/main/java/app/otakureader/core/network/cloudflare/CloudflareInterceptor.kt
@@ -4,6 +4,8 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.Interceptor
 import okhttp3.Response
+import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -33,6 +35,18 @@ class CloudflareInterceptor @Inject constructor(
          * Generous enough for a real CAPTCHA, short enough that a forgotten screen recovers.
          */
         const val SOLVE_TIMEOUT_MS = 3 * 60 * 1000L
+
+        /**
+         * Cap on the challenge page kept in memory while the user solves it.
+         *
+         * A Cloudflare interstitial is a few KB of HTML. This exists only so the response can be
+         * handed back intact if the user gives up, without holding the connection open for the
+         * length of the challenge.
+         */
+        const val MAX_CHALLENGE_BODY_BYTES = 256L * 1024
+
+        /** Stand-in when the challenge body could not be buffered; the status code still carries. */
+        val EMPTY_BODY: ResponseBody = ByteArray(0).toResponseBody(null)
     }
 
     override fun intercept(chain: Interceptor.Chain): Response {
@@ -40,13 +54,21 @@ class CloudflareInterceptor @Inject constructor(
         if (!response.isCloudflareChallenge()) return response
 
         val url = response.request.url
-        // The body is never read, so it must be closed explicitly or the connection leaks while
-        // the user is off solving the challenge — potentially for minutes.
+
+        // Buffer the challenge page, then release the connection before waiting on the user.
+        //
+        // Both halves matter. Holding the response open would tie up a connection for as long
+        // as the challenge takes, which can be minutes. Closing it without buffering would
+        // leave nothing to hand back if the user gives up — which is how an earlier version
+        // ended up re-issuing the request on failure, doubling the traffic and risking a
+        // repeated side effect for a POST. A challenge page is a few KB of HTML, so keeping a
+        // bounded copy costs nothing.
+        val buffered = runCatching { response.peekBody(MAX_CHALLENGE_BODY_BYTES) }.getOrNull()
         response.close()
 
         // Blocking is correct: this call *is* the thing waiting on the user, and the timeout
-        // above bounds it. Solving is coalesced by host in the implementation, so the twenty
-        // parallel image requests behind a blocked page produce one WebView, not twenty.
+        // bounds it. Solving is coalesced by host in the implementation, so the twenty parallel
+        // image requests behind a blocked page produce one WebView, not twenty.
         val solved = runBlocking {
             withTimeoutOrNull(SOLVE_TIMEOUT_MS) {
                 solver.solve(url.host, url.toString())
@@ -54,13 +76,16 @@ class CloudflareInterceptor @Inject constructor(
         }
 
         if (!solved) {
-            // Re-issue rather than fabricate a response, so the caller sees the site's real
-            // answer — an extension parsing an error page is easier to diagnose than one handed
-            // a synthetic failure that never came from the server.
-            return chain.proceed(chain.request())
+            // Hand back the site's own answer rather than repeating the request. The caller
+            // sees the real challenge page and the real status code, which is both honest and
+            // cheaper — and for a non-idempotent request it is the difference between one
+            // POST and two.
+            return response.newBuilder()
+                .body(buffered ?: EMPTY_BODY)
+                .build()
         }
 
-        // Retry once only. If clearance did not take, retrying again just re-opens the WebView
+        // Retry once only. If clearance did not take, retrying again would re-open the WebView
         // in a loop the user cannot escape.
         return chain.proceed(chain.request())
     }

--- a/core/network/src/main/java/app/otakureader/core/network/cloudflare/CloudflareInterceptor.kt
+++ b/core/network/src/main/java/app/otakureader/core/network/cloudflare/CloudflareInterceptor.kt
@@ -32,9 +32,19 @@ class CloudflareInterceptor @Inject constructor(
          *
          * This blocks an OkHttp dispatcher thread, so it cannot wait indefinitely: a handful of
          * abandoned challenges would otherwise consume the pool and stall unrelated requests.
-         * Generous enough for a real CAPTCHA, short enough that a forgotten screen recovers.
+         *
+         * **Must stay below the client's `callTimeout`, currently 2 minutes** (see
+         * `NetworkModule.provideOkHttpClient`). This is an application interceptor, so it runs
+         * *inside* the call, and `callTimeout` spans the original request, this wait, and the
+         * retry together. A budget above it is not merely unreachable — the call would be
+         * cancelled mid-challenge and the user's work thrown away just as they finished.
+         *
+         * 100 seconds leaves room for the retry to complete afterwards. Raising the client's
+         * `callTimeout` instead was the alternative and is worse: it applies to every request
+         * the app makes, so a stalled page download would hang proportionally longer for the
+         * sake of a path most requests never take.
          */
-        const val SOLVE_TIMEOUT_MS = 3 * 60 * 1000L
+        const val SOLVE_TIMEOUT_MS = 100 * 1000L
 
         /**
          * Cap on the challenge page kept in memory while the user solves it.
@@ -63,7 +73,14 @@ class CloudflareInterceptor @Inject constructor(
         // ended up re-issuing the request on failure, doubling the traffic and risking a
         // repeated side effect for a POST. A challenge page is a few KB of HTML, so keeping a
         // bounded copy costs nothing.
-        val buffered = runCatching { response.peekBody(MAX_CHALLENGE_BODY_BYTES) }.getOrNull()
+        // Peek one byte past the cap so an oversized page is *detectable* rather than silently
+        // truncated. A caller handed half a challenge page would parse the fragment as if it
+        // were the whole document — a wrong result that looks successful, which is worse than an
+        // empty body it can recognise as a failure.
+        val buffered = runCatching {
+            response.peekBody(MAX_CHALLENGE_BODY_BYTES + 1)
+                .takeIf { it.contentLength() <= MAX_CHALLENGE_BODY_BYTES }
+        }.getOrNull()
         response.close()
 
         // Blocking is correct: this call *is* the thing waiting on the user, and the timeout

--- a/core/network/src/main/java/app/otakureader/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/app/otakureader/core/network/di/NetworkModule.kt
@@ -1,6 +1,8 @@
 package app.otakureader.core.network.di
 
 import app.otakureader.core.common.network.PageImageHeaders
+import app.otakureader.core.network.cloudflare.ChallengeUserAgentInterceptor
+import app.otakureader.core.network.cloudflare.CloudflareInterceptor
 import app.otakureader.core.network.BuildConfig
 import app.otakureader.core.network.BytesEventListener
 import app.otakureader.core.network.BytesRecorder
@@ -52,8 +54,23 @@ object NetworkModule {
     @Singleton
     fun provideOkHttpClient(
         bytesRecorder: BytesRecorder,
+        cloudflareInterceptor: CloudflareInterceptor,
+        challengeUserAgentInterceptor: ChallengeUserAgentInterceptor,
     ): OkHttpClient {
         val builder = OkHttpClient.Builder()
+            // On the SHARED client, unlike the page-image headers: a User-Agent is not a
+            // per-source secret, and every backend needs the bypass — APK extensions through
+            // NetworkHelper, JavaScript sources through JsHttpBridge, and the page-image client,
+            // all of which derive from this one.
+            //
+            // An APPLICATION interceptor, because it must see the finished response and re-run
+            // the whole call after the user solves the challenge. A network interceptor sees
+            // one hop and cannot retry the request.
+            .addInterceptor(cloudflareInterceptor)
+            // A NETWORK interceptor, so each hop is stamped with the identity registered for
+            // its own host. A redirect to a different host gets that host's User-Agent, or the
+            // caller's own if it was never challenged.
+            .addNetworkInterceptor(challengeUserAgentInterceptor)
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)

--- a/core/network/src/test/java/app/otakureader/core/network/cloudflare/CloudflareDetectionTest.kt
+++ b/core/network/src/test/java/app/otakureader/core/network/cloudflare/CloudflareDetectionTest.kt
@@ -1,0 +1,75 @@
+package app.otakureader.core.network.cloudflare
+
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers when a response counts as a Cloudflare challenge.
+ *
+ * Both directions carry a real cost, which is why the detector requires two signals rather than
+ * one. Too eager and the app throws a WebView at ordinary 403s — a permission error on a tracker
+ * API becomes a browser window the user cannot make sense of. Too conservative and a
+ * Cloudflare-protected source keeps failing silently, which is the bug this whole flow exists to
+ * fix.
+ */
+class CloudflareDetectionTest {
+
+    private fun response(code: Int, server: String?): Response =
+        Response.Builder()
+            .request(Request.Builder().url("https://example.test/manga").build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message("")
+            .apply { server?.let { header("Server", it) } }
+            .build()
+
+    @Test
+    fun `503 from cloudflare is a challenge`() {
+        assertTrue(response(503, "cloudflare").isCloudflareChallenge())
+    }
+
+    @Test
+    fun `403 from cloudflare is a challenge`() {
+        assertTrue(response(403, "cloudflare").isCloudflareChallenge())
+    }
+
+    @Test
+    fun `the nginx variant is recognised`() {
+        assertTrue(response(403, "cloudflare-nginx").isCloudflareChallenge())
+    }
+
+    @Test
+    fun `the server header is matched case-insensitively`() {
+        assertTrue(response(503, "Cloudflare").isCloudflareChallenge())
+    }
+
+    /**
+     * The reason the `Server` header is required. Plenty of APIs answer 403 for ordinary
+     * permission reasons, and opening a WebView at each one would be worse than the problem.
+     */
+    @Test
+    fun `an ordinary 403 is not a challenge`() {
+        assertFalse(response(403, "nginx").isCloudflareChallenge())
+        assertFalse(response(403, null).isCloudflareChallenge())
+    }
+
+    /**
+     * The reason the status code is required. Most Cloudflare-fronted sites serve *every*
+     * response with this header, so matching on it alone would treat successful page loads as
+     * challenges.
+     */
+    @Test
+    fun `a successful response from cloudflare is not a challenge`() {
+        assertFalse(response(200, "cloudflare").isCloudflareChallenge())
+        assertFalse(response(404, "cloudflare").isCloudflareChallenge())
+    }
+
+    @Test
+    fun `a server error that is not a challenge code is ignored`() {
+        assertFalse(response(500, "cloudflare").isCloudflareChallenge())
+    }
+}

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/ChallengeUserAgentStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/ChallengeUserAgentStore.kt
@@ -1,0 +1,64 @@
+package app.otakureader.core.preferences
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import app.otakureader.core.common.di.ApplicationScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The User-Agent that solved each host's Cloudflare challenge.
+ *
+ * Persisted, because the clearance cookie is persisted: Android's `CookieManager` keeps it across
+ * restarts, so a User-Agent held only in memory would be forgotten while the cookie it belongs to
+ * survives. The pair would then disagree on the next launch and the user would be challenged
+ * again for a host they had already cleared — the bypass appearing to work, then silently
+ * regressing every time the app restarts.
+ *
+ * Reads are served from an in-memory map rather than DataStore, because [userAgentFor] is called
+ * from inside an OkHttp interceptor. That is a blocking call on a dispatcher thread, and a
+ * suspending disk read there would put I/O in front of every image in every chapter.
+ */
+@Singleton
+class ChallengeUserAgentStore @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+    @ApplicationScope scope: CoroutineScope,
+) {
+
+    private val cache = ConcurrentHashMap<String, String>()
+
+    init {
+        // Hydrated by a live collection, so the cache follows the stored values without any
+        // explicit invalidation. A request arriving in the moment before the first emission
+        // sees no User-Agent and may be challenged once; that self-corrects, and it is the
+        // cheaper failure than blocking startup on a disk read.
+        scope.launch {
+            dataStore.data.first().asMap().forEach { (key, value) ->
+                val name = key.name
+                if (name.startsWith(KEY_PREFIX) && value is String) {
+                    cache[name.removePrefix(KEY_PREFIX)] = value
+                }
+            }
+        }
+    }
+
+    /** Non-suspending by design — see the class note on the interceptor hot path. */
+    fun userAgentFor(host: String): String? = cache[host]
+
+    suspend fun store(host: String, userAgent: String) {
+        // Cache first so the retry that follows a solved challenge sees it immediately; the
+        // DataStore write is what makes it survive a restart, and is not on the critical path.
+        cache[host] = userAgent
+        dataStore.edit { it[stringPreferencesKey("$KEY_PREFIX$host")] = userAgent }
+    }
+
+    private companion object {
+        const val KEY_PREFIX = "challenge_user_agent_"
+    }
+}

--- a/core/preferences/src/main/java/app/otakureader/core/preferences/ChallengeUserAgentStore.kt
+++ b/core/preferences/src/main/java/app/otakureader/core/preferences/ChallengeUserAgentStore.kt
@@ -34,10 +34,15 @@ class ChallengeUserAgentStore @Inject constructor(
     private val cache = ConcurrentHashMap<String, String>()
 
     init {
-        // Hydrated by a live collection, so the cache follows the stored values without any
-        // explicit invalidation. A request arriving in the moment before the first emission
-        // sees no User-Agent and may be challenged once; that self-corrects, and it is the
-        // cheaper failure than blocking startup on a disk read.
+        // Read ONCE at construction, not collected continuously — and that is sufficient
+        // rather than a shortcut. Every write goes through [store], which updates this cache
+        // before it touches disk, so the only thing a live collector would catch is a change
+        // made by something else. Nothing else writes these keys: they are namespaced by
+        // KEY_PREFIX and this is the only class that reads or writes them.
+        //
+        // A request arriving before this read completes sees no User-Agent and may be
+        // challenged once; that self-corrects on the next launch, and it is the cheaper failure
+        // than blocking startup on disk I/O.
         scope.launch {
             dataStore.data.first().asMap().forEach { (key, value) ->
                 val name = key.name

--- a/core/webview/build.gradle.kts
+++ b/core/webview/build.gradle.kts
@@ -9,11 +9,22 @@ android {
 }
 
 dependencies {
+    // @ApplicationScope lives here. Not transitive through core:preferences, which exposes
+    // core:common as `implementation` rather than `api`.
+    implementation(projects.core.common)
     implementation(projects.core.navigation)
     implementation(projects.core.preferences)
+    // Implements CloudflareChallengeSolver, declared there so :core:network needs no UI dep.
+    implementation(projects.core.network)
     implementation(libs.lifecycle.runtime.compose)
     implementation(libs.compose.material.icons.extended)
     // Cookie syncing between WebView's CookieManager and OkHttp's CookieJar
     implementation(platform(libs.okhttp.bom))
     implementation(libs.okhttp.core)
+}
+
+dependencies {
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewChallengeManager.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewChallengeManager.kt
@@ -1,81 +1,100 @@
 package app.otakureader.core.webview
 
+import app.otakureader.core.network.cloudflare.CloudflareChallengeSolver
+import app.otakureader.core.common.di.ApplicationScope
+import app.otakureader.core.preferences.ChallengeUserAgentStore
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import okhttp3.CookieJar
+import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Mediates WebView challenge requests between extension sources and the app's navigation layer.
+ * Mediates Cloudflare challenges between the network layer and the app's navigation layer.
  *
- * Usage flow:
- * 1. An extension source detects a Cloudflare/CAPTCHA barrier and calls [requestChallenge].
- * 2. This class emits a [ChallengeRequest] on [pendingChallenge] and suspends.
- * 3. The app's navigation layer observes [pendingChallenge] and navigates to the WebView screen.
- * 4. When the user finishes and closes the WebView, the nav layer calls [completeChallenge].
- * 5. [requestChallenge] resumes and returns `true` if cookies were obtained, `false` if cancelled.
+ * Flow:
+ * 1. [app.otakureader.core.network.cloudflare.CloudflareInterceptor] sees a challenge response
+ *    and calls [solve], which suspends.
+ * 2. A [ChallengeRequest] is emitted on [pendingChallenge].
+ * 3. The navigation host observes it and opens the WebView.
+ * 4. On close, the nav layer calls [completeChallenge] with the cookies and the WebView's
+ *    User-Agent.
+ * 5. [solve] resumes; the interceptor retries the original request.
+ *
+ * Keyed by **host**, not by source. Cloudflare clearance is granted per domain, so two sources
+ * on the same host share one challenge — and, more importantly, the interceptor only ever knows
+ * a URL. An earlier version keyed on a source id that nothing in the network layer could supply,
+ * which is part of why none of this was ever wired up.
  */
 @Singleton
 class WebViewChallengeManager @Inject constructor(
-    private val cookieBridge: WebViewCookieBridge,
-) {
+    private val userAgentStore: ChallengeUserAgentStore,
+    @param:ApplicationScope private val scope: CoroutineScope,
+) : CloudflareChallengeSolver {
 
-    data class ChallengeRequest(val sourceId: Long, val url: String)
+    data class ChallengeRequest(val host: String, val url: String)
 
-    private val _pendingChallenge = MutableSharedFlow<ChallengeRequest>(extraBufferCapacity = 1)
+    private val _pendingChallenge = MutableSharedFlow<ChallengeRequest>(extraBufferCapacity = 8)
 
-    /** Emits whenever a source requests a WebView challenge. Observe in the navigation host. */
+    /** Emits whenever a host needs a challenge solved. Observe in the navigation host. */
     val pendingChallenge: SharedFlow<ChallengeRequest> = _pendingChallenge.asSharedFlow()
 
-    private val pendingCompletions = ConcurrentHashMap<Long, CompletableDeferred<Boolean>>()
+    /** In-flight challenges, one per host. See [solve] for why this exists. */
+    private val inFlight = ConcurrentHashMap<String, CompletableDeferred<Boolean>>()
 
     /**
-     * Requests a WebView challenge for [url] on behalf of source [sourceId].
-     * Suspends until [completeChallenge] is called with a matching [sourceId].
+     * Suspend until [host]'s challenge is solved or abandoned.
      *
-     * @return `true` if the challenge completed with cookies, `false` if the user cancelled.
+     * **Coalesced by host**, which is not an optimisation but a usability requirement: a blocked
+     * chapter fires one request per page, so twenty callers arrive here within milliseconds of
+     * each other. Without coalescing the user would face twenty stacked WebViews for one
+     * challenge. `putIfAbsent` decides the winner atomically — a check-then-put would let two
+     * callers both believe they were first.
      */
-    suspend fun requestChallenge(sourceId: Long, url: String): Boolean {
-        val deferred = CompletableDeferred<Boolean>()
-        // Complete any existing deferred for this source so it doesn't hang indefinitely.
-        // Use remove(key, value) in finally so we only remove OUR deferred, not a subsequent one.
-        // The entire body (emit + await) is inside try/finally so cancellation during emit
-        // also cleans up the deferred from the map.
-        pendingCompletions.put(sourceId, deferred)?.complete(false)
+    override suspend fun solve(host: String, url: String): Boolean {
+        val fresh = CompletableDeferred<Boolean>()
+        val existing = inFlight.putIfAbsent(host, fresh)
+        if (existing != null) return existing.await()
+
         return try {
-            _pendingChallenge.emit(ChallengeRequest(sourceId, url))
-            deferred.await()
+            _pendingChallenge.emit(ChallengeRequest(host, url))
+            fresh.await()
+        } catch (e: CancellationException) {
+            // Completing before rethrowing is what keeps the joiners alive. They await this
+            // deferred directly, so once it leaves the map below, nothing else can ever
+            // complete it — and every other page of the chapter would hang until its own
+            // timeout. The leader's cancellation must not become everyone's.
+            fresh.complete(false)
+            throw e
         } finally {
-            pendingCompletions.remove(sourceId, deferred)
+            // remove(key, value) so a challenge started after ours is never removed by us.
+            inFlight.remove(host, fresh)
         }
     }
 
+    override fun solvedUserAgent(host: String): String? = userAgentStore.userAgentFor(host)
+
     /**
-     * Signals that the WebView challenge for source [sourceId] is done.
+     * Signal that the WebView for [host] has closed.
      *
-     * If [cookieJar] is provided and [cookieString] is non-empty, the cookies are
-     * synced from Android's [android.webkit.CookieManager] into OkHttp so subsequent
-     * requests from the same source carry the freshly acquired session cookies.
+     * Cookies need no transfer: the app's cookie jar is backed by the same Android
+     * `CookieManager` the WebView writes to, so clearance is already visible to OkHttp.
      *
-     * @param sourceId   The source that initiated the challenge.
-     * @param url        The URL that was opened in the WebView.
-     * @param cookieString Raw cookie string from [android.webkit.CookieManager]; null if none.
-     * @param cookieJar  Optional OkHttp jar to receive the synced cookies.
+     * The [userAgent] is the part that would otherwise be lost, and losing it makes the whole
+     * flow useless — the cookie is bound to it, so a request under any other identity is
+     * challenged again. It is stored only alongside a cookie that actually arrived, so a stored
+     * User-Agent always corresponds to clearance that was really obtained.
      */
-    fun completeChallenge(
-        sourceId: Long,
-        url: String,
-        cookieString: String?,
-        cookieJar: CookieJar? = null,
-    ) {
-        if (cookieJar != null && !cookieString.isNullOrEmpty()) {
-            cookieBridge.syncCookiesToOkHttp(url, cookieJar)
+    fun completeChallenge(host: String, cookieString: String?, userAgent: String?) {
+        val cleared = !cookieString.isNullOrEmpty()
+        if (cleared && !userAgent.isNullOrBlank()) {
+            scope.launch { userAgentStore.store(host, userAgent) }
         }
-        val success = !cookieString.isNullOrEmpty()
-        pendingCompletions[sourceId]?.complete(success)
+        inFlight[host]?.complete(cleared)
     }
 }

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewChallengeManager.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewChallengeManager.kt
@@ -6,9 +6,10 @@ import app.otakureader.core.preferences.ChallengeUserAgentStore
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
@@ -39,10 +40,21 @@ class WebViewChallengeManager @Inject constructor(
 
     data class ChallengeRequest(val host: String, val url: String)
 
-    private val _pendingChallenge = MutableSharedFlow<ChallengeRequest>(extraBufferCapacity = 8)
+    private val _pendingChallenges = MutableStateFlow<List<ChallengeRequest>>(emptyList())
 
-    /** Emits whenever a host needs a challenge solved. Observe in the navigation host. */
-    val pendingChallenge: SharedFlow<ChallengeRequest> = _pendingChallenge.asSharedFlow()
+    /**
+     * Hosts currently awaiting a challenge. Observe in the navigation host.
+     *
+     * **State, not an event stream.** A `SharedFlow` emission is dropped outright when nothing is
+     * subscribed, so a challenge raised while the navigation layer was being torn down or
+     * recreated — a rotation, a process-death restore — would vanish, and the blocked request
+     * would sit waiting for its full timeout with no WebView ever appearing. Holding the pending
+     * set as state means a collector that arrives late still sees the work.
+     *
+     * A list rather than a single value because two hosts can be blocked at once; the navigation
+     * layer shows them one at a time.
+     */
+    val pendingChallenges: StateFlow<List<ChallengeRequest>> = _pendingChallenges.asStateFlow()
 
     /** In-flight challenges, one per host. See [solve] for why this exists. */
     private val inFlight = ConcurrentHashMap<String, CompletableDeferred<Boolean>>()
@@ -62,7 +74,9 @@ class WebViewChallengeManager @Inject constructor(
         if (existing != null) return existing.await()
 
         return try {
-            _pendingChallenge.emit(ChallengeRequest(host, url))
+            _pendingChallenges.update { pending ->
+                if (pending.any { it.host == host }) pending else pending + ChallengeRequest(host, url)
+            }
             fresh.await()
         } catch (e: CancellationException) {
             // Completing before rethrowing is what keeps the joiners alive. They await this
@@ -74,10 +88,14 @@ class WebViewChallengeManager @Inject constructor(
         } finally {
             // remove(key, value) so a challenge started after ours is never removed by us.
             inFlight.remove(host, fresh)
+            clearPending(host)
         }
     }
 
     override fun solvedUserAgent(host: String): String? = userAgentStore.userAgentFor(host)
+
+    private fun String.containsClearanceCookie(): Boolean =
+        split(';').any { it.substringBefore('=').trim() == CLEARANCE_COOKIE }
 
     /**
      * Signal that the WebView for [host] has closed.
@@ -91,10 +109,28 @@ class WebViewChallengeManager @Inject constructor(
      * User-Agent always corresponds to clearance that was really obtained.
      */
     fun completeChallenge(host: String, cookieString: String?, userAgent: String?) {
-        val cleared = !cookieString.isNullOrEmpty()
+        val cleared = cookieString.orEmpty().containsClearanceCookie()
         if (cleared && !userAgent.isNullOrBlank()) {
             scope.launch { userAgentStore.store(host, userAgent) }
         }
         inFlight[host]?.complete(cleared)
+        clearPending(host)
+    }
+
+    private fun clearPending(host: String) {
+        _pendingChallenges.update { pending -> pending.filterNot { it.host == host } }
+    }
+
+    private companion object {
+        /**
+         * The cookie Cloudflare issues on passing a challenge.
+         *
+         * Success has to be judged on *this* cookie, not on the cookie header being non-empty.
+         * The WebView reports every cookie the site has set, so a session or consent cookie from
+         * merely loading the page would read as clearance — the request would be released, the
+         * User-Agent stored as if it had earned something, and the single retry would fail
+         * against a challenge the user never actually passed.
+         */
+        const val CLEARANCE_COOKIE = "cf_clearance"
     }
 }

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewChallengeManager.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewChallengeManager.kt
@@ -129,10 +129,16 @@ class WebViewChallengeManager @Inject constructor(
         if (cleared && !userAgent.isNullOrBlank()) {
             scope.launch { userAgentStore.store(host, userAgent) }
         }
+        // Completing the deferred is the whole job. Removing the pending entry is deliberately
+        // NOT done here: [solve]'s own cleanup does it, by id, the instant its await returns.
+        //
+        // A host-wide removal here would race a re-challenge — the old solve can finish and a
+        // new one add its entry in the window between completing the deferred and clearing, and
+        // the host-wide sweep would delete the newcomer, leaving its caller blocked with no
+        // WebView. Giving the pending set exactly one owner removes the race rather than
+        // narrowing it; this method had kept a second, host-wide path after solve's was made
+        // identity-matched.
         inFlight[host]?.complete(cleared)
-        // By host, not id: this is the user answering whichever challenge was on screen for
-        // that host, and solve()'s own cleanup removes the entry by id immediately afterwards.
-        _pendingChallenges.update { pending -> pending.filterNot { it.host == host } }
     }
 
     private fun clearPending(id: Long) {

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewChallengeManager.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewChallengeManager.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -21,7 +22,7 @@ import javax.inject.Singleton
  * Flow:
  * 1. [app.otakureader.core.network.cloudflare.CloudflareInterceptor] sees a challenge response
  *    and calls [solve], which suspends.
- * 2. A [ChallengeRequest] is emitted on [pendingChallenge].
+ * 2. A [ChallengeRequest] is added to [pendingChallenges].
  * 3. The navigation host observes it and opens the WebView.
  * 4. On close, the nav layer calls [completeChallenge] with the cookies and the WebView's
  *    User-Agent.
@@ -38,7 +39,18 @@ class WebViewChallengeManager @Inject constructor(
     @param:ApplicationScope private val scope: CoroutineScope,
 ) : CloudflareChallengeSolver {
 
-    data class ChallengeRequest(val host: String, val url: String)
+    /**
+     * [id] exists so cleanup can remove exactly its own entry.
+     *
+     * Without it, the two orderings of "drop the in-flight deferred" and "drop the pending
+     * entry" are each wrong in a different way: clearing last lets a re-challenge slot in
+     * between and have its brand-new pending entry deleted by the old challenge's cleanup, so
+     * no WebView ever opens for it; clearing first leaves the stale deferred momentarily
+     * reachable, so the re-challenge joins an already-completed one and gets a stale answer.
+     * Matching on identity removes the choice — the same reason [inFlight] uses
+     * `remove(key, value)`.
+     */
+    data class ChallengeRequest(val id: Long, val host: String, val url: String)
 
     private val _pendingChallenges = MutableStateFlow<List<ChallengeRequest>>(emptyList())
 
@@ -59,6 +71,8 @@ class WebViewChallengeManager @Inject constructor(
     /** In-flight challenges, one per host. See [solve] for why this exists. */
     private val inFlight = ConcurrentHashMap<String, CompletableDeferred<Boolean>>()
 
+    private val nextChallengeId = AtomicLong(0)
+
     /**
      * Suspend until [host]'s challenge is solved or abandoned.
      *
@@ -73,9 +87,10 @@ class WebViewChallengeManager @Inject constructor(
         val existing = inFlight.putIfAbsent(host, fresh)
         if (existing != null) return existing.await()
 
+        val request = ChallengeRequest(nextChallengeId.incrementAndGet(), host, url)
         return try {
             _pendingChallenges.update { pending ->
-                if (pending.any { it.host == host }) pending else pending + ChallengeRequest(host, url)
+                if (pending.any { it.host == host }) pending else pending + request
             }
             fresh.await()
         } catch (e: CancellationException) {
@@ -86,9 +101,10 @@ class WebViewChallengeManager @Inject constructor(
             fresh.complete(false)
             throw e
         } finally {
-            // remove(key, value) so a challenge started after ours is never removed by us.
+            // Both removals match on identity, so neither can touch a challenge that replaced
+            // ours — which makes the order between them irrelevant rather than merely chosen.
             inFlight.remove(host, fresh)
-            clearPending(host)
+            clearPending(request.id)
         }
     }
 
@@ -114,11 +130,13 @@ class WebViewChallengeManager @Inject constructor(
             scope.launch { userAgentStore.store(host, userAgent) }
         }
         inFlight[host]?.complete(cleared)
-        clearPending(host)
+        // By host, not id: this is the user answering whichever challenge was on screen for
+        // that host, and solve()'s own cleanup removes the entry by id immediately afterwards.
+        _pendingChallenges.update { pending -> pending.filterNot { it.host == host } }
     }
 
-    private fun clearPending(host: String) {
-        _pendingChallenges.update { pending -> pending.filterNot { it.host == host } }
+    private fun clearPending(id: Long) {
+        _pendingChallenges.update { pending -> pending.filterNot { it.id == id } }
     }
 
     private companion object {

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewScreen.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewScreen.kt
@@ -1,6 +1,7 @@
 package app.otakureader.core.webview
 
 import android.webkit.WebView
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -31,7 +32,6 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import app.otakureader.core.navigation.Route
-import androidx.activity.compose.BackHandler
 
 /**
  * Full-screen embedded WebView with optional ad blocking.
@@ -59,13 +59,18 @@ fun WebViewScreen(
     // Closing the challenge is what releases the blocked request, and the top bar's button was
     // the only thing that did it. System and gesture back pop the destination directly, leaving
     // the caller waiting out its full timeout for a screen the user has already dismissed.
-    // Routing hardware back through the same callback makes every exit complete the challenge.
-    BackHandler {
+    //
+    // One lambda for both exits rather than two copies: what counts as "the result" is the
+    // cookie/User-Agent pair, and the two paths drifting apart would mean one exit reporting
+    // clearance and the other reporting none for the very same screen.
+    val reportClose = {
         onClose(
             webViewRef?.let { viewModel.cookiesForUrl(url) },
             webViewRef?.settings?.userAgentString,
         )
     }
+
+    BackHandler { reportClose() }
 
     DisposableEffect(Unit) {
         onDispose {
@@ -79,12 +84,7 @@ fun WebViewScreen(
             // to the identity that earned it; a cookie replayed under a different one is
             // challenged again, so returning the cookie alone would leave the user solving the
             // same challenge forever.
-            onBack = {
-                onClose(
-                    webViewRef?.let { viewModel.cookiesForUrl(url) },
-                    webViewRef?.settings?.userAgentString,
-                )
-            },
+            onBack = reportClose,
             onNavigateBack = { webViewRef?.goBack() },
             onNavigateForward = { webViewRef?.goForward() },
             onReload = { webViewRef?.reload() },

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewScreen.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewScreen.kt
@@ -31,6 +31,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import app.otakureader.core.navigation.Route
+import androidx.activity.compose.BackHandler
 
 /**
  * Full-screen embedded WebView with optional ad blocking.
@@ -54,6 +55,17 @@ fun WebViewScreen(
     val adBlockEnabled by viewModel.adBlockEnabled.collectAsStateWithLifecycle(initialValue = true)
     val context = LocalContext.current
     var webViewRef by remember { mutableStateOf<WebView?>(null) }
+
+    // Closing the challenge is what releases the blocked request, and the top bar's button was
+    // the only thing that did it. System and gesture back pop the destination directly, leaving
+    // the caller waiting out its full timeout for a screen the user has already dismissed.
+    // Routing hardware back through the same callback makes every exit complete the challenge.
+    BackHandler {
+        onClose(
+            webViewRef?.let { viewModel.cookiesForUrl(url) },
+            webViewRef?.settings?.userAgentString,
+        )
+    }
 
     DisposableEffect(Unit) {
         onDispose {

--- a/core/webview/src/main/java/app/otakureader/core/webview/WebViewScreen.kt
+++ b/core/webview/src/main/java/app/otakureader/core/webview/WebViewScreen.kt
@@ -47,7 +47,7 @@ import app.otakureader.core.navigation.Route
 fun WebViewScreen(
     url: String,
     @Suppress("UnusedParameter") purpose: WebViewPurpose,
-    onClose: (cookieString: String?) -> Unit,
+    onClose: (cookieString: String?, userAgent: String?) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: WebViewViewModel = hiltViewModel(),
 ) {
@@ -63,7 +63,16 @@ fun WebViewScreen(
 
     Column(modifier = modifier.fillMaxSize()) {
         WebViewTopBar(
-            onBack = { onClose(webViewRef?.let { viewModel.cookiesForUrl(url) }) },
+            // The User-Agent travels with the cookies because Cloudflare binds clearance
+            // to the identity that earned it; a cookie replayed under a different one is
+            // challenged again, so returning the cookie alone would leave the user solving the
+            // same challenge forever.
+            onBack = {
+                onClose(
+                    webViewRef?.let { viewModel.cookiesForUrl(url) },
+                    webViewRef?.settings?.userAgentString,
+                )
+            },
             onNavigateBack = { webViewRef?.goBack() },
             onNavigateForward = { webViewRef?.goForward() },
             onReload = { webViewRef?.reload() },
@@ -164,11 +173,13 @@ private fun WebViewTopBar(
 /**
  * Registers the [WebViewScreen] destination in the app's [NavGraphBuilder].
  *
- * The [onClose] callback receives the source ID, the URL, and the cookie string
- * so that callers (e.g. extension WebView bridges) can act on the result.
+ * The [onClose] callback receives the URL, the cookie string, and the WebView's User-Agent.
+ * The last of these is what lets the network layer replay the clearance cookie under the same
+ * identity that earned it — without it, the bypass appears to succeed and the next request is
+ * challenged again.
  */
 fun NavGraphBuilder.webViewScreen(
-    onClose: (sourceId: Long, url: String, cookieString: String?) -> Unit,
+    onClose: (url: String, cookieString: String?, userAgent: String?) -> Unit,
 ) {
     composable<Route.WebView> { backStackEntry ->
         val route = backStackEntry.toRoute<Route.WebView>()
@@ -176,7 +187,7 @@ fun NavGraphBuilder.webViewScreen(
             url = route.url,
             purpose = runCatching { WebViewPurpose.valueOf(route.purpose) }
                 .getOrDefault(WebViewPurpose.GENERAL),
-            onClose = { cookies -> onClose(route.sourceId, route.url, cookies) },
+            onClose = { cookies, userAgent -> onClose(route.url, cookies, userAgent) },
         )
     }
 }

--- a/core/webview/src/test/java/app/otakureader/core/webview/WebViewChallengeManagerTest.kt
+++ b/core/webview/src/test/java/app/otakureader/core/webview/WebViewChallengeManagerTest.kt
@@ -1,0 +1,129 @@
+package app.otakureader.core.webview
+
+import app.otakureader.core.preferences.ChallengeUserAgentStore
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the coalescing and completion rules, which is where this class earns its keep.
+ *
+ * Note on the harness: the collector is launched in the *test* scope, not `backgroundScope`.
+ * `pendingChallenge` has no replay, so a subscriber must exist before the emission — and a
+ * `backgroundScope.launch` does not start under `advanceUntilIdle()`, leaving the flow with zero
+ * subscribers and every assertion reading an empty list. That looked like a coalescing bug and
+ * was purely a test-harness one.
+ *
+ * A blocked chapter fires one request per page, so every caller arrives within milliseconds of
+ * every other. Getting this wrong is not subtle in the field — it is twenty stacked WebViews, or
+ * nineteen requests hanging until they time out.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class WebViewChallengeManagerTest {
+
+    private fun manager(scope: kotlinx.coroutines.CoroutineScope): WebViewChallengeManager {
+        val store = mockk<ChallengeUserAgentStore>(relaxed = true)
+        every { store.userAgentFor(any()) } returns null
+        coEvery { store.store(any(), any()) } returns Unit
+        return WebViewChallengeManager(store, scope)
+    }
+
+    /** The property that keeps one challenge from becoming twenty WebViews. */
+    @Test
+    fun `concurrent callers for one host produce a single challenge`() = runTest {
+        val subject = manager(backgroundScope)
+        val seen = mutableListOf<WebViewChallengeManager.ChallengeRequest>()
+        val collector = launch { subject.pendingChallenge.collect { seen += it } }
+        advanceUntilIdle()
+
+        val callers = List(20) {
+            async { subject.solve("example.test", "https://example.test/manga") }
+        }
+        advanceUntilIdle()
+
+        assertEquals("one challenge for twenty callers", 1, seen.size)
+
+        subject.completeChallenge("example.test", "cf_clearance=abc", "UA/1.0")
+        advanceUntilIdle()
+
+        assertTrue("every caller must be released", callers.all { it.await() })
+        collector.cancel()
+    }
+
+    /** Different hosts are unrelated; clearing one must not release the other. */
+    @Test
+    fun `different hosts get their own challenges`() = runTest {
+        val subject = manager(backgroundScope)
+        val seen = mutableListOf<WebViewChallengeManager.ChallengeRequest>()
+        val collector = launch { subject.pendingChallenge.collect { seen += it } }
+        advanceUntilIdle()
+
+        val a = async { subject.solve("a.test", "https://a.test/x") }
+        val b = async { subject.solve("b.test", "https://b.test/y") }
+        advanceUntilIdle()
+
+        assertEquals(2, seen.size)
+
+        subject.completeChallenge("a.test", "cf_clearance=abc", "UA/1.0")
+        advanceUntilIdle()
+        assertTrue(a.await())
+
+        subject.completeChallenge("b.test", null, null)
+        advanceUntilIdle()
+        assertFalse("no cookie means no clearance", b.await())
+        collector.cancel()
+    }
+
+    /** A user who closes the WebView without solving must not leave callers hanging. */
+    @Test
+    fun `closing without cookies releases callers as unsolved`() = runTest {
+        val subject = manager(backgroundScope)
+        val collector = launch { subject.pendingChallenge.collect { } }
+        advanceUntilIdle()
+
+        val caller = async { subject.solve("example.test", "https://example.test/manga") }
+        advanceUntilIdle()
+
+        subject.completeChallenge("example.test", cookieString = "", userAgent = null)
+        advanceUntilIdle()
+
+        assertFalse(caller.await())
+        collector.cancel()
+    }
+
+    /**
+     * A second challenge for the same host must work after the first finished — otherwise
+     * clearance expiring would leave the host permanently unsolvable.
+     */
+    @Test
+    fun `a host can be challenged again after completing`() = runTest {
+        val subject = manager(backgroundScope)
+        val seen = mutableListOf<WebViewChallengeManager.ChallengeRequest>()
+        val collector = launch { subject.pendingChallenge.collect { seen += it } }
+        advanceUntilIdle()
+
+        val first = async { subject.solve("example.test", "https://example.test/1") }
+        advanceUntilIdle()
+        subject.completeChallenge("example.test", "cf_clearance=abc", "UA/1.0")
+        advanceUntilIdle()
+        assertTrue(first.await())
+
+        val second = async { subject.solve("example.test", "https://example.test/2") }
+        advanceUntilIdle()
+        assertEquals("the second challenge must actually be raised", 2, seen.size)
+
+        subject.completeChallenge("example.test", "cf_clearance=def", "UA/1.0")
+        advanceUntilIdle()
+        assertTrue(second.await())
+        collector.cancel()
+    }
+}

--- a/core/webview/src/test/java/app/otakureader/core/webview/WebViewChallengeManagerTest.kt
+++ b/core/webview/src/test/java/app/otakureader/core/webview/WebViewChallengeManagerTest.kt
@@ -17,11 +17,11 @@ import org.junit.Test
 /**
  * Covers the coalescing and completion rules, which is where this class earns its keep.
  *
- * Note on the harness: the collector is launched in the *test* scope, not `backgroundScope`.
- * `pendingChallenge` has no replay, so a subscriber must exist before the emission — and a
- * `backgroundScope.launch` does not start under `advanceUntilIdle()`, leaving the flow with zero
- * subscribers and every assertion reading an empty list. That looked like a coalescing bug and
- * was purely a test-harness one.
+ * Pending challenges are read straight off the StateFlow rather than collected. An earlier
+ * version of this class published them on a replay-less SharedFlow, which meant a challenge
+ * raised while the navigation layer was absent was dropped and the caller waited out its whole
+ * timeout with no WebView. State also makes these tests read the real thing instead of a
+ * collector whose subscription timing they had to get right.
  *
  * A blocked chapter fires one request per page, so every caller arrives within milliseconds of
  * every other. Getting this wrong is not subtle in the field — it is twenty stacked WebViews, or
@@ -41,8 +41,6 @@ class WebViewChallengeManagerTest {
     @Test
     fun `concurrent callers for one host produce a single challenge`() = runTest {
         val subject = manager(backgroundScope)
-        val seen = mutableListOf<WebViewChallengeManager.ChallengeRequest>()
-        val collector = launch { subject.pendingChallenge.collect { seen += it } }
         advanceUntilIdle()
 
         val callers = List(20) {
@@ -50,44 +48,39 @@ class WebViewChallengeManagerTest {
         }
         advanceUntilIdle()
 
-        assertEquals("one challenge for twenty callers", 1, seen.size)
+        assertEquals("one challenge for twenty callers", 1, subject.pendingChallenges.value.size)
 
-        subject.completeChallenge("example.test", "cf_clearance=abc", "UA/1.0")
+        subject.completeChallenge("example.test", "foo=1; cf_clearance=abc", "UA/1.0")
         advanceUntilIdle()
 
         assertTrue("every caller must be released", callers.all { it.await() })
-        collector.cancel()
     }
 
     /** Different hosts are unrelated; clearing one must not release the other. */
     @Test
     fun `different hosts get their own challenges`() = runTest {
         val subject = manager(backgroundScope)
-        val seen = mutableListOf<WebViewChallengeManager.ChallengeRequest>()
-        val collector = launch { subject.pendingChallenge.collect { seen += it } }
         advanceUntilIdle()
 
         val a = async { subject.solve("a.test", "https://a.test/x") }
         val b = async { subject.solve("b.test", "https://b.test/y") }
         advanceUntilIdle()
 
-        assertEquals(2, seen.size)
+        assertEquals(2, subject.pendingChallenges.value.size)
 
-        subject.completeChallenge("a.test", "cf_clearance=abc", "UA/1.0")
+        subject.completeChallenge("a.test", "foo=1; cf_clearance=abc", "UA/1.0")
         advanceUntilIdle()
         assertTrue(a.await())
 
         subject.completeChallenge("b.test", null, null)
         advanceUntilIdle()
         assertFalse("no cookie means no clearance", b.await())
-        collector.cancel()
     }
 
     /** A user who closes the WebView without solving must not leave callers hanging. */
     @Test
     fun `closing without cookies releases callers as unsolved`() = runTest {
         val subject = manager(backgroundScope)
-        val collector = launch { subject.pendingChallenge.collect { } }
         advanceUntilIdle()
 
         val caller = async { subject.solve("example.test", "https://example.test/manga") }
@@ -97,7 +90,6 @@ class WebViewChallengeManagerTest {
         advanceUntilIdle()
 
         assertFalse(caller.await())
-        collector.cancel()
     }
 
     /**
@@ -107,23 +99,71 @@ class WebViewChallengeManagerTest {
     @Test
     fun `a host can be challenged again after completing`() = runTest {
         val subject = manager(backgroundScope)
-        val seen = mutableListOf<WebViewChallengeManager.ChallengeRequest>()
-        val collector = launch { subject.pendingChallenge.collect { seen += it } }
         advanceUntilIdle()
 
         val first = async { subject.solve("example.test", "https://example.test/1") }
         advanceUntilIdle()
-        subject.completeChallenge("example.test", "cf_clearance=abc", "UA/1.0")
+        subject.completeChallenge("example.test", "foo=1; cf_clearance=abc", "UA/1.0")
         advanceUntilIdle()
         assertTrue(first.await())
 
         val second = async { subject.solve("example.test", "https://example.test/2") }
         advanceUntilIdle()
-        assertEquals("the second challenge must actually be raised", 2, seen.size)
+        assertEquals("the second challenge must be raised again", 1, subject.pendingChallenges.value.size)
 
         subject.completeChallenge("example.test", "cf_clearance=def", "UA/1.0")
         advanceUntilIdle()
         assertTrue(second.await())
-        collector.cancel()
+    }
+
+    /**
+     * Success must hinge on the Cloudflare clearance cookie, not on the cookie header being
+     * non-empty. The WebView reports every cookie the site set, so merely loading the page can
+     * produce a session or consent cookie — which would read as clearance, release the request,
+     * and store a User-Agent that earned nothing.
+     */
+    @Test
+    fun `unrelated cookies do not count as clearance`() = runTest {
+        val subject = manager(backgroundScope)
+        advanceUntilIdle()
+
+        val caller = async { subject.solve("example.test", "https://example.test/manga") }
+        advanceUntilIdle()
+
+        subject.completeChallenge("example.test", "session=xyz; consent=1", "UA/1.0")
+        advanceUntilIdle()
+
+        assertFalse("a session cookie is not clearance", caller.await())
+    }
+
+    @Test
+    fun `the clearance cookie is recognised among others`() = runTest {
+        val subject = manager(backgroundScope)
+        advanceUntilIdle()
+
+        val caller = async { subject.solve("example.test", "https://example.test/manga") }
+        advanceUntilIdle()
+
+        subject.completeChallenge("example.test", "a=1; cf_clearance=token; b=2", "UA/1.0")
+        advanceUntilIdle()
+
+        assertTrue(caller.await())
+    }
+
+    /** A solved host must leave the pending set, or the navigation layer would reopen it. */
+    @Test
+    fun `completing a challenge clears it from the pending set`() = runTest {
+        val subject = manager(backgroundScope)
+        advanceUntilIdle()
+
+        val caller = async { subject.solve("example.test", "https://example.test/manga") }
+        advanceUntilIdle()
+        assertEquals(1, subject.pendingChallenges.value.size)
+
+        subject.completeChallenge("example.test", "cf_clearance=abc", "UA/1.0")
+        advanceUntilIdle()
+        caller.await()
+
+        assertTrue("pending must be empty once solved", subject.pendingChallenges.value.isEmpty())
     }
 }


### PR DESCRIPTION
## **User description**
## 📋 Description

Stage 4b-2. This started as "add User-Agent sync" and turned into something larger once I looked: **a Cloudflare-protected source had no path to recovery at all.** Not a bad error message — no WebView opened, nothing prompted, nothing explained. Given how many manga hosts sit behind Cloudflare, that's a broad and entirely silent class of "this source doesn't work", which is the complaint that started this rebuild.

The parts all existed. None of them were connected.

| Piece | State before |
|---|---|
| `requestChallenge()` | no production caller — only its own KDoc |
| `completeChallenge()` | no production caller — only its own KDoc |
| `pendingChallenge` | **no collector**, despite the KDoc saying "the app's navigation layer observes `pendingChallenge`" |
| `onClose` | registered, but `{ _, _, _ -> popBackStack() }` — discarded the cookies, completed nothing |
| `CloudflareInterceptor` | absent; `NetworkHelper`'s KDoc notes its absence |

I'd have added UA sync to a flow that never ran.

## 🔧 The four gaps

1. **Detect** — `CloudflareInterceptor` on the shared client suspends the call on a challenge.
2. **Open** — the navigation host collects `pendingChallenge` and opens the WebView.
3. **Complete** — `onClose` releases the blocked request, which is what triggers the retry.
4. **Keep clearance valid** — the WebView's User-Agent is captured and replayed for that host.

**(4) is not polish.** Cloudflare binds clearance to the identity that earned it, and `NetworkHelper` sends a fixed `DEFAULT_USER_AGENT` while the WebView reports the system WebView's own string — so they are *guaranteed* to differ. Without it the user solves a challenge, the next request is challenged again, and the bypass looks broken rather than mismatched.

### Detection needs both signals

A 403/503 **and** a `cloudflare` `Server` header. The code alone matches every ordinary 403 on the internet and would throw a WebView at permission errors; the header alone matches every **successful** response from a Cloudflare-fronted site, which is most of them. Seven tests cover both directions.

### One thing the plan expected to build turned out unnecessary

`AndroidCookieJar` reads and writes the same Android `CookieManager` the WebView uses, so clearance is **already** visible to OkHttp with no sync step. Checked rather than assumed.

## 🧵 Concurrency

Keyed by **host**, not source: clearance is per domain, and the interceptor only ever knows a URL. The old `sourceId` key was unsatisfiable from the network layer — part of why this was never wired. `Route.WebView` loses its now-meaningless `sourceId` rather than being handed a placeholder.

Solving is **coalesced by host** via `putIfAbsent`, which is a usability requirement rather than an optimisation: a blocked chapter fires one request per page, so twenty callers arrive within milliseconds and would otherwise produce twenty stacked WebViews for one challenge. A cancelled leader completes its deferred *before* removing it from the map — otherwise the joiners would wait on something nothing could ever complete.

The interceptor blocks a dispatcher thread while the user solves, bounded at three minutes so abandoned challenges can't consume the pool.

## 🧭 Placement, following what #1226 taught

| | Where | Why |
|---|---|---|
| User-Agent | **Shared** client, network interceptor | Every backend needs the bypass, and a UA is not a per-source secret — unlike the page-image headers, which stay on a derived client precisely because they are. Per hop, so each host gets its own identity. |
| Challenge detector | **Shared** client, application interceptor | Must see the finished response and re-run the whole call; a network interceptor sees one hop and cannot retry. |

## 🔄 Type of Change
- [x] 🐛 Bug fix — Cloudflare-protected sources were unusable with no recovery path

## 🧪 Testing

| Check | Result |
|---|---|
| `:app:assembleDebug` | ✅ |
| `testDebugUnitTest` (all modules) | ✅ |
| `detekt` | ✅ |
| `ktlintCheck` | ✅ |

- **Detection** (7 tests): both challenge codes, the nginx variant, case-insensitive matching, and — importantly — that an ordinary 403 and a *successful* Cloudflare response are both rejected.
- **Coalescing** (4 tests): twenty concurrent callers produce one challenge and all are released; different hosts stay independent; closing without cookies releases callers as unsolved; a host can be challenged again after completing, so expiring clearance doesn't lock it out permanently.

### A test failure worth recording

Three tests failed initially and **the production code was not the reason.** `backgroundScope.launch` does not start under `advanceUntilIdle()` in this coroutines version, so the collector never subscribed to a replay-less `SharedFlow` and every assertion read an empty list. It presented exactly like a coalescing bug.

I found it by probing `subscriptionCount` rather than reasoning about it — the reasoning would have sent me to "fix" working code. Noted in the test's KDoc so the next person doesn't lose the same hour.

## ✅ Checklist
- [x] Code follows style guidelines
- [x] Self-review completed (against the checklist added in #1225)
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings
- [x] Tests pass

## 📸 Screenshots
N/A — no new UI; the existing WebView screen is now reachable when it should be.

## 🔗 Related Issues

Part of the source-system rebuild. Follows #1226.

**Not verified on a device.** Confirming this end to end needs a real Cloudflare-protected host, so it belongs to the Stage 8 device pass.

**Split out to a later stage:** cancellation tokens, sticky source per manga, `sortMap` round-trip, `TachiyomiSourceAdapter`'s `chapter.hashCode()` page IDs (unstable across processes), and the three unbounded caches in `SourceRepositoryImpl`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoEui2mCCcqArdhyQyFwnR)_

## Summary by Sourcery

Wire the Cloudflare browser challenge flow so Cloudflare-protected sources become recoverable instead of failing silently.

Bug Fixes:
- Allow requests to Cloudflare-protected hosts to be retried after the user solves a browser challenge instead of failing with no recovery path.

Enhancements:
- Key Cloudflare challenge coordination by host and coalesce concurrent callers so a single WebView is opened per challenged domain.
- Propagate the WebView’s User-Agent back to the network layer and persist it per host so clearance cookies remain valid across retries and app restarts.
- Remove the now-meaningless sourceId from the WebView navigation route and adapt the WebView close callback to report URL, cookies, and User-Agent.
- Introduce a Cloudflare challenge solver interface and bind it to the WebView-based implementation to keep the network layer UI-agnostic.

Build:
- Register Cloudflare interceptors in the shared OkHttp client and add necessary module dependencies for webview, network, and preferences integration.

Tests:
- Add unit tests covering Cloudflare challenge detection rules and WebView challenge coalescing, completion, and re-challenge behaviour.


___

## **CodeAnt-AI Description**
Enable recovery from Cloudflare challenges in protected sources

### What Changed
- Cloudflare-protected requests now open an in-app challenge screen instead of failing without a recovery path
- The original request retries after the challenge is completed, while abandoned challenges time out or return the server’s original response
- Concurrent requests for the same host share one challenge screen rather than opening duplicates
- Clearance is reused with the WebView’s User-Agent and persists across app restarts, preventing repeated challenges
- Ordinary 403, 404, and 500 responses are not mistaken for Cloudflare challenges

### Impact
`✅ Cloudflare-protected sources can recover`
`✅ Fewer repeated CAPTCHA prompts`
`✅ Fewer silent source failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the Cloudflare challenge flow so Cloudflare‑protected sources recover instead of failing silently. On detection, we open a WebView, capture clearance + User‑Agent, retry once, or return the original challenge body if abandoned; only one challenge screen is visible at a time and screens are matched by id across the whole back stack.

- **Bug Fixes**
  - Detect and suspend on challenges in `CloudflareInterceptor` (403/503 + `Server: cloudflare`); buffer the challenge body (≤256 KiB), close the connection, wait up to 100 seconds, retry once after solve, or return the buffered response if not solved.
  - The nav host observes `pendingChallenges` and opens `Route.WebView`; shows at most one challenge; matches screens by `challengeId` across the whole back stack so unrelated WebViews don’t mask challenges, stranded screens don’t wedge, and no duplicates are pushed; both `BackHandler` and `onClose` complete via `WebViewChallengeManager`.
  - Require the `cf_clearance` cookie to count as solved; coalesce by host; pending entries are removed by id in solver cleanup (single owner) to avoid re‑challenge races.
  - Persist and apply the solving User‑Agent per host with `ChallengeUserAgentStore` + `ChallengeUserAgentInterceptor`; cookies are shared via Android `CookieManager`. `CloudflareChallengeSolver` is bound to the WebView implementation in app DI.

- **Migration**
  - `Route.WebView` no longer takes `sourceId` and now carries an optional `challengeId`; `webViewScreen` callback is `onClose(url, cookieString, userAgent)`.

<sup>Written for commit afd69836308df174c0c0f276d3ce0a70d7e90c1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HeartlessVeteran2/Otaku-Reader/pull/1227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

