### PR TITLE
Stage 5a (1/n): type AniList GraphQL variables so mutations stop being rejected

### DIFF
--- a/data/src/main/java/app/otakureader/data/tracking/api/TrackingApis.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/api/TrackingApis.kt
@@ -2,6 +2,7 @@ package app.otakureader.data.tracking.api
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.Field
@@ -116,7 +117,16 @@ interface AniListApi {
 @Serializable
 data class AniListGraphQlQuery(
     val query: String,
-    val variables: Map<String, String> = emptyMap()
+    /**
+     * GraphQL variables, typed.
+     *
+     * A `Map<String, String>` serialized every value as a JSON string, so `mediaId` went out as
+     * `"12345"` against a declared `Int` and `score` as `"8.0"` against a `Float`. AniList
+     * validates variables against the operation's declared types and rejected the whole
+     * document — which is why updates never persisted. [JsonObject] lets each value keep the
+     * type the query declares.
+     */
+    val variables: JsonObject = JsonObject(emptyMap())
 )
 
 @Serializable

--- a/data/src/main/java/app/otakureader/data/tracking/tracker/AniListTracker.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/tracker/AniListTracker.kt
@@ -8,6 +8,8 @@ import app.otakureader.domain.model.TrackStatus
 import app.otakureader.domain.model.TrackerType
 import app.otakureader.domain.tracking.Tracker
 import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 /**
  * Tracker implementation for [AniList](https://anilist.co/).
@@ -65,7 +67,7 @@ class AniListTracker(
               } }
             }
         """.trimIndent()
-        val variables = mapOf("search" to query)
+        val variables = buildJsonObject { put("search", query) }
         val response = api.query(AniListGraphQlQuery(gqlQuery, variables))
         return response.data?.page?.media.orEmpty().map { media ->
             TrackEntry(
@@ -87,7 +89,8 @@ class AniListTracker(
               }
             }
         """.trimIndent()
-        val variables = mapOf("id" to remoteId.toString())
+        // Int, not a quoted string: the query declares `${'$'}id: Int`.
+        val variables = buildJsonObject { put("id", remoteId) }
         return try {
             val response = api.query(AniListGraphQlQuery(gqlQuery, variables))
             val media = response.data?.media ?: return null
@@ -118,12 +121,14 @@ class AniListTracker(
               }
             }
         """.trimIndent()
-        val variables = mapOf(
-            "mediaId" to entry.remoteId.toString(),
-            "status" to statusToAniList(entry.status),
-            "score" to entry.score.toString(),
-            "progress" to entry.lastChapterRead.toInt().toString()
-        )
+        // Each value keeps the type the mutation declares. Sending these as strings is what
+        // made every update fail server-side while looking successful here.
+        val variables = buildJsonObject {
+            put("mediaId", entry.remoteId)
+            put("status", statusToAniList(entry.status))
+            put("score", entry.score)
+            put("progress", entry.lastChapterRead.toInt())
+        }
         return try {
             api.query(AniListGraphQlQuery(gqlMutation, variables))
             entry

--- a/data/src/test/java/app/otakureader/data/tracking/tracker/AniListTrackerTest.kt
+++ b/data/src/test/java/app/otakureader/data/tracking/tracker/AniListTrackerTest.kt
@@ -24,6 +24,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Test
 
 /**
@@ -323,7 +324,12 @@ class AniListTrackerTest {
         tracker.update(entry)
 
         assertNotNull(capturedQuery)
-        assertEquals("999", capturedQuery!!.variables["mediaId"])
+        // Unquoted: the old assertion expected the string "999", which is exactly the
+// mis-typing AniList rejected. `content` is "999" either way, so it is the
+// primitive's isString flag that actually distinguishes them.
+        val mediaId = capturedQuery!!.variables["mediaId"]!!.jsonPrimitive
+        assertEquals("999", mediaId.content)
+        assertEquals(false, mediaId.isString)
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -391,7 +397,7 @@ class AniListTrackerTest {
             )
         )
 
-        assertEquals("CURRENT", capturedQuery!!.variables["status"])
+        assertEquals("CURRENT", capturedQuery!!.variables["status"]!!.jsonPrimitive.content)
     }
 
     @Test
@@ -409,7 +415,7 @@ class AniListTrackerTest {
             )
         )
 
-        assertEquals("PAUSED", capturedQuery!!.variables["status"])
+        assertEquals("PAUSED", capturedQuery!!.variables["status"]!!.jsonPrimitive.content)
     }
 
     @Test
@@ -427,7 +433,7 @@ class AniListTrackerTest {
             )
         )
 
-        assertEquals("PLANNING", capturedQuery!!.variables["status"])
+        assertEquals("PLANNING", capturedQuery!!.variables["status"]!!.jsonPrimitive.content)
     }
 
     @Test
@@ -445,7 +451,7 @@ class AniListTrackerTest {
             )
         )
 
-        assertEquals("REPEATING", capturedQuery!!.variables["status"])
+        assertEquals("REPEATING", capturedQuery!!.variables["status"]!!.jsonPrimitive.content)
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/data/src/test/java/app/otakureader/data/tracking/tracker/AniListTrackerTest.kt
+++ b/data/src/test/java/app/otakureader/data/tracking/tracker/AniListTrackerTest.kt
@@ -325,8 +325,8 @@ class AniListTrackerTest {
 
         assertNotNull(capturedQuery)
         // Unquoted: the old assertion expected the string "999", which is exactly the
-// mis-typing AniList rejected. `content` is "999" either way, so it is the
-// primitive's isString flag that actually distinguishes them.
+        // mis-typing AniList rejected. `content` is "999" either way, so it is the
+        // primitive's isString flag that actually distinguishes them.
         val mediaId = capturedQuery!!.variables["mediaId"]!!.jsonPrimitive
         assertEquals("999", mediaId.content)
         assertEquals(false, mediaId.isString)

--- a/data/src/test/java/app/otakureader/data/tracking/tracker/AniListVariableTypingTest.kt
+++ b/data/src/test/java/app/otakureader/data/tracking/tracker/AniListVariableTypingTest.kt
@@ -1,0 +1,61 @@
+package app.otakureader.data.tracking.tracker
+
+import app.otakureader.data.tracking.api.AniListGraphQlQuery
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Locks down how GraphQL variables are serialized.
+ *
+ * AniList validates variables against the types the operation declares, and rejects the whole
+ * document on a mismatch. The previous `Map<String, String>` sent every value quoted, so
+ * `mediaId` arrived as `"12345"` against a declared `Int` — every update failed server-side
+ * while the client reported success, because `update()` swallowed the error and returned its
+ * input unchanged.
+ *
+ * Asserting on the serialized JSON rather than on the Kotlin object is the point: the Kotlin
+ * side looked correct under the old type too. Only the wire format showed the bug.
+ */
+class AniListVariableTypingTest {
+
+    private val json = Json { encodeDefaults = true }
+
+    @Test
+    fun `numeric variables serialize unquoted`() {
+        val query = AniListGraphQlQuery(
+            query = "mutation {}",
+            variables = buildJsonObject {
+                put("mediaId", 12345L)
+                put("progress", 7)
+                put("score", 8.5f)
+            },
+        )
+
+        val encoded = json.encodeToString(AniListGraphQlQuery.serializer(), query)
+
+        assertTrue("mediaId must not be quoted: $encoded", encoded.contains("\"mediaId\":12345"))
+        assertTrue("progress must not be quoted: $encoded", encoded.contains("\"progress\":7"))
+        assertTrue("score must not be quoted: $encoded", encoded.contains("\"score\":8.5"))
+    }
+
+    @Test
+    fun `string variables stay quoted`() {
+        // The fix must not overcorrect: enum and search values are genuinely strings, and
+        // unquoting them would break the query in the opposite direction.
+        val query = AniListGraphQlQuery(
+            query = "query {}",
+            variables = buildJsonObject {
+                put("search", "Berserk")
+                put("status", "CURRENT")
+            },
+        )
+
+        val encoded = json.encodeToString(AniListGraphQlQuery.serializer(), query)
+
+        assertTrue("search must stay quoted: $encoded", encoded.contains("\"search\":\"Berserk\""))
+        assertTrue("status must stay quoted: $encoded", encoded.contains("\"status\":\"CURRENT\""))
+    }
+}


### PR DESCRIPTION
## **User description**
First piece of Stage 5. Verified before implementing, per the pattern in #1231 — and unlike Stage 4b-3, **this premise holds**.

## What was wrong

`AniListGraphQlQuery.variables` was `Map<String, String>`, so kotlinx.serialization emitted every value quoted:

```json
{"mediaId":"12345","progress":"7","score":"8.0"}
```

against a mutation declaring `$mediaId: Int, $score: Float, $progress: Int`. AniList validates variables against the operation's declared types and rejects the whole document, so **no update ever persisted**.

## Why it survived this long

It failed silently. `update()` catches the exception and returns its input unchanged, so the app reported success and showed the new progress locally while the server had rejected it. Nothing surfaced — the tracker looked like it worked.

## The fix

`variables` is now a `JsonObject`, and the three call sites build one. Numbers stay numbers; `search` and the status enum stay strings — the fix must not overcorrect in the other direction, which is why there's a test for that too.

## The old test asserted the bug

`update mutation variables contain correct mediaId` asserted the value equalled the **string** `"999"` — exactly the mis-typing AniList was rejecting. A test named for correctness was pinning the defect in place, and it went green on every run.

It now asserts on the JSON primitive and checks `isString` is **false**, not just that `content` matches. `content` is `"999"` either way, so the quoting flag is the only thing that distinguishes the broken encoding from the fixed one — comparing content alone would pass under both.

The four status assertions moved to `jsonPrimitive.content` for the same reason.

A new `AniListVariableTypingTest` asserts the **serialized wire format** directly, because the Kotlin side looked correct under the old type too. Only the encoded JSON showed the problem.

## Still outstanding in Stage 5a

Verified present in the current file, deliberately not in this PR — both are about *login*, which is a separate change from the transport encoding:

- `authorizationUrl()` is not overridden, so login lands on a bare endpoint with no `client_id` / `redirect_uri` / `response_type`.
- `ANILIST_CLIENT_ID` has no entry in `TrackerCredentials` — it's the only tracker missing one.

Neither is reachable until the other lands, so they belong together in the next slice.

## Verification

`./gradlew :app:assembleDebug testDebugUnitTest detekt ktlintCheck` → **BUILD SUCCESSFUL**, 559 tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoEui2mCCcqArdhyQyFwnR)_

