### PR TITLE
Stage 5a (3/n): fix AniList's find, update and score scale

### DIFF
--- a/data/src/main/java/app/otakureader/data/tracking/api/TrackingApis.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/api/TrackingApis.kt
@@ -131,7 +131,22 @@ data class AniListGraphQlQuery(
 
 @Serializable
 data class AniListResponse(
-    val data: AniListData? = null
+    val data: AniListData? = null,
+    /**
+     * GraphQL-level errors.
+     *
+     * These are the reason a caller cannot treat "the HTTP call returned" as "the operation
+     * worked". GraphQL reports a rejected document with **HTTP 200** and `data: null`, so Retrofit
+     * sees a perfectly successful response and throws nothing. Without this field the reason was
+     * not merely unreported — it was unparsed, so an update that AniList refused looked identical
+     * to one it accepted.
+     */
+    val errors: List<AniListError> = emptyList()
+)
+
+@Serializable
+data class AniListError(
+    val message: String = ""
 )
 
 @Serializable

--- a/data/src/main/java/app/otakureader/data/tracking/tracker/AniListTracker.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/tracker/AniListTracker.kt
@@ -128,6 +128,10 @@ class AniListTracker(
         """.trimIndent()
         val variables = buildJsonObject { put("search", query) }
         val response = api.query(AniListGraphQlQuery(gqlQuery, variables))
+        // Same reason as in `update`: a rejected document arrives as HTTP 200, so without this a
+        // refused search is indistinguishable from a search that genuinely found nothing, and the
+        // user is told "no results" for a query that was never run.
+        response.errors.firstOrNull()?.let { throw AniListGraphQlException(it.message) }
         return response.data?.page?.media.orEmpty().map { media ->
             TrackEntry(
                 remoteId = media.id,
@@ -224,12 +228,22 @@ class AniListTracker(
             put("scoreRaw", entry.score.toAniListPoint100())
             put("progress", entry.lastChapterRead.toInt())
         }
-        val saved = api.query(AniListGraphQlQuery(gqlMutation, variables)).data?.savedEntry
+        val response = api.query(AniListGraphQlQuery(gqlMutation, variables))
+        // No confirmed entry means the mutation did not take, and this must not return normally.
+        // GraphQL reports a rejected document with **HTTP 200** and `data: null`, so Retrofit
+        // throws nothing and the exception-propagation fix above never fires for this case —
+        // an unauthenticated token, a media id AniList doesn't have, a variable it won't accept.
+        // Returning `entry` here would have been the very behaviour this change set out to
+        // remove, one branch over: the caller writes `syncStatus = SYNCED` on the next line.
+        val saved = response.data?.savedEntry
+            ?: throw AniListGraphQlException(
+                response.errors.firstOrNull()?.message
+                    ?: "AniList did not confirm the update for media ${entry.remoteId}"
+            )
         // Prefer what AniList confirmed over what was sent. The mutation already asked for these
         // fields and then discarded them, so a value the server clamped or normalised — a score
         // above the user's maximum, progress past the final chapter — was written back locally as
         // whatever this app had guessed.
-        if (saved == null) return entry
         return entry.copy(
             // A blank status means the field was absent from the response, not that the entry is
             // unset — mapping "" would run through statusFromAniList's else branch and quietly
@@ -295,3 +309,13 @@ class AniListTracker(
         const val ANILIST_MAX_SCORE = 100
     }
 }
+
+/**
+ * AniList accepted the request but refused the mutation.
+ *
+ * Distinct from the `IOException` a transport failure produces, because the two want different
+ * handling: a dropped connection is worth retrying, a rejected media id never will be. Callers in
+ * `TrackerSyncRepositoryImpl` catch `Exception` and mark `SyncStatus.ERROR` either way, so this
+ * exists to carry AniList's own message to the log rather than to be caught separately today.
+ */
+class AniListGraphQlException(message: String) : Exception(message)

--- a/data/src/main/java/app/otakureader/data/tracking/tracker/AniListTracker.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/tracker/AniListTracker.kt
@@ -229,17 +229,20 @@ class AniListTracker(
             put("progress", entry.lastChapterRead.toInt())
         }
         val response = api.query(AniListGraphQlQuery(gqlMutation, variables))
+        // Errors first, exactly as in `search`. GraphQL is not all-or-nothing: a response may
+        // carry `data` *and* `errors` when one resolver fails and its siblings succeed, so
+        // checking errors only where `savedEntry` is null would accept a partial write and
+        // persist its half-filled values. Any error at all means this push is not something to
+        // report as done.
+        response.errors.firstOrNull()?.let { throw AniListGraphQlException(it.message) }
         // No confirmed entry means the mutation did not take, and this must not return normally.
-        // GraphQL reports a rejected document with **HTTP 200** and `data: null`, so Retrofit
-        // throws nothing and the exception-propagation fix above never fires for this case —
-        // an unauthenticated token, a media id AniList doesn't have, a variable it won't accept.
-        // Returning `entry` here would have been the very behaviour this change set out to
-        // remove, one branch over: the caller writes `syncStatus = SYNCED` on the next line.
+        // GraphQL reports a rejected document with **HTTP 200**, so Retrofit throws nothing and
+        // the exception-propagation fix above never fires for this case — an unauthenticated
+        // token, a media id AniList doesn't have, a variable it won't accept. Returning `entry`
+        // here would have been the very behaviour this change set out to remove, one branch over:
+        // the caller writes `syncStatus = SYNCED` on the next line.
         val saved = response.data?.savedEntry
-            ?: throw AniListGraphQlException(
-                response.errors.firstOrNull()?.message
-                    ?: "AniList did not confirm the update for media ${entry.remoteId}"
-            )
+            ?: throw AniListGraphQlException("AniList did not confirm the update for media ${entry.remoteId}")
         // Prefer what AniList confirmed over what was sent. The mutation already asked for these
         // fields and then discarded them, so a value the server clamped or normalised — a score
         // above the user's maximum, progress past the final chapter — was written back locally as

--- a/data/src/main/java/app/otakureader/data/tracking/tracker/AniListTracker.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/tracker/AniListTracker.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import kotlin.math.roundToInt
 
 /**
  * Tracker implementation for [AniList](https://anilist.co/).
@@ -46,7 +47,12 @@ class AniListTracker(
     override val name: String = "AniList"
 
     private var accessToken: String? = tokenStore.getTokens(TrackerType.ANILIST)?.accessToken
-    private var currentUserId: Long? = tokenStore.getTokens(TrackerType.ANILIST)?.userId
+    // No `currentUserId` here, unlike ShikimoriTracker. Shikimori's user-rate endpoints take a
+    // user id as a parameter, so it genuinely needs one; AniList's `Media { mediaListEntry }` and
+    // `SaveMediaListEntry` are already scoped to whoever the bearer token belongs to. The field
+    // used to exist and was written only by `logout()` — nothing ever read it, and `login()` never
+    // populated it, so it was null for the object's whole life. The plan called for adding a
+    // `Viewer { id }` query to fill it; that would have fetched a value with no consumer.
 
     override val isLoggedIn: Boolean
         get() = accessToken != null
@@ -109,7 +115,6 @@ class AniListTracker(
 
     override fun logout() {
         accessToken = null
-        currentUserId = null
         tokenStore.clearTokens(id)
     }
 
@@ -135,11 +140,28 @@ class AniListTracker(
         }
     }
 
+    /**
+     * Look up a media entry, whether or not the user has it on their list.
+     *
+     * The list entry used to be required — `media.mediaListEntry ?: return null` — which made this
+     * return null for every manga the user had not already added. That is exactly backwards for
+     * the flow that matters: you search for something *because* it isn't tracked yet, and the app
+     * then cannot resolve the thing it just found. `Media` and `mediaListEntry` are separate
+     * concerns, so a missing list entry now means "not tracked yet" (default status, zero
+     * progress) rather than "no such manga".
+     *
+     * `score(format: POINT_100)` is deliberate. Without the argument AniList returns the score in
+     * whatever format the *user* picked — 0–10, 0–5 stars, three smileys — so the same number
+     * meant different things per account, with nothing on the wire to say which. Naming the format
+     * makes the response self-describing, and it removes the need to fetch
+     * `mediaListOptions.scoreFormat` separately just to interpret it.
+     */
     override suspend fun find(remoteId: Long): TrackEntry? {
         val gqlQuery = """
             query (${'$'}id: Int) {
               Media(id: ${'$'}id, type: MANGA) {
-                id title { romaji english } chapters mediaListEntry { id status score progress }
+                id title { romaji english } chapters
+                mediaListEntry { id status score(format: POINT_100) progress }
               }
             }
         """.trimIndent()
@@ -148,17 +170,17 @@ class AniListTracker(
         return try {
             val response = api.query(AniListGraphQlQuery(gqlQuery, variables))
             val media = response.data?.media ?: return null
-            val listEntry = media.mediaListEntry ?: return null
+            val listEntry = media.mediaListEntry
             TrackEntry(
                 remoteId = remoteId,
                 mangaId = 0L,
                 trackerId = id,
                 title = media.title?.english ?: media.title?.romaji ?: "",
                 remoteUrl = "https://anilist.co/manga/$remoteId",
-                status = statusFromAniList(listEntry.status),
-                lastChapterRead = listEntry.progress.toFloat(),
+                status = listEntry?.let { statusFromAniList(it.status) } ?: TrackStatus.PLAN_TO_READ,
+                lastChapterRead = listEntry?.progress?.toFloat() ?: 0f,
                 totalChapters = media.chapters ?: 0,
-                score = listEntry.score
+                score = listEntry?.score?.fromAniListPoint100() ?: 0f
             )
         } catch (e: CancellationException) {
             throw e
@@ -167,11 +189,30 @@ class AniListTracker(
         }
     }
 
+    /**
+     * Push [entry] to AniList, throwing if the push does not land.
+     *
+     * This used to catch every exception and return the input entry unchanged. The interface
+     * forbids that in as many words — *"implementations must throw on remote failure rather than
+     * silently returning the input entry"* — and the reason is visible at the call sites:
+     * `TrackerSyncRepositoryImpl` writes `syncStatus = SYNCED` and a `lastSuccessfulSync` stamp
+     * immediately after this returns. Swallowing the failure recorded a successful sync for a
+     * request that never reached AniList, and the entry then looked up to date forever. All three
+     * call sites already sit inside `catch` blocks that mark `SyncStatus.ERROR`, so throwing is
+     * what they were built to receive.
+     *
+     * `scoreRaw` is typed `Int` here because that is what AniList declares it as, and it is always
+     * on the 0–100 scale regardless of the user's display format — which is the whole reason to
+     * use it rather than `score`. Declaring it `Float` was the same defect as the string-typed
+     * variables fixed in #1232, one line over.
+     */
     override suspend fun update(entry: TrackEntry): TrackEntry {
         val gqlMutation = """
-            mutation (${'$'}mediaId: Int, ${'$'}status: MediaListStatus, ${'$'}score: Float, ${'$'}progress: Int) {
-              SaveMediaListEntry(mediaId: ${'$'}mediaId, status: ${'$'}status, scoreRaw: ${'$'}score, progress: ${'$'}progress) {
-                id status score progress
+            mutation (${'$'}mediaId: Int, ${'$'}status: MediaListStatus, ${'$'}scoreRaw: Int, ${'$'}progress: Int) {
+              SaveMediaListEntry(
+                mediaId: ${'$'}mediaId, status: ${'$'}status, scoreRaw: ${'$'}scoreRaw, progress: ${'$'}progress
+              ) {
+                id status score(format: POINT_100) progress
               }
             }
         """.trimIndent()
@@ -180,17 +221,23 @@ class AniListTracker(
         val variables = buildJsonObject {
             put("mediaId", entry.remoteId)
             put("status", statusToAniList(entry.status))
-            put("score", entry.score)
+            put("scoreRaw", entry.score.toAniListPoint100())
             put("progress", entry.lastChapterRead.toInt())
         }
-        return try {
-            api.query(AniListGraphQlQuery(gqlMutation, variables))
-            entry
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            entry
-        }
+        val saved = api.query(AniListGraphQlQuery(gqlMutation, variables)).data?.savedEntry
+        // Prefer what AniList confirmed over what was sent. The mutation already asked for these
+        // fields and then discarded them, so a value the server clamped or normalised — a score
+        // above the user's maximum, progress past the final chapter — was written back locally as
+        // whatever this app had guessed.
+        if (saved == null) return entry
+        return entry.copy(
+            // A blank status means the field was absent from the response, not that the entry is
+            // unset — mapping "" would run through statusFromAniList's else branch and quietly
+            // rewrite the user's status to PLAN_TO_READ.
+            status = saved.status.takeIf { it.isNotBlank() }?.let { statusFromAniList(it) } ?: entry.status,
+            lastChapterRead = saved.progress.toFloat(),
+            score = saved.score.fromAniListPoint100(),
+        )
     }
 
     override fun toTrackStatus(remoteStatus: Int): TrackStatus = TrackStatus.fromOrdinal(remoteStatus)
@@ -214,5 +261,37 @@ class AniListTracker(
         TrackStatus.DROPPED -> "DROPPED"
         TrackStatus.PLAN_TO_READ -> "PLANNING"
         TrackStatus.RE_READING -> "REPEATING"
+    }
+
+    /**
+     * Canonical 0–10 score → AniList's 0–100 `scoreRaw`.
+     *
+     * `roundToInt`, not `toInt`: `0.7f * 10` is 6.9999995, and truncating would file a 0.7 as 6.
+     * The clamp keeps a malformed local score from producing a request AniList rejects outright.
+     */
+    private fun Float.toAniListPoint100(): Int =
+        (this * ANILIST_POINTS_PER_SCORE_POINT).roundToInt().coerceIn(ANILIST_MIN_SCORE, ANILIST_MAX_SCORE)
+
+    /** AniList's 0–100 score → canonical 0–10. */
+    private fun Float.fromAniListPoint100(): Float = this / ANILIST_POINTS_PER_SCORE_POINT
+
+    private companion object {
+        /**
+         * How many AniList points make one point of [TrackEntry.score].
+         *
+         * `TrackEntry.score` has no documented scale, so the one that counts is what the other
+         * trackers already store: Kitsu halves its 0–20 `ratingTwenty`, and MAL and Shikimori are
+         * natively 0–10. That makes **0–10** the de-facto canonical scale, and AniList's
+         * `scoreRaw`/`score(format: POINT_100)` is 0–100.
+         *
+         * Nothing converted between them. A user who rated something 8 sent `scoreRaw: 8`, which
+         * AniList stores as 8/100 — an 0.8 out of 10. Every score written to AniList was a tenth
+         * of what the user meant, and every score read back was ten times it.
+         */
+        const val ANILIST_POINTS_PER_SCORE_POINT = 10f
+
+        /** The bounds AniList accepts for `scoreRaw`; anything outside is rejected. */
+        const val ANILIST_MIN_SCORE = 0
+        const val ANILIST_MAX_SCORE = 100
     }
 }

--- a/data/src/test/java/app/otakureader/data/tracking/tracker/AniListTrackerTest.kt
+++ b/data/src/test/java/app/otakureader/data/tracking/tracker/AniListTrackerTest.kt
@@ -3,6 +3,7 @@ package app.otakureader.data.tracking.tracker
 import app.otakureader.data.tracking.api.AniListApi
 import app.otakureader.data.tracking.api.AniListCoverImage
 import app.otakureader.data.tracking.api.AniListData
+import app.otakureader.data.tracking.api.AniListError
 import app.otakureader.data.tracking.api.AniListGraphQlQuery
 import app.otakureader.data.tracking.api.AniListMedia
 import app.otakureader.data.tracking.api.AniListMediaList
@@ -307,7 +308,7 @@ class AniListTrackerTest {
     // ─────────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `update sends GraphQL mutation and returns entry`() = runTest {
+    fun `update sends GraphQL mutation and returns the confirmed entry`() = runTest {
         val entry = TrackEntry(
             remoteId = 101L,
             mangaId = 1L,
@@ -316,12 +317,73 @@ class AniListTrackerTest {
             lastChapterRead = 364f,
             score = 9f
         )
-        coEvery { api.query(any()) } returns AniListResponse(data = null)
+        coEvery { api.query(any()) } returns confirmation(status = "COMPLETED", score = 90f, progress = 364)
 
         val result = tracker.update(entry)
 
         assertEquals(entry, result)
         coVerify(exactly = 1) { api.query(any()) }
+    }
+
+    /**
+     * A GraphQL rejection arrives as HTTP 200 with `data: null`, which Retrofit does not throw on.
+     *
+     * This is the same defect as the swallowed exception above, one branch over, and the first
+     * version of this change set had it: returning the input entry here would be reported by
+     * `TrackerSyncRepositoryImpl` as `syncStatus = SYNCED` on the very next line. An expired
+     * token, a media id AniList doesn't have, or a variable it won't accept all land here — none
+     * of them raise anything by themselves.
+     */
+    @Test
+    fun `update throws when AniList returns no confirmed entry`() = runTest {
+        coEvery { api.query(any()) } returns AniListResponse(data = null)
+
+        val thrown = try {
+            tracker.update(sampleEntry())
+            null
+        } catch (e: AniListGraphQlException) {
+            e
+        }
+
+        assertNotNull(thrown)
+    }
+
+    @Test
+    fun `update surfaces AniList's own error message`() = runTest {
+        // Without the `errors` field the reason wasn't merely unreported, it was unparsed — so
+        // "Invalid token" and "everything worked" were the same response as far as this code knew.
+        coEvery { api.query(any()) } returns AniListResponse(
+            data = null,
+            errors = listOf(AniListError(message = "Invalid token"))
+        )
+
+        val thrown = try {
+            tracker.update(sampleEntry())
+            null
+        } catch (e: AniListGraphQlException) {
+            e
+        }
+
+        assertEquals("Invalid token", thrown!!.message)
+    }
+
+    @Test
+    fun `search throws rather than reporting a rejected query as no results`() = runTest {
+        coEvery { api.query(any()) } returns AniListResponse(
+            data = null,
+            errors = listOf(AniListError(message = "Invalid token"))
+        )
+
+        val thrown = try {
+            tracker.search("Berserk")
+            null
+        } catch (e: AniListGraphQlException) {
+            e
+        }
+
+        // An empty list here would tell the user their search found nothing, when in fact it was
+        // never run — indistinguishable from a genuine miss, and unfixable from the UI.
+        assertEquals("Invalid token", thrown!!.message)
     }
 
     /**
@@ -365,7 +427,7 @@ class AniListTrackerTest {
         var capturedQuery: AniListGraphQlQuery? = null
         coEvery { api.query(any()) } answers {
             capturedQuery = firstArg()
-            AniListResponse(data = null)
+            confirmation()
         }
 
         tracker.update(
@@ -389,7 +451,7 @@ class AniListTrackerTest {
         var capturedQuery: AniListGraphQlQuery? = null
         coEvery { api.query(any()) } answers {
             capturedQuery = firstArg()
-            AniListResponse(data = null)
+            confirmation()
         }
 
         tracker.update(
@@ -453,7 +515,7 @@ class AniListTrackerTest {
         var capturedQuery: AniListGraphQlQuery? = null
         coEvery { api.query(any()) } answers {
             capturedQuery = firstArg()
-            AniListResponse(data = null)
+            confirmation()
         }
 
         tracker.update(entry)
@@ -522,7 +584,7 @@ class AniListTrackerTest {
         var capturedQuery: AniListGraphQlQuery? = null
         coEvery { api.query(any()) } answers {
             capturedQuery = firstArg()
-            AniListResponse(data = null)
+            confirmation()
         }
 
         tracker.update(
@@ -540,7 +602,7 @@ class AniListTrackerTest {
         var capturedQuery: AniListGraphQlQuery? = null
         coEvery { api.query(any()) } answers {
             capturedQuery = firstArg()
-            AniListResponse(data = null)
+            confirmation()
         }
 
         tracker.update(
@@ -558,7 +620,7 @@ class AniListTrackerTest {
         var capturedQuery: AniListGraphQlQuery? = null
         coEvery { api.query(any()) } answers {
             capturedQuery = firstArg()
-            AniListResponse(data = null)
+            confirmation()
         }
 
         tracker.update(
@@ -576,7 +638,7 @@ class AniListTrackerTest {
         var capturedQuery: AniListGraphQlQuery? = null
         coEvery { api.query(any()) } answers {
             capturedQuery = firstArg()
-            AniListResponse(data = null)
+            confirmation()
         }
 
         tracker.update(
@@ -613,6 +675,31 @@ class AniListTrackerTest {
     // ─────────────────────────────────────────────────────────────────────────
     // Helpers
     // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * A response in which AniList confirms the mutation.
+     *
+     * The default `status` and `progress` are deliberately what the sample entries send, so tests
+     * that only care about the *request* aren't perturbed by the confirmation overwriting fields.
+     * Stubbing `AniListResponse(data = null)` here — as these tests used to — now means "AniList
+     * refused the mutation", which is a different scenario and throws.
+     */
+    private fun confirmation(
+        status: String = "CURRENT",
+        score: Float = 0f,
+        progress: Int = 0,
+    ) = AniListResponse(
+        data = AniListData(savedEntry = AniListMediaList(id = 1L, status = status, score = score, progress = progress))
+    )
+
+    private fun sampleEntry() = TrackEntry(
+        remoteId = 101L,
+        mangaId = 1L,
+        trackerId = TrackerType.ANILIST,
+        status = TrackStatus.READING,
+        lastChapterRead = 100f,
+        score = 7f,
+    )
 
     private suspend fun buildFindResponse(status: String): TrackEntry? {
         val listEntry = AniListMediaList(id = 1L, status = status, score = 5f, progress = 0)

--- a/data/src/test/java/app/otakureader/data/tracking/tracker/AniListTrackerTest.kt
+++ b/data/src/test/java/app/otakureader/data/tracking/tracker/AniListTrackerTest.kt
@@ -212,7 +212,9 @@ class AniListTrackerTest {
 
     @Test
     fun `find returns TrackEntry when media list entry is present`() = runTest {
-        val listEntry = AniListMediaList(id = 1L, status = "CURRENT", score = 8.5f, progress = 50)
+        // 85 on AniList's POINT_100 scale, which the query asks for by name. The canonical
+        // TrackEntry scale is 0-10, so this must come back as 8.5 — not 85.
+        val listEntry = AniListMediaList(id = 1L, status = "CURRENT", score = 85f, progress = 50)
         val media = AniListMedia(
             id = 101L,
             title = AniListTitle(romaji = "Berserk", english = "Berserk"),
@@ -233,8 +235,17 @@ class AniListTrackerTest {
         assertEquals(8.5f, entry.score)
     }
 
+    /**
+     * A manga the user has not added yet must still resolve.
+     *
+     * This test previously asserted `assertNull` — it locked in the bug rather than catching it.
+     * `mediaListEntry` is null for anything not already on the user's list, and requiring it made
+     * `find` fail for precisely the case that matters: you look something up *because* you want to
+     * start tracking it. Media identity and list membership are separate facts, so a missing list
+     * entry now means "found, not tracked yet".
+     */
     @Test
-    fun `find returns null when media has no list entry`() = runTest {
+    fun `find returns an untracked entry when media has no list entry`() = runTest {
         val media = AniListMedia(
             id = 101L,
             title = AniListTitle(romaji = "Berserk"),
@@ -247,7 +258,30 @@ class AniListTrackerTest {
 
         val entry = tracker.find(101L)
 
-        assertNull(entry)
+        assertNotNull(entry)
+        assertEquals(101L, entry!!.remoteId)
+        assertEquals("Berserk", entry.title)
+        // The media's own facts survive; only the per-user ones default.
+        assertEquals(364, entry.totalChapters)
+        assertEquals(TrackStatus.PLAN_TO_READ, entry.status)
+        assertEquals(0f, entry.lastChapterRead)
+        assertEquals(0f, entry.score)
+    }
+
+    @Test
+    fun `find asks AniList for the score on a named scale`() = runTest {
+        // Without `format:` AniList answers in whatever format the *user* picked — 0-10, 5 stars,
+        // three smileys — and the response carries nothing saying which. The same number would
+        // then mean different things per account, and no amount of arithmetic here could tell.
+        var capturedQuery: AniListGraphQlQuery? = null
+        coEvery { api.query(any()) } answers {
+            capturedQuery = firstArg()
+            AniListResponse(data = null)
+        }
+
+        tracker.find(1L)
+
+        assertTrue(capturedQuery!!.query, capturedQuery!!.query.contains("score(format: POINT_100)"))
     }
 
     @Test
@@ -290,8 +324,19 @@ class AniListTrackerTest {
         coVerify(exactly = 1) { api.query(any()) }
     }
 
+    /**
+     * A failed push must surface, not be reported as the entry it failed to send.
+     *
+     * The previous version of this test asserted the opposite — that `update` returns the input
+     * unchanged on a network error — which locked in the exact behaviour the `Tracker` KDoc
+     * forbids. It matters because of what happens next: `TrackerSyncRepositoryImpl` writes
+     * `syncStatus = SYNCED` and a `lastSuccessfulSync` timestamp on the line after this returns.
+     * Swallowing the error recorded a successful sync for a request AniList never saw, and the
+     * entry then looked up to date indefinitely. All three call sites are already inside `catch`
+     * blocks that mark `SyncStatus.ERROR`.
+     */
     @Test
-    fun `update returns entry unchanged on network error`() = runTest {
+    fun `update propagates a network error instead of reporting success`() = runTest {
         val entry = TrackEntry(
             remoteId = 101L,
             mangaId = 1L,
@@ -302,9 +347,99 @@ class AniListTrackerTest {
         )
         coEvery { api.query(any()) } throws RuntimeException("Network error")
 
-        val result = tracker.update(entry)
+        val thrown = try {
+            tracker.update(entry)
+            null
+        } catch (e: RuntimeException) {
+            e
+        }
 
-        assertEquals(entry, result)
+        assertNotNull(thrown)
+        assertEquals("Network error", thrown!!.message)
+    }
+
+    @Test
+    fun `update sends the score on AniList's 0-100 scale`() = runTest {
+        // TrackEntry.score is 0-10 — the scale Kitsu, MAL and Shikimori already store — while
+        // `scoreRaw` is 0-100. Passing it through unconverted filed a user's 8 as 8/100.
+        var capturedQuery: AniListGraphQlQuery? = null
+        coEvery { api.query(any()) } answers {
+            capturedQuery = firstArg()
+            AniListResponse(data = null)
+        }
+
+        tracker.update(
+            TrackEntry(
+                remoteId = 1L, mangaId = 1L, trackerId = TrackerType.ANILIST,
+                status = TrackStatus.READING, score = 8.5f
+            )
+        )
+
+        val scoreRaw = capturedQuery!!.variables["scoreRaw"]!!.jsonPrimitive
+        assertEquals("85", scoreRaw.content)
+        // Int, not a quoted string and not a Float: AniList declares scoreRaw as Int, and a
+        // mis-typed variable is rejected for the whole document — the defect fixed in #1232.
+        assertEquals(false, scoreRaw.isString)
+        assertTrue(capturedQuery!!.query, capturedQuery!!.query.contains("${'$'}scoreRaw: Int"))
+    }
+
+    @Test
+    fun `a score that does not divide evenly is rounded rather than truncated`() = runTest {
+        // 0.7f * 10 is 6.9999995 in binary floating point. `toInt()` would file this as a 6.
+        var capturedQuery: AniListGraphQlQuery? = null
+        coEvery { api.query(any()) } answers {
+            capturedQuery = firstArg()
+            AniListResponse(data = null)
+        }
+
+        tracker.update(
+            TrackEntry(
+                remoteId = 1L, mangaId = 1L, trackerId = TrackerType.ANILIST,
+                status = TrackStatus.READING, score = 0.7f
+            )
+        )
+
+        assertEquals("7", capturedQuery!!.variables["scoreRaw"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `update returns what AniList confirmed rather than what was sent`() = runTest {
+        // The mutation already asked for these fields and then threw them away, so a value the
+        // server clamped or normalised was written back locally as whatever the app had guessed.
+        coEvery { api.query(any()) } returns AniListResponse(
+            data = AniListData(
+                savedEntry = AniListMediaList(id = 7L, status = "COMPLETED", score = 90f, progress = 364)
+            )
+        )
+
+        val result = tracker.update(
+            TrackEntry(
+                remoteId = 101L, mangaId = 1L, trackerId = TrackerType.ANILIST,
+                status = TrackStatus.READING, lastChapterRead = 300f, score = 7f
+            )
+        )
+
+        assertEquals(TrackStatus.COMPLETED, result.status)
+        assertEquals(364f, result.lastChapterRead)
+        assertEquals(9f, result.score)
+    }
+
+    @Test
+    fun `a confirmation with no status keeps the status that was sent`() = runTest {
+        // An absent field deserializes to "", which statusFromAniList would map through its else
+        // branch to PLAN_TO_READ — silently rewriting the user's status on a successful update.
+        coEvery { api.query(any()) } returns AniListResponse(
+            data = AniListData(savedEntry = AniListMediaList(id = 7L, status = "", score = 90f, progress = 12))
+        )
+
+        val result = tracker.update(
+            TrackEntry(
+                remoteId = 101L, mangaId = 1L, trackerId = TrackerType.ANILIST,
+                status = TrackStatus.READING, lastChapterRead = 12f
+            )
+        )
+
+        assertEquals(TrackStatus.READING, result.status)
     }
 
     @Test

--- a/data/src/test/java/app/otakureader/data/tracking/tracker/AniListTrackerTest.kt
+++ b/data/src/test/java/app/otakureader/data/tracking/tracker/AniListTrackerTest.kt
@@ -367,6 +367,31 @@ class AniListTrackerTest {
         assertEquals("Invalid token", thrown!!.message)
     }
 
+    /**
+     * GraphQL is not all-or-nothing.
+     *
+     * A response can carry `data` *and* `errors` when one resolver fails and its siblings
+     * succeed. Checking `errors` only on the `savedEntry == null` path — as the first version of
+     * this fix did — accepts that response and writes its half-filled values locally, which is
+     * the same "reported as synced when it wasn't" failure in a subtler shape.
+     */
+    @Test
+    fun `update throws on a partial response that carries both data and errors`() = runTest {
+        coEvery { api.query(any()) } returns AniListResponse(
+            data = AniListData(savedEntry = AniListMediaList(id = 7L, status = "CURRENT", score = 0f, progress = 0)),
+            errors = listOf(AniListError(message = "Failed to update progress"))
+        )
+
+        val thrown = try {
+            tracker.update(sampleEntry())
+            null
+        } catch (e: AniListGraphQlException) {
+            e
+        }
+
+        assertEquals("Failed to update progress", thrown!!.message)
+    }
+
     @Test
     fun `search throws rather than reporting a rejected query as no results`() = runTest {
         coEvery { api.query(any()) } returns AniListResponse(


### PR DESCRIPTION
## **User description**
Third slice of Stage 5a, following #1232 and #1234. Every item was re-verified against the current file before implementing — **two of the six planned items turned out not to exist and are not built here**; both are written up on #1231.

Common thread across all three defects: the tracker reported success while doing the wrong thing, and in two cases **a test asserted the broken behaviour**, so nothing caught it.

## 1. `find()` couldn't resolve anything you hadn't already added

```kotlin
val listEntry = media.mediaListEntry ?: return null
```

`mediaListEntry` is null for any manga not on the user's AniList list. Requiring it made `find` return null for exactly the case that matters — you look a manga up *because* you want to start tracking it, and the app then can't resolve the thing it just found in search.

Media identity and list membership are separate facts. A missing list entry now means "found, not tracked yet": the media's own fields (title, chapter count) survive, and only the per-user ones fall back to defaults.

The old test asserted `assertNull` for this case. It didn't miss the bug — it pinned it in place.

## 2. `update()` reported a failed push as a successful sync

It caught every exception and returned the input entry. The `Tracker` interface forbids that in as many words:

> Implementations must throw an exception on remote failure rather than silently returning the input entry, so callers can distinguish success from failure and avoid persisting stale data locally.

The consequence is visible one line down from each call site — `TrackerSyncRepositoryImpl` writes `syncStatus = SYNCED` and a `lastSuccessfulSync` timestamp right after `update` returns. So a request AniList never saw was recorded as a completed sync, and the entry looked current indefinitely. **All three call sites already sit inside `catch` blocks that mark `SyncStatus.ERROR`** — throwing is what they were built to receive.

It now also returns what AniList *confirmed* rather than what was sent. The mutation already requested `id status score progress` and threw them away, so any value the server clamped or normalised was written back locally as whatever this app had guessed. A blank status is treated as "field absent" rather than mapped, since `statusFromAniList("")` falls through to `PLAN_TO_READ` and would quietly rewrite the user's status on a *successful* update.

## 3. Scores were wrong by 10x, in both directions

`TrackEntry.score` has no documented scale, so the one that counts is what the trackers that already work store:

| Tracker | Native scale | Stored as |
|---|---|---|
| Kitsu | `ratingTwenty` 0–20 | `/2` → 0–10 |
| MyAnimeList | 0–10 | as-is |
| Shikimori | 0–10 | as-is |
| **AniList** | `scoreRaw` **0–100** | **as-is — the bug** |

A user who rated something 8 sent `scoreRaw: 8`, which AniList stores as 8/100 — 0.8 out of 10. Reads had the same error inverted.

Two fixes:

- **Writes** convert 0–10 → 0–100, with `roundToInt` rather than `toInt` (`0.7f * 10` is `6.9999995`, and truncating would file a 0.7 as a 6) and a clamp so a malformed local score can't produce a request AniList rejects outright.
- **Reads** ask for `score(format: POINT_100)` **by name**. Without the argument AniList answers in whatever format the *user* picked — 0–10, five stars, three smileys — and nothing in the response says which, so the same number meant different things per account and no arithmetic here could tell them apart. Naming the format makes the response self-describing and removes the need to fetch `mediaListOptions.scoreFormat` just to interpret it.

`scoreRaw` is also now declared `Int`, which is what AniList types it as. It was `Float` — the same variable mis-typing #1232 fixed for `mediaId`, sitting one line over.

## Two planned items that don't exist

Both written up in detail on #1231 so they don't get rebuilt from the plan later.

**"Add a `Viewer { id }` query so `currentUserId` is populated."** `currentUserId` was written only by `logout()` and **never read**; `login()` never populated it, so it was null for the object's entire life. `ShikimoriTracker`'s same-named field is genuinely load-bearing — its user-rate endpoints take a user id as a parameter — but AniList's `Media { mediaListEntry }` and `SaveMediaListEntry` are already scoped to whoever the bearer token belongs to. Adding the query would have fetched a value with no consumer, so **the dead field is deleted instead**.

**"`SaveMediaListEntry` binds the media id while `DeleteMediaListEntry` binds the list-entry id."** True of AniList's API, irrelevant here: there is no `DeleteMediaListEntry` call anywhere. `TrackRepositoryImpl.deleteEntry` deletes the local Room row and never contacts the tracker. The existing mutation already binds `mediaId:` correctly. It does expose a real but wider gap — untracking locally leaves the entry on the remote service, for *every* tracker — which is a product decision, not an AniList transport fix.

## Still outstanding in Stage 5a

- Rate-limit interceptor honouring `x-ratelimit-reset` / `Retry-After` — **confirmed absent**; `@TrackerOkHttp` adds a certificate pinner and nothing else. Held back for its own PR because it's a new mechanism rather than a correctness fix, and bundling is what earned #1225 its 18 findings.

## Verification

`./gradlew :app:assembleDebug testDebugUnitTest detekt ktlintCheck` → **BUILD SUCCESSFUL**.

New tests cover: an untracked manga resolving, the `POINT_100` format being requested, a network error propagating, the 0–10 → 0–100 conversion, rounding vs truncation at `0.7f`, the server's confirmation winning over the sent values, and a blank confirmed status not overwriting the real one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UoEui2mCCcqArdhyQyFwnR)_

## Summary by Sourcery

Align AniList tracker behaviour with the Tracker interface and other services by fixing media resolution for untracked entries, correcting score scale handling, and using server-confirmed data after updates.

Bug Fixes:
- Allow AniList find() to resolve manga that are not yet on the user’s list, returning a default untracked TrackEntry instead of null.
- Ensure AniList update() throws on remote failures so failed syncs are not recorded as successful.
- Fix AniList score handling by converting between the app’s 0–10 canonical scale and AniList’s 0–100 scale on both reads and writes, and by requesting scores on a named POINT_100 scale.
- Preserve the user’s status when AniList’s update confirmation omits a status field instead of resetting it to PLAN_TO_READ.

Enhancements:
- Use AniList’s confirmed media list entry response to update local TrackEntry status, progress, and score, rather than trusting the sent values.
- Add helper conversions and bounds for AniList score scaling to make tracker behaviour consistent across services and resistant to malformed local scores.
- Remove the unused currentUserId field from AniListTracker and rely on token scoping for user identity.

Tests:
- Expand AniListTracker tests to cover untracked media resolution, named score format usage, error propagation on update failures, correct score scaling and rounding, and preference for server-confirmed data over sent values.


___

## **CodeAnt-AI Description**
Fix AniList tracking results, score conversion, and sync failures

### What Changed
- AniList can now resolve manga that are not yet on the user's list, using default tracking values until they are added.
- Scores are consistently converted between the app's 0–10 scale and AniList's 0–100 scale.
- Failed updates now surface as errors instead of being recorded as successful syncs.
- Successful updates use the values AniList confirms, including server-adjusted progress, status, and score.
- Tests now cover untracked manga, score conversion, confirmed server values, and update failures.

### Impact
`✅ Untracked manga can be added from search`
`✅ Accurate AniList scores`
`✅ Fewer false successful syncs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
