### PR TITLE
Stage 4b-3 (1/3): bound the browse caches, delete a dead page-id parameter

### DIFF
--- a/core/common/src/main/java/app/otakureader/core/common/collection/BoundedCache.kt
+++ b/core/common/src/main/java/app/otakureader/core/common/collection/BoundedCache.kt
@@ -1,0 +1,49 @@
+package app.otakureader.core.common.collection
+
+/**
+ * A thread-safe, fixed-capacity cache that evicts the least recently *used* entry.
+ *
+ * `accessOrder = true` on the backing map is the point, not a detail: with insertion order the
+ * entries a user is actively working with would be evicted on the same schedule as ones they
+ * left behind an hour ago, so the cache would keep discarding exactly what it should keep.
+ *
+ * Every operation is synchronized because `LinkedHashMap` is not thread-safe and a *read* mutates
+ * it here — access-ordering relinks the entry on `get`. That makes the usual "concurrent reads
+ * are fine" intuition wrong for this map specifically: two simultaneous `get`s can corrupt it.
+ *
+ * `ConcurrentHashMap` is not an alternative, because it has no eviction at all — which is the one
+ * property this type exists to provide.
+ */
+class BoundedCache<K : Any, V : Any>(private val maxEntries: Int) {
+
+    init {
+        require(maxEntries > 0) { "maxEntries must be positive, was $maxEntries" }
+    }
+
+    private val entries = object : LinkedHashMap<K, V>(INITIAL_CAPACITY, LOAD_FACTOR, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, V>?): Boolean =
+            size > maxEntries
+    }
+
+    operator fun get(key: K): V? = synchronized(entries) { entries[key] }
+
+    operator fun set(key: K, value: V) {
+        synchronized(entries) { entries[key] = value }
+    }
+
+    fun putAll(from: Map<K, V>) {
+        synchronized(entries) { entries.putAll(from) }
+    }
+
+    fun clear() {
+        synchronized(entries) { entries.clear() }
+    }
+
+    /** Current entry count. Exposed for tests asserting that eviction actually happened. */
+    val size: Int get() = synchronized(entries) { entries.size }
+
+    private companion object {
+        const val INITIAL_CAPACITY = 16
+        const val LOAD_FACTOR = 0.75f
+    }
+}

--- a/core/common/src/main/java/app/otakureader/core/common/network/PageImageHeaders.kt
+++ b/core/common/src/main/java/app/otakureader/core/common/network/PageImageHeaders.kt
@@ -1,5 +1,6 @@
 package app.otakureader.core.common.network
 
+import app.otakureader.core.common.collection.BoundedCache
 import java.net.URI
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -61,8 +62,8 @@ class PageImageHeaders @Inject constructor() {
         const val REFERER = "Referer"
     }
 
-    private val perPage = lruMap<String, Map<String, String>>(MAX_PAGE_ENTRIES)
-    private val perHost = lruMap<String, Map<String, String>>(MAX_HOST_ENTRIES)
+    private val perPage = BoundedCache<String, Map<String, String>>(MAX_PAGE_ENTRIES)
+    private val perHost = BoundedCache<String, Map<String, String>>(MAX_HOST_ENTRIES)
 
     /**
      * Register the fallback `Referer` for every host in [pageUrls], derived from [sourceBaseUrl].
@@ -73,9 +74,7 @@ class PageImageHeaders @Inject constructor() {
     fun registerReferer(sourceBaseUrl: String, pageUrls: List<String>) {
         val referer = sourceBaseUrl.takeIf { it.isNotBlank() } ?: return
         val headers = mapOf(REFERER to referer)
-        synchronized(perHost) {
-            pageUrls.mapNotNull { it.hostOrNull() }.distinct().forEach { perHost[it] = headers }
-        }
+        pageUrls.mapNotNull { it.hostOrNull() }.distinct().forEach { perHost[it] = headers }
     }
 
     /**
@@ -87,29 +86,17 @@ class PageImageHeaders @Inject constructor() {
      */
     fun registerPageHeaders(headersByUrl: Map<String, Map<String, String>>) {
         if (headersByUrl.isEmpty()) return
-        synchronized(perPage) { perPage.putAll(headersByUrl) }
+        perPage.putAll(headersByUrl)
     }
 
     /** Headers for [url], or empty when nothing was registered for it. */
     fun headersFor(url: String): Map<String, String> {
         val host = url.hostOrNull()
-        val hostHeaders = host?.let { synchronized(perHost) { perHost[it] } }.orEmpty()
-        val pageHeaders = synchronized(perPage) { perPage[url] }.orEmpty()
+        val hostHeaders = host?.let { perHost[it] }.orEmpty()
+        val pageHeaders = perPage[url].orEmpty()
         return hostHeaders + pageHeaders
     }
 
     private fun String.hostOrNull(): String? =
         runCatching { URI(this).host }.getOrNull()?.takeIf { it.isNotBlank() }
 }