## Summary by Sourcery

Type AniList GraphQL variables correctly so numeric mutation variables are sent as proper JSON numbers instead of strings, ensuring AniList updates persist.

Bug Fixes:
- Fix AniList mutations being rejected by sending numeric variables (mediaId, progress, score) as JSON numbers instead of quoted strings.

Enhancements:
- Change AniList GraphQL query variable container from a string map to a JsonObject so each variable preserves its intended JSON type.

Tests:
- Adjust AniList tracker tests to assert numeric variables are encoded as non-string JSON primitives while status enums remain strings.
- Add AniListVariableTypingTest to lock down the serialized JSON wire format for numeric and string GraphQL variables.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix AniList GraphQL variable typing so mutations stop being rejected. Variables now serialize with correct types, so updates persist server-side instead of failing silently.

- **Bug Fixes**
  - Changed `AniListGraphQlQuery.variables` to `JsonObject`; send numbers (`mediaId`, `progress`, `score`) as numbers, keep `search` and status as strings.
  - Updated tests to assert JSON primitives and wire format; added `AniListVariableTypingTest`; fixed comment indentation.

<sup>Written for commit f0f16290f51bfa89bbdcf7e2d4aa654b47cac58d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HeartlessVeteran2/Otaku-Reader/pull/1232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Send AniList GraphQL variables with the correct types

### What Changed
- AniList searches, lookups, and updates now send numbers as JSON numbers instead of quoted strings.
- Status and search values remain strings, matching AniList's expected input types.
- Added coverage for the serialized request format and updated tracker assertions to detect incorrect quoting.

### Impact
`✅ AniList progress updates can be saved successfully`
`✅ Fewer silently rejected tracker updates`
`✅ Reliable AniList search and lookup requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
