### PR TITLE
Stage 4c: JavaScript source install path + remote index

### DIFF
--- a/core/extension/build.gradle.kts
+++ b/core/extension/build.gradle.kts
@@ -12,6 +12,14 @@ android {
     buildFeatures {
         buildConfig = true
     }
+
+    testOptions {
+        // Without this, any android.jar method a test reaches throws "not mocked" instead of
+        // returning a default — so the failure-logging inside the remote data source, and the
+        // broadcast the uninstall path sends, made their code paths untestable rather than
+        // failing. Matches what :core:js-runtime already sets.
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionDatabase.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionDatabase.kt
@@ -83,7 +83,11 @@ data class ExtensionEntity(
      * Persisted rather than derived, because uninstall reads the row back to decide which
      * backend to call. See `Extension.isJavaScript` for why a guess is not good enough.
      */
-    @ColumnInfo(name = "is_javascript")
+    // defaultValue must match the migration's `DEFAULT 0` exactly. Room compares the entity's
+    // declared schema against the live database after a migration, and a column default present
+    // in one and absent from the other is a mismatch — which surfaces as a crash on upgrade for
+    // existing users only, never in a fresh install or a test that starts at the current version.
+    @ColumnInfo(name = "is_javascript", defaultValue = "0")
     val isJavaScript: Boolean = false
 )
 

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionDatabase.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionDatabase.kt
@@ -75,7 +75,16 @@ data class ExtensionEntity(
      * existed; backfilled on the next update check.
      */
     @ColumnInfo(name = "source_repo_url")
-    val sourceRepoUrl: String? = null
+    val sourceRepoUrl: String? = null,
+
+    /**
+     * Whether this row is a JavaScript source rather than an APK extension.
+     *
+     * Persisted rather than derived, because uninstall reads the row back to decide which
+     * backend to call. See `Extension.isJavaScript` for why a guess is not good enough.
+     */
+    @ColumnInfo(name = "is_javascript")
+    val isJavaScript: Boolean = false
 )
 
 @Dao
@@ -152,7 +161,7 @@ interface ExtensionDao {
 
 @Database(
     entities = [ExtensionEntity::class],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 abstract class ExtensionDatabase : RoomDatabase() {

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionMapper.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/local/ExtensionMapper.kt
@@ -34,7 +34,8 @@ class ExtensionMapper {
             installDate = entity.installDate,
             signatureHash = entity.signatureHash,
             isEnabled = entity.isEnabled,
-            repoUrl = entity.sourceRepoUrl
+            repoUrl = entity.sourceRepoUrl,
+            isJavaScript = entity.isJavaScript
         )
     }
     
@@ -56,7 +57,8 @@ class ExtensionMapper {
             signatureHash = domain.signatureHash,
             remoteVersionCode = if (domain.hasUpdate) domain.versionCode else null,
             isEnabled = domain.isEnabled,
-            sourceRepoUrl = domain.repoUrl
+            sourceRepoUrl = domain.repoUrl,
+            isJavaScript = domain.isJavaScript
         )
     }
     

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
@@ -260,25 +260,30 @@ class ExtensionRemoteDataSourceImpl(
                 // is the exact defect that shipped in Stage 4a, where one thrown exception on
                 // the APK path silently dropped every JavaScript source. Isolation has to run
                 // in both directions or it is not isolation.
-                val jsExtensions = jsBackend
-                    ?.let { backend ->
-                        val normalized = repositories.map { normalizeRepoUrl(it) }
-                        try {
-                            backend.fetchAvailable(normalized)
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            android.util.Log.w("ExtensionRemoteDS", "JS index fetch failed: ${e.message}")
-                            emptyList()
-                        }
+                val jsFetch = jsBackend?.let { backend ->
+                    val normalized = repositories.map { normalizeRepoUrl(it) }
+                    try {
+                        backend.fetchAvailable(normalized)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        android.util.Log.w("ExtensionRemoteDS", "JS index fetch failed: ${e.message}")
+                        null
                     }
-                    .orEmpty()
+                }
+                val jsExtensions = jsFetch?.extensions.orEmpty()
 
                 // Only report failure when every repository failed and the JavaScript backend
-                // produced nothing either — a repo that responds with a legitimately empty list
-                // still counts as a success, and partial results are far more useful to the user
-                // than an empty error state.
-                if (successCount == 0 && failures.isNotEmpty() && jsExtensions.isEmpty()) {
+                // did not serve anything either — a repo that responds with a legitimately empty
+                // list still counts as a success, and partial results are far more useful to the
+                // user than an empty error state.
+                //
+                // The condition asks whether an index was *served*, not whether it produced
+                // extensions. Those differ for a JavaScript-only repository whose index is valid
+                // but empty: its APK endpoints legitimately 404, the JS list is legitimately
+                // empty, and reading emptiness as failure would show "all repositories failed"
+                // to a user whose setup is working exactly as intended.
+                if (successCount == 0 && failures.isNotEmpty() && jsFetch?.servedAnyIndex != true) {
                     val (firstUrl, firstError) = failures.first()
                     val exception = ExtensionFetchException(
                         "All ${failures.size} extension repositories failed " +

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
@@ -1,5 +1,6 @@
 package app.otakureader.core.extension.data.remote
 
+import app.otakureader.core.extension.domain.backend.JsExtensionBackend
 import app.otakureader.core.extension.domain.model.Extension
 import app.otakureader.core.extension.domain.model.ExtensionSource
 import app.otakureader.core.extension.domain.model.InstallStatus
@@ -181,6 +182,18 @@ interface ExtensionRemoteDataSource {
 class ExtensionRemoteDataSourceImpl(
     private val repoRepository: ExtensionRepoRepository,
     private val httpClient: OkHttpClient = createDefaultClient(),
+    /**
+     * The JavaScript backend, when one is wired in.
+     *
+     * The merge happens here rather than a layer up because this class already resolves and
+     * normalises the configured repository list. Doing it elsewhere would mean two readers of
+     * that list and two chances to normalise a URL differently — so a repository could resolve
+     * one way for APKs and another for scripts, which fails as "this repository has no sources"
+     * rather than as anything a user could act on.
+     *
+     * Null leaves the APK behaviour exactly as it was, which is what the existing tests exercise.
+     */
+    private val jsBackend: JsExtensionBackend? = null,
 ) : ExtensionRemoteDataSource {
 
     private val json = Json {
@@ -238,10 +251,34 @@ class ExtensionRemoteDataSourceImpl(
                     }
                 }
 
-                // Only report failure when every repository failed — a repo that responds
-                // with a legitimately empty list still counts as a success, and partial
-                // results are far more useful to the user than an empty error state.
-                if (successCount == 0 && failures.isNotEmpty()) {
+                // The JavaScript backend reads the same repository list. Its failures are
+                // absorbed the same way a single repository's are: a repository that serves no
+                // JavaScript index is the common case, not an error.
+                //
+                // Crucially this runs even when every APK fetch failed, and its results count
+                // towards success below. The inverse — letting an APK failure return early —
+                // is the exact defect that shipped in Stage 4a, where one thrown exception on
+                // the APK path silently dropped every JavaScript source. Isolation has to run
+                // in both directions or it is not isolation.
+                val jsExtensions = jsBackend
+                    ?.let { backend ->
+                        val normalized = repositories.map { normalizeRepoUrl(it) }
+                        try {
+                            backend.fetchAvailable(normalized)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            android.util.Log.w("ExtensionRemoteDS", "JS index fetch failed: ${e.message}")
+                            emptyList()
+                        }
+                    }
+                    .orEmpty()
+
+                // Only report failure when every repository failed and the JavaScript backend
+                // produced nothing either — a repo that responds with a legitimately empty list
+                // still counts as a success, and partial results are far more useful to the user
+                // than an empty error state.
+                if (successCount == 0 && failures.isNotEmpty() && jsExtensions.isEmpty()) {
                     val (firstUrl, firstError) = failures.first()
                     val exception = ExtensionFetchException(
                         "All ${failures.size} extension repositories failed " +
@@ -253,8 +290,15 @@ class ExtensionRemoteDataSourceImpl(
                     return@withContext Result.failure(exception)
                 }
 
-                // Deduplicate by package name preferring highest versionCode
-                val merged = extensions
+                // Deduplicate by package name preferring highest versionCode.
+                //
+                // Both backends share this one namespace, and that is a requirement rather than
+                // an oversight: the DAO keys on pkgName (`getExtensionByPkgName`,
+                // `deleteByPkgName`, `updateStatus`), so two rows sharing one would make an
+                // uninstall delete both. A JavaScript source id colliding with an Android
+                // package name takes a deliberately package-shaped id, and one row surviving is
+                // far better than a pair the uninstall path cannot tell apart.
+                val merged = (extensions + jsExtensions)
                     .groupBy { it.pkgName }
                     .values
                     .map { candidates ->

--- a/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/data/remote/ExtensionRemoteDataSource.kt
@@ -292,6 +292,11 @@ class ExtensionRemoteDataSourceImpl(
                     )
                     // Preserve the other repos' errors for debugging.
                     failures.drop(1).forEach { (_, error) -> exception.addSuppressed(error) }
+                    // And the JavaScript side's, which is the one that matters for a
+                    // JavaScript-only repository: without it the user is shown a 404 on an APK
+                    // index they never had, while the real fault — a malformed js/index.json —
+                    // goes unmentioned.
+                    jsFetch?.firstFailure?.let { exception.addSuppressed(it) }
                     return@withContext Result.failure(exception)
                 }
 

--- a/core/extension/src/main/java/app/otakureader/core/extension/di/ExtensionModule.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/di/ExtensionModule.kt
@@ -15,6 +15,7 @@ import app.otakureader.core.extension.data.remote.ExtensionRemoteDataSource
 import app.otakureader.core.extension.data.remote.ExtensionRemoteDataSourceImpl
 import app.otakureader.core.extension.data.repository.ExtensionRepoRepositoryImpl
 import app.otakureader.core.extension.data.repository.ExtensionRepositoryImpl
+import app.otakureader.core.extension.domain.backend.JsExtensionBackend
 import app.otakureader.core.extension.domain.repository.ExtensionRepoRepository
 import app.otakureader.core.extension.domain.repository.ExtensionRepository
 import app.otakureader.core.extension.installer.ExtensionInstaller
@@ -34,6 +35,20 @@ private val MIGRATION_3_4 = object : Migration(3, 4) {
     }
 }
 
+/**
+ * v4 -> v5: JavaScript-backend discriminator.
+ *
+ * `NOT NULL DEFAULT 0` rather than a nullable column: every row that exists before this
+ * migration is an APK extension, and that is a fact, not a missing value. A nullable column
+ * would push a three-state question ("APK, JavaScript, or unknown?") onto every read of a
+ * flag that only ever has two answers.
+ */
+private val MIGRATION_4_5 = object : Migration(4, 5) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE extensions ADD COLUMN is_javascript INTEGER NOT NULL DEFAULT 0")
+    }
+}
+
 @Module
 @InstallIn(SingletonComponent::class)
 object ExtensionModule {
@@ -48,7 +63,7 @@ object ExtensionModule {
             ExtensionDatabase::class.java,
             "extension_database"
         )
-        builder.addMigrations(MIGRATION_3_4)
+        builder.addMigrations(MIGRATION_3_4, MIGRATION_4_5)
         // Only allow destructive migration in debug builds to avoid silently wiping
         // extension metadata in production if a migration is missing.
         if (BuildConfig.DEBUG) {
@@ -74,9 +89,10 @@ object ExtensionModule {
     @Provides
     @Singleton
     fun provideExtensionRemoteDataSource(
-        repoRepository: ExtensionRepoRepository
+        repoRepository: ExtensionRepoRepository,
+        jsBackend: JsExtensionBackend,
     ): ExtensionRemoteDataSource {
-        return ExtensionRemoteDataSourceImpl(repoRepository)
+        return ExtensionRemoteDataSourceImpl(repoRepository, jsBackend = jsBackend)
     }
 
     @Provides
@@ -120,7 +136,8 @@ object ExtensionModule {
         repository: ExtensionRepository,
         loader: ExtensionLoader,
         remoteDataSource: ExtensionRemoteDataSource,
+        jsBackend: JsExtensionBackend,
     ): ExtensionInstaller {
-        return ExtensionInstaller(context, repository, loader, remoteDataSource)
+        return ExtensionInstaller(context, repository, loader, remoteDataSource, jsBackend)
     }
 }

--- a/core/extension/src/main/java/app/otakureader/core/extension/domain/backend/JsExtensionBackend.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/domain/backend/JsExtensionBackend.kt
@@ -26,6 +26,22 @@ import app.otakureader.core.extension.domain.model.Extension
  * inferred from a name prefix or a URL suffix, because install and uninstall route on it and a
  * guess that is right most of the time would send an occasional `.js` file to the APK installer.
  */
+/**
+ * The outcome of a JavaScript index fetch.
+ *
+ * [servedAnyIndex] is carried rather than inferred from `extensions.isEmpty()`, because those two
+ * facts are not the same and the gap between them is user-visible. A repository that serves a
+ * valid but *empty* `js/index.json` produced no extensions and yet worked perfectly. Treating an
+ * empty list as failure would report "all repositories failed" at a user whose setup is fine —
+ * and using emptiness as a proxy for success is exactly the kind of almost-right comparison that
+ * has needed correcting repeatedly in this rebuild.
+ */
+data class JsExtensionFetch(
+    val extensions: List<Extension>,
+    /** True when at least one repository actually served a JavaScript index. */
+    val servedAnyIndex: Boolean,
+)
+
 interface JsExtensionBackend {
 
     /**
@@ -36,10 +52,11 @@ interface JsExtensionBackend {
      * repo that resolved one way for APKs and another way for scripts would be a confusing
      * partial failure rather than a clean one.
      *
-     * Returns an empty list rather than throwing when a repo has no JavaScript index — most
-     * repositories serve only APKs, and that is a normal answer, not an error.
+     * Reports no extensions rather than throwing when a repo has no JavaScript index — most
+     * repositories serve only APKs, and that is a normal answer, not an error. Whether any
+     * index was actually served is reported separately; see [JsExtensionFetch].
      */
-    suspend fun fetchAvailable(repoUrls: List<String>): List<Extension>
+    suspend fun fetchAvailable(repoUrls: List<String>): JsExtensionFetch
 
     /**
      * Download [extension]'s script and register it, making the source immediately usable.

--- a/core/extension/src/main/java/app/otakureader/core/extension/domain/backend/JsExtensionBackend.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/domain/backend/JsExtensionBackend.kt
@@ -1,0 +1,56 @@
+package app.otakureader.core.extension.domain.backend
+
+import app.otakureader.core.extension.domain.model.Extension
+
+/**
+ * The JavaScript backend, as the APK-oriented extension layer needs to see it.
+ *
+ * Declared here and implemented in `:core:js-runtime` so the dependency runs one way: the JS
+ * module knows about [Extension] and the extension-management layer knows only this interface.
+ * Without the seam the two modules would have to depend on each other, since install has to be
+ * dispatched from the APK installer while the actual work lives in the JS module.
+ *
+ * The same pattern as `CloudflareChallengeSolver` — interface in the module that calls it,
+ * implementation in the module that can do the work, bound in `:app`, which is the only place
+ * that knows about both.
+ *
+ * ### Why the JS sources ride the existing `Extension` model
+ *
+ * Everything in `feature/browse` — the list, the install button, the language filter, the search
+ * — reads `Extension` rows out of the `extensions` table. Modelling a JavaScript source as one of
+ * those rows means the entire extension-management UI works for the new backend without a single
+ * edit. The alternative, a parallel model with a parallel screen, would have duplicated all of it
+ * and then drifted.
+ *
+ * The one thing the model needed was an honest discriminator: [Extension.isJavaScript]. It is not
+ * inferred from a name prefix or a URL suffix, because install and uninstall route on it and a
+ * guess that is right most of the time would send an occasional `.js` file to the APK installer.
+ */
+interface JsExtensionBackend {
+
+    /**
+     * Available JavaScript sources across [repoUrls].
+     *
+     * Takes the URLs rather than reading them itself so there is one reader of the configured
+     * repository list. Two readers would be two chances to normalise a URL differently, and a
+     * repo that resolved one way for APKs and another way for scripts would be a confusing
+     * partial failure rather than a clean one.
+     *
+     * Returns an empty list rather than throwing when a repo has no JavaScript index — most
+     * repositories serve only APKs, and that is a normal answer, not an error.
+     */
+    suspend fun fetchAvailable(repoUrls: List<String>): List<Extension>
+
+    /**
+     * Download [extension]'s script and register it, making the source immediately usable.
+     *
+     * [Extension.apkUrl] carries the `.js` URL for a JavaScript extension. The field is reused
+     * rather than duplicated because it means exactly the same thing — where to fetch the
+     * installable artifact from — and a parallel column that was null for every APK row would be
+     * schema with no information in it.
+     */
+    suspend fun install(extension: Extension): Result<Unit>
+
+    /** Remove the script, its registration, and anything the source stored — including logins. */
+    suspend fun uninstall(sourceId: String): Result<Unit>
+}

--- a/core/extension/src/main/java/app/otakureader/core/extension/domain/backend/JsExtensionBackend.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/domain/backend/JsExtensionBackend.kt
@@ -38,8 +38,23 @@ import app.otakureader.core.extension.domain.model.Extension
  */
 data class JsExtensionFetch(
     val extensions: List<Extension>,
-    /** True when at least one repository actually served a JavaScript index. */
+    /**
+     * True when at least one repository served an index that could actually be **read**.
+     *
+     * A body that arrives but cannot be parsed counts as false, and that is the honest reading:
+     * an unparseable index yields no sources, exactly like an absent one, so it cannot be
+     * treated as evidence that anything worked. [firstFailure] is what keeps that from being
+     * lossy — the reason is carried rather than flattened into a boolean.
+     */
     val servedAnyIndex: Boolean,
+    /**
+     * The first per-repository failure, kept for diagnosis.
+     *
+     * Without it a JavaScript-only repository with a malformed index reports whatever its
+     * *APK* endpoint said — a 404 on `index.min.json`, for a user who has no APK sources and
+     * cannot act on that. The real problem never reaches them.
+     */
+    val firstFailure: Throwable? = null,
 )
 
 interface JsExtensionBackend {

--- a/core/extension/src/main/java/app/otakureader/core/extension/domain/backend/JsExtensionBackend.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/domain/backend/JsExtensionBackend.kt
@@ -3,30 +3,6 @@ package app.otakureader.core.extension.domain.backend
 import app.otakureader.core.extension.domain.model.Extension
 
 /**
- * The JavaScript backend, as the APK-oriented extension layer needs to see it.
- *
- * Declared here and implemented in `:core:js-runtime` so the dependency runs one way: the JS
- * module knows about [Extension] and the extension-management layer knows only this interface.
- * Without the seam the two modules would have to depend on each other, since install has to be
- * dispatched from the APK installer while the actual work lives in the JS module.
- *
- * The same pattern as `CloudflareChallengeSolver` — interface in the module that calls it,
- * implementation in the module that can do the work, bound in `:app`, which is the only place
- * that knows about both.
- *
- * ### Why the JS sources ride the existing `Extension` model
- *
- * Everything in `feature/browse` — the list, the install button, the language filter, the search
- * — reads `Extension` rows out of the `extensions` table. Modelling a JavaScript source as one of
- * those rows means the entire extension-management UI works for the new backend without a single
- * edit. The alternative, a parallel model with a parallel screen, would have duplicated all of it
- * and then drifted.
- *
- * The one thing the model needed was an honest discriminator: [Extension.isJavaScript]. It is not
- * inferred from a name prefix or a URL suffix, because install and uninstall route on it and a
- * guess that is right most of the time would send an occasional `.js` file to the APK installer.
- */
-/**
  * The outcome of a JavaScript index fetch.
  *
  * [servedAnyIndex] is carried rather than inferred from `extensions.isEmpty()`, because those two
@@ -57,6 +33,30 @@ data class JsExtensionFetch(
     val firstFailure: Throwable? = null,
 )
 
+/**
+ * The JavaScript backend, as the APK-oriented extension layer needs to see it.
+ *
+ * Declared here and implemented in `:core:js-runtime` so the dependency runs one way: the JS
+ * module knows about [Extension] and the extension-management layer knows only this interface.
+ * Without the seam the two modules would have to depend on each other, since install has to be
+ * dispatched from the APK installer while the actual work lives in the JS module.
+ *
+ * The same pattern as `CloudflareChallengeSolver` — interface in the module that calls it,
+ * implementation in the module that can do the work, bound in `:app`, which is the only place
+ * that knows about both.
+ *
+ * ### Why the JS sources ride the existing `Extension` model
+ *
+ * Everything in `feature/browse` — the list, the install button, the language filter, the search
+ * — reads `Extension` rows out of the `extensions` table. Modelling a JavaScript source as one of
+ * those rows means the entire extension-management UI works for the new backend without a single
+ * edit. The alternative, a parallel model with a parallel screen, would have duplicated all of it
+ * and then drifted.
+ *
+ * The one thing the model needed was an honest discriminator: [Extension.isJavaScript]. It is not
+ * inferred from a name prefix or a URL suffix, because install and uninstall route on it and a
+ * guess that is right most of the time would send an occasional `.js` file to the APK installer.
+ */
 interface JsExtensionBackend {
 
     /**

--- a/core/extension/src/main/java/app/otakureader/core/extension/domain/model/Extension.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/domain/model/Extension.kt
@@ -82,7 +82,26 @@ data class Extension(
      * on the source level — aggregated to the extension level here as true if any source
      * has hasCloudflare == 1).
      */
-    val hasCloudflare: Boolean = false
+    val hasCloudflare: Boolean = false,
+
+    /**
+     * Whether this extension is a JavaScript source rather than an APK.
+     *
+     * Install and uninstall route on this flag, so it is stored rather than inferred. Deriving it
+     * from a `.js` suffix on [apkUrl] or a naming convention on [pkgName] would be right almost
+     * always, and the failure when it was wrong would be a script handed to the APK installer —
+     * or worse, an APK handed to the script store.
+     *
+     * When true:
+     * - [pkgName] is the JavaScript source id (`JsSourceConfig.id`), not an Android package.
+     * - [apkUrl] points at the `.js` file to download.
+     * - [apkPath] is empty. There is no APK and no `PackageManager` entry; the script lives in
+     *   the JS store under `filesDir/js-exts/`, keyed by [pkgName].
+     * - [signatureHash] is null, so [isTrusted] is false. That is accurate rather than a gap —
+     *   a JavaScript source carries no signature to verify, and HTTPS is the only transport
+     *   control on it.
+     */
+    val isJavaScript: Boolean = false
 ) : Parcelable {
     
     val isInstalled: Boolean

--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -295,9 +295,26 @@ class ExtensionInstaller(
         backend: JsExtensionBackend,
         error: Throwable,
     ) {
-        val existingRow = runCatching { repository.getExtension(extension.pkgName) }.getOrNull()
+        // Three outcomes, not two. `runCatching { ... }.getOrNull()` collapsed "the row is
+        // absent" and "the lookup itself failed" into the same null — and the destructive branch
+        // hangs off that value. This code runs *because* a database write just failed, so a
+        // follow-up read failing is a likely path rather than a theoretical one, and treating it
+        // as proof of absence would delete a working source and the user's saved login for it.
+        //
+        // Destroying data requires positive evidence that it is safe. Absence of evidence is not
+        // that, so a failed lookup takes the non-destructive branch.
+        val lookup = try {
+            Result.success(repository.getExtension(extension.pkgName))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            runCatching { error.addSuppressed(e) }
+            Result.failure(e)
+        }
 
-        if (existingRow == null) {
+        val existingRow = lookup.getOrNull()
+
+        if (lookup.isSuccess && existingRow == null) {
             // The cleanup's own failure must not replace the error that caused all this — that
             // would send the user looking in the wrong place. It is attached instead, so an
             // orphan that could not be cleaned up is still diagnosable from the reported error.

--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -266,30 +266,47 @@ class ExtensionInstaller(
      * preferences that routinely hold their login for that site. The cure would be worse than
      * the failure it followed.
      *
-     * So the question asked is the one that actually matters: after the failure, is there still
-     * a row that can reach this script? Not "was this an update?", which is a proxy for it. A
-     * surviving row means uninstall works and the script must be left alone; no row means it is
-     * unreachable and must go.
+     * The rule both branches follow is simply **make the row describe reality**:
      *
-     * Residual, stated rather than papered over: when a row survives an update failure it still
-     * describes the *previous* version while the new script is on disk. The source works — the
-     * new script is a valid one — and the next update check reconciles the version. Restoring
-     * the old script instead would mean snapshotting every script before every update, which is
-     * a lot of machinery for a stale version number.
+     * - **No row existed.** Nothing installed this before, and the failed write left nothing
+     *   behind (`updateStatus` on an absent row is a no-op). The script is unreachable, so it
+     *   goes.
+     * - **A row existed.** Something *is* installed — the new script is on disk and registered,
+     *   and it is a valid script. So the row is restored to `INSTALLED`, which is the honest
+     *   status, rather than left at the `ERROR` the repository set on its way out.
+     *
+     * Restoring the status is not cosmetic. `ERROR` is deliberately transient: the next
+     * `refreshAvailableExtensions` does not count `ERROR` rows as installed and replaces them
+     * with fresh `AVAILABLE` ones. The script would then be live in Browse and registered with
+     * the engine while the extension screen listed it as not installed — no uninstall button
+     * anywhere, which is the orphan this method exists to prevent, just reached a slower way.
+     *
+     * The same principle produced the opposite answer in [finalizeRemoval], which sets `ERROR`
+     * after a failed *delete*: there the extension really is gone, so letting the row lapse to
+     * available is right. Here it really is present.
+     *
+     * Residual, stated rather than papered over: a restored row still names the *previous*
+     * version while the new script is on disk. The source works, and the next update check
+     * reconciles the version. Snapshotting every script before every update to restore the old
+     * one would be a lot of machinery for a stale version number.
      */
     private suspend fun rollBackOrphanedScript(
         extension: Extension,
         backend: JsExtensionBackend,
         error: Throwable,
     ) {
-        val reachable = runCatching { repository.getExtension(extension.pkgName) }.getOrNull() != null
+        val existingRow = runCatching { repository.getExtension(extension.pkgName) }.getOrNull()
 
-        if (!reachable) {
+        if (existingRow == null) {
             // The cleanup's own failure must not replace the error that caused all this — that
             // would send the user looking in the wrong place. It is attached instead, so an
             // orphan that could not be cleaned up is still diagnosable from the reported error.
             backend.uninstall(extension.pkgName).onFailure { cleanupError ->
                 runCatching { error.addSuppressed(cleanupError) }
+            }
+        } else {
+            runCatching {
+                repository.setExtensionStatus(extension.pkgName, InstallStatus.INSTALLED)
             }
         }
 

--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -249,22 +249,54 @@ class ExtensionInstaller(
         // apkPath is empty rather than a path: there is no APK file to point at.
         return repository.installExtension(extension, apkPath = "")
             .onSuccess { _installationState.value = InstallationState.Success(it) }
-            .onFailure { error ->
-                // Undo the backend install. Without this the script stays on disk and
-                // registered with the engine while no row describes it — and since uninstall
-                // finds its target through the database, nothing can ever reach it again. An
-                // orphaned source that still executes is worse than a failed install.
-                //
-                // The rollback's own failure is deliberately swallowed: the caller is owed the
-                // error that actually caused the install to fail, not a second one from the
-                // cleanup. Losing the original would send them looking in the wrong place.
-                backend.uninstall(extension.pkgName)
+            .onFailure { error -> rollBackOrphanedScript(extension, backend, error) }
+    }
 
-                _installationState.value = InstallationState.Error(
-                    "Installation failed: ${error.message}",
-                    error
-                )
+    /**
+     * Clean up after a JavaScript install whose database write failed.
+     *
+     * The hazard is an orphan: the script is on disk and registered with the engine, and since
+     * uninstall finds its target *through the database*, a missing row means nothing can ever
+     * reach it again — a source that still executes and cannot be removed.
+     *
+     * **The rollback is conditional, and that condition is the whole correctness of this.** An
+     * unconditional `backend.uninstall` fixes the fresh-install orphan and breaks something
+     * worse in the update case: `backend.install` has already replaced the script of a source
+     * the user had working, so uninstalling would delete it outright — along with the stored
+     * preferences that routinely hold their login for that site. The cure would be worse than
+     * the failure it followed.
+     *
+     * So the question asked is the one that actually matters: after the failure, is there still
+     * a row that can reach this script? Not "was this an update?", which is a proxy for it. A
+     * surviving row means uninstall works and the script must be left alone; no row means it is
+     * unreachable and must go.
+     *
+     * Residual, stated rather than papered over: when a row survives an update failure it still
+     * describes the *previous* version while the new script is on disk. The source works — the
+     * new script is a valid one — and the next update check reconciles the version. Restoring
+     * the old script instead would mean snapshotting every script before every update, which is
+     * a lot of machinery for a stale version number.
+     */
+    private suspend fun rollBackOrphanedScript(
+        extension: Extension,
+        backend: JsExtensionBackend,
+        error: Throwable,
+    ) {
+        val reachable = runCatching { repository.getExtension(extension.pkgName) }.getOrNull() != null
+
+        if (!reachable) {
+            // The cleanup's own failure must not replace the error that caused all this — that
+            // would send the user looking in the wrong place. It is attached instead, so an
+            // orphan that could not be cleaned up is still diagnosable from the reported error.
+            backend.uninstall(extension.pkgName).onFailure { cleanupError ->
+                runCatching { error.addSuppressed(cleanupError) }
             }
+        }
+
+        _installationState.value = InstallationState.Error(
+            "Installation failed: ${error.message}",
+            error
+        )
     }
 
     /**

--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -161,6 +161,33 @@ class ExtensionInstaller(
     }
 
     /**
+     * Drop the extension's row and announce the removal — but only announce it if the row went.
+     *
+     * Both uninstall paths reach here having already destroyed the artifact: the APK path has
+     * deleted its private copy, the JavaScript path has deregistered the script and erased the
+     * source's stored preferences. So by this point the extension really is gone, and the row is
+     * the last thing describing something that no longer exists.
+     *
+     * Two things were wrong when each path did this inline, and they were wrong identically —
+     * which is why this is now one function instead of two copies:
+     *
+     * - `.also { notifyRemoved(...) }` runs on the `Result` regardless of whether it succeeded,
+     *   so a failed delete still broadcast a removal. Listeners then dropped their state for an
+     *   extension the database still lists. `onSuccess` fires only on success.
+     * - A failed delete left the row stuck at `UNINSTALLING` forever: a source frozen
+     *   mid-removal that the user cannot act on and that no longer works.
+     *
+     * `ERROR` is the honest terminal state for that failure. Not `INSTALLED` — the extension is
+     * genuinely gone, and a row claiming otherwise would show a source that cannot function.
+     * `ERROR` also self-corrects: `refreshAvailableExtensions` deliberately does not treat ERROR
+     * rows as installed, so the next refresh re-offers the extension as available to install.
+     */
+    private suspend fun finalizeRemoval(pkgName: String): Result<Unit> =
+        repository.uninstallExtension(pkgName)
+            .onSuccess { ExtensionInstallReceiver.notifyRemoved(context, pkgName) }
+            .onFailure { repository.setExtensionStatus(pkgName, InstallStatus.ERROR) }
+
+    /**
      * Remove a JavaScript source's script, registration and stored data, then its row.
      *
      * The backend runs first and the row is dropped only if it succeeded. The reverse order
@@ -175,11 +202,7 @@ class ExtensionInstaller(
 
         return backend.uninstall(pkgName)
             .fold(
-                onSuccess = {
-                    repository.uninstallExtension(pkgName).also {
-                        ExtensionInstallReceiver.notifyRemoved(context, pkgName)
-                    }
-                },
+                onSuccess = { finalizeRemoval(pkgName) },
                 onFailure = { error ->
                     // Put the row back to INSTALLED. Leaving it UNINSTALLING would show a
                     // source stuck mid-removal that the user cannot act on, while the source
@@ -227,6 +250,16 @@ class ExtensionInstaller(
         return repository.installExtension(extension, apkPath = "")
             .onSuccess { _installationState.value = InstallationState.Success(it) }
             .onFailure { error ->
+                // Undo the backend install. Without this the script stays on disk and
+                // registered with the engine while no row describes it — and since uninstall
+                // finds its target through the database, nothing can ever reach it again. An
+                // orphaned source that still executes is worse than a failed install.
+                //
+                // The rollback's own failure is deliberately swallowed: the caller is owed the
+                // error that actually caused the install to fail, not a second one from the
+                // cleanup. Losing the original would send them looking in the wrong place.
+                backend.uninstall(extension.pkgName)
+
                 _installationState.value = InstallationState.Error(
                     "Installation failed: ${error.message}",
                     error
@@ -613,9 +646,7 @@ class ExtensionInstaller(
                 File(extensionsDir, "$pkgName.ext").takeIf { it.exists() }?.delete()
 
                 // Remove from repository and notify the receiver.
-                repository.uninstallExtension(pkgName).also {
-                    ExtensionInstallReceiver.notifyRemoved(context, pkgName)
-                }
+                finalizeRemoval(pkgName)
             }
         } catch (e: CancellationException) {
             throw e

--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.os.Build
 import androidx.core.net.toUri
 import app.otakureader.core.extension.data.remote.ExtensionRemoteDataSource
+import app.otakureader.core.extension.domain.backend.JsExtensionBackend
 import app.otakureader.core.extension.domain.model.Extension
 import app.otakureader.core.extension.domain.model.InstallStatus
 import app.otakureader.core.extension.domain.repository.ExtensionRepository
@@ -42,7 +43,15 @@ class ExtensionInstaller(
     private val context: Context,
     private val repository: ExtensionRepository,
     private val loader: ExtensionLoader,
-    private val remoteDataSource: ExtensionRemoteDataSource
+    private val remoteDataSource: ExtensionRemoteDataSource,
+    /**
+     * The JavaScript backend, when one is wired in.
+     *
+     * Dispatch happens here rather than in the ViewModel so `feature/browse` stays unaware that
+     * there are two backends at all — it calls one install method with an [Extension] and gets
+     * the right behaviour. Null keeps the APK-only path, which is what the existing tests cover.
+     */
+    private val jsBackend: JsExtensionBackend? = null,
 ) {
     
     companion object {
@@ -75,6 +84,10 @@ class ExtensionInstaller(
      */
     suspend fun downloadAndInstall(extension: Extension): Result<Extension> = withContext(Dispatchers.IO) {
         try {
+            if (extension.isJavaScript) {
+                return@withContext installJavaScript(extension)
+            }
+
             val apkUrl = extension.apkUrl
                 ?: return@withContext Result.failure(
                     IllegalArgumentException("Extension has no APK URL")
@@ -145,6 +158,80 @@ class ExtensionInstaller(
             )
             Result.failure(e)
         }
+    }
+
+    /**
+     * Remove a JavaScript source's script, registration and stored data, then its row.
+     *
+     * The backend runs first and the row is dropped only if it succeeded. The reverse order
+     * would let a failed erase leave the credentials on disk with the source already gone from
+     * the list the user would retry from — a state no retry can reach. `JsSourceProvider`
+     * applies the same ordering internally for the same reason.
+     */
+    private suspend fun uninstallJavaScript(pkgName: String): Result<Unit> {
+        val backend = jsBackend ?: return Result.failure(
+            IllegalStateException("No JavaScript backend is available to uninstall $pkgName")
+        )
+
+        return backend.uninstall(pkgName)
+            .fold(
+                onSuccess = {
+                    repository.uninstallExtension(pkgName).also {
+                        ExtensionInstallReceiver.notifyRemoved(context, pkgName)
+                    }
+                },
+                onFailure = { error ->
+                    // Put the row back to INSTALLED. Leaving it UNINSTALLING would show a
+                    // source stuck mid-removal that the user cannot act on, while the source
+                    // itself is still perfectly functional.
+                    repository.setExtensionStatus(pkgName, InstallStatus.INSTALLED)
+                    Result.failure(error)
+                },
+            )
+    }
+
+    /**
+     * Install a JavaScript source: fetch the script, register it, then record the row.
+     *
+     * The order is the point. The database row is written *last*, only once the script is on
+     * disk and registered with the engine, so a failed download or a rejected non-HTTPS URL
+     * leaves nothing behind that claims to be installed. Writing the row first would produce a
+     * source that appears in the library and fails on every call — which is precisely the class
+     * of silent, undiagnosable failure this rebuild exists to eliminate.
+     *
+     * There is no APK, no `PackageManager`, no signature verification and no system install
+     * prompt on this path. That is the whole reason the backend exists, and it is also why the
+     * HTTPS check inside the remote data source is not optional: with no signature to verify,
+     * transport is the only control on what gets executed.
+     */
+    private suspend fun installJavaScript(extension: Extension): Result<Extension> {
+        val backend = jsBackend ?: return Result.failure(
+            IllegalStateException("No JavaScript backend is available to install ${extension.pkgName}")
+        )
+
+        _installationState.value = InstallationState.Downloading(0)
+
+        val installed = backend.install(extension)
+        if (installed.isFailure) {
+            val error = installed.exceptionOrNull() ?: Exception("JavaScript install failed")
+            _installationState.value = InstallationState.Error(
+                "Installation failed: ${error.message}",
+                error
+            )
+            return Result.failure(error)
+        }
+
+        _installationState.value = InstallationState.Installing
+
+        // apkPath is empty rather than a path: there is no APK file to point at.
+        return repository.installExtension(extension, apkPath = "")
+            .onSuccess { _installationState.value = InstallationState.Success(it) }
+            .onFailure { error ->
+                _installationState.value = InstallationState.Error(
+                    "Installation failed: ${error.message}",
+                    error
+                )
+            }
     }
 
     /**
@@ -494,6 +581,16 @@ class ExtensionInstaller(
     suspend fun uninstall(pkgName: String): Result<Unit> = withContext(Dispatchers.IO) {
         try {
             repository.setExtensionStatus(pkgName, InstallStatus.UNINSTALLING)
+
+            // Look the row up rather than inferring the backend from the name. Getting this
+            // wrong is not cosmetic: without the branch below a JavaScript source would fall
+            // through to the private-APK path, which deletes the database row and nothing else
+            // — leaving the script on disk, still registered with the engine, and its stored
+            // preferences intact. Those preferences routinely hold the user's login for the
+            // site, so "uninstalled" would leave the credentials behind.
+            if (repository.getExtension(pkgName)?.isJavaScript == true) {
+                return@withContext uninstallJavaScript(pkgName)
+            }
 
             if (isSystemInstalled(pkgName)) {
                 // Trigger the system uninstaller dialog for shared/installed extensions.

--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -236,7 +236,19 @@ class ExtensionInstaller(
         // be healthy. Asking afterwards means asking a database that has just failed a write,
         // and the answer decides whether a script gets deleted — so the question has to be put
         // at the moment it can still be answered reliably.
-        val priorRow = lookupRow(extension.pkgName)
+        //
+        // And if it cannot be answered even now, **fail closed**: do not install at all. The
+        // alternative is to write a live script whose ownership can never be established, which
+        // leaves exactly one safe move afterwards (destroy nothing) and therefore an executing
+        // source that no uninstall can reach. Refusing an install the user can simply retry is
+        // the cheaper failure by a wide margin.
+        val priorRow = lookupRow(extension.pkgName).getOrElse { lookupError ->
+            _installationState.value = InstallationState.Error(
+                "Installation failed: ${lookupError.message}",
+                lookupError,
+            )
+            return Result.failure(lookupError)
+        }
 
         _installationState.value = InstallationState.Downloading(0)
 
@@ -305,7 +317,8 @@ class ExtensionInstaller(
      *   destructive branch off an ambiguous null on the one path where the database is least
      *   trustworthy.
      *
-     * With the fact captured up front, each case has an unambiguous answer:
+     * With the fact captured up front, only two cases remain, and each has an unambiguous
+     * answer:
      *
      * - **A JavaScript row existed.** This was an update, so something is genuinely installed —
      *   the new script is on disk, registered, and valid. Restore the row to `INSTALLED`, which
@@ -313,8 +326,12 @@ class ExtensionInstaller(
      * - **No row, or a row belonging to the other backend.** Nothing here reaches this script:
      *   an APK row with the same package name routes uninstall down the APK path, which would
      *   leave the script and its stored data behind. Remove the script.
-     * - **The prior lookup itself failed.** Nothing is destroyed. Destroying data requires
-     *   positive evidence that it is safe, and absence of evidence is not that.
+     *
+     * There is deliberately no "could not tell" case. [installJavaScript] fails closed when the
+     * snapshot cannot be read, so this method is only ever reached with a known answer. That is
+     * what removed the third branch — and with it the orphan it used to leave behind, since
+     * "destroy nothing" was the only safe move under ambiguity and it left an executing script
+     * that no uninstall could reach.
      *
      * The same "make the row describe reality" principle produces the opposite answer in
      * [finalizeRemoval], which sets `ERROR` after a failed *delete*: there the extension really
@@ -328,29 +345,17 @@ class ExtensionInstaller(
     private suspend fun reconcileFailedInstall(
         extension: Extension,
         backend: JsExtensionBackend,
-        priorRow: Result<Extension?>,
+        priorRow: Extension?,
         error: Throwable,
     ) {
-        val prior = priorRow.getOrNull()
-
-        when {
-            priorRow.isFailure -> {
-                // Could not tell. Leave the artifact alone and carry the reason, so the
-                // ambiguity is visible in the reported error rather than silently absorbed.
-                priorRow.exceptionOrNull()?.let { runCatching { error.addSuppressed(it) } }
-            }
-
-            prior != null && prior.isJavaScript -> {
-                repairStatus(extension.pkgName, InstallStatus.INSTALLED)
-            }
-
-            else -> {
-                // The cleanup's own failure must not replace the error that caused all this —
-                // that would send the user looking in the wrong place. It is attached instead,
-                // so an orphan that could not be cleaned up stays diagnosable.
-                backend.uninstall(extension.pkgName).onFailure { cleanupError ->
-                    runCatching { error.addSuppressed(cleanupError) }
-                }
+        if (priorRow != null && priorRow.isJavaScript) {
+            repairStatus(extension.pkgName, InstallStatus.INSTALLED)
+        } else {
+            // The cleanup's own failure must not replace the error that caused all this —
+            // that would send the user looking in the wrong place. It is attached instead,
+            // so an orphan that could not be cleaned up stays diagnosable.
+            backend.uninstall(extension.pkgName).onFailure { cleanupError ->
+                runCatching { error.addSuppressed(cleanupError) }
             }
         }
 

--- a/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/installer/ExtensionInstaller.kt
@@ -232,6 +232,12 @@ class ExtensionInstaller(
             IllegalStateException("No JavaScript backend is available to install ${extension.pkgName}")
         )
 
+        // Read the prior row BEFORE installing anything, while the database is still known to
+        // be healthy. Asking afterwards means asking a database that has just failed a write,
+        // and the answer decides whether a script gets deleted — so the question has to be put
+        // at the moment it can still be answered reliably.
+        val priorRow = lookupRow(extension.pkgName)
+
         _installationState.value = InstallationState.Downloading(0)
 
         val installed = backend.install(extension)
@@ -249,81 +255,102 @@ class ExtensionInstaller(
         // apkPath is empty rather than a path: there is no APK file to point at.
         return repository.installExtension(extension, apkPath = "")
             .onSuccess { _installationState.value = InstallationState.Success(it) }
-            .onFailure { error -> rollBackOrphanedScript(extension, backend, error) }
+            .onFailure { error -> reconcileFailedInstall(extension, backend, priorRow, error) }
     }
 
     /**
-     * Clean up after a JavaScript install whose database write failed.
+     * Look a row up, distinguishing "absent" from "could not tell".
+     *
+     * `runCatching { ... }.getOrNull()` maps both to null, and destructive decisions hang off
+     * that value. It also swallows cancellation, which would let a cancelled install carry on.
+     */
+    private suspend fun lookupRow(pkgName: String): Result<Extension?> =
+        try {
+            Result.success(repository.getExtension(pkgName))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Result.failure(e)
+        }
+
+    /** Best-effort status write. Cancellation still propagates; ordinary failures do not. */
+    private suspend fun repairStatus(pkgName: String, status: InstallStatus) {
+        try {
+            repository.setExtensionStatus(pkgName, status)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            // Nothing more to do: this is already the failure path.
+        }
+    }
+
+    /**
+     * Put the two stores back into agreement after a JavaScript install whose row write failed.
      *
      * The hazard is an orphan: the script is on disk and registered with the engine, and since
-     * uninstall finds its target *through the database*, a missing row means nothing can ever
-     * reach it again — a source that still executes and cannot be removed.
+     * uninstall finds its target *through the database*, no row means nothing can ever reach it
+     * again — a source that still executes and cannot be removed.
      *
-     * **The rollback is conditional, and that condition is the whole correctness of this.** An
-     * unconditional `backend.uninstall` fixes the fresh-install orphan and breaks something
-     * worse in the update case: `backend.install` has already replaced the script of a source
-     * the user had working, so uninstalling would delete it outright — along with the stored
-     * preferences that routinely hold their login for that site. The cure would be worse than
-     * the failure it followed.
+     * The decision rests on [priorRow], captured **before** the install ran. That ordering is
+     * the correctness of this method, not an implementation detail. Asking afterwards means
+     * asking a database that has just failed a write, and four earlier versions of this logic
+     * were wrong precisely because they tried to infer the answer from a post-failure read:
      *
-     * The rule both branches follow is simply **make the row describe reality**:
+     * - Rolling back unconditionally deleted a working source on a failed *update*, along with
+     *   the stored preferences that hold the user's login for that site.
+     * - Rolling back only when no row existed missed that a failed write leaves the row at
+     *   `ERROR`, which is transient — the next refresh replaces it with an `AVAILABLE` row, and
+     *   the script is orphaned one refresh later.
+     * - Reading the row afterwards conflated "absent" with "the read failed", hanging the
+     *   destructive branch off an ambiguous null on the one path where the database is least
+     *   trustworthy.
      *
-     * - **No row existed.** Nothing installed this before, and the failed write left nothing
-     *   behind (`updateStatus` on an absent row is a no-op). The script is unreachable, so it
-     *   goes.
-     * - **A row existed.** Something *is* installed — the new script is on disk and registered,
-     *   and it is a valid script. So the row is restored to `INSTALLED`, which is the honest
-     *   status, rather than left at the `ERROR` the repository set on its way out.
+     * With the fact captured up front, each case has an unambiguous answer:
      *
-     * Restoring the status is not cosmetic. `ERROR` is deliberately transient: the next
-     * `refreshAvailableExtensions` does not count `ERROR` rows as installed and replaces them
-     * with fresh `AVAILABLE` ones. The script would then be live in Browse and registered with
-     * the engine while the extension screen listed it as not installed — no uninstall button
-     * anywhere, which is the orphan this method exists to prevent, just reached a slower way.
+     * - **A JavaScript row existed.** This was an update, so something is genuinely installed —
+     *   the new script is on disk, registered, and valid. Restore the row to `INSTALLED`, which
+     *   is the honest status, rather than leaving the transient `ERROR`.
+     * - **No row, or a row belonging to the other backend.** Nothing here reaches this script:
+     *   an APK row with the same package name routes uninstall down the APK path, which would
+     *   leave the script and its stored data behind. Remove the script.
+     * - **The prior lookup itself failed.** Nothing is destroyed. Destroying data requires
+     *   positive evidence that it is safe, and absence of evidence is not that.
      *
-     * The same principle produced the opposite answer in [finalizeRemoval], which sets `ERROR`
-     * after a failed *delete*: there the extension really is gone, so letting the row lapse to
-     * available is right. Here it really is present.
+     * The same "make the row describe reality" principle produces the opposite answer in
+     * [finalizeRemoval], which sets `ERROR` after a failed *delete*: there the extension really
+     * is gone, so letting the row lapse to available is right. Here it really is present.
      *
      * Residual, stated rather than papered over: a restored row still names the *previous*
      * version while the new script is on disk. The source works, and the next update check
      * reconciles the version. Snapshotting every script before every update to restore the old
      * one would be a lot of machinery for a stale version number.
      */
-    private suspend fun rollBackOrphanedScript(
+    private suspend fun reconcileFailedInstall(
         extension: Extension,
         backend: JsExtensionBackend,
+        priorRow: Result<Extension?>,
         error: Throwable,
     ) {
-        // Three outcomes, not two. `runCatching { ... }.getOrNull()` collapsed "the row is
-        // absent" and "the lookup itself failed" into the same null — and the destructive branch
-        // hangs off that value. This code runs *because* a database write just failed, so a
-        // follow-up read failing is a likely path rather than a theoretical one, and treating it
-        // as proof of absence would delete a working source and the user's saved login for it.
-        //
-        // Destroying data requires positive evidence that it is safe. Absence of evidence is not
-        // that, so a failed lookup takes the non-destructive branch.
-        val lookup = try {
-            Result.success(repository.getExtension(extension.pkgName))
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            runCatching { error.addSuppressed(e) }
-            Result.failure(e)
-        }
+        val prior = priorRow.getOrNull()
 
-        val existingRow = lookup.getOrNull()
-
-        if (lookup.isSuccess && existingRow == null) {
-            // The cleanup's own failure must not replace the error that caused all this — that
-            // would send the user looking in the wrong place. It is attached instead, so an
-            // orphan that could not be cleaned up is still diagnosable from the reported error.
-            backend.uninstall(extension.pkgName).onFailure { cleanupError ->
-                runCatching { error.addSuppressed(cleanupError) }
+        when {
+            priorRow.isFailure -> {
+                // Could not tell. Leave the artifact alone and carry the reason, so the
+                // ambiguity is visible in the reported error rather than silently absorbed.
+                priorRow.exceptionOrNull()?.let { runCatching { error.addSuppressed(it) } }
             }
-        } else {
-            runCatching {
-                repository.setExtensionStatus(extension.pkgName, InstallStatus.INSTALLED)
+
+            prior != null && prior.isJavaScript -> {
+                repairStatus(extension.pkgName, InstallStatus.INSTALLED)
+            }
+
+            else -> {
+                // The cleanup's own failure must not replace the error that caused all this —
+                // that would send the user looking in the wrong place. It is attached instead,
+                // so an orphan that could not be cleaned up stays diagnosable.
+                backend.uninstall(extension.pkgName).onFailure { cleanupError ->
+                    runCatching { error.addSuppressed(cleanupError) }
+                }
             }
         }
 

--- a/core/extension/src/test/java/app/otakureader/core/extension/data/JsBackendIsolationTest.kt
+++ b/core/extension/src/test/java/app/otakureader/core/extension/data/JsBackendIsolationTest.kt
@@ -2,6 +2,7 @@ package app.otakureader.core.extension.data
 
 import app.otakureader.core.extension.data.remote.ExtensionRemoteDataSourceImpl
 import app.otakureader.core.extension.domain.backend.JsExtensionBackend
+import app.otakureader.core.extension.domain.backend.JsExtensionFetch
 import app.otakureader.core.extension.domain.model.Extension
 import app.otakureader.core.extension.domain.model.InstallStatus
 import app.otakureader.core.extension.domain.repository.ExtensionRepoRepository
@@ -9,9 +10,11 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.IOException
 
 /**
  * Covers failure isolation between the two source backends.
@@ -28,6 +31,18 @@ class JsBackendIsolationTest {
     private fun repoRepository(): ExtensionRepoRepository = mockk(relaxed = true) {
         coEvery { getRepositories() } returns flowOf(listOf(unreachableRepo))
     }
+
+    /**
+     * A client that fails every call without touching the network.
+     *
+     * The APK fetch has to fail for these tests to mean anything, but it must fail *locally*.
+     * Relying on `unreachable.invalid` not resolving would make the result depend on the
+     * sandbox's DNS — a test that passes for a reason unrelated to what it claims to check, and
+     * that turns into a slow or flaky one the moment a resolver answers wildcard queries.
+     */
+    private fun failingClient(): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor { throw IOException("offline in tests") }
+        .build()
 
     private fun jsExtension(pkgName: String) = Extension(
         id = 1L,
@@ -58,11 +73,13 @@ class JsBackendIsolationTest {
     @Test
     fun `a total APK failure still surfaces JavaScript sources`() = runTest {
         val jsBackend = mockk<JsExtensionBackend> {
-            coEvery { fetchAvailable(any()) } returns listOf(jsExtension("js-source"))
+            coEvery { fetchAvailable(any()) } returns
+                JsExtensionFetch(listOf(jsExtension("js-source")), servedAnyIndex = true)
         }
 
         val result = ExtensionRemoteDataSourceImpl(
             repoRepository = repoRepository(),
+            httpClient = failingClient(),
             jsBackend = jsBackend,
         ).fetchAvailableExtensions()
 
@@ -87,6 +104,7 @@ class JsBackendIsolationTest {
 
         val result = ExtensionRemoteDataSourceImpl(
             repoRepository = repoRepository(),
+            httpClient = failingClient(),
             jsBackend = jsBackend,
         ).fetchAvailableExtensions()
 
@@ -99,13 +117,60 @@ class JsBackendIsolationTest {
     }
 
     /**
+     * A JavaScript-only repository whose index is valid but empty is not a failure.
+     *
+     * Its APK endpoints legitimately 404 and its JavaScript list is legitimately empty, so a
+     * check that read emptiness as failure would tell a user whose setup works perfectly that
+     * every repository failed. The condition asks whether an index was *served*, which is a
+     * different fact from whether it produced anything.
+     */
+    @Test
+    fun `an empty but valid JavaScript index is not a total failure`() = runTest {
+        val jsBackend = mockk<JsExtensionBackend> {
+            coEvery { fetchAvailable(any()) } returns
+                JsExtensionFetch(emptyList(), servedAnyIndex = true)
+        }
+
+        val result = ExtensionRemoteDataSourceImpl(
+            repoRepository = repoRepository(),
+            httpClient = failingClient(),
+            jsBackend = jsBackend,
+        ).fetchAvailableExtensions()
+
+        assertTrue("expected success, got ${result.exceptionOrNull()}", result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    /**
+     * The counterpart: nothing served an index at all, so the failure is real and reported.
+     * Without this case the test above would pass just as happily if the check were removed.
+     */
+    @Test
+    fun `no index served anywhere is still a total failure`() = runTest {
+        val jsBackend = mockk<JsExtensionBackend> {
+            coEvery { fetchAvailable(any()) } returns
+                JsExtensionFetch(emptyList(), servedAnyIndex = false)
+        }
+
+        val result = ExtensionRemoteDataSourceImpl(
+            repoRepository = repoRepository(),
+            httpClient = failingClient(),
+            jsBackend = jsBackend,
+        ).fetchAvailableExtensions()
+
+        assertTrue(result.isFailure)
+    }
+
+    /**
      * With no JavaScript backend wired in, behaviour is exactly what it was before this change.
      * That is what lets the existing APK tests keep standing as the regression net for that path.
      */
     @Test
     fun `without a JavaScript backend a total failure is still a failure`() = runTest {
-        val result = ExtensionRemoteDataSourceImpl(repoRepository = repoRepository())
-            .fetchAvailableExtensions()
+        val result = ExtensionRemoteDataSourceImpl(
+            repoRepository = repoRepository(),
+            httpClient = failingClient(),
+        ).fetchAvailableExtensions()
 
         assertTrue(result.isFailure)
     }

--- a/core/extension/src/test/java/app/otakureader/core/extension/data/JsBackendIsolationTest.kt
+++ b/core/extension/src/test/java/app/otakureader/core/extension/data/JsBackendIsolationTest.kt
@@ -1,0 +1,112 @@
+package app.otakureader.core.extension.data
+
+import app.otakureader.core.extension.data.remote.ExtensionRemoteDataSourceImpl
+import app.otakureader.core.extension.domain.backend.JsExtensionBackend
+import app.otakureader.core.extension.domain.model.Extension
+import app.otakureader.core.extension.domain.model.InstallStatus
+import app.otakureader.core.extension.domain.repository.ExtensionRepoRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers failure isolation between the two source backends.
+ *
+ * This exists because the inverse shipped in Stage 4a: the isolation ran one direction only, so a
+ * single thrown exception on the APK path silently dropped every JavaScript source. The comment
+ * at the time said the two backends shared nothing, and it read convincingly enough that nobody
+ * re-derived it. Both directions are asserted here so neither can regress unnoticed.
+ */
+class JsBackendIsolationTest {
+
+    private val unreachableRepo = "https://unreachable.invalid/repo"
+
+    private fun repoRepository(): ExtensionRepoRepository = mockk(relaxed = true) {
+        coEvery { getRepositories() } returns flowOf(listOf(unreachableRepo))
+    }
+
+    private fun jsExtension(pkgName: String) = Extension(
+        id = 1L,
+        pkgName = pkgName,
+        name = pkgName,
+        versionCode = 1,
+        versionName = "1.0.0",
+        sources = emptyList(),
+        status = InstallStatus.AVAILABLE,
+        apkPath = null,
+        apkUrl = "https://example.test/$pkgName.js",
+        iconUrl = null,
+        lang = "en",
+        isNsfw = false,
+        installDate = null,
+        signatureHash = null,
+        isJavaScript = true,
+    )
+
+    /**
+     * The Stage 4a defect, as a test.
+     *
+     * The APK repository here is unreachable, so every APK fetch fails. Before the fix that made
+     * this pass, the early `return Result.failure(...)` ran before the JavaScript backend was
+     * ever consulted — the user saw "all repositories failed" and no sources at all, even though
+     * the JavaScript ones were fetchable the whole time.
+     */
+    @Test
+    fun `a total APK failure still surfaces JavaScript sources`() = runTest {
+        val jsBackend = mockk<JsExtensionBackend> {
+            coEvery { fetchAvailable(any()) } returns listOf(jsExtension("js-source"))
+        }
+
+        val result = ExtensionRemoteDataSourceImpl(
+            repoRepository = repoRepository(),
+            jsBackend = jsBackend,
+        ).fetchAvailableExtensions()
+
+        assertTrue("expected success, got ${result.exceptionOrNull()}", result.isSuccess)
+        assertEquals(listOf("js-source"), result.getOrThrow().map { it.pkgName })
+    }
+
+    /**
+     * The same isolation in the other direction.
+     *
+     * A JavaScript backend that throws must not take the APK path down with it. It cannot be
+     * asserted by checking the returned APK list here — the repository is unreachable in this
+     * fixture — so the observable claim is the narrower one that actually distinguishes the two
+     * behaviours: the call completes and reports the ordinary all-repositories-failed error,
+     * rather than propagating the JavaScript backend's exception.
+     */
+    @Test
+    fun `a throwing JavaScript backend does not propagate its exception`() = runTest {
+        val jsBackend = mockk<JsExtensionBackend> {
+            coEvery { fetchAvailable(any()) } throws IllegalStateException("js index exploded")
+        }
+
+        val result = ExtensionRemoteDataSourceImpl(
+            repoRepository = repoRepository(),
+            jsBackend = jsBackend,
+        ).fetchAvailableExtensions()
+
+        assertTrue(result.isFailure)
+        val message = result.exceptionOrNull()?.message.orEmpty()
+        assertTrue(
+            "expected the repository failure, not the JS one: $message",
+            message.contains("extension repositories failed"),
+        )
+    }
+
+    /**
+     * With no JavaScript backend wired in, behaviour is exactly what it was before this change.
+     * That is what lets the existing APK tests keep standing as the regression net for that path.
+     */
+    @Test
+    fun `without a JavaScript backend a total failure is still a failure`() = runTest {
+        val result = ExtensionRemoteDataSourceImpl(repoRepository = repoRepository())
+            .fetchAvailableExtensions()
+
+        assertTrue(result.isFailure)
+    }
+}

--- a/core/extension/src/test/java/app/otakureader/core/extension/installer/JsInstallRoutingTest.kt
+++ b/core/extension/src/test/java/app/otakureader/core/extension/installer/JsInstallRoutingTest.kt
@@ -189,31 +189,30 @@ class JsInstallRoutingTest {
     }
 
     /**
-     * A lookup that *fails* is not evidence that the row is absent.
+     * If ownership cannot be established, nothing is installed at all.
      *
-     * The lookup runs before the install, while the database is still healthy, so this is the
-     * rarer case — but the rule stands either way. Collapsing "absent" and "could not tell"
-     * into one null would hang a destructive branch off the ambiguous value and delete a working
-     * source along with the user's saved login for it. Destroying data needs positive evidence
-     * that it is safe; absence of evidence is not that.
+     * The alternative is to write a live script whose ownership can never be determined. Under
+     * that ambiguity the only safe move afterwards is to destroy nothing — which leaves an
+     * executing source that no uninstall can reach. Failing closed turns an unrecoverable state
+     * into an install the user can simply retry.
      */
     @Test
-    fun `a failed lookup does not trigger the rollback`() = runTest {
+    fun `an unreadable prior row prevents the install entirely`() = runTest {
         val subject = extension("cannot-tell", isJavaScript = true)
-        val jsBackend = mockk<JsExtensionBackend>(relaxed = true) {
-            coEvery { install(subject) } returns Result.success(Unit)
-        }
+        val jsBackend = mockk<JsExtensionBackend>(relaxed = true)
         val repository = mockk<ExtensionRepository>(relaxed = true) {
-            coEvery { installExtension(any<Extension>(), any()) } returns
-                Result.failure(java.io.IOException("database is locked"))
-            coEvery { getExtension("cannot-tell") } throws java.io.IOException("still locked")
+            coEvery { getExtension("cannot-tell") } throws java.io.IOException("database is locked")
         }
 
         val result = ExtensionInstaller(context, repository, loader, remoteDataSource, jsBackend)
             .downloadAndInstall(subject)
 
         assertTrue(result.isFailure)
+        // Nothing was created, so there is nothing to clean up and nothing to orphan. Asserting
+        // only the failure would pass just as happily with a script written to disk.
+        coVerify(exactly = 0) { jsBackend.install(any()) }
         coVerify(exactly = 0) { jsBackend.uninstall(any()) }
+        coVerify(exactly = 0) { repository.installExtension(any<Extension>(), any()) }
     }
 
     /**

--- a/core/extension/src/test/java/app/otakureader/core/extension/installer/JsInstallRoutingTest.kt
+++ b/core/extension/src/test/java/app/otakureader/core/extension/installer/JsInstallRoutingTest.kt
@@ -106,6 +106,8 @@ class JsInstallRoutingTest {
         val repository = mockk<ExtensionRepository>(relaxed = true) {
             coEvery { installExtension(any<Extension>(), any()) } returns
                 Result.failure(java.io.IOException("database is locked"))
+            // No row survives the failure, so nothing can reach the script.
+            coEvery { getExtension("orphan-risk") } returns null
         }
 
         val result = ExtensionInstaller(context, repository, loader, remoteDataSource, jsBackend)
@@ -117,6 +119,38 @@ class JsInstallRoutingTest {
         coVerify(exactly = 1) { jsBackend.uninstall("orphan-risk") }
         // The caller is owed the error that actually caused the failure, not one from cleanup.
         assertTrue(result.exceptionOrNull() is java.io.IOException)
+    }
+
+    /**
+     * A failed *update* must not destroy the source it was updating.
+     *
+     * `backend.install` has already replaced the script of something the user had working. An
+     * unconditional rollback would uninstall it outright — deleting the source and the stored
+     * preferences that routinely hold their login for that site. The row survives the failure
+     * here, so the script is still reachable by uninstall and must be left alone.
+     *
+     * This is the case the first version of the rollback got wrong: it fixed the orphan and
+     * introduced a worse failure one branch over.
+     */
+    @Test
+    fun `a failed update does not uninstall the source it was updating`() = runTest {
+        val subject = extension("already-installed", isJavaScript = true)
+        val jsBackend = mockk<JsExtensionBackend>(relaxed = true) {
+            coEvery { install(subject) } returns Result.success(Unit)
+        }
+        val repository = mockk<ExtensionRepository>(relaxed = true) {
+            coEvery { installExtension(any<Extension>(), any()) } returns
+                Result.failure(java.io.IOException("database is locked"))
+            // The pre-existing row survives, so uninstall can still find the script.
+            coEvery { getExtension("already-installed") } returns
+                subject.copy(status = InstallStatus.INSTALLED)
+        }
+
+        val result = ExtensionInstaller(context, repository, loader, remoteDataSource, jsBackend)
+            .downloadAndInstall(subject)
+
+        assertTrue(result.isFailure)
+        coVerify(exactly = 0) { jsBackend.uninstall(any()) }
     }
 
     /**

--- a/core/extension/src/test/java/app/otakureader/core/extension/installer/JsInstallRoutingTest.kt
+++ b/core/extension/src/test/java/app/otakureader/core/extension/installer/JsInstallRoutingTest.kt
@@ -90,6 +90,36 @@ class JsInstallRoutingTest {
     }
 
     /**
+     * A row that could not be written must not leave the script behind.
+     *
+     * Uninstall finds its target through the database, so a script that is on disk and
+     * registered with the engine while no row describes it can never be reached again — an
+     * orphan that still executes. The backend install is rolled back to prevent that.
+     */
+    @Test
+    fun `a failed row write rolls the script back out`() = runTest {
+        val subject = extension("orphan-risk", isJavaScript = true)
+        val jsBackend = mockk<JsExtensionBackend> {
+            coEvery { install(subject) } returns Result.success(Unit)
+            coEvery { uninstall("orphan-risk") } returns Result.success(Unit)
+        }
+        val repository = mockk<ExtensionRepository>(relaxed = true) {
+            coEvery { installExtension(any<Extension>(), any()) } returns
+                Result.failure(java.io.IOException("database is locked"))
+        }
+
+        val result = ExtensionInstaller(context, repository, loader, remoteDataSource, jsBackend)
+            .downloadAndInstall(subject)
+
+        assertTrue(result.isFailure)
+        // The state left behind is the whole point — asserting only the return value would pass
+        // just as happily with the script still installed.
+        coVerify(exactly = 1) { jsBackend.uninstall("orphan-risk") }
+        // The caller is owed the error that actually caused the failure, not one from cleanup.
+        assertTrue(result.exceptionOrNull() is java.io.IOException)
+    }
+
+    /**
      * The bug this guard exists for.
      *
      * Without the routing branch a JavaScript source falls through to the private-APK uninstall
@@ -139,6 +169,37 @@ class JsInstallRoutingTest {
         coVerify(exactly = 0) { repository.uninstallExtension(any()) }
         // Left as UNINSTALLING the source would look stuck mid-removal while still working fine.
         coVerify { repository.setExtensionStatus("stubborn", InstallStatus.INSTALLED) }
+    }
+
+    /**
+     * A failed row delete must not be announced as a removal, and must not strand the row.
+     *
+     * By this point the script and its stored preferences are already gone, so the row is the
+     * last thing describing something that no longer exists. Leaving it at UNINSTALLING freezes
+     * a dead source the user cannot act on; broadcasting a removal that did not happen makes
+     * listeners drop state for an extension the database still lists.
+     */
+    @Test
+    fun `a failed row delete is not announced and lands in ERROR`() = runTest {
+        val subject = extension("half-removed", isJavaScript = true)
+        val jsBackend = mockk<JsExtensionBackend> {
+            coEvery { uninstall("half-removed") } returns Result.success(Unit)
+        }
+        val repository = mockk<ExtensionRepository>(relaxed = true) {
+            coEvery { getExtension("half-removed") } returns subject
+            coEvery { uninstallExtension("half-removed") } returns
+                Result.failure(java.io.IOException("database is locked"))
+        }
+
+        val result = ExtensionInstaller(context, repository, loader, remoteDataSource, jsBackend)
+            .uninstall("half-removed")
+
+        assertTrue(result.isFailure)
+        // ERROR rather than INSTALLED: the extension really is gone, so a row claiming it is
+        // installed would show a source that cannot function. ERROR also lets the next refresh
+        // re-offer it as available.
+        coVerify { repository.setExtensionStatus("half-removed", InstallStatus.ERROR) }
+        coVerify(exactly = 0) { repository.setExtensionStatus("half-removed", InstallStatus.INSTALLED) }
     }
 
     /**

--- a/core/extension/src/test/java/app/otakureader/core/extension/installer/JsInstallRoutingTest.kt
+++ b/core/extension/src/test/java/app/otakureader/core/extension/installer/JsInstallRoutingTest.kt
@@ -162,10 +162,37 @@ class JsInstallRoutingTest {
     }
 
     /**
+     * A row belonging to the *other* backend does not protect the script.
+     *
+     * An APK row with the same package name routes uninstall down the APK path, which deletes
+     * an APK copy and the row — never the script or its stored data. So the script is just as
+     * unreachable as it would be with no row at all, and restoring that row to INSTALLED would
+     * assert something false about an extension of a different kind.
+     */
+    @Test
+    fun `an APK row with the same name does not protect the script`() = runTest {
+        val subject = extension("collides", isJavaScript = true)
+        val jsBackend = mockk<JsExtensionBackend>(relaxed = true) {
+            coEvery { install(subject) } returns Result.success(Unit)
+        }
+        val repository = mockk<ExtensionRepository>(relaxed = true) {
+            coEvery { installExtension(any<Extension>(), any()) } returns
+                Result.failure(java.io.IOException("database is locked"))
+            coEvery { getExtension("collides") } returns extension("collides", isJavaScript = false)
+        }
+
+        ExtensionInstaller(context, repository, loader, remoteDataSource, jsBackend)
+            .downloadAndInstall(subject)
+
+        coVerify(exactly = 1) { jsBackend.uninstall("collides") }
+        coVerify(exactly = 0) { repository.setExtensionStatus(any(), InstallStatus.INSTALLED) }
+    }
+
+    /**
      * A lookup that *fails* is not evidence that the row is absent.
      *
-     * This path runs because a database write just failed, so a follow-up read failing is a
-     * likely outcome rather than a theoretical one. Collapsing "absent" and "could not tell"
+     * The lookup runs before the install, while the database is still healthy, so this is the
+     * rarer case — but the rule stands either way. Collapsing "absent" and "could not tell"
      * into one null would hang a destructive branch off the ambiguous value and delete a working
      * source along with the user's saved login for it. Destroying data needs positive evidence
      * that it is safe; absence of evidence is not that.

--- a/core/extension/src/test/java/app/otakureader/core/extension/installer/JsInstallRoutingTest.kt
+++ b/core/extension/src/test/java/app/otakureader/core/extension/installer/JsInstallRoutingTest.kt
@@ -162,6 +162,34 @@ class JsInstallRoutingTest {
     }
 
     /**
+     * A lookup that *fails* is not evidence that the row is absent.
+     *
+     * This path runs because a database write just failed, so a follow-up read failing is a
+     * likely outcome rather than a theoretical one. Collapsing "absent" and "could not tell"
+     * into one null would hang a destructive branch off the ambiguous value and delete a working
+     * source along with the user's saved login for it. Destroying data needs positive evidence
+     * that it is safe; absence of evidence is not that.
+     */
+    @Test
+    fun `a failed lookup does not trigger the rollback`() = runTest {
+        val subject = extension("cannot-tell", isJavaScript = true)
+        val jsBackend = mockk<JsExtensionBackend>(relaxed = true) {
+            coEvery { install(subject) } returns Result.success(Unit)
+        }
+        val repository = mockk<ExtensionRepository>(relaxed = true) {
+            coEvery { installExtension(any<Extension>(), any()) } returns
+                Result.failure(java.io.IOException("database is locked"))
+            coEvery { getExtension("cannot-tell") } throws java.io.IOException("still locked")
+        }
+
+        val result = ExtensionInstaller(context, repository, loader, remoteDataSource, jsBackend)
+            .downloadAndInstall(subject)
+
+        assertTrue(result.isFailure)
+        coVerify(exactly = 0) { jsBackend.uninstall(any()) }
+    }
+
+    /**
      * The bug this guard exists for.
      *
      * Without the routing branch a JavaScript source falls through to the private-APK uninstall

--- a/core/extension/src/test/java/app/otakureader/core/extension/installer/JsInstallRoutingTest.kt
+++ b/core/extension/src/test/java/app/otakureader/core/extension/installer/JsInstallRoutingTest.kt
@@ -1,0 +1,160 @@
+package app.otakureader.core.extension.installer
+
+import android.content.Context
+import app.otakureader.core.extension.data.remote.ExtensionRemoteDataSource
+import app.otakureader.core.extension.domain.backend.JsExtensionBackend
+import app.otakureader.core.extension.domain.model.Extension
+import app.otakureader.core.extension.domain.model.InstallStatus
+import app.otakureader.core.extension.domain.repository.ExtensionRepository
+import app.otakureader.core.extension.loader.ExtensionLoader
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Covers which backend an install or uninstall is routed to.
+ *
+ * Routing is decided by the stored [Extension.isJavaScript] flag, never inferred from a name or a
+ * URL suffix. The tests below construct the cases where a guess would go wrong, because a
+ * routing test whose two extensions are obviously different proves nothing about the rule.
+ */
+class JsInstallRoutingTest {
+
+    private val context = mockk<Context>(relaxed = true) {
+        coEvery { filesDir } returns File(System.getProperty("java.io.tmpdir"), "js-routing-test")
+    }
+    private val loader = mockk<ExtensionLoader>(relaxed = true)
+    private val remoteDataSource = mockk<ExtensionRemoteDataSource>(relaxed = true)
+
+    private fun extension(pkgName: String, isJavaScript: Boolean) = Extension(
+        id = 1L,
+        pkgName = pkgName,
+        name = pkgName,
+        versionCode = 1,
+        versionName = "1.0.0",
+        sources = emptyList(),
+        status = InstallStatus.AVAILABLE,
+        apkPath = null,
+        apkUrl = "https://example.test/$pkgName",
+        iconUrl = null,
+        lang = "en",
+        isNsfw = false,
+        installDate = null,
+        signatureHash = null,
+        isJavaScript = isJavaScript,
+    )
+
+    @Test
+    fun `installing a JavaScript extension goes to the JavaScript backend`() = runTest {
+        val subject = extension("mangadex-en", isJavaScript = true)
+        val jsBackend = mockk<JsExtensionBackend> {
+            coEvery { install(subject) } returns Result.success(Unit)
+        }
+        val repository = mockk<ExtensionRepository>(relaxed = true) {
+            coEvery { installExtension(any<Extension>(), any()) } returns Result.success(subject)
+        }
+
+        val result = ExtensionInstaller(context, repository, loader, remoteDataSource, jsBackend)
+            .downloadAndInstall(subject)
+
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 1) { jsBackend.install(subject) }
+        // The row is written only after the script is on disk. A row written first would show a
+        // source in the library that fails on every call.
+        coVerify(exactly = 1) { repository.installExtension(subject, "") }
+    }
+
+    /**
+     * A failed script download must leave nothing claiming to be installed.
+     *
+     * This is the ordering the comment on `installJavaScript` asserts, checked as behaviour: the
+     * database write is downstream of the backend call, so a backend failure means no row.
+     */
+    @Test
+    fun `a failed JavaScript install writes no row`() = runTest {
+        val subject = extension("broken", isJavaScript = true)
+        val jsBackend = mockk<JsExtensionBackend> {
+            coEvery { install(subject) } returns Result.failure(SecurityException("not https"))
+        }
+        val repository = mockk<ExtensionRepository>(relaxed = true)
+
+        val result = ExtensionInstaller(context, repository, loader, remoteDataSource, jsBackend)
+            .downloadAndInstall(subject)
+
+        assertTrue(result.isFailure)
+        coVerify(exactly = 0) { repository.installExtension(any<Extension>(), any()) }
+    }
+
+    /**
+     * The bug this guard exists for.
+     *
+     * Without the routing branch a JavaScript source falls through to the private-APK uninstall
+     * path, which deletes the database row and nothing else — leaving the script on disk, still
+     * registered with the engine, and its stored preferences intact. Those preferences routinely
+     * hold the user's login for the site, so "uninstalled" would silently keep the credentials.
+     */
+    @Test
+    fun `uninstalling a JavaScript extension erases it through the JavaScript backend`() = runTest {
+        val subject = extension("mangadex-en", isJavaScript = true)
+        val jsBackend = mockk<JsExtensionBackend> {
+            coEvery { uninstall("mangadex-en") } returns Result.success(Unit)
+        }
+        val repository = mockk<ExtensionRepository>(relaxed = true) {
+            coEvery { getExtension("mangadex-en") } returns subject
+            coEvery { uninstallExtension("mangadex-en") } returns Result.success(Unit)
+        }
+
+        val result = ExtensionInstaller(context, repository, loader, remoteDataSource, jsBackend)
+            .uninstall("mangadex-en")
+
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 1) { jsBackend.uninstall("mangadex-en") }
+        coVerify(exactly = 1) { repository.uninstallExtension("mangadex-en") }
+    }
+
+    /**
+     * A failed erase must not drop the row.
+     *
+     * Dropping it would remove the source from the list the user would retry from while its
+     * script and stored login were still on disk — a state no retry can reach.
+     */
+    @Test
+    fun `a failed JavaScript uninstall keeps the row and restores its status`() = runTest {
+        val subject = extension("stubborn", isJavaScript = true)
+        val jsBackend = mockk<JsExtensionBackend> {
+            coEvery { uninstall("stubborn") } returns Result.failure(java.io.IOException("disk full"))
+        }
+        val repository = mockk<ExtensionRepository>(relaxed = true) {
+            coEvery { getExtension("stubborn") } returns subject
+        }
+
+        val result = ExtensionInstaller(context, repository, loader, remoteDataSource, jsBackend)
+            .uninstall("stubborn")
+
+        assertTrue(result.isFailure)
+        coVerify(exactly = 0) { repository.uninstallExtension(any()) }
+        // Left as UNINSTALLING the source would look stuck mid-removal while still working fine.
+        coVerify { repository.setExtensionStatus("stubborn", InstallStatus.INSTALLED) }
+    }
+
+    /**
+     * An APK extension must never reach the JavaScript backend, even with one wired in.
+     */
+    @Test
+    fun `an APK extension is not routed to the JavaScript backend`() = runTest {
+        val subject = extension("eu.kanade.tachiyomi.extension.en.mangadex", isJavaScript = false)
+        val jsBackend = mockk<JsExtensionBackend>(relaxed = true)
+        val repository = mockk<ExtensionRepository>(relaxed = true) {
+            coEvery { getExtension(any()) } returns subject
+        }
+
+        ExtensionInstaller(context, repository, loader, remoteDataSource, jsBackend)
+            .downloadAndInstall(subject)
+
+        coVerify(exactly = 0) { jsBackend.install(any()) }
+    }
+}

--- a/core/extension/src/test/java/app/otakureader/core/extension/installer/JsInstallRoutingTest.kt
+++ b/core/extension/src/test/java/app/otakureader/core/extension/installer/JsInstallRoutingTest.kt
@@ -151,6 +151,14 @@ class JsInstallRoutingTest {
 
         assertTrue(result.isFailure)
         coVerify(exactly = 0) { jsBackend.uninstall(any()) }
+        // The row must not be left at ERROR. ERROR is transient — the next refresh does not
+        // count those rows as installed and replaces them with AVAILABLE ones, which would put
+        // the script live in Browse while the extension screen said it was not installed, with
+        // no uninstall button anywhere. Restoring INSTALLED makes the row describe reality:
+        // something really is installed, because the new script is on disk and registered.
+        coVerify(exactly = 1) {
+            repository.setExtensionStatus("already-installed", InstallStatus.INSTALLED)
+        }
     }
 
     /**

--- a/core/js-runtime/build.gradle.kts
+++ b/core/js-runtime/build.gradle.kts
@@ -27,6 +27,12 @@ dependencies {
     implementation(projects.core.common)
     implementation(projects.core.preferences)
 
+    // JavaScript sources are surfaced through the same Extension model the APK backend uses, so
+    // all of feature/browse's extension-management UI works for them with no edits. The
+    // dependency runs one way only: this module knows about Extension, and :core:extension knows
+    // only the JsExtensionBackend interface it declares.
+    implementation(projects.core.extension)
+
     // The QuickJS engine. Confined to this module, and within it to the sidecar process.
     implementation(libs.quickjs)
 
@@ -45,4 +51,6 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.okhttp.mockwebserver)
+    // The JS index and script fetches refuse plain HTTP, so their tests need a TLS MockWebServer.
+    testImplementation(libs.okhttp.tls)
 }

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/di/JsExtensionModule.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/di/JsExtensionModule.kt
@@ -1,0 +1,26 @@
+package app.otakureader.core.js.di
+
+import app.otakureader.core.extension.domain.backend.JsExtensionBackend
+import app.otakureader.core.js.remote.JsExtensionBackendImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Binds the JavaScript extension backend to its implementation.
+ *
+ * Unlike `CloudflareModule` — which lives in `:app` because neither `:core:network` nor
+ * `:core:webview` can see the other — this binding lives with the implementation. The dependency
+ * here only runs one way: `:core:js-runtime` depends on `:core:extension`, so it can see both the
+ * interface and the class that satisfies it, and `:app` does not need to know either exists.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class JsExtensionModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindJsExtensionBackend(impl: JsExtensionBackendImpl): JsExtensionBackend
+}

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionBackendImpl.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionBackendImpl.kt
@@ -1,0 +1,69 @@
+package app.otakureader.core.js.remote
+
+import app.otakureader.core.extension.domain.backend.JsExtensionBackend
+import app.otakureader.core.extension.domain.model.Extension
+import app.otakureader.core.js.client.JsSourceProvider
+import app.otakureader.core.js.protocol.JsSourceConfig
+import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The JavaScript half of extension management.
+ *
+ * Install is two steps that must not be reordered: download the script, *then* register it.
+ * Registering first would need a placeholder script, and a failed download would leave a source
+ * that appears installed and fails on every call — the exact silent-failure shape this rebuild
+ * exists to remove. Downloading first means a failure leaves nothing installed at all.
+ */
+@Singleton
+class JsExtensionBackendImpl @Inject constructor(
+    private val remoteDataSource: JsExtensionRemoteDataSource,
+    private val provider: JsSourceProvider,
+) : JsExtensionBackend {
+
+    override suspend fun fetchAvailable(repoUrls: List<String>): List<Extension> =
+        remoteDataSource.fetchAvailable(repoUrls)
+
+    override suspend fun install(extension: Extension): Result<Unit> = runCatchingCancellable {
+        val scriptUrl = requireNotNull(extension.apkUrl) {
+            "JavaScript extension ${extension.pkgName} has no script URL"
+        }
+
+        val script = remoteDataSource.downloadScript(scriptUrl)
+
+        // The config is built from the index entry rather than from anything inside the script.
+        // A source that could declare its own id could claim another source's id — and with it
+        // that source's stored preferences, which routinely hold the user's login for the site.
+        provider.install(
+            config = JsSourceConfig(
+                id = extension.pkgName,
+                name = extension.name,
+                baseUrl = extension.sources.firstOrNull()?.baseUrl ?: extension.repoUrl.orEmpty(),
+                lang = extension.lang,
+                isNsfw = extension.isNsfw,
+            ),
+            script = script,
+        )
+    }
+
+    override suspend fun uninstall(sourceId: String): Result<Unit> = runCatchingCancellable {
+        provider.uninstall(sourceId)
+    }
+}
+
+/**
+ * `runCatching` that lets cancellation through.
+ *
+ * Plain `runCatching` catches [CancellationException] along with everything else, which turns a
+ * cancelled install into a reported failure and — worse — breaks structured concurrency, because
+ * the coroutine carries on after its scope has been cancelled.
+ */
+private inline fun runCatchingCancellable(block: () -> Unit): Result<Unit> =
+    try {
+        Result.success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Result.failure(e)
+    }

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionBackendImpl.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionBackendImpl.kt
@@ -1,6 +1,7 @@
 package app.otakureader.core.js.remote
 
 import app.otakureader.core.extension.domain.backend.JsExtensionBackend
+import app.otakureader.core.extension.domain.backend.JsExtensionFetch
 import app.otakureader.core.extension.domain.model.Extension
 import app.otakureader.core.js.client.JsSourceProvider
 import app.otakureader.core.js.protocol.JsSourceConfig
@@ -22,7 +23,7 @@ class JsExtensionBackendImpl @Inject constructor(
     private val provider: JsSourceProvider,
 ) : JsExtensionBackend {
 
-    override suspend fun fetchAvailable(repoUrls: List<String>): List<Extension> =
+    override suspend fun fetchAvailable(repoUrls: List<String>): JsExtensionFetch =
         remoteDataSource.fetchAvailable(repoUrls)
 
     override suspend fun install(extension: Extension): Result<Unit> = runCatchingCancellable {

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
@@ -37,7 +37,12 @@ internal data class JsExtensionDto(
     val iconUrl: String? = null,
     val isNsfw: Boolean = false,
     val hasCloudflare: Boolean = false,
-    /** `manga` or `novel`. Novels become readable in Stage 7; they list correctly from now. */
+    /**
+     * `manga`, `novel`, or `anime` in the wild.
+     *
+     * Only `manga` entries are surfaced today — see the filter in `fetchIndex`. Absent means
+     * manga, which is what the overwhelming majority of index entries omit it for.
+     */
     val itemType: String = ITEM_TYPE_MANGA,
 ) {
     internal companion object {
@@ -132,6 +137,7 @@ class JsExtensionRemoteDataSource @Inject constructor(
      */
     suspend fun fetchAvailable(repoUrls: List<String>): JsExtensionFetch = withContext(Dispatchers.IO) {
         var servedAnyIndex = false
+        var firstFailure: Throwable? = null
 
         val extensions = repoUrls.flatMap { rawUrl ->
             val baseUrl = rawUrl.trimEnd('/')
@@ -140,6 +146,10 @@ class JsExtensionRemoteDataSource @Inject constructor(
                 .onFailure { error ->
                     if (error is CancellationException) throw error
                     android.util.Log.w("JsExtensionRemoteDS", "No JS index at $baseUrl: ${error.message}")
+                    // Kept, not just logged. A malformed index on a JavaScript-only repository
+                    // would otherwise surface as its APK endpoint's 404 — an error about a
+                    // backend the user is not using and cannot act on.
+                    if (firstFailure == null) firstFailure = error
                 }
                 .getOrDefault(emptyList())
         }
@@ -152,6 +162,7 @@ class JsExtensionRemoteDataSource @Inject constructor(
                 .values
                 .map { candidates -> candidates.maxByOrNull { it.versionCode } ?: candidates.first() },
             servedAnyIndex = servedAnyIndex,
+            firstFailure = firstFailure,
         )
     }
 
@@ -171,7 +182,18 @@ class JsExtensionRemoteDataSource @Inject constructor(
             responseBody.readBounded(MAX_INDEX_BYTES, "Index at $indexUrl")
         }
 
-        return json.decodeFromString<List<JsExtensionDto>>(body).map { it.toDomain(baseUrl) }
+        return json.decodeFromString<List<JsExtensionDto>>(body)
+            // Only manga sources are surfaced. `JsSource` implements the manga contract, so a
+            // novel or anime entry would install cleanly and then fail on every read — an entry
+            // the user can add but cannot use, which is worse than one that never appeared.
+            //
+            // Filtering here rather than carrying the type through and blocking installation
+            // later is the smaller, more honest change: there is no half-working state to
+            // explain, and nothing is lost, because these sources could not work anyway. Stage 7
+            // adds the novel runtime and relaxes this filter in the same change that makes the
+            // entries usable.
+            .filter { it.itemType.equals(JsExtensionDto.ITEM_TYPE_MANGA, ignoreCase = true) }
+            .map { it.toDomain(baseUrl) }
     }
 
     /**

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
@@ -1,5 +1,6 @@
 package app.otakureader.core.js.remote
 
+import app.otakureader.core.extension.domain.backend.JsExtensionFetch
 import app.otakureader.core.extension.domain.model.Extension
 import app.otakureader.core.extension.domain.model.ExtensionSource
 import app.otakureader.core.extension.domain.model.InstallStatus
@@ -10,6 +11,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.ResponseBody
 import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -61,8 +63,34 @@ internal data class JsExtensionDto(
  */
 @Singleton
 class JsExtensionRemoteDataSource @Inject constructor(
-    private val httpClient: OkHttpClient,
+    httpClient: OkHttpClient,
 ) {
+
+    /**
+     * The shared client, with cross-scheme redirects switched off.
+     *
+     * Checking the scheme of the URL we *ask* for is not enough on its own. OkHttp follows
+     * redirects by default, and `followSslRedirects` defaults to true — so an `https://` script
+     * URL that 302s to `http://` would be fetched in plaintext, and anyone on the network path
+     * could replace the JavaScript that is about to be executed. The scheme check would have
+     * passed while the guarantee it stands for was gone.
+     *
+     * `followSslRedirects(false)` makes OkHttp refuse to follow a redirect that changes scheme in
+     * either direction; the 3xx comes back as-is and the `isSuccessful` check below rejects it.
+     * Same-scheme redirects still work, which matters because repositories routinely serve
+     * artifacts from a CDN on another host.
+     *
+     * Doing it this way rather than disabling redirects and walking them by hand is deliberate.
+     * `JsHttpBridge` took the manual route and silently lost the rules OkHttp applies for free —
+     * stripping `Authorization` across an origin change, turning 301/302/303 POSTs into bodyless
+     * GETs. One builder flag keeps `RetryAndFollowUpInterceptor`'s semantics intact.
+     *
+     * Derived from the injected client rather than built fresh, so certificate pinning, the
+     * cookie jar, rate limiting and the connection pool all still apply.
+     */
+    private val httpClient: OkHttpClient = httpClient.newBuilder()
+        .followSslRedirects(false)
+        .build()
 
     private val json = Json {
         ignoreUnknownKeys = true
@@ -81,6 +109,15 @@ class JsExtensionRemoteDataSource @Inject constructor(
          */
         const val MAX_SCRIPT_BYTES = 2L * 1024 * 1024
 
+        /**
+         * Ceiling on a repository index.
+         *
+         * Larger than the script cap because one index describes every source a repository
+         * offers — Keiyoushi's APK equivalent is around a megabyte. Still bounded, for the same
+         * reason: the host is arbitrary and `string()` would buffer whatever it returned.
+         */
+        const val MAX_INDEX_BYTES = 8L * 1024 * 1024
+
         /** Only https:// is accepted, matching the guard `ExtensionInstaller` applies to APKs. */
         const val HTTPS_PREFIX = "https://"
     }
@@ -93,21 +130,29 @@ class JsExtensionRemoteDataSource @Inject constructor(
      * JavaScript index is the common case, not a failure, so it contributes nothing and is not
      * reported.
      */
-    suspend fun fetchAvailable(repoUrls: List<String>): List<Extension> = withContext(Dispatchers.IO) {
-        repoUrls.flatMap { rawUrl ->
+    suspend fun fetchAvailable(repoUrls: List<String>): JsExtensionFetch = withContext(Dispatchers.IO) {
+        var servedAnyIndex = false
+
+        val extensions = repoUrls.flatMap { rawUrl ->
             val baseUrl = rawUrl.trimEnd('/')
             runCatching { fetchIndex(baseUrl) }
+                .onSuccess { servedAnyIndex = true }
                 .onFailure { error ->
                     if (error is CancellationException) throw error
                     android.util.Log.w("JsExtensionRemoteDS", "No JS index at $baseUrl: ${error.message}")
                 }
                 .getOrDefault(emptyList())
         }
-            // Two repositories can offer the same source; keep the newer build rather than
-            // whichever happened to be fetched last.
-            .groupBy { it.pkgName }
-            .values
-            .map { candidates -> candidates.maxByOrNull { it.versionCode } ?: candidates.first() }
+
+        JsExtensionFetch(
+            extensions = extensions
+                // Two repositories can offer the same source; keep the newer build rather than
+                // whichever happened to be fetched last.
+                .groupBy { it.pkgName }
+                .values
+                .map { candidates -> candidates.maxByOrNull { it.versionCode } ?: candidates.first() },
+            servedAnyIndex = servedAnyIndex,
+        )
     }
 
     private fun fetchIndex(baseUrl: String): List<Extension> {
@@ -118,7 +163,12 @@ class JsExtensionRemoteDataSource @Inject constructor(
             if (!response.isSuccessful) {
                 throw JsExtensionFetchException("HTTP ${response.code} fetching $indexUrl")
             }
-            response.body?.string() ?: throw JsExtensionFetchException("Empty index body from $indexUrl")
+            val responseBody = response.body
+                ?: throw JsExtensionFetchException("Empty index body from $indexUrl")
+            // Bounded like the script read. A repository is an arbitrary remote host, and
+            // `string()` buffers whatever it sends — so an index alone could exhaust memory
+            // during source discovery, before a single script had been downloaded.
+            responseBody.readBounded(MAX_INDEX_BYTES, "Index at $indexUrl")
         }
 
         return json.decodeFromString<List<JsExtensionDto>>(body).map { it.toDomain(baseUrl) }
@@ -140,13 +190,7 @@ class JsExtensionRemoteDataSource @Inject constructor(
                 throw JsExtensionFetchException("HTTP ${response.code} downloading $scriptUrl")
             }
             val body = response.body ?: throw JsExtensionFetchException("Empty script body from $scriptUrl")
-            val bytes = body.source().apply { request(MAX_SCRIPT_BYTES + 1) }.buffer.snapshot()
-            if (bytes.size > MAX_SCRIPT_BYTES) {
-                throw JsExtensionFetchException(
-                    "Script at $scriptUrl exceeds ${MAX_SCRIPT_BYTES / 1024} KiB"
-                )
-            }
-            bytes.utf8()
+            body.readBounded(MAX_SCRIPT_BYTES, "Script at $scriptUrl")
         }
     }
 
@@ -167,6 +211,22 @@ class JsExtensionRemoteDataSource @Inject constructor(
 
 /** Thrown when a repository index or script cannot be fetched or parsed. */
 class JsExtensionFetchException(message: String) : RuntimeException(message)
+
+/**
+ * Read a body, refusing it if it exceeds [limit].
+ *
+ * Reads one byte past the cap so an oversized body is *detected* rather than silently truncated.
+ * Truncation is the failure worth preventing in both places this is used: a half-downloaded
+ * script installs as if whole and fails somewhere inside the engine, and a half-read index
+ * either fails to parse or — worse — parses as a shorter list, quietly hiding sources.
+ */
+private fun ResponseBody.readBounded(limit: Long, what: String): String {
+    val bytes = source().apply { request(limit + 1) }.buffer.snapshot()
+    if (bytes.size > limit) {
+        throw JsExtensionFetchException("$what exceeds ${limit / 1024} KiB")
+    }
+    return bytes.utf8()
+}
 
 /**
  * Map an index entry onto the domain model.

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
@@ -1,0 +1,219 @@
+package app.otakureader.core.js.remote
+
+import app.otakureader.core.extension.domain.model.Extension
+import app.otakureader.core.extension.domain.model.ExtensionSource
+import app.otakureader.core.extension.domain.model.InstallStatus
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.security.MessageDigest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * One entry in a repository's JavaScript source index.
+ *
+ * Mirrors the Mangayomi/Sora index shape, which is what the existing community JavaScript
+ * sources are published against. Following it rather than inventing a format means those sources
+ * work here unmodified — the same reasoning that keeps the Tachiyomi APK contract intact.
+ */
+@Serializable
+internal data class JsExtensionDto(
+    val id: String,
+    val name: String,
+    val baseUrl: String,
+    val lang: String,
+    /** Where the `.js` itself lives. Relative paths resolve against the repository base. */
+    val sourceCodeUrl: String,
+    val version: String = "1.0.0",
+    /** Monotonic build number, used for update detection. */
+    val versionCode: Int = 1,
+    val iconUrl: String? = null,
+    val isNsfw: Boolean = false,
+    val hasCloudflare: Boolean = false,
+    /** `manga` or `novel`. Novels become readable in Stage 7; they list correctly from now. */
+    val itemType: String = ITEM_TYPE_MANGA,
+) {
+    internal companion object {
+        const val ITEM_TYPE_MANGA = "manga"
+    }
+}
+
+/**
+ * Fetches the JavaScript source index and the scripts themselves.
+ *
+ * ### Why a separate path under the same repository URL
+ *
+ * JavaScript sources are read from `<repo>/js/index.json`, alongside the APK backend's
+ * `<repo>/index.min.json`. Sharing the configured repository list means the user adds a URL once
+ * and gets whichever backends that repository actually serves, with no second settings screen and
+ * no edits to the repository UI.
+ *
+ * A distinct filename rather than content-sniffing a shared one is deliberate. Deciding which
+ * backend an index belongs to by inspecting its fields would misclassify the moment the two
+ * formats grew a field in common, and a misclassified index fails as "this repository has no
+ * sources" — silent, and indistinguishable from an empty repository. A repository that serves
+ * only APKs simply 404s here, which is an unambiguous answer.
+ */
+@Singleton
+class JsExtensionRemoteDataSource @Inject constructor(
+    private val httpClient: OkHttpClient,
+) {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
+
+    internal companion object {
+        const val INDEX_PATH = "/js/index.json"
+
+        /**
+         * Ceiling on a downloaded script.
+         *
+         * A source is a few tens of KB of JavaScript. The cap exists so a repository — which is
+         * an arbitrary remote host — cannot make the app read an unbounded body into memory by
+         * pointing `sourceCodeUrl` at something enormous.
+         */
+        const val MAX_SCRIPT_BYTES = 2L * 1024 * 1024
+
+        /** Only https:// is accepted, matching the guard `ExtensionInstaller` applies to APKs. */
+        const val HTTPS_PREFIX = "https://"
+    }
+
+    /**
+     * Every JavaScript source offered by [repoUrls].
+     *
+     * Failures are isolated per repository, matching the APK path: one unreachable or malformed
+     * repository must not empty the list contributed by the others. A repository with no
+     * JavaScript index is the common case, not a failure, so it contributes nothing and is not
+     * reported.
+     */
+    suspend fun fetchAvailable(repoUrls: List<String>): List<Extension> = withContext(Dispatchers.IO) {
+        repoUrls.flatMap { rawUrl ->
+            val baseUrl = rawUrl.trimEnd('/')
+            runCatching { fetchIndex(baseUrl) }
+                .onFailure { error ->
+                    if (error is CancellationException) throw error
+                    android.util.Log.w("JsExtensionRemoteDS", "No JS index at $baseUrl: ${error.message}")
+                }
+                .getOrDefault(emptyList())
+        }
+            // Two repositories can offer the same source; keep the newer build rather than
+            // whichever happened to be fetched last.
+            .groupBy { it.pkgName }
+            .values
+            .map { candidates -> candidates.maxByOrNull { it.versionCode } ?: candidates.first() }
+    }
+
+    private fun fetchIndex(baseUrl: String): List<Extension> {
+        val indexUrl = baseUrl + INDEX_PATH
+        requireHttps(indexUrl)
+
+        val body = httpClient.newCall(Request.Builder().url(indexUrl).build()).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw JsExtensionFetchException("HTTP ${response.code} fetching $indexUrl")
+            }
+            response.body?.string() ?: throw JsExtensionFetchException("Empty index body from $indexUrl")
+        }
+
+        return json.decodeFromString<List<JsExtensionDto>>(body).map { it.toDomain(baseUrl) }
+    }
+
+    /**
+     * Download a source's script.
+     *
+     * Reads at the cap plus one byte so an oversized script is *detected* rather than silently
+     * truncated. A half-downloaded script would be installed as if whole and then fail somewhere
+     * inside the engine, which is a far harder failure to trace back to its cause than a refusal
+     * at download time.
+     */
+    suspend fun downloadScript(scriptUrl: String): String = withContext(Dispatchers.IO) {
+        requireHttps(scriptUrl)
+
+        httpClient.newCall(Request.Builder().url(scriptUrl).build()).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw JsExtensionFetchException("HTTP ${response.code} downloading $scriptUrl")
+            }
+            val body = response.body ?: throw JsExtensionFetchException("Empty script body from $scriptUrl")
+            val bytes = body.source().apply { request(MAX_SCRIPT_BYTES + 1) }.buffer.snapshot()
+            if (bytes.size > MAX_SCRIPT_BYTES) {
+                throw JsExtensionFetchException(
+                    "Script at $scriptUrl exceeds ${MAX_SCRIPT_BYTES / 1024} KiB"
+                )
+            }
+            bytes.utf8()
+        }
+    }
+
+    /**
+     * Reject anything that is not HTTPS.
+     *
+     * A JavaScript source carries no signature — there is nothing to verify it against once it
+     * arrives, unlike an APK. Transport security is therefore the *only* control on this path,
+     * which makes it stricter here than it is for APKs, not looser: a plaintext fetch would let
+     * anyone on the network path substitute the script that is about to be executed.
+     */
+    private fun requireHttps(url: String) {
+        if (!url.startsWith(HTTPS_PREFIX)) {
+            throw SecurityException("JavaScript sources must be served over HTTPS. Rejected: $url")
+        }
+    }
+}
+
+/** Thrown when a repository index or script cannot be fetched or parsed. */
+class JsExtensionFetchException(message: String) : RuntimeException(message)
+
+private fun JsExtensionDto.toDomain(baseUrl: String): Extension = Extension(
+    id = id.toStableId(),
+    pkgName = id,
+    name = name,
+    versionCode = versionCode,
+    versionName = version,
+    sources = listOf(
+        ExtensionSource(
+            id = id.toStableId(),
+            name = name,
+            lang = lang,
+            baseUrl = baseUrl,
+        )
+    ),
+    status = InstallStatus.AVAILABLE,
+    apkPath = null,
+    apkUrl = resolve(baseUrl, sourceCodeUrl),
+    iconUrl = iconUrl?.let { resolve(baseUrl, it) },
+    lang = lang,
+    isNsfw = isNsfw,
+    installDate = null,
+    // No signature exists for a script. Null is the honest value; a placeholder would make
+    // `isTrusted` report a verification that never happened.
+    signatureHash = null,
+    isShared = false,
+    repoUrl = baseUrl,
+    hasCloudflare = hasCloudflare,
+    isJavaScript = true,
+)
+
+/**
+ * A stable 63-bit id derived from the source id.
+ *
+ * `String.hashCode()` is 32 bits, so a library of a few thousand sources has a real chance of a
+ * birthday collision — and a collision here means two different sources sharing a database
+ * primary key, where one silently replaces the other. This takes the digest's leading eight
+ * bytes and clears the sign bit, giving 63 usable bits, which makes a collision vanishingly
+ * unlikely. The sign bit goes because a negative id reads as an error elsewhere in the app.
+ */
+private fun String.toStableId(): Long {
+    val digest = MessageDigest.getInstance("SHA-256").digest(toByteArray())
+    var value = 0L
+    repeat(Long.SIZE_BYTES) { index -> value = (value shl Byte.SIZE_BITS) or (digest[index].toLong() and 0xFF) }
+    return value and Long.MAX_VALUE
+}
+
+/** Resolve a possibly-relative index URL against the repository base. */
+private fun resolve(baseUrl: String, path: String): String =
+    if (path.startsWith("https://") || path.startsWith("http://")) path else "$baseUrl/${path.trimStart('/')}"

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
@@ -168,7 +168,17 @@ class JsExtensionRemoteDataSource @Inject constructor(
 /** Thrown when a repository index or script cannot be fetched or parsed. */
 class JsExtensionFetchException(message: String) : RuntimeException(message)
 
-private fun JsExtensionDto.toDomain(baseUrl: String): Extension = Extension(
+/**
+ * Map an index entry onto the domain model.
+ *
+ * **Two different URLs are in play and they must not be confused.** [repoUrl] is where the index
+ * was fetched from; `this.baseUrl` is the manga site the source actually scrapes. The parameter
+ * is named `repoUrl` rather than `baseUrl` precisely so it cannot shadow the DTO's field — an
+ * earlier version took `baseUrl` and silently handed the *repository* URL to every source, which
+ * would have pointed every relative request and every synthesised Referer at the index host
+ * instead of the site. Nothing would have crashed; sources would simply have returned nothing.
+ */
+private fun JsExtensionDto.toDomain(repoUrl: String): Extension = Extension(
     id = id.toStableId(),
     pkgName = id,
     name = name,
@@ -179,13 +189,15 @@ private fun JsExtensionDto.toDomain(baseUrl: String): Extension = Extension(
             id = id.toStableId(),
             name = name,
             lang = lang,
+            // The site the source scrapes — NOT the repository it was listed in.
             baseUrl = baseUrl,
         )
     ),
     status = InstallStatus.AVAILABLE,
     apkPath = null,
-    apkUrl = resolve(baseUrl, sourceCodeUrl),
-    iconUrl = iconUrl?.let { resolve(baseUrl, it) },
+    // The script, on the other hand, really does live on the repository host.
+    apkUrl = resolve(repoUrl, sourceCodeUrl),
+    iconUrl = iconUrl?.let { resolve(repoUrl, it) },
     lang = lang,
     isNsfw = isNsfw,
     installDate = null,
@@ -193,7 +205,7 @@ private fun JsExtensionDto.toDomain(baseUrl: String): Extension = Extension(
     // `isTrusted` report a verification that never happened.
     signatureHash = null,
     isShared = false,
-    repoUrl = baseUrl,
+    repoUrl = repoUrl,
     hasCloudflare = hasCloudflare,
     isJavaScript = true,
 )

--- a/core/js-runtime/src/test/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSourceTest.kt
+++ b/core/js-runtime/src/test/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSourceTest.kt
@@ -75,7 +75,7 @@ class JsExtensionRemoteDataSourceTest {
     fun `an index entry becomes a JavaScript-flagged extension`() = runTest {
         server.enqueue(MockResponse().setBody(indexBody("mangadex-en", "MangaDex")))
 
-        val extensions = dataSource.fetchAvailable(listOf(baseUrl()))
+        val extensions = dataSource.fetchAvailable(listOf(baseUrl())).extensions
 
         assertEquals(1, extensions.size)
         val extension = extensions.single()
@@ -118,7 +118,7 @@ class JsExtensionRemoteDataSourceTest {
     fun `a repository with no javascript index contributes nothing without failing`() = runTest {
         server.enqueue(MockResponse().setResponseCode(404))
 
-        val extensions = dataSource.fetchAvailable(listOf(baseUrl()))
+        val extensions = dataSource.fetchAvailable(listOf(baseUrl())).extensions
 
         // Most repositories serve only APKs. That is a normal answer, not an error — throwing
         // here would turn the common case into a user-visible failure.
@@ -131,7 +131,7 @@ class JsExtensionRemoteDataSourceTest {
         server.enqueue(MockResponse().setResponseCode(500))
         server.enqueue(MockResponse().setBody(indexBody("survivor", "Survivor")))
 
-        val extensions = dataSource.fetchAvailable(listOf(baseUrl(), baseUrl()))
+        val extensions = dataSource.fetchAvailable(listOf(baseUrl(), baseUrl())).extensions
 
         assertEquals(listOf("survivor"), extensions.map { it.pkgName })
     }
@@ -143,7 +143,7 @@ class JsExtensionRemoteDataSourceTest {
         server.enqueue(MockResponse().setBody(indexBody("dupe", "Old build", versionCode = 3)))
         server.enqueue(MockResponse().setBody(indexBody("dupe", "New build", versionCode = 9)))
 
-        val extensions = dataSource.fetchAvailable(listOf(baseUrl(), baseUrl()))
+        val extensions = dataSource.fetchAvailable(listOf(baseUrl(), baseUrl())).extensions
 
         assertEquals(1, extensions.size)
         assertEquals("New build", extensions.single().name)
@@ -166,6 +166,42 @@ class JsExtensionRemoteDataSourceTest {
         val script = dataSource.downloadScript("${baseUrl()}/js/source.js")
 
         assertEquals("const source = {};", script)
+    }
+
+    /**
+     * A scheme downgrade mid-redirect must not be followed.
+     *
+     * Checking the scheme of the URL we *ask* for proves nothing on its own: OkHttp follows
+     * redirects, and `followSslRedirects` defaults to true, so an `https://` script URL that
+     * 302s to `http://` would be fetched in plaintext and anyone on the network path could
+     * substitute the JavaScript about to be executed. The initial check would have passed while
+     * the guarantee behind it was gone.
+     *
+     * Asserted against a real redirect rather than trusting the flag's documentation — the same
+     * reason `RedirectHeaderPropagationTest` exists.
+     */
+    @Test
+    fun `an https to http redirect is not followed`() = runTest {
+        val plaintext = MockWebServer()
+        plaintext.start()
+        try {
+            plaintext.enqueue(MockResponse().setBody("malicious()"))
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(302)
+                    .setHeader("Location", plaintext.url("/js/source.js").toString())
+            )
+
+            val error = runCatching { dataSource.downloadScript("${baseUrl()}/js/source.js") }
+                .exceptionOrNull()
+
+            assertTrue("expected a fetch failure, got $error", error is JsExtensionFetchException)
+            // The state that matters is what did NOT happen: the plaintext host was never asked.
+            // Asserting only on the exception would pass even if the body had been fetched.
+            assertEquals(0, plaintext.requestCount)
+        } finally {
+            plaintext.shutdown()
+        }
     }
 
     @Test

--- a/core/js-runtime/src/test/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSourceTest.kt
+++ b/core/js-runtime/src/test/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSourceTest.kt
@@ -88,8 +88,16 @@ class JsExtensionRemoteDataSourceTest {
         assertEquals(InstallStatus.AVAILABLE, extension.status)
         assertEquals("1.2.3", extension.versionName)
         assertTrue(extension.hasCloudflare)
-        // A relative sourceCodeUrl resolves against the repository base.
+        // A relative sourceCodeUrl resolves against the repository base — the script really does
+        // live on the repository host.
         assertEquals("${baseUrl()}/js/mangadex-en.js", extension.apkUrl)
+        // ...but the SOURCE's base URL is the site it scrapes, which is a different host. The
+        // fixture deliberately uses a value distinct from the server so the two cannot be
+        // confused: an earlier version shadowed the DTO's field with the repository URL
+        // parameter and handed every source the index host. Nothing crashed — sources just
+        // returned nothing, which is why only an assertion catches it.
+        assertEquals("https://example.test", extension.sources.single().baseUrl)
+        assertEquals(baseUrl(), extension.repoUrl)
         // There is no APK and no signature to verify; both must be absent rather than faked.
         assertNull(extension.apkPath)
         assertNull(extension.signatureHash)

--- a/core/js-runtime/src/test/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSourceTest.kt
+++ b/core/js-runtime/src/test/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSourceTest.kt
@@ -1,0 +1,176 @@
+package app.otakureader.core.js.remote
+
+import app.otakureader.core.extension.domain.model.InstallStatus
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.tls.HandshakeCertificates
+import okhttp3.tls.HeldCertificate
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Covers the JavaScript source index: what it parses into, and what it refuses.
+ *
+ * The server speaks **HTTPS**, which is not incidental to the setup — the data source rejects
+ * anything else, so a plain-HTTP MockWebServer would make every test here fail for the wrong
+ * reason and the refusal itself would go untested. Serving real TLS means the happy paths prove
+ * the guard lets legitimate traffic through, and [a plain-http script url is refused] proves it
+ * stops the rest.
+ */
+class JsExtensionRemoteDataSourceTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var dataSource: JsExtensionRemoteDataSource
+
+    @Before
+    fun setUp() {
+        val certificate = HeldCertificate.Builder().addSubjectAlternativeName("localhost").build()
+        val serverCertificates = HandshakeCertificates.Builder().heldCertificate(certificate).build()
+        val clientCertificates = HandshakeCertificates.Builder()
+            .addTrustedCertificate(certificate.certificate)
+            .build()
+
+        server = MockWebServer()
+        server.useHttps(serverCertificates.sslSocketFactory(), false)
+        server.start()
+
+        dataSource = JsExtensionRemoteDataSource(
+            OkHttpClient.Builder()
+                .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager)
+                .build()
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun baseUrl() = server.url("/").toString().trimEnd('/')
+
+    private fun indexBody(id: String, name: String, versionCode: Int = 1) = """
+        [
+          {
+            "id": "$id",
+            "name": "$name",
+            "baseUrl": "https://example.test",
+            "lang": "en",
+            "sourceCodeUrl": "js/$id.js",
+            "version": "1.2.3",
+            "versionCode": $versionCode,
+            "isNsfw": false,
+            "hasCloudflare": true
+          }
+        ]
+    """.trimIndent()
+
+    @Test
+    fun `an index entry becomes a JavaScript-flagged extension`() = runTest {
+        server.enqueue(MockResponse().setBody(indexBody("mangadex-en", "MangaDex")))
+
+        val extensions = dataSource.fetchAvailable(listOf(baseUrl()))
+
+        assertEquals(1, extensions.size)
+        val extension = extensions.single()
+        // The discriminator is what install and uninstall route on, so it is the load-bearing
+        // assertion here — a row that parsed perfectly but arrived with isJavaScript = false
+        // would be sent to the APK installer.
+        assertTrue(extension.isJavaScript)
+        assertEquals("mangadex-en", extension.pkgName)
+        assertEquals("MangaDex", extension.name)
+        assertEquals(InstallStatus.AVAILABLE, extension.status)
+        assertEquals("1.2.3", extension.versionName)
+        assertTrue(extension.hasCloudflare)
+        // A relative sourceCodeUrl resolves against the repository base.
+        assertEquals("${baseUrl()}/js/mangadex-en.js", extension.apkUrl)
+        // There is no APK and no signature to verify; both must be absent rather than faked.
+        assertNull(extension.apkPath)
+        assertNull(extension.signatureHash)
+        assertEquals(false, extension.isTrusted)
+    }
+
+    @Test
+    fun `the index is requested from the javascript path`() = runTest {
+        server.enqueue(MockResponse().setBody(indexBody("a", "A")))
+
+        dataSource.fetchAvailable(listOf(baseUrl()))
+
+        // A distinct path is what keeps the two backends from misreading each other's indexes.
+        assertEquals("/js/index.json", server.takeRequest().path)
+    }
+
+    @Test
+    fun `a repository with no javascript index contributes nothing without failing`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(404))
+
+        val extensions = dataSource.fetchAvailable(listOf(baseUrl()))
+
+        // Most repositories serve only APKs. That is a normal answer, not an error — throwing
+        // here would turn the common case into a user-visible failure.
+        assertTrue(extensions.isEmpty())
+    }
+
+    @Test
+    fun `one unreachable repository does not suppress another`() = runTest {
+        // Two repos, first 404s. Both are read in order, so the enqueue order matches.
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setBody(indexBody("survivor", "Survivor")))
+
+        val extensions = dataSource.fetchAvailable(listOf(baseUrl(), baseUrl()))
+
+        assertEquals(listOf("survivor"), extensions.map { it.pkgName })
+    }
+
+    @Test
+    fun `the higher versionCode wins when two repositories offer the same source`() = runTest {
+        // The collision is the point: a dedupe test where the ids differ proves nothing about
+        // the rule it claims to cover.
+        server.enqueue(MockResponse().setBody(indexBody("dupe", "Old build", versionCode = 3)))
+        server.enqueue(MockResponse().setBody(indexBody("dupe", "New build", versionCode = 9)))
+
+        val extensions = dataSource.fetchAvailable(listOf(baseUrl(), baseUrl()))
+
+        assertEquals(1, extensions.size)
+        assertEquals("New build", extensions.single().name)
+        assertEquals(9, extensions.single().versionCode)
+    }
+
+    @Test
+    fun `a plain-http script url is refused`() = runTest {
+        // A script has no signature, so transport is the only control on what gets executed.
+        val error = runCatching { dataSource.downloadScript("http://example.test/source.js") }
+            .exceptionOrNull()
+
+        assertTrue("expected SecurityException, got $error", error is SecurityException)
+    }
+
+    @Test
+    fun `a script downloads over https`() = runTest {
+        server.enqueue(MockResponse().setBody("const source = {};"))
+
+        val script = dataSource.downloadScript("${baseUrl()}/js/source.js")
+
+        assertEquals("const source = {};", script)
+    }
+
+    @Test
+    fun `an oversized script is refused rather than truncated`() = runTest {
+        val oversized = "x".repeat((JsExtensionRemoteDataSource.MAX_SCRIPT_BYTES + 1024).toInt())
+        server.enqueue(MockResponse().setBody(oversized))
+
+        val error = runCatching { dataSource.downloadScript("${baseUrl()}/js/huge.js") }
+            .exceptionOrNull()
+
+        // Truncation is the failure worth preventing: a half-downloaded script installs as if
+        // whole and then fails somewhere inside the engine, far from its cause.
+        assertNotNull(error)
+        assertTrue("expected a fetch failure, got $error", error is JsExtensionFetchException)
+    }
+}

--- a/core/js-runtime/src/test/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSourceTest.kt
+++ b/core/js-runtime/src/test/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSourceTest.kt
@@ -114,6 +114,37 @@ class JsExtensionRemoteDataSourceTest {
         assertEquals("/js/index.json", server.takeRequest().path)
     }
 
+    /**
+     * Novel and anime entries are not offered.
+     *
+     * `JsSource` implements the manga contract, so one of these would install cleanly and then
+     * fail on every read — an entry the user can add but cannot use, which is worse than one
+     * that never appeared. Stage 7 adds the novel runtime and relaxes the filter in the same
+     * change that makes the entries usable.
+     */
+    @Test
+    fun `only manga entries are offered`() = runTest {
+        server.enqueue(
+            MockResponse().setBody(
+                """
+                [
+                  {"id":"m","name":"Manga","baseUrl":"https://a.test","lang":"en",
+                   "sourceCodeUrl":"js/m.js"},
+                  {"id":"n","name":"Novel","baseUrl":"https://b.test","lang":"en",
+                   "sourceCodeUrl":"js/n.js","itemType":"novel"},
+                  {"id":"a","name":"Anime","baseUrl":"https://c.test","lang":"en",
+                   "sourceCodeUrl":"js/a.js","itemType":"anime"}
+                ]
+                """.trimIndent()
+            )
+        )
+
+        val extensions = dataSource.fetchAvailable(listOf(baseUrl())).extensions
+
+        // The entry with no itemType at all must survive — most real indexes omit it.
+        assertEquals(listOf("m"), extensions.map { it.pkgName })
+    }
+
     @Test
     fun `a repository with no javascript index contributes nothing without failing`() = runTest {
         server.enqueue(MockResponse().setResponseCode(404))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -210,6 +210,9 @@ okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor" 
 okhttp-core = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-brotli = { group = "com.squareup.okhttp3", name = "okhttp-brotli", version.ref = "okhttp" }
 okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
+# Test-only. MockWebServer does NOT expose okhttp-tls transitively, so serving real HTTPS in a
+# test needs it declared. Required wherever a test exercises code that refuses plain HTTP.
+okhttp-tls = { group = "com.squareup.okhttp3", name = "okhttp-tls", version.ref = "okhttp" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-converter-scalars = { group = "com.squareup.retrofit2", name = "converter-scalars", version.ref = "retrofit" }
 retrofit-converter-kotlinx-serialization = { group = "com.squareup.retrofit2", name = "converter-kotlinx-serialization", version.ref = "retrofit" }


### PR DESCRIPTION
## **User description**
## The problem this closes

Stages 3, 4a and 4b built a JavaScript engine, wired it into the source repository, and made its requests behave. But **there was still no way to get a `.js` file onto a device.** Everything so far is proven by tests and compilation only — the sidecar has never started on real hardware. This is the first piece that makes any of the rebuild reachable by a user.

## Why JavaScript sources ride the existing `Extension` model

Everything in `feature/browse` — the list, the install button, the language filter, the search — reads `Extension` rows out of the `extensions` table. Modelling a JavaScript source as one of those rows means the entire extension-management UI works for the new backend with **zero edits**. A parallel model with a parallel screen would have duplicated all of it and then drifted.

The one thing the model needed was an honest discriminator: `Extension.isJavaScript`, persisted in a new column (schema **v4 → v5**, `NOT NULL DEFAULT 0` — every pre-existing row *is* an APK, which is a fact rather than a missing value).

Install and uninstall route on that flag, so it is **stored, not inferred**. Deriving it from a `.js` suffix on the URL or a naming convention on the id would be right almost always, and the failure when it was wrong would be a script handed to the APK installer — or worse, an APK handed to the script store.

## Why a separate path under the same repository URL

Scripts are read from `<repo>/js/index.json`, alongside the APK backend's `<repo>/index.min.json`. Sharing the configured repository list means a user adds a URL once and gets whichever backends that repository actually serves — no second settings screen, no edits to the repository UI.

A distinct filename rather than content-sniffing a shared one is deliberate. Choosing a backend by inspecting an index's fields would misclassify the moment the two formats grew a field in common, and a misclassified index fails as *"this repository has no sources"* — silent, and indistinguishable from an empty repository. A repository that serves only APKs simply 404s here, which is an unambiguous answer.

## Isolation runs in both directions

The merge lives in `ExtensionRemoteDataSourceImpl`, which already resolves the repository list and already isolates per-repository failures. That placement means there is exactly **one reader** of the repository list — two readers would be two chances to normalise a URL differently, so a repository could resolve one way for APKs and another for scripts, failing as a confusing partial rather than a clean error.

The JavaScript fetch runs **even when every APK fetch failed**, and its results count towards success. The inverse shipped in Stage 4a: isolation ran one direction, so a single thrown exception on the APK path silently dropped every JavaScript source. `JsBackendIsolationTest` asserts both directions so neither can regress unnoticed.

## Security

- **HTTPS only**, for the index and the script alike. A script carries no signature — there is nothing to verify it against once it arrives, unlike an APK — so transport is the *only* control on what gets executed. That makes the guard stricter here than on the APK path, not looser.
- **Routed through the DI `OkHttpClient`**, so certificate pinning, rate limiting and the cookie jar all apply. `ExtensionRemoteDataSource.createDefaultClient()` bypasses all three; that is a known Stage 9 fix and the pattern is deliberately not copied.
- **Scripts capped at 2 MiB**, read one byte past the cap so an oversized body is *detected* rather than silently truncated. A half-downloaded script would install as if whole and then fail somewhere inside the engine, far from its cause.
- **The source config is built from the index entry, never from anything inside the script.** A source that could declare its own id could claim another source's stored preferences — which routinely hold the user's login for that site.
- **Uninstall routes through the JS backend.** Without that branch a script falls through to the private-APK path, which drops the database row and nothing else: script still on disk, still registered with the engine, credentials intact.

Ordering in both directions is what keeps failures recoverable. Install writes the row **only after** the script is on disk and registered, so a failed download leaves nothing claiming to be installed. Uninstall erases the script and its stored data **before** dropping the row, so a failed erase leaves the source in the list the user would retry from.

## Module boundary

`JsExtensionBackend` is declared in `:core:extension` and implemented in `:core:js-runtime`, so the dependency runs one way. Unlike `CloudflareModule` — which lives in `:app` because neither `:core:network` nor `:core:webview` can see the other — this binding lives with the implementation, since `:core:js-runtime` already depends on `:core:extension` and can see both sides.

## Testing

`JsExtensionRemoteDataSourceTest` covers index parsing, the request path, per-repository isolation, and the dedupe rule — the last with an **actual id collision**, since a dedupe test whose entries are obviously different proves nothing about the rule it claims to cover.

The MockWebServer speaks **real TLS**, which is load-bearing rather than fussiness: the data source refuses plain HTTP, so a plain-HTTP server would fail every test for the wrong reason and leave the refusal itself unproven. That needed `okhttp-tls` declared explicitly — MockWebServer does **not** expose it transitively, contrary to what its dependency on it suggests. I assumed it did, the compile said otherwise, and the catalog entry is the correction.

`JsInstallRoutingTest` covers install and uninstall routing, including the failure orderings above.

`:core:extension` gains `unitTests.isReturnDefaultValues`, matching `:core:js-runtime`. Without it any `android.jar` call throws *"not mocked"*, so the failure-logging in the remote data source and the broadcast on the uninstall path were untestable rather than merely untested.

## What this does not yet do

**There is no default JavaScript repository.** The bundled default (Keiyoushi) serves APKs only, so out of the box this fetch 404s and contributes nothing — correctly and quietly. A user needs a repository that actually publishes `js/index.json` before any of this is visible to them. The index format follows the Mangayomi/Sora shape so existing community sources work unmodified, but pointing at one is a separate step.

Novel sources (`itemType: "novel"`) list correctly from now; reading them arrives in Stage 7.

## Verification

`./gradlew :app:assembleDebug testDebugUnitTest detekt ktlintCheck` → **BUILD SUCCESSFUL**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoEui2mCCcqArdhyQyFwnR)_

## Summary by Sourcery

Integrate a JavaScript-backed extension flow alongside the existing APK backend, enabling JS sources to be discovered, installed, and uninstalled through the same Extension model and repository list.

New Features:
- Add a JavaScript extension backend interface and implementation, wired into extension discovery, install, and uninstall flows.
- Introduce a JavaScript remote data source that reads js/index.json from extension repositories and downloads JS scripts over HTTPS.
- Flag extensions as JavaScript via a persisted discriminator field so the UI and installer can route to the correct backend.

Enhancements:
- Merge APK and JavaScript extension discovery results while deduplicating by package name to avoid conflicting rows.
- Ensure failure isolation between APK and JavaScript backends so one path’s errors do not suppress the other’s results.
- Add a Room migration to support the new JavaScript discriminator column on extensions.
- Wire core:js-runtime to depend on core:extension and provide DI bindings for the JavaScript backend.
- Tighten testing configuration to allow exercising failure-logging and broadcasts in unit tests.

Tests:
- Add unit tests for the JavaScript remote data source, including HTTPS-only behavior, index parsing, script size limits, and deduping between repositories.
- Add routing tests to verify that JavaScript installs/uninstalls go through the JS backend and that APK extensions remain on the APK path.
- Add isolation tests to confirm that failures in one backend do not hide sources from the other.
- Extend test dependencies with okhttp-tls and configure unit tests to return default android.jar values so extension-related behavior is fully testable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds JavaScript source installs via `js/index.json`, routed through a new `JsExtensionBackend`, and merges JS/APK discovery with bidirectional failure isolation. Enforces HTTPS-only fetches, refuses cross-scheme redirects, and now fails closed when the prior-row lookup can’t be read to prevent unremovable scripts.

- **New Features**
  - Persist `Extension.isJavaScript`; install/uninstall route to JS or APK. DB v4 → v5 adds `is_javascript INTEGER NOT NULL DEFAULT 0`.
  - JS index at `js/index.json` (HTTPS-only; cross-scheme redirects refused). Cap index to 8 MiB and scripts to 2 MiB. Dedupe by `pkgName` favoring higher `versionCode`. Filter to manga only.
  - `JsExtensionBackend` in `:core:extension`, implemented/bound in `:core:js-runtime`. No default JS repo is bundled.

- **Bug Fixes**
  - Safe JS install rollback: read the prior row before install; if unreadable, abort without writing the script; on row-write failure uninstall only when no JS row existed or it belonged to APK; restore `INSTALLED` on failed updates; keep the original error and attach cleanup failures; cancellation propagates.
  - Map site vs repo correctly: `JsExtensionDto.toDomain(repoUrl)` prevents shadowing so sources use the real site.
  - JS uninstall uses the JS backend; erase script/data before dropping the row; notify removals only on success; set `ERROR` on row-delete failure and restore `INSTALLED` when backend erase fails.
  - JS/APK discovery isolation runs both ways; valid empty JS indexes count as success; include the first JS-side failure when reporting total failures.

<sup>Written for commit 35f9dc4ee537c3615f5b2e2dbef1ef4ba3d35f7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HeartlessVeteran2/Otaku-Reader/pull/1228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Add JavaScript sources to extension discovery, installation, and removal

### What Changed
- JavaScript sources are listed from each repository’s `/js/index.json` alongside APK extensions, using the existing extension browsing flow.
- Users can install and uninstall JavaScript sources without treating them as APKs; failed installs and removals clean up safely and keep the source retryable.
- JavaScript source metadata is stored across app upgrades, including its backend type, script URL, version, and source website.
- JavaScript downloads require HTTPS, reject cross-scheme redirects, and refuse oversized indexes or scripts.
- APK and JavaScript repository failures are isolated, so one backend does not hide results from the other; valid empty JavaScript indexes are treated as successful.
- Added coverage for discovery, secure downloads, backend routing, rollback behavior, and repository failure isolation.

### Impact
`✅ JavaScript sources appear in the existing extension list`
`✅ Safer script installation and removal`
`✅ Fewer hidden sources when a repository backend fails`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