-
-/**
- * Access-ordered map that evicts the least recently used entry past [maxEntries].
- *
- * `accessOrder = true` is the point: with insertion order, the pages a reader is actually
- * looking at would be evicted on the same schedule as ones they left behind an hour ago.
- */
-private fun <K, V> lruMap(maxEntries: Int): LinkedHashMap<K, V> =
-    object : LinkedHashMap<K, V>(16, 0.75f, true) {
-        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, V>?): Boolean =
-            size > maxEntries
-    }

--- a/core/common/src/main/java/app/otakureader/core/common/network/PageImageHeaders.kt
+++ b/core/common/src/main/java/app/otakureader/core/common/network/PageImageHeaders.kt
@@ -70,11 +70,16 @@ class PageImageHeaders @Inject constructor() {
      *
      * Applies to every backend — an APK-backed source needs this exactly as much as a JavaScript
      * one, so it is registered from the shared repository path rather than inside either backend.
+     *
+     * One `putAll` rather than a write per host, so a chapter's registration lands as a unit.
+     * `BoundedCache` locks per operation, so a loop of `set` calls would let two sources
+     * registering at once interleave — the extraction of the cache would otherwise have quietly
+     * dropped the batching the previous inline `synchronized` block provided.
      */
     fun registerReferer(sourceBaseUrl: String, pageUrls: List<String>) {
         val referer = sourceBaseUrl.takeIf { it.isNotBlank() } ?: return
         val headers = mapOf(REFERER to referer)
-        pageUrls.mapNotNull { it.hostOrNull() }.distinct().forEach { perHost[it] = headers }
+        perHost.putAll(pageUrls.mapNotNull { it.hostOrNull() }.distinct().associateWith { headers })
     }
 
     /**

--- a/core/common/src/test/java/app/otakureader/core/common/collection/BoundedCacheTest.kt
+++ b/core/common/src/test/java/app/otakureader/core/common/collection/BoundedCacheTest.kt
@@ -1,0 +1,114 @@
+package app.otakureader.core.common.collection
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * Covers the two properties this type exists for: it stays bounded, and it evicts the right entry.
+ *
+ * The eviction *order* matters more than the bound. A cache that evicted by insertion order would
+ * also stay within its limit and would also pass a naive size assertion — while discarding
+ * precisely the entries the user is working with. So the tests below construct the case where the
+ * two policies disagree.
+ */
+class BoundedCacheTest {
+
+    @Test
+    fun `entries past the cap are evicted`() {
+        val cache = BoundedCache<Int, String>(3)
+
+        repeat(5) { cache[it] = "v$it" }
+
+        assertEquals(3, cache.size)
+        // The two oldest are gone; nothing was touched, so oldest means least recently written.
+        assertNull(cache[0])
+        assertNull(cache[1])
+        assertNotNull(cache[4])
+    }
+
+    /**
+     * The case that separates least-recently-USED from least-recently-INSERTED.
+     *
+     * Key 0 is the oldest by insertion but the newest by access, so an insertion-ordered cache
+     * evicts it and an access-ordered one keeps it. Without the read in the middle this test
+     * would pass under either policy and prove nothing.
+     */
+    @Test
+    fun `reading an entry protects it from eviction`() {
+        val cache = BoundedCache<Int, String>(3)
+        cache[0] = "a"
+        cache[1] = "b"
+        cache[2] = "c"
+
+        cache[0] // touch the oldest
+
+        cache[3] = "d" // forces one eviction
+
+        assertEquals("a", cache[0])
+        // Key 1 is now the least recently used and is the one that goes.
+        assertNull(cache[1])
+    }
+
+    @Test
+    fun `putAll respects the cap`() {
+        val cache = BoundedCache<Int, String>(2)
+
+        cache.putAll((0..4).associateWith { "v$it" })
+
+        assertEquals(2, cache.size)
+    }
+
+    @Test
+    fun `clear empties the cache`() {
+        val cache = BoundedCache<Int, String>(4)
+        repeat(3) { cache[it] = "v$it" }
+
+        cache.clear()
+
+        assertEquals(0, cache.size)
+        assertNull(cache[0])
+    }
+
+    @Test
+    fun `a non-positive capacity is rejected`() {
+        // A zero-capacity cache would evict everything immediately and silently behave as a
+        // no-op, which is far harder to notice than a construction failure.
+        assertThrows(IllegalArgumentException::class.java) { BoundedCache<Int, String>(0) }
+    }
+
+    /**
+     * Concurrent access must not corrupt the map.
+     *
+     * This is not a general "is it thread-safe" gesture: access ordering means a *read* structurally
+     * modifies the backing `LinkedHashMap`, so concurrent gets — not just concurrent writes — can
+     * corrupt it. That is the exact reason `get` is synchronized, and the reason
+     * `ConcurrentHashMap` could not be swapped in for the lock.
+     */
+    @Test
+    fun `concurrent reads and writes stay consistent`() {
+        val cache = BoundedCache<Int, String>(64)
+
+        // Real threads, deliberately — not `runTest` with `async`. A coroutine test runs on a
+        // single virtual-time dispatcher, so those coroutines would interleave cooperatively and
+        // never actually contend. The test would have looked like a concurrency test and proven
+        // nothing about it.
+        val threads = (0 until 8).map { worker ->
+            Thread {
+                repeat(2_000) { i ->
+                    val key = (worker * 2_000 + i) % 128
+                    cache[key] = "v$key"
+                    cache[key]
+                }
+            }
+        }
+        threads.forEach { it.start() }
+        threads.forEach { it.join() }
+
+        // The invariant is the bound; which specific keys survive is timing-dependent. Without
+        // the lock this typically corrupts the map or loops forever rather than failing here.
+        assertEquals(64, cache.size)
+    }
+}

--- a/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/compat/TachiyomiModelsAdapter.kt
+++ b/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/compat/TachiyomiModelsAdapter.kt
@@ -68,10 +68,19 @@ object TachiyomiModelsAdapter {
     }
 
     /**
-     * Convert Tachiyomi SPage to Otaku Reader Page
+     * Convert Tachiyomi SPage to Otaku Reader Page.
+     *
+     * This used to take a `chapterId`, derived by the caller from `chapter.hashCode()`, and then
+     * ignore it — [app.otakureader.sourceapi.Page] has no id field at all. The suppression that
+     * silenced the unused parameter is gone with it: both remaining parameters are used, so the
+     * warning is doing its job again rather than being pre-emptively muted.
+     *
+     * Worth recording because the dead parameter read as a live bug. `hashCode()` is unstable
+     * across processes, so a page id derived from it would have been genuinely broken — but no
+     * page id was ever derived from it. Deleting the parameter is the fix; making the hash stable
+     * would have preserved a value nobody reads.
      */
-    @Suppress("UnusedParameter")
-    fun toPage(sPage: eu.kanade.tachiyomi.source.model.Page, chapterId: Long, index: Int): app.otakureader.sourceapi.Page {
+    fun toPage(sPage: eu.kanade.tachiyomi.source.model.Page, index: Int): app.otakureader.sourceapi.Page {
         return app.otakureader.sourceapi.Page(
             index = index,
             url = sPage.imageUrl ?: sPage.url,
@@ -82,9 +91,9 @@ object TachiyomiModelsAdapter {
     /**
      * Convert list of SPage to list of Page
      */
-    fun toPageList(sPages: List<eu.kanade.tachiyomi.source.model.Page>, chapterId: Long): List<app.otakureader.sourceapi.Page> {
+    fun toPageList(sPages: List<eu.kanade.tachiyomi.source.model.Page>): List<app.otakureader.sourceapi.Page> {
         return sPages.mapIndexed { index, sPage ->
-            toPage(sPage, chapterId, index)
+            toPage(sPage, index)
         }
     }
 

--- a/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/compat/TachiyomiSourceAdapter.kt
+++ b/core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/compat/TachiyomiSourceAdapter.kt
@@ -105,7 +105,7 @@ class TachiyomiSourceAdapter(
         return withContext(Dispatchers.IO) {
             val sChapter = TachiyomiModelsAdapter.toTachiyomiSChapter(chapter)
             val sPages = tachiyomiSource.getPageList(sChapter)
-            TachiyomiModelsAdapter.toPageList(sPages, chapter.hashCode().toLong())
+            TachiyomiModelsAdapter.toPageList(sPages)
         }
     }
 

--- a/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
@@ -34,6 +34,7 @@ import okhttp3.Request
 import eu.kanade.tachiyomi.source.CatalogueSource
 import java.io.File
 import java.io.InterruptedIOException
+import app.otakureader.core.common.collection.BoundedCache
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -60,6 +61,23 @@ class SourceRepositoryImpl @Inject constructor(
 
     private companion object {
         const val TAG = "SourceRepositoryImpl"
+
+        /**
+         * Browse pages kept per source.
+         *
+         * Sized for how a source is actually read — a user scrolls a handful of pages deep and
+         * then either opens something or moves on — with enough slack that paging back up is
+         * still a cache hit rather than a refetch.
+         */
+        const val MAX_CACHED_PAGES_PER_SOURCE = 32
+
+        /**
+         * Search results kept per source, keyed by (query, page).
+         *
+         * Lower than the page cap because the key space is unbounded: every distinct string a
+         * user types is a new entry, so this is the one that grew without limit before.
+         */
+        const val MAX_CACHED_SEARCHES_PER_SOURCE = 16
     }
 
     /**
@@ -112,10 +130,22 @@ class SourceRepositoryImpl @Inject constructor(
         _sources.value = sources
     }
 
-    // Cache for manga pages to avoid repeated network calls
-    private val popularMangaCache = ConcurrentHashMap<String, ConcurrentHashMap<Int, MangaPage>>()
-    private val latestMangaCache = ConcurrentHashMap<String, ConcurrentHashMap<Int, MangaPage>>()
-    private val searchCache = ConcurrentHashMap<String, ConcurrentHashMap<Pair<String, Int>, MangaPage>>()
+    /**
+     * Cached browse results, per source.
+     *
+     * The outer map is bounded in practice — its keys are installed source ids, and entries are
+     * dropped on refresh and on uninstall. The inner maps were the unbounded ones, and
+     * [searchCache] worst of all: keyed by (query, page), it retained a full page of results for
+     * every distinct search string the user had ever typed, for the lifetime of the process.
+     * Nothing evicted them, so browsing was a slow memory leak that grew with use.
+     *
+     * [BoundedCache] evicts least-recently-*used*, which matters more than the bound itself: a
+     * reader paging through one source keeps their pages warm while a source they glanced at
+     * earlier falls out.
+     */
+    private val popularMangaCache = ConcurrentHashMap<String, BoundedCache<Int, MangaPage>>()
+    private val latestMangaCache = ConcurrentHashMap<String, BoundedCache<Int, MangaPage>>()
+    private val searchCache = ConcurrentHashMap<String, BoundedCache<Pair<String, Int>, MangaPage>>()
 
     init {
         // Load all installed extensions on initialization
@@ -172,7 +202,7 @@ class SourceRepositoryImpl @Inject constructor(
                 val mangaPage = source.fetchPopularManga(page)
 
                 // Cache the result
-                popularMangaCache.computeIfAbsent(sourceId) { ConcurrentHashMap() }[page] = mangaPage
+                popularMangaCache.computeIfAbsent(sourceId) { BoundedCache(MAX_CACHED_PAGES_PER_SOURCE) }[page] = mangaPage
 
                 // Record success
                 healthMonitor.recordSuccess(sourceId)
@@ -213,7 +243,7 @@ class SourceRepositoryImpl @Inject constructor(
                 val mangaPage = source.fetchLatestUpdates(page)
 
                 // Cache the result
-                latestMangaCache.computeIfAbsent(sourceId) { ConcurrentHashMap() }[page] = mangaPage
+                latestMangaCache.computeIfAbsent(sourceId) { BoundedCache(MAX_CACHED_PAGES_PER_SOURCE) }[page] = mangaPage
 
                 // Record success
                 healthMonitor.recordSuccess(sourceId)
@@ -271,7 +301,7 @@ class SourceRepositoryImpl @Inject constructor(
                 // Cache only when no filters are active
                 if (!filtersAreActive) {
                     val cacheKey = query to page
-                    searchCache.computeIfAbsent(sourceId) { ConcurrentHashMap() }[cacheKey] = mangaPage
+                    searchCache.computeIfAbsent(sourceId) { BoundedCache(MAX_CACHED_SEARCHES_PER_SOURCE) }[cacheKey] = mangaPage
                 }
 
                 // Record success

--- a/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
@@ -627,22 +627,19 @@ class SourceRepositoryImpl @Inject constructor(
     }
 
     /**
-     * Clear all caches
+     * Drop every cached browse result.
+     *
+     * Swaps the generation rather than clearing the maps: a fetch already in flight holds the old
+     * instance and writes its now-stale result there, where nothing will read it.
+     *
+     * There is deliberately no per-source variant. One existed, was never called by anything, and
+     * carried this same race in a form the swap cannot fix — removing one source's entries from
+     * the live generation is an in-place edit, so an in-flight fetch for that source repopulates
+     * it. Anyone adding per-source invalidation later has to solve that, and inheriting a helper
+     * that looks usable and quietly is not would make it likelier they miss it.
      */
     fun clearCaches() {
-        // Swap, don't clear. A fetch already in flight holds the old instance and will write its
-        // now-stale result there, where nothing will read it.
         browseCaches = BrowseCaches()
-    }
-
-    /**
-     * Clear cache for a specific source
-     */
-    fun clearSourceCache(sourceId: String) {
-        val caches = browseCaches
-        caches.popular.remove(sourceId)
-        caches.latest.remove(sourceId)
-        caches.search.remove(sourceId)
     }
 }
 

--- a/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
@@ -131,21 +131,32 @@ class SourceRepositoryImpl @Inject constructor(
     }
 
     /**
-     * Cached browse results, per source.
+     * One generation of cached browse results.
      *
-     * The outer map is bounded in practice — its keys are installed source ids, and entries are
-     * dropped on refresh and on uninstall. The inner maps were the unbounded ones, and
-     * [searchCache] worst of all: keyed by (query, page), it retained a full page of results for
-     * every distinct search string the user had ever typed, for the lifetime of the process.
-     * Nothing evicted them, so browsing was a slow memory leak that grew with use.
+     * Invalidation swaps this whole object rather than clearing the maps in place, and that is
+     * what makes it correct rather than merely tidy. A fetch captures the instance it started
+     * against and writes its result back into *that* instance. If an invalidation lands while the
+     * network call is in flight, the write goes into an object nothing reads any more, instead of
+     * resurrecting pre-refresh data under a source id that has just been rebuilt.
      *
-     * [BoundedCache] evicts least-recently-*used*, which matters more than the bound itself: a
-     * reader paging through one source keeps their pages warm while a source they glanced at
-     * earlier falls out.
+     * Clearing in place cannot express that: `remove` then `computeIfAbsent` is a read-then-act
+     * pair across a suspension point, so the late write recreates the map it was supposed to
+     * have been erased from. Comparing object identity removes the window entirely rather than
+     * narrowing it — no lock spanning the network call, and nothing to get the ordering wrong.
+     *
+     * The inner maps are bounded because they were the unbounded ones. [search] worst of all:
+     * keyed by (query, page), it retained a full page of results for every distinct string the
+     * user had ever typed, for the lifetime of the process.
      */
-    private val popularMangaCache = ConcurrentHashMap<String, BoundedCache<Int, MangaPage>>()
-    private val latestMangaCache = ConcurrentHashMap<String, BoundedCache<Int, MangaPage>>()
-    private val searchCache = ConcurrentHashMap<String, BoundedCache<Pair<String, Int>, MangaPage>>()
+    private class BrowseCaches {
+        val popular = ConcurrentHashMap<String, BoundedCache<Int, MangaPage>>()
+        val latest = ConcurrentHashMap<String, BoundedCache<Int, MangaPage>>()
+        val search = ConcurrentHashMap<String, BoundedCache<Pair<String, Int>, MangaPage>>()
+    }
+
+    /** Volatile so a swap by [clearCaches] is visible to threads already reading it. */
+    @Volatile
+    private var browseCaches = BrowseCaches()
 
     init {
         // Load all installed extensions on initialization
@@ -183,7 +194,7 @@ class SourceRepositoryImpl @Inject constructor(
         return withContext(Dispatchers.IO) {
             // Check source health before attempting request; still allow cached data
             if (!healthMonitor.isSourceHealthy(sourceId)) {
-                popularMangaCache[sourceId]?.get(page)?.let {
+                browseCaches.popular[sourceId]?.get(page)?.let {
                     return@withContext Result.success(it)
                 }
                 val message = healthMonitor.getHealthMessage(sourceId) ?: "Source is temporarily unavailable"
@@ -195,14 +206,16 @@ class SourceRepositoryImpl @Inject constructor(
                     ?: return@withContext Result.failure(IllegalArgumentException("Source not found: $sourceId"))
 
                 // Check cache first
-                popularMangaCache[sourceId]?.get(page)?.let {
+                browseCaches.popular[sourceId]?.get(page)?.let {
                     return@withContext Result.success(it)
                 }
 
+                // Captured before the call: the result belongs to the generation that was
+                // current when the request started, not to whatever replaced it meanwhile.
+                val caches = browseCaches
                 val mangaPage = source.fetchPopularManga(page)
 
-                // Cache the result
-                popularMangaCache.computeIfAbsent(sourceId) { BoundedCache(MAX_CACHED_PAGES_PER_SOURCE) }[page] = mangaPage
+                caches.popular.computeIfAbsent(sourceId) { BoundedCache(MAX_CACHED_PAGES_PER_SOURCE) }[page] = mangaPage
 
                 // Record success
                 healthMonitor.recordSuccess(sourceId)
@@ -224,7 +237,7 @@ class SourceRepositoryImpl @Inject constructor(
         return withContext(Dispatchers.IO) {
             // Check source health before attempting request; still allow cached data
             if (!healthMonitor.isSourceHealthy(sourceId)) {
-                latestMangaCache[sourceId]?.get(page)?.let {
+                browseCaches.latest[sourceId]?.get(page)?.let {
                     return@withContext Result.success(it)
                 }
                 val message = healthMonitor.getHealthMessage(sourceId) ?: "Source is temporarily unavailable"
@@ -236,14 +249,14 @@ class SourceRepositoryImpl @Inject constructor(
                     ?: return@withContext Result.failure(IllegalArgumentException("Source not found: $sourceId"))
 
                 // Check cache first
-                latestMangaCache[sourceId]?.get(page)?.let {
+                browseCaches.latest[sourceId]?.get(page)?.let {
                     return@withContext Result.success(it)
                 }
 
+                val caches = browseCaches
                 val mangaPage = source.fetchLatestUpdates(page)
 
-                // Cache the result
-                latestMangaCache.computeIfAbsent(sourceId) { BoundedCache(MAX_CACHED_PAGES_PER_SOURCE) }[page] = mangaPage
+                caches.latest.computeIfAbsent(sourceId) { BoundedCache(MAX_CACHED_PAGES_PER_SOURCE) }[page] = mangaPage
 
                 // Record success
                 healthMonitor.recordSuccess(sourceId)
@@ -287,11 +300,12 @@ class SourceRepositoryImpl @Inject constructor(
                 // Use cache when no filters are active (all at defaults)
                 if (!filtersAreActive) {
                     val cacheKey = query to page
-                    searchCache[sourceId]?.get(cacheKey)?.let {
+                    browseCaches.search[sourceId]?.get(cacheKey)?.let {
                         return@withContext Result.success(it)
                     }
                 }
 
+                val caches = browseCaches
                 val mangaPage = source.fetchSearchManga(
                     page = page,
                     query = query,
@@ -301,7 +315,7 @@ class SourceRepositoryImpl @Inject constructor(
                 // Cache only when no filters are active
                 if (!filtersAreActive) {
                     val cacheKey = query to page
-                    searchCache.computeIfAbsent(sourceId) { BoundedCache(MAX_CACHED_SEARCHES_PER_SOURCE) }[cacheKey] = mangaPage
+                    caches.search.computeIfAbsent(sourceId) { BoundedCache(MAX_CACHED_SEARCHES_PER_SOURCE) }[cacheKey] = mangaPage
                 }
 
                 // Record success
@@ -616,18 +630,19 @@ class SourceRepositoryImpl @Inject constructor(
      * Clear all caches
      */
     fun clearCaches() {
-        popularMangaCache.clear()
-        latestMangaCache.clear()
-        searchCache.clear()
+        // Swap, don't clear. A fetch already in flight holds the old instance and will write its
+        // now-stale result there, where nothing will read it.
+        browseCaches = BrowseCaches()
     }
 
     /**
      * Clear cache for a specific source
      */
     fun clearSourceCache(sourceId: String) {
-        popularMangaCache.remove(sourceId)
-        latestMangaCache.remove(sourceId)
-        searchCache.remove(sourceId)
+        val caches = browseCaches
+        caches.popular.remove(sourceId)
+        caches.latest.remove(sourceId)
+        caches.search.remove(sourceId)
     }
 }
 


### PR DESCRIPTION
## **User description**
First of three slices of Stage 4b-3. Deliberately split: #1228 drew 19 review findings across 7 rounds largely because several ideas travelled together, so the remaining items — cancellation tokens, and sticky source + `sortMap` — get their own PRs.

## Browsing leaked memory in proportion to use

`SourceRepositoryImpl` held three two-level caches. The outer level is bounded in practice (keyed by installed source id, cleared on refresh and uninstall), but **the inner maps had no bound at all**.

`searchCache` was the worst: keyed by `(query, page)`, it retained a full page of results for **every distinct string the user had ever typed**, for the lifetime of the process. Nothing evicted them, so browsing was a slow leak that grew with use.

All three now use `BoundedCache`, extracted to `:core:common` from the private LRU already living inside `PageImageHeaders` — so this doesn't become a third hand-rolled copy. `PageImageHeaders` is refactored onto it, which also removes the four `synchronized` blocks it had spelled out at its call sites; the locking belongs inside the type, not repeated by every caller.

Caps: 32 pages per source, 16 searches per source. Search is lower because its key space is unbounded — every new query is a new entry — whereas page numbers are naturally small.

## Why least-recently-*used* rather than a plain cap

An insertion-ordered cache would also stay within its limit, and would also pass a naive size assertion — while discarding exactly the pages a reader is currently working through. So the eviction-order test constructs the case where the two policies disagree: key 0 is oldest by insertion but newest by access. Without the read in the middle, that test would pass under either policy and prove nothing.

## The concurrency test uses real threads

Not `runTest` with `async`. A coroutine test runs on a single virtual-time dispatcher, so those coroutines interleave cooperatively and never actually contend — it would have *looked* like a concurrency test while proving nothing about it.

That matters here specifically: access ordering means a **read** structurally modifies the backing `LinkedHashMap`, so concurrent `get`s — not just concurrent writes — can corrupt it. That's why every operation is synchronized, and why `ConcurrentHashMap` isn't an alternative: it has no eviction, which is the one property this type exists to provide.

## The unstable page id was not a bug

The Stage 4b-3 list carried *"fix `TachiyomiSourceAdapter.fetchPageList` deriving page IDs from `chapter.hashCode()` (unstable across processes)"*.

**The premise is wrong.** `toPageList` threaded that value into `toPage`, which ignored it — `Page` has no id field at all, only `index`, `url` and `imageUrl`. Grepping every caller confirms the value is computed and dropped. No page id was ever derived from it.

So the fix is to **delete the parameter**, not to make the hash stable — stabilising it would have preserved a value nobody reads. The `@Suppress("UnusedParameter")` that silenced the resulting warning goes with it, since both remaining parameters are now used and the warning should be doing its job again.

Worth flagging rather than quietly doing: the dead parameter read convincingly as a live bug. `hashCode()` really is unstable across processes, and a page id built on it really would have been broken. It just wasn't one — which is why the note stays in the KDoc for whoever reads it next.

## Verification

`./gradlew :app:assembleDebug testDebugUnitTest detekt ktlintCheck` → **BUILD SUCCESSFUL**.

Six new tests on `BoundedCache`: the bound, LRU-vs-insertion ordering, `putAll`, `clear`, rejection of a non-positive capacity (a zero-capacity cache would silently behave as a no-op), and real-thread contention.

## Still to come in Stage 4b-3

- **(2/3)** Cancellation tokens — `SourceParams(cancelToken)` + `cancelRequest`, with a registry keyed by logical operation so a new search cancels the in-flight one.
- **(3/3)** Sticky source per manga + user-defined source ordering in DataStore, and the opaque `sortMap` round-tripped detail → chapter → page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoEui2mCCcqArdhyQyFwnR)_

## Summary by Sourcery

Introduce a shared bounded LRU cache for browsing and header data and remove an unused page identifier parameter from the Tachiyomi compatibility layer.

New Features:
- Add a reusable, thread-safe BoundedCache utility for fixed-capacity, least-recently-used caching.

Bug Fixes:
- Prevent unbounded growth of in-memory browse and search caches in SourceRepositoryImpl by capping per-source entries.
- Eliminate a misleading chapterId parameter derived from an unstable hash that was never actually used when converting Tachiyomi pages.

Enhancements:
- Refactor PageImageHeaders to use the shared BoundedCache implementation and simplify its synchronization patterns.

Tests:
- Add unit tests for BoundedCache covering eviction behavior, capacity enforcement, clearing, invalid capacities, and concurrent access.


___

## **CodeAnt-AI Description**
Bound browsing caches and remove unused page identifier handling

### What Changed
- Browse and search results now have per-source limits and evict the least recently used entries, preventing memory growth during extended browsing.
- Recently viewed pages remain cached while older or unused results are discarded.
- Shared header caches retain their existing limits and now use the same bounded, thread-safe cache behavior.
- Page loading no longer passes or derives an unused chapter-based page identifier.

### Impact
`✅ Stable memory use during long browsing sessions`
`✅ Fewer repeated fetches for recently viewed pages`
`✅ Reliable concurrent cache access`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounded browse caches with thread-safe LRU `BoundedCache` and now swap cache generations on invalidation to prevent stale writes. Also batch-register Referer hosts, remove an unused page-id parameter, and delete the unused per-source cache invalidation.

- **Bug Fixes**
  - Replaced per-source inner maps in `SourceRepositoryImpl` with `BoundedCache` for search/page results.
  - Caps: 32 pages per source; 16 searches per source; evicts least recently used.
  - Fixed invalidation race by swapping a `BrowseCaches` instance; in-flight writes go to the old generation.
  - `PageImageHeaders` now uses `BoundedCache` and batch-registers Referer hosts via `putAll`.

- **Refactors**
  - Introduced `BoundedCache` in `:core:common` with tests for bounds, LRU ordering, bulk ops, invalid capacity, and concurrency.
  - Removed unused `chapterId` from `TachiyomiModelsAdapter.toPage`/`toPageList`; updated `TachiyomiSourceAdapter`.
  - Deleted unused `clearSourceCache`; per-source invalidation is not provided, and `clearCaches` swaps generations instead.

<sup>Written for commit 2126b9c90b702d13e963d88b41dc8a409bf7a8fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HeartlessVeteran2/Otaku-Reader/pull/1230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

