### PR TITLE
Stage 5a (4/n): wait out AniList's rate limit instead of failing the sync

### DIFF
--- a/data/src/main/java/app/otakureader/data/tracking/api/AniListRateLimitInterceptor.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/api/AniListRateLimitInterceptor.kt
@@ -36,13 +36,21 @@ import java.io.IOException
  * Retrofit instance only — `@TrackerOkHttp` is shared by MAL, Kitsu, Shikimori and MangaUpdates,
  * whose rate limits and headers differ.
  *
- * ### Blocking is correct here
+ * ### Blocking is correct here, but a plain sleep is not
  *
- * `Thread.sleep` inside an interceptor blocks an OkHttp dispatcher thread, which is the intended
- * shape: the call is already suspended from the coroutine's point of view, and OkHttp's thread
- * pool exists to be occupied by in-flight calls. Interrupting the thread — which is how OkHttp
- * cancels a call — surfaces as an [IOException] rather than being swallowed, so a cancelled sync
- * does not sit here waiting out a limit nobody is waiting on any more.
+ * Blocking an OkHttp dispatcher thread is the intended shape: the call is already suspended from
+ * the coroutine's point of view, and the thread pool exists to be occupied by in-flight calls.
+ *
+ * The wait still cannot be a single `Thread.sleep(waitMs)`, because **`Call.cancel()` does not
+ * interrupt the thread running the interceptor chain** — it cancels the underlying exchange, and
+ * OkHttp notices at the next I/O operation. There is no I/O inside a sleep. So a cancelled call
+ * (which is also what a cancelled coroutine triggers, via Retrofit's suspend adapter) would sit
+ * here for the rest of the wait — up to [MAX_WAIT_MS] — holding a dispatcher thread for work
+ * nobody is waiting on any more.
+ *
+ * The wait is therefore split into [POLL_INTERVAL_MS] slices with a cancellation check between
+ * them, so cancelling is noticed within that interval instead of at the end. Thread interruption
+ * is honoured too, since a caller may still interrupt directly.
  */
 class AniListRateLimitInterceptor : Interceptor {
 
@@ -58,20 +66,44 @@ class AniListRateLimitInterceptor : Interceptor {
             // request and shows up much later as connection starvation.
             response.close()
 
-            try {
-                Thread.sleep(waitMs)
-            } catch (e: InterruptedException) {
-                // Restore the flag the catch cleared, so anything above this still sees the
-                // cancellation, then fail the call rather than retrying something nobody awaits.
-                Thread.currentThread().interrupt()
-                throw IOException("Interrupted while waiting out AniList's rate limit", e)
-            }
+            chain.awaitCancellably(waitMs)
 
             attempt++
             response = chain.proceed(chain.request())
         }
 
         return response
+    }
+
+    /**
+     * Sleep for [waitMs], giving up early if the call is cancelled.
+     *
+     * Cancellation is checked between short slices rather than waited on, because there is nothing
+     * to wait *on*: `Call.cancel()` sets a flag and cancels the exchange, and a thread inside
+     * `Thread.sleep` never observes either. Polling is the mechanism OkHttp's own contract leaves
+     * available — the alternative, a plain sleep, means a cancelled request keeps a dispatcher
+     * thread for up to [MAX_WAIT_MS].
+     *
+     * The deadline is computed once from a monotonic clock, so the total wait is [waitMs] no
+     * matter how the slices land — accumulating `sleep` calls would drift longer with each one.
+     */
+    private fun Interceptor.Chain.awaitCancellably(waitMs: Long) {
+        val deadlineNanos = System.nanoTime() + waitMs * NANOS_PER_MILLI
+        while (true) {
+            if (call().isCanceled()) {
+                throw IOException("Canceled while waiting out AniList's rate limit")
+            }
+            val remainingMs = (deadlineNanos - System.nanoTime()) / NANOS_PER_MILLI
+            if (remainingMs <= 0) return
+            try {
+                Thread.sleep(minOf(POLL_INTERVAL_MS, remainingMs))
+            } catch (e: InterruptedException) {
+                // A direct interrupt, which is a different thing from an OkHttp cancel. Restore
+                // the flag `catch` cleared so frames above still see it, then fail the call.
+                Thread.currentThread().interrupt()
+                throw IOException("Interrupted while waiting out AniList's rate limit", e)
+            }
+        }
     }
 
     /**
@@ -103,6 +135,15 @@ class AniListRateLimitInterceptor : Interceptor {
         const val HEADER_RATELIMIT_RESET = "X-RateLimit-Reset"
 
         const val MILLIS_PER_SECOND = 1_000L
+        const val NANOS_PER_MILLI = 1_000_000L
+
+        /**
+         * How often the wait checks for cancellation.
+         *
+         * Short enough that a cancelled sync releases its thread promptly, long enough that a
+         * 90-second wait costs at most a few hundred flag reads rather than a spin.
+         */
+        const val POLL_INTERVAL_MS = 250L
 
         /**
          * AniList's window is a minute, so one retry normally suffices and a second covers a

--- a/data/src/main/java/app/otakureader/data/tracking/api/AniListRateLimitInterceptor.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/api/AniListRateLimitInterceptor.kt
@@ -1,0 +1,124 @@
+package app.otakureader.data.tracking.api
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+/**
+ * Waits out AniList's rate limit instead of surfacing it as a failure.
+ *
+ * ### Why this is needed
+ *
+ * AniList allows 90 requests per minute and answers the 91st with **429 Too Many Requests**. That
+ * is easy to hit here without doing anything unusual: a library sync walks every tracked manga,
+ * and each one is a `find` plus an `update`. Without this, the first request past the limit fails,
+ * `TrackerSyncRepositoryImpl` records `SyncStatus.ERROR`, and the user sees a sync that half
+ * worked — for a condition the server explicitly told us how to recover from.
+ *
+ * ### Reading the headers
+ *
+ * Two headers can say when to come back, and **they are not the same units**:
+ *
+ * | Header | Meaning |
+ * |---|---|
+ * | `Retry-After` | Seconds **from now** (a delta) |
+ * | `X-RateLimit-Reset` | A Unix **timestamp** (an absolute point in time) |
+ *
+ * Treating a reset timestamp as a delta would sleep for decades; treating a delta as a timestamp
+ * would compute a wait in the distant past and hammer the server immediately. Both are converted
+ * to a delta here, and [MAX_WAIT_MS] bounds the result — a clock skewed against the server's, or a
+ * header this code has misread, cannot park a request indefinitely.
+ *
+ * ### Why an interceptor rather than retry logic in the tracker
+ *
+ * Every AniList call is one `POST /graphql`, so a single interceptor covers `search`, `find` and
+ * `update` at once and cannot be forgotten at a new call site. It is registered on the AniList
+ * Retrofit instance only — `@TrackerOkHttp` is shared by MAL, Kitsu, Shikimori and MangaUpdates,
+ * whose rate limits and headers differ.
+ *
+ * ### Blocking is correct here
+ *
+ * `Thread.sleep` inside an interceptor blocks an OkHttp dispatcher thread, which is the intended
+ * shape: the call is already suspended from the coroutine's point of view, and OkHttp's thread
+ * pool exists to be occupied by in-flight calls. Interrupting the thread — which is how OkHttp
+ * cancels a call — surfaces as an [IOException] rather than being swallowed, so a cancelled sync
+ * does not sit here waiting out a limit nobody is waiting on any more.
+ */
+class AniListRateLimitInterceptor : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        var response = chain.proceed(chain.request())
+        var attempt = 0
+
+        while (response.code == HTTP_TOO_MANY_REQUESTS && attempt < MAX_RETRIES) {
+            val waitMs = response.retryDelayMillis() ?: return response
+
+            // Close before retrying. A 429 body is small but real, and an unclosed body holds its
+            // connection out of the pool permanently — a leak that grows with every rate-limited
+            // request and shows up much later as connection starvation.
+            response.close()
+
+            try {
+                Thread.sleep(waitMs)
+            } catch (e: InterruptedException) {
+                // Restore the flag the catch cleared, so anything above this still sees the
+                // cancellation, then fail the call rather than retrying something nobody awaits.
+                Thread.currentThread().interrupt()
+                throw IOException("Interrupted while waiting out AniList's rate limit", e)
+            }
+
+            attempt++
+            response = chain.proceed(chain.request())
+        }
+
+        return response
+    }
+
+    /**
+     * How long to wait, or null when the response says nothing usable.
+     *
+     * Null means "give up and return the 429 as-is" rather than "wait a default". A server that
+     * did not say when to come back has given no reason to believe a retry will fare better, and
+     * guessing turns one rejected request into several.
+     */
+    private fun Response.retryDelayMillis(): Long? {
+        // Retry-After first: it is a delta, so it needs no clock agreement with the server.
+        header(HEADER_RETRY_AFTER)?.toLongOrNull()?.let { seconds ->
+            return (seconds * MILLIS_PER_SECOND).coerceIn(MIN_WAIT_MS, MAX_WAIT_MS)
+        }
+        // X-RateLimit-Reset is an absolute Unix timestamp, so it must be turned into a delta
+        // against our own clock. A reset already in the past yields a non-positive delta, which
+        // the floor lifts to a short pause rather than an immediate re-send.
+        header(HEADER_RATELIMIT_RESET)?.toLongOrNull()?.let { resetEpochSeconds ->
+            val deltaMs = resetEpochSeconds * MILLIS_PER_SECOND - System.currentTimeMillis()
+            return deltaMs.coerceIn(MIN_WAIT_MS, MAX_WAIT_MS)
+        }
+        return null
+    }
+
+    private companion object {
+        const val HTTP_TOO_MANY_REQUESTS = 429
+
+        const val HEADER_RETRY_AFTER = "Retry-After"
+        const val HEADER_RATELIMIT_RESET = "X-RateLimit-Reset"
+
+        const val MILLIS_PER_SECOND = 1_000L
+
+        /**
+         * AniList's window is a minute, so one retry normally suffices and a second covers a
+         * window boundary landing awkwardly. Beyond that the caller is better served by an error
+         * it can report than by a request that appears to hang.
+         */
+        const val MAX_RETRIES = 2
+
+        /** A floor, so a stale or past reset time cannot become a busy loop. */
+        const val MIN_WAIT_MS = 1_000L
+
+        /**
+         * A ceiling, because the wait is only as trustworthy as the header it came from. AniList's
+         * window is 60 seconds; anything asking for meaningfully longer is a misread header or a
+         * clock disagreement, and blocking a dispatcher thread on it helps nobody.
+         */
+        const val MAX_WAIT_MS = 90_000L
+    }
+}

--- a/data/src/main/java/app/otakureader/data/tracking/di/TrackingModule.kt
+++ b/data/src/main/java/app/otakureader/data/tracking/di/TrackingModule.kt
@@ -1,6 +1,7 @@
 package app.otakureader.data.tracking.di
 
 import app.otakureader.data.tracking.api.AniListApi
+import app.otakureader.data.tracking.api.AniListRateLimitInterceptor
 import app.otakureader.data.tracking.api.KitsuApi
 import app.otakureader.data.tracking.api.KitsuOAuthApi
 import app.otakureader.data.tracking.api.MangaUpdatesApi
@@ -132,12 +133,28 @@ object TrackingNetworkModule {
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
 
+    /**
+     * AniList gets its own client, derived from the shared tracker one.
+     *
+     * `newBuilder()` keeps everything `@TrackerOkHttp` configures — certificate pinning above all
+     * — and adds one interceptor on top. Registering the rate-limit interceptor on
+     * `@TrackerOkHttp` itself would apply AniList's 429 semantics to MAL, Kitsu, Shikimori and
+     * MangaUpdates, whose limits and headers differ; a retry policy read from the wrong service's
+     * headers is worse than none.
+     *
+     * An application interceptor, not a network one: it retries the whole call, and a network
+     * interceptor runs per hop, so it would not see the retry as the same logical request.
+     */
     @Provides
     @Singleton
     @AniListApiQ
     fun provideAniListRetrofit(@TrackerOkHttp okHttpClient: OkHttpClient, json: Json): Retrofit =
         Retrofit.Builder()
-            .client(okHttpClient)
+            .client(
+                okHttpClient.newBuilder()
+                    .addInterceptor(AniListRateLimitInterceptor())
+                    .build()
+            )
             .baseUrl("https://graphql.anilist.co/")
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()

--- a/data/src/test/java/app/otakureader/data/tracking/api/AniListRateLimitInterceptorTest.kt
+++ b/data/src/test/java/app/otakureader/data/tracking/api/AniListRateLimitInterceptorTest.kt
@@ -1,0 +1,206 @@
+package app.otakureader.data.tracking.api
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Covers the three things this interceptor has to get right: it retries a 429, it waits the amount
+ * the server asked for, and it gives up rather than retrying forever.
+ *
+ * A real [MockWebServer] rather than a mocked `Chain`, because the properties under test are about
+ * how many requests actually reach a server and in what order — which a mocked chain would assert
+ * by construction rather than observe.
+ */
+class AniListRateLimitInterceptorTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = OkHttpClient.Builder()
+            .addInterceptor(AniListRateLimitInterceptor())
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun call() = client.newCall(Request.Builder().url(server.url("/graphql")).build()).execute()
+
+    @Test
+    fun `a 429 carrying Retry-After is retried and the retry's result is returned`() {
+        server.enqueue(MockResponse().setResponseCode(429).setHeader("Retry-After", "1").setBody("slow down"))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"data":{}}"""))
+
+        val response = call()
+
+        assertEquals(200, response.code)
+        assertEquals("""{"data":{}}""", response.body!!.string())
+        // Two requests reached the server: the assertion that the retry actually happened rather
+        // than the interceptor having somehow returned the queued second response directly.
+        assertEquals(2, server.requestCount)
+    }
+
+    @Test
+    fun `the wait is at least as long as Retry-After asked for`() {
+        server.enqueue(MockResponse().setResponseCode(429).setHeader("Retry-After", "1"))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val elapsed = measureElapsed { call() }
+
+        // Without this the test would pass on an implementation that retried instantly, which is
+        // the failure mode that gets a client rate-limited harder rather than less.
+        assertTrue("waited ${elapsed}ms", elapsed >= 1_000L)
+    }
+
+    /**
+     * `X-RateLimit-Reset` is an absolute Unix timestamp, not a delta.
+     *
+     * Reading it as a delta would sleep for however many seconds have elapsed since 1970 — tens of
+     * millions — so the cap is what stands between a misread header and a request that never
+     * returns. Here the reset is two seconds out, and the wait must be about that, not about
+     * `now`-as-seconds.
+     */
+    @Test
+    fun `X-RateLimit-Reset is treated as a timestamp rather than a delta`() {
+        val resetAt = System.currentTimeMillis() / 1_000 + 2
+        server.enqueue(MockResponse().setResponseCode(429).setHeader("X-RateLimit-Reset", resetAt.toString()))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val elapsed = measureElapsed { call() }
+
+        assertTrue("waited ${elapsed}ms", elapsed in 1_000L..10_000L)
+        assertEquals(2, server.requestCount)
+    }
+
+    @Test
+    fun `a reset time already in the past still pauses instead of re-sending immediately`() {
+        // A clock a few seconds ahead of the server's produces a negative delta. Retrying with no
+        // pause at all would spend the retry budget inside a millisecond and change nothing.
+        val resetAt = System.currentTimeMillis() / 1_000 - 30
+        server.enqueue(MockResponse().setResponseCode(429).setHeader("X-RateLimit-Reset", resetAt.toString()))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        var code = 0
+        val elapsed = measureElapsed { code = call().code }
+
+        assertTrue("waited ${elapsed}ms", elapsed >= 1_000L)
+        assertEquals(200, code)
+    }
+
+    /**
+     * The rate-limited response's body must be closed before retrying.
+     *
+     * An unclosed body holds its connection out of the pool for good. That is invisible at first
+     * and compounds: every rate-limited request during a library sync strands one more connection,
+     * and the symptom arrives much later as the pool running dry. Connection count is the way to
+     * observe it — OkHttp only returns a connection to the pool once its body is finished, so a
+     * leak shows up here as a second connection for what should be one reused socket.
+     */
+    @Test
+    fun `the rate-limited response's connection is released for reuse`() {
+        server.enqueue(MockResponse().setResponseCode(429).setHeader("Retry-After", "1").setBody("slow down"))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+
+        call().close()
+
+        assertEquals(1, client.connectionPool.connectionCount())
+    }
+
+    @Test
+    fun `a 429 with no timing header is returned rather than retried on a guess`() {
+        server.enqueue(MockResponse().setResponseCode(429))
+
+        val response = call()
+
+        assertEquals(429, response.code)
+        // A server that did not say when to come back has given no reason to think a retry will
+        // do better, and guessing turns one rejected request into several.
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `retries are capped and the last 429 is returned`() {
+        repeat(5) {
+            server.enqueue(MockResponse().setResponseCode(429).setHeader("Retry-After", "1"))
+        }
+
+        val response = call()
+
+        assertEquals(429, response.code)
+        // One original attempt plus MAX_RETRIES. Asserting the count, not just the status, is what
+        // distinguishes a working cap from an interceptor that never retried at all.
+        assertEquals(3, server.requestCount)
+    }
+
+    @Test
+    fun `a success passes through untouched`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+
+        val response = call()
+
+        assertEquals(200, response.code)
+        assertEquals("ok", response.body!!.string())
+        assertEquals(1, server.requestCount)
+    }
+
+    /**
+     * An interrupt during the wait must fail the call, not be swallowed.
+     *
+     * Interrupting the thread is how a cancelled call unblocks, so continuing to sleep — or
+     * retrying afterwards — would leave a sync nobody is waiting on holding a dispatcher thread
+     * for the rest of the rate-limit window.
+     */
+    @Test
+    fun `an interrupt while waiting fails the call and preserves the interrupt flag`() {
+        server.enqueue(MockResponse().setResponseCode(429).setHeader("Retry-After", "30"))
+
+        val started = CountDownLatch(1)
+        var thrown: Throwable? = null
+        var interruptFlagStillSet = false
+
+        val worker = Thread {
+            started.countDown()
+            try {
+                call()
+            } catch (e: Throwable) {
+                thrown = e
+                interruptFlagStillSet = Thread.currentThread().isInterrupted
+            }
+        }
+        worker.start()
+        started.await(5, TimeUnit.SECONDS)
+        // Give the call time to reach the sleep before interrupting it.
+        Thread.sleep(500)
+        worker.interrupt()
+        worker.join(TimeUnit.SECONDS.toMillis(10))
+
+        assertNotNull("expected the call to fail", thrown)
+        assertTrue("expected an IOException, got $thrown", thrown is IOException)
+        // `catch (InterruptedException)` clears the flag; not restoring it would hide the
+        // cancellation from every frame above this one.
+        assertTrue(interruptFlagStillSet)
+    }
+
+    private fun measureElapsed(block: () -> Unit): Long {
+        val start = System.nanoTime()
+        block()
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start)
+    }
+}

--- a/data/src/test/java/app/otakureader/data/tracking/api/AniListRateLimitInterceptorTest.kt
+++ b/data/src/test/java/app/otakureader/data/tracking/api/AniListRateLimitInterceptorTest.kt
@@ -161,11 +161,56 @@ class AniListRateLimitInterceptorTest {
     }
 
     /**
-     * An interrupt during the wait must fail the call, not be swallowed.
+     * The test this file was missing, and the reason the wait is polled rather than slept.
      *
-     * Interrupting the thread is how a cancelled call unblocks, so continuing to sleep — or
-     * retrying afterwards — would leave a sync nobody is waiting on holding a dispatcher thread
-     * for the rest of the rate-limit window.
+     * `Call.cancel()` — which is also what a cancelled coroutine triggers through Retrofit's
+     * suspend adapter — cancels the underlying exchange and sets a flag. It does **not** interrupt
+     * the thread running the interceptor chain, and there is no I/O inside a sleep for OkHttp to
+     * notice the cancellation at. So a single `Thread.sleep(waitMs)` would hold a dispatcher
+     * thread for the full window after the caller had already walked away.
+     *
+     * The first version of this interceptor did exactly that, and the interrupt test below passed
+     * anyway — because it interrupted the thread itself, which is not what cancelling does. The
+     * assertion here is the elapsed time: it must be nowhere near the 30 seconds requested.
+     */
+    @Test
+    fun `cancelling the call ends the wait promptly rather than at the deadline`() {
+        server.enqueue(MockResponse().setResponseCode(429).setHeader("Retry-After", "30"))
+
+        val call = client.newCall(Request.Builder().url(server.url("/graphql")).build())
+        val started = CountDownLatch(1)
+        var thrown: Throwable? = null
+        var elapsed = 0L
+
+        val worker = Thread {
+            started.countDown()
+            elapsed = measureElapsed {
+                try {
+                    call.execute()
+                } catch (e: Throwable) {
+                    thrown = e
+                }
+            }
+        }
+        worker.start()
+        started.await(5, TimeUnit.SECONDS)
+        // Let the call reach the wait, then cancel it the way OkHttp's own machinery does.
+        Thread.sleep(500)
+        call.cancel()
+        worker.join(TimeUnit.SECONDS.toMillis(10))
+
+        assertNotNull("expected the cancelled call to fail", thrown)
+        assertTrue("expected an IOException, got $thrown", thrown is IOException)
+        // Generous bound: the point is that it is not ~30_000.
+        assertTrue("waited ${elapsed}ms after cancel", elapsed < 5_000L)
+    }
+
+    /**
+     * A direct interrupt is a different thing from an OkHttp cancel, and is still honoured.
+     *
+     * Kept because callers can interrupt a thread themselves, but note what it does *not* prove:
+     * this test drives the interrupt itself, so it says nothing about cancellation. That gap is
+     * what the test above covers.
      */
     @Test
     fun `an interrupt while waiting fails the call and preserves the interrupt flag`() {


### PR DESCRIPTION
## **User description**
Final slice of Stage 5a, following #1232, #1234 and #1235. This was the last of the six planned items that survived verification — the other two dissolved and are written up on #1231.

## What was wrong

AniList allows **90 requests per minute** and answers the 91st with `429 Too Many Requests`. Nothing in the app honoured that.

It is not a hypothetical limit to reach. A library sync walks every tracked manga and issues a `find` plus an `update` for each, so a library of ~45 tracked titles crosses it in a single pass. The first request past the limit failed, `TrackerSyncRepositoryImpl` recorded `SyncStatus.ERROR`, and the user saw a half-finished sync — for a condition the server had explicitly told us how to recover from.

`@TrackerOkHttp` adds a certificate pinner and nothing else; there was no interceptor reading `x-ratelimit-reset` or `Retry-After` anywhere.

## The two headers are not the same units

This is the part worth getting right, because both are "a number of seconds" and they mean opposite things:

| Header | Meaning | Misreading it does what |
|---|---|---|
| `Retry-After` | Seconds **from now** (delta) | Read as a timestamp → a wait in 1970 → immediate re-send |
| `X-RateLimit-Reset` | A Unix **timestamp** (absolute) | Read as a delta → sleep for ~57 years |

Both are converted to a delta and clamped:

- **Ceiling (90s)** — the wait is only as trustworthy as the header it came from. AniList's window is 60 seconds; anything asking meaningfully longer is a misread header or a clock disagreement, and blocking a dispatcher thread on it helps nobody.
- **Floor (1s)** — a clock a few seconds ahead of the server's produces a *negative* delta from `X-RateLimit-Reset`. Without a floor the retry budget would be spent inside a millisecond and change nothing.

A 429 with **no** timing header is returned as-is rather than retried on a guess. A server that didn't say when to come back has given no reason to believe a retry will fare better, and guessing turns one rejected request into several — which is how a client gets rate-limited harder rather than less.

## Where it's registered, and why not the shared client

On the AniList Retrofit instance via `okHttpClient.newBuilder()`, which keeps everything `@TrackerOkHttp` configures — **certificate pinning above all** — and adds one interceptor.

Putting it on `@TrackerOkHttp` itself would apply AniList's 429 semantics to MAL, Kitsu, Shikimori and MangaUpdates, whose limits and headers differ. A retry policy driven by the wrong service's headers is worse than no retry policy.

It's an **application** interceptor rather than a network one: it retries the whole call, and a network interceptor runs per hop, so it wouldn't see the retry as the same logical request.

## Two details that are tested rather than asserted in a comment

Both are the kind of thing that reads as correct and isn't:

- **The 429's body is closed before retrying.** An unclosed body holds its connection out of the pool permanently — invisible at first, compounding with every rate-limited request in a sync, and surfacing much later as connection starvation. I verified the test actually bites by commenting out the `close()` and confirming the connection-count assertion fails (2 of 9 tests red), then restoring it.
- **An interrupt during the wait restores the flag `catch` clears, and fails the call as `IOException`.** Interrupting the thread is how OkHttp cancels a call, so sleeping through it would leave a sync nobody is waiting on holding a dispatcher thread for the rest of the window.

## Verification

`./gradlew :app:assembleDebug testDebugUnitTest detekt ktlintCheck` → **BUILD SUCCESSFUL**.

Nine tests against a real `MockWebServer` rather than a mocked `Chain` — the properties under test are *how many requests actually reach a server and how long apart*, which a mocked chain would assert by construction rather than observe. Covered: a `Retry-After` 429 is retried and the retry's result returned; the wait is at least as long as asked (a test that fails on an implementation retrying instantly); `X-RateLimit-Reset` is treated as a timestamp; a past reset still pauses; a header-less 429 isn't retried; retries are capped at 3 total requests; success passes through; the connection is released; an interrupt fails the call.

## Stage 5a is complete after this

Six planned items → four real, two dissolved:

| Item | Outcome |
|---|---|
| GraphQL variables serialized as strings | Fixed, #1232 |
| `authorizationUrl` missing entirely | Fixed, #1234 (plus the CSRF state that was generated but never sent) |
| `find()` null on missing `mediaListEntry` | Fixed, #1235 |
| `update()` swallowing exceptions | Fixed, #1235 (plus the GraphQL-error paths that returned success) |
| Score normalization | Fixed, #1235 — canonical 0–10 vs AniList's 0–100 |
| Rate limiting | **This PR** |
| `Viewer { id }` for `currentUserId` | Dissolved — field was never read; deleted in #1235 |
| `SaveMediaListEntry` vs `DeleteMediaListEntry` ids | Dissolved — no delete call exists; see #1231 |

Next is **5b**: the metadata layer, Room `manga_metadata` at v41, and `MatchAniListMediaUseCase`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UoEui2mCCcqArdhyQyFwnR)_

## Summary by Sourcery

Handle AniList rate limiting by retrying 429 responses with bounded waits instead of failing syncs outright.

Enhancements:
- Introduce an AniList-specific OkHttp interceptor that interprets rate-limit headers, waits within safe bounds, and retries 429 responses a limited number of times.
- Wire the AniList Retrofit client to use a derived tracker OkHttpClient with the AniList rate-limit interceptor applied only to AniList traffic.

Tests:
- Add MockWebServer-based tests covering AniList rate-limit handling, including header parsing, minimum/maximum waits, retry capping, connection reuse, success passthrough, and interruption behavior during waits.


___

## **CodeAnt-AI Description**
Retry AniList rate-limit responses instead of failing library syncs

### What Changed
- AniList requests now wait and retry when the service returns a 429 response with a retry time
- Retry timing is read correctly from both relative and absolute server headers, with safe minimum and maximum waits
- Responses without usable timing information remain failed, and retries stop after a limited number of attempts
- Cancelled waits fail promptly without leaving connections occupied; other tracker services keep their existing behavior
- Added coverage for retry timing, retry limits, connection reuse, cancellation, and successful requests

### Impact
`✅ Fewer half-finished AniList library syncs`
`✅ Fewer repeated rate-limit failures`
`✅ No connection leaks during rate-limited syncs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry AniList 429 responses with bounded, cancellable waits to avoid half-finished library syncs. Adds an AniList-only OkHttp interceptor that reads `Retry-After` and `X-RateLimit-Reset` and retries up to 2 times.

- **Bug Fixes**
  - Made waits cancellable: split into 250ms polls with `call().isCanceled()` checks and a monotonic deadline; direct interrupts still fail with `IOException` and restore the interrupt flag.
  - Interprets headers correctly, clamps waits to 1s–90s, closes the 429 body before retrying, and returns 429 when no timing header is present; max 2 retries.
  - Scoped to the AniList Retrofit client via `okHttpClient.newBuilder()`, preserving `@TrackerOkHttp` settings and avoiding cross-service effects; `MockWebServer` tests cover cancellation timing, header parsing, bounds, retry cap, connection reuse, and success passthrough.

<sup>Written for commit ed24e44f7902d4fc4a8dc580ea5236b6146ae954. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HeartlessVeteran2/Otaku-Reader/pull/1236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

