### PR TITLE
Stage 5b (1/n): the AniList title matcher

### DIFF
--- a/domain/src/main/java/app/otakureader/domain/model/AniListMatchModels.kt
+++ b/domain/src/main/java/app/otakureader/domain/model/AniListMatchModels.kt
@@ -1,0 +1,29 @@
+package app.otakureader.domain.model
+
+/**
+ * A candidate AniList media entry, reduced to what title matching needs.
+ *
+ * Deliberately not the full metadata model: matching runs before anything is fetched in detail, so
+ * taking only titles keeps the matcher a pure function that a test can drive from a fixture table.
+ */
+data class AniListMediaCandidate(
+    val mediaId: Long,
+    val romaji: String = "",
+    val english: String? = null,
+    val native: String? = null,
+    val synonyms: List<String> = emptyList(),
+)
+
+/** The outcome of matching, carrying enough for a picker UI to explain itself. */
+data class AniListMatch(
+    val candidate: AniListMediaCandidate,
+    /** 0.0 to 1.0. Clamped for reporting; ranking uses an unclamped value internally. */
+    val score: Float,
+    /**
+     * False when nothing cleared the accept threshold and this is a best guess.
+     *
+     * The distinction is what keeps a guess out of the manga row as a confirmed `anilistId` while
+     * still giving the details screen something to show.
+     */
+    val confident: Boolean,
+)

--- a/domain/src/main/java/app/otakureader/domain/usecase/metadata/MatchAniListMediaUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/metadata/MatchAniListMediaUseCase.kt
@@ -1,0 +1,188 @@
+package app.otakureader.domain.usecase.metadata
+
+import app.otakureader.domain.model.AniListMatch
+import app.otakureader.domain.model.AniListMediaCandidate
+import app.otakureader.domain.util.StringSimilarity
+import app.otakureader.domain.util.TitleNormalizer
+import javax.inject.Inject
+
+/**
+ * Picks the AniList media that corresponds to a manga from a source.
+ *
+ * ### Why this is hard enough to need scoring
+ *
+ * A source calls it `"Boku no Hero Academia"`; AniList's English title is `"My Hero Academia"`;
+ * another source says `"僕のヒーローアカデミア"`; a third appends `"(Official Colored)"`. There is no
+ * identifier in common — only strings that a human would recognise as the same work. So every
+ * candidate is scored against **every** title the target is known by, and the best takes it.
+ *
+ * ### Scoring
+ *
+ * Three measures blended, because each is blind to something the others catch (see
+ * [StringSimilarity]):
+ *
+ * ```
+ * 0.4 * tokenSetRatio  +  0.3 * partialRatio  +  0.3 * ratio
+ * ```
+ *
+ * Then a season adjustment of ±[SEASON_WEIGHT]. Sequels are the failure case that a pure string
+ * measure cannot survive: `"Kaguya-sama: Love is War"` and `"Kaguya-sama: Love is War Season 2"`
+ * differ by one token out of six and would otherwise be near-indistinguishable — while being
+ * different entries with different chapter counts, which is precisely the mistake a user notices.
+ *
+ * ### Season numbers come from the raw title, not the normalized one
+ *
+ * [TitleNormalizer.normalize] **strips a trailing `season N` / `part N`** as noise, which is right
+ * for its own purpose and fatal here: extracting the season after normalizing would find nothing
+ * for every title, the bonus would never fire, and the code would look like it handled sequels.
+ * So [seasonOf] reads the raw string, and normalization happens afterwards.
+ *
+ * ### Every candidate is scored against the whole title set at once
+ *
+ * Not one title at a time with an early return. Scoring `savedTitle` against all candidates, then
+ * `english` against all candidates, and so on, lets a weak match on an early title beat a strong
+ * match on a later one purely because it was checked first.
+ */
+class MatchAniListMediaUseCase @Inject constructor() {
+
+    /**
+     * @param sourceTitle the title as the source names it — the one the user actually sees.
+     * @param alternativeTitles any other names known locally (a manual override, a previous match).
+     * @param candidates AniList search results to choose between.
+     * @return the best match, or null when [candidates] is empty.
+     */
+    operator fun invoke(
+        sourceTitle: String,
+        alternativeTitles: List<String> = emptyList(),
+        candidates: List<AniListMediaCandidate>,
+    ): AniListMatch? {
+        if (candidates.isEmpty()) return null
+
+        val targets = buildTitleSet(listOf(sourceTitle) + alternativeTitles)
+        if (targets.isEmpty()) return null
+        val targetSeason = seasonOf(sourceTitle)
+
+        // Ranked on the *unclamped* score, and every candidate is scored — both for the same
+        // reason. `TitleNormalizer.normalize` strips the season marker, so a title and its sequel
+        // normalize to the same string and both reach a base of 1.0; the season term is the only
+        // thing that separates them. Clamping to 1.0 before comparing would erase exactly that
+        // term, and an early exit on the first 1.0 would return whichever the search happened to
+        // list first. The clamp still applies to the score that is *reported* — a caller comparing
+        // against a threshold should not see 1.3.
+        val best = candidates
+            .map { it to rawScore(it, targets, targetSeason) }
+            .maxByOrNull { (_, score) -> score }
+            ?: return null
+
+        val (candidate, raw) = best
+        return AniListMatch(
+            candidate = candidate,
+            score = raw.coerceIn(0f, 1f),
+            confident = raw >= ACCEPT_THRESHOLD,
+        )
+    }
+
+    /** Similarity plus the season term, deliberately not clamped — see [invoke]. */
+    private fun rawScore(
+        candidate: AniListMediaCandidate,
+        targets: List<TitleForm>,
+        targetSeason: Int?,
+    ): Float {
+        val candidateTitles = buildTitleSet(
+            listOfNotNull(candidate.romaji, candidate.english, candidate.native) + candidate.synonyms
+        )
+        if (candidateTitles.isEmpty()) return 0f
+
+        var best = 0f
+        for (target in targets) {
+            for (candidateTitle in candidateTitles) {
+                best = maxOf(best, similarity(target, candidateTitle))
+            }
+        }
+        return best + seasonAdjustment(targetSeason, candidate.seasonOfAny())
+    }
+
+    private fun similarity(a: TitleForm, b: TitleForm): Float {
+        val light = WEIGHT_TOKEN_SET * StringSimilarity.tokenSetRatio(a.normalized, b.normalized) +
+            WEIGHT_PARTIAL * StringSimilarity.partialRatio(a.normalized, b.normalized) +
+            WEIGHT_RATIO * StringSimilarity.ratio(a.normalized, b.normalized)
+        // The heavy form is a fallback, not a replacement: it discards spacing and the word
+        // "season" entirely, which rescues "Re:Zero kara Hajimeru" vs "ReZero kara Hajimeru" but
+        // would also flatten distinctions the light form keeps. Taking the max means it can only
+        // ever help.
+        val heavy = StringSimilarity.ratio(a.heavy, b.heavy)
+        return maxOf(light, heavy)
+    }
+
+    /**
+     * A bonus when the seasons agree, a penalty when they disagree, nothing when either is unknown.
+     *
+     * "Unknown" has to mean neutral rather than "season 1". Most titles carry no season marker at
+     * all, so treating absence as 1 would penalise every unmarked title against every sequel — the
+     * common case made worse to handle the rare one.
+     */
+    private fun seasonAdjustment(target: Int?, candidate: Int?): Float = when {
+        target == null || candidate == null -> 0f
+        target == candidate -> SEASON_WEIGHT
+        else -> -SEASON_WEIGHT
+    }
+
+    private fun AniListMediaCandidate.seasonOfAny(): Int? =
+        (listOfNotNull(romaji, english, native) + synonyms).firstNotNullOfOrNull { seasonOf(it) }
+
+    /**
+     * The season number stated in [rawTitle], or null when it states none.
+     *
+     * Reads the **raw** title deliberately — see the class docs. The three forms are the ones that
+     * actually appear in the wild: `"2nd Season"`, `"Season 2"`, and a bare trailing number as in
+     * `"Overlord 2"`.
+     */
+    private fun seasonOf(rawTitle: String): Int? {
+        val lower = rawTitle.lowercase()
+        ORDINAL_SEASON.find(lower)?.groupValues?.get(1)?.toIntOrNull()?.let { return it }
+        SEASON_NUMBER.find(lower)?.groupValues?.get(1)?.toIntOrNull()?.let { return it }
+        TRAILING_NUMBER.find(lower)?.groupValues?.get(1)?.toIntOrNull()?.let { return it }
+        return null
+    }
+
+    /** Both normalizations of a title, computed once so the inner loops don't redo them. */
+    private data class TitleForm(val normalized: String, val heavy: String)
+
+    private fun buildTitleSet(titles: List<String>): List<TitleForm> =
+        titles.asSequence()
+            .filter { it.isNotBlank() && it.trim() !in PLACEHOLDER_TITLES }
+            .map { TitleForm(normalized = TitleNormalizer.normalize(it), heavy = heavyNormalize(it)) }
+            .filter { it.normalized.isNotEmpty() || it.heavy.isNotEmpty() }
+            .distinct()
+            .toList()
+
+    /** Normalized, then stripped of the word "season" and every non-alphanumeric character. */
+    private fun heavyNormalize(title: String): String =
+        TitleNormalizer.normalize(title)
+            .replace(SEASON_WORD, " ")
+            .replace(NON_ALPHANUMERIC, "")
+
+    companion object {
+        const val WEIGHT_TOKEN_SET = 0.4f
+        const val WEIGHT_PARTIAL = 0.3f
+        const val WEIGHT_RATIO = 0.3f
+
+        /** How much agreeing (or disagreeing) on a season moves the score. */
+        const val SEASON_WEIGHT = 0.3f
+
+        /** At or above this, the match is reported as [AniListMatch.confident]. */
+        const val ACCEPT_THRESHOLD = 0.7f
+
+        /**
+         * Titles that carry no information and would otherwise match each other perfectly.
+         * Sources really do emit these for entries with a missing localized name.
+         */
+        private val PLACEHOLDER_TITLES = setOf("?", "??", "???", "-", "N/A")
+
+        private val ORDINAL_SEASON = Regex("""(\d+)(?:st|nd|rd|th)\s+season""")
+        private val SEASON_NUMBER = Regex("""season\s+(\d+)""")
+        private val TRAILING_NUMBER = Regex("""\s(\d{1,2})\s*$""")
+        private val SEASON_WORD = Regex("""\bseason\b""")
+        private val NON_ALPHANUMERIC = Regex("""[^\p{L}\p{N}]""")
+    }
+}

--- a/domain/src/main/java/app/otakureader/domain/usecase/metadata/MatchAniListMediaUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/metadata/MatchAniListMediaUseCase.kt
@@ -30,12 +30,15 @@ import javax.inject.Inject
  * differ by one token out of six and would otherwise be near-indistinguishable — while being
  * different entries with different chapter counts, which is precisely the mistake a user notices.
  *
- * ### Season numbers come from the raw title, not the normalized one
+ * ### Season numbers come from the raw title, and belong to the title
  *
  * [TitleNormalizer.normalize] **strips a trailing `season N` / `part N`** as noise, which is right
  * for its own purpose and fatal here: extracting the season after normalizing would find nothing
  * for every title, the bonus would never fire, and the code would look like it handled sequels.
- * So [seasonOf] reads the raw string, and normalization happens afterwards.
+ * So [seasonOf] reads the raw string, and every [TitleForm] carries its own season.
+ *
+ * Per *title*, not per manga or per candidate — an entry's romaji and english titles can disagree
+ * about which season they name, and the one that counts is the one that actually matched.
  *
  * ### Every candidate is scored against the whole title set at once
  *
@@ -60,7 +63,6 @@ class MatchAniListMediaUseCase @Inject constructor() {
 
         val targets = buildTitleSet(listOf(sourceTitle) + alternativeTitles)
         if (targets.isEmpty()) return null
-        val targetSeason = seasonOf(sourceTitle)
 
         // Ranked on the *unclamped* score, and every candidate is scored — both for the same
         // reason. `TitleNormalizer.normalize` strips the season marker, so a title and its sequel
@@ -70,7 +72,7 @@ class MatchAniListMediaUseCase @Inject constructor() {
         // list first. The clamp still applies to the score that is *reported* — a caller comparing
         // against a threshold should not see 1.3.
         val best = candidates
-            .map { it to rawScore(it, targets, targetSeason) }
+            .map { it to rawScore(it, targets) }
             .maxByOrNull { (_, score) -> score }
             ?: return null
 
@@ -82,12 +84,21 @@ class MatchAniListMediaUseCase @Inject constructor() {
         )
     }
 
-    /** Similarity plus the season term, deliberately not clamped — see [invoke]. */
-    private fun rawScore(
-        candidate: AniListMediaCandidate,
-        targets: List<TitleForm>,
-        targetSeason: Int?,
-    ): Float {
+    /**
+     * The best score over every (target title, candidate title) pair, deliberately not clamped.
+     *
+     * **The season term belongs to the pair, not to the candidate.** Deriving it once per candidate
+     * — from whichever of its titles happened to be listed first — applied one title's season to a
+     * match made by a different title: an entry whose romaji says `Season 5` while its english says
+     * `Season 2` was judged season 5 even when the english title was what matched. Scoring each
+     * pair whole removes the question.
+     *
+     * It also fixes the mirror-image problem on the target side for free. The season used to come
+     * from `sourceTitle` alone, so a season stated in an `alternativeTitles` override — the manual
+     * "this is really X" path — contributed nothing, which disabled the season term in exactly the
+     * case the override exists to repair.
+     */
+    private fun rawScore(candidate: AniListMediaCandidate, targets: List<TitleForm>): Float {
         val candidateTitles = buildTitleSet(
             listOfNotNull(candidate.romaji, candidate.english, candidate.native) + candidate.synonyms
         )
@@ -96,10 +107,12 @@ class MatchAniListMediaUseCase @Inject constructor() {
         var best = 0f
         for (target in targets) {
             for (candidateTitle in candidateTitles) {
-                best = maxOf(best, similarity(target, candidateTitle))
+                val paired = similarity(target, candidateTitle) +
+                    seasonAdjustment(target.season, candidateTitle.season)
+                best = maxOf(best, paired)
             }
         }
-        return best + seasonAdjustment(targetSeason, candidate.seasonOfAny())
+        return best
     }
 
     private fun similarity(a: TitleForm, b: TitleForm): Float {
@@ -127,40 +140,57 @@ class MatchAniListMediaUseCase @Inject constructor() {
         else -> -SEASON_WEIGHT
     }
 
-    private fun AniListMediaCandidate.seasonOfAny(): Int? =
-        (listOfNotNull(romaji, english, native) + synonyms).firstNotNullOfOrNull { seasonOf(it) }
-
     /**
      * The season number stated in [rawTitle], or null when it states none.
      *
-     * Reads the **raw** title deliberately — see the class docs. The three forms are the ones that
-     * actually appear in the wild: `"2nd Season"`, `"Season 2"`, and a bare trailing number as in
-     * `"Overlord 2"`.
+     * Reads the **raw** title deliberately — see the class docs.
+     *
+     * The bare-trailing-number form (`"Overlord 2"`) is the loose one, and it is deliberately
+     * refused when the number is introduced by a unit word. Manga titles end in numbers for all
+     * sorts of reasons — `"… Vol 3"`, `"… Part 2"`, `"… Chapter 12"` — and reading one of those as
+     * a season is worse than missing a real season: a wrong season produces a ±0.3 swing that can
+     * flip an otherwise correct match, while a missed one merely leaves the term neutral.
      */
     private fun seasonOf(rawTitle: String): Int? {
         val lower = rawTitle.lowercase()
         ORDINAL_SEASON.find(lower)?.groupValues?.get(1)?.toIntOrNull()?.let { return it }
         SEASON_NUMBER.find(lower)?.groupValues?.get(1)?.toIntOrNull()?.let { return it }
+        if (UNIT_QUALIFIED_NUMBER.containsMatchIn(lower)) return null
         TRAILING_NUMBER.find(lower)?.groupValues?.get(1)?.toIntOrNull()?.let { return it }
         return null
     }
 
-    /** Both normalizations of a title, computed once so the inner loops don't redo them. */
-    private data class TitleForm(val normalized: String, val heavy: String)
+    /**
+     * Both normalizations of a title plus the season it states, computed once.
+     *
+     * The season rides along here because it has to be read from the **raw** title:
+     * `TitleNormalizer.normalize` strips a trailing `season N`, so by the time a `TitleForm` exists
+     * the marker is gone from both normalized forms.
+     */
+    private data class TitleForm(val normalized: String, val heavy: String, val season: Int?)
 
     private fun buildTitleSet(titles: List<String>): List<TitleForm> =
         titles.asSequence()
-            .filter { it.isNotBlank() && it.trim() !in PLACEHOLDER_TITLES }
-            .map { TitleForm(normalized = TitleNormalizer.normalize(it), heavy = heavyNormalize(it)) }
+            // Uppercased on both sides: sources emit "n/a" as readily as "N/A", and a
+            // case-sensitive check would let one variant through to match another perfectly.
+            .filter { it.isNotBlank() && it.trim().uppercase() !in PLACEHOLDER_TITLES }
+            .map { raw ->
+                // Normalized once and reused. `heavyNormalize` used to call `TitleNormalizer`
+                // again, running its full regex chain twice per title on every candidate set.
+                val normalized = TitleNormalizer.normalize(raw)
+                TitleForm(
+                    normalized = normalized,
+                    heavy = heavyNormalize(normalized),
+                    season = seasonOf(raw),
+                )
+            }
             .filter { it.normalized.isNotEmpty() || it.heavy.isNotEmpty() }
             .distinct()
             .toList()
 
-    /** Normalized, then stripped of the word "season" and every non-alphanumeric character. */
-    private fun heavyNormalize(title: String): String =
-        TitleNormalizer.normalize(title)
-            .replace(SEASON_WORD, " ")
-            .replace(NON_ALPHANUMERIC, "")
+    /** Strips the word "season" and every non-alphanumeric character from an already-normalized title. */
+    private fun heavyNormalize(normalized: String): String =
+        normalized.replace(SEASON_WORD, " ").replace(NON_ALPHANUMERIC, "")
 
     companion object {
         const val WEIGHT_TOKEN_SET = 0.4f
@@ -181,6 +211,13 @@ class MatchAniListMediaUseCase @Inject constructor() {
 
         private val ORDINAL_SEASON = Regex("""(\d+)(?:st|nd|rd|th)\s+season""")
         private val SEASON_NUMBER = Regex("""season\s+(\d+)""")
+
+        /**
+         * A trailing number introduced by a unit word, which is therefore *not* a season.
+         * `"Berserk Vol 3"` and `"Gantz Chapter 12"` are the same manga as their unmarked forms.
+         */
+        private val UNIT_QUALIFIED_NUMBER =
+            Regex("""\b(?:vol|volume|part|pt|ch|chapter|book|arc|ep|episode)\.?\s*\d+\s*$""")
         private val TRAILING_NUMBER = Regex("""\s(\d{1,2})\s*$""")
         private val SEASON_WORD = Regex("""\bseason\b""")
         private val NON_ALPHANUMERIC = Regex("""[^\p{L}\p{N}]""")

--- a/domain/src/main/java/app/otakureader/domain/usecase/migration/SearchMigrationTargetsUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/migration/SearchMigrationTargetsUseCase.kt
@@ -4,6 +4,7 @@ import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.model.MigrationCandidate
 import app.otakureader.domain.repository.SourceRepository
+import app.otakureader.domain.util.StringSimilarity
 import app.otakureader.domain.util.TitleNormalizer
 import app.otakureader.sourceapi.SourceManga
 import javax.inject.Inject
@@ -178,46 +179,15 @@ class SearchMigrationTargetsUseCase @Inject constructor(
     /**
      * Calculate similarity score between two titles using Levenshtein distance.
      * Returns a score from 0.0 (completely different) to 1.0 (identical).
+     *
+     * Delegates to [StringSimilarity.ratio], which is the same `1 - distance / maxLength` measure
+     * this file used to implement privately. It moved because the AniList matcher needs the same
+     * arithmetic, and two Levenshtein implementations in one module drift apart — the second one
+     * is written from the same description rather than the same code, and the difference only
+     * shows up as two features disagreeing about whether two titles are the same manga.
      */
-    private fun calculateSimilarity(title1: String, title2: String): Float {
-        val normalized1 = title1.lowercase().trim()
-        val normalized2 = title2.lowercase().trim()
-
-        if (normalized1 == normalized2) return 1.0f
-
-        // Simple similarity check: calculate Levenshtein distance
-        val distance = levenshteinDistance(normalized1, normalized2)
-        val maxLength = maxOf(normalized1.length, normalized2.length)
-
-        return if (maxLength == 0) 1.0f
-        else 1.0f - (distance.toFloat() / maxLength)
-    }
-
-    /**
-     * Calculate Levenshtein distance between two strings.
-     */
-    private fun levenshteinDistance(s1: String, s2: String): Int {
-        val len1 = s1.length
-        val len2 = s2.length
-
-        val dp = Array(len1 + 1) { IntArray(len2 + 1) }
-
-        for (i in 0..len1) dp[i][0] = i
-        for (j in 0..len2) dp[0][j] = j
-
-        for (i in 1..len1) {
-            for (j in 1..len2) {
-                val cost = if (s1[i - 1] == s2[j - 1]) 0 else 1
-                dp[i][j] = minOf(
-                    dp[i - 1][j] + 1,      // deletion
-                    dp[i][j - 1] + 1,      // insertion
-                    dp[i - 1][j - 1] + cost // substitution
-                )
-            }
-        }
-
-        return dp[len1][len2]
-    }
+    private fun calculateSimilarity(title1: String, title2: String): Float =
+        StringSimilarity.ratio(title1.lowercase().trim(), title2.lowercase().trim())
 
     private fun SourceManga.toMigrationCandidate(
         sourceId: Long,

--- a/domain/src/main/java/app/otakureader/domain/util/StringSimilarity.kt
+++ b/domain/src/main/java/app/otakureader/domain/util/StringSimilarity.kt
@@ -1,0 +1,125 @@
+package app.otakureader.domain.util
+
+/**
+ * String similarity measures used for matching manga titles across services.
+ *
+ * ### What these are, precisely
+ *
+ * These follow the *shape* of FuzzyWuzzy's `ratio` / `partial_ratio` / `token_set_ratio`, but the
+ * base measure is **Levenshtein-normalized** (`1 - distance / maxLength`) rather than
+ * `SequenceMatcher`'s matching-blocks ratio. The two agree on identical and wildly different
+ * strings and differ modestly in between. Stated plainly because the alternative — calling this
+ * "fuzzywuzzy's algorithm" — would invite someone to port a threshold from a Python project and
+ * find it doesn't behave the same.
+ *
+ * Implemented here rather than pulling in `me.xdrop:fuzzywuzzy`: it is under a hundred lines, it
+ * keeps `domain` free of a dependency, and the matching thresholds need to be tuned against this
+ * repo's fixtures anyway.
+ *
+ * ### Why three measures instead of one
+ *
+ * Each fails on a case the others handle, which is why the caller blends them:
+ *
+ * | Measure | Good at | Blind to |
+ * |---|---|---|
+ * | [ratio] | Small edits, typos | Word reordering; one title being a subset of another |
+ * | [partialRatio] | A short title inside a long one (`"Berserk"` vs `"Berserk: Deluxe Edition"`) | Reordering |
+ * | [tokenSetRatio] | Reordering and extra words (`"Boku no Hero"` vs `"Hero Academia, Boku no"`) | Typos inside a token |
+ *
+ * All three take strings that are **already normalized** — none of them lowercase or strip
+ * punctuation. Normalizing once at the call site avoids doing it three times per candidate.
+ */
+object StringSimilarity {
+
+    /**
+     * Levenshtein-normalized similarity, 0.0 to 1.0.
+     *
+     * Two empty strings are 1.0 (identical), not 0.0 — the alternative makes empty input look
+     * maximally *different* from itself, which propagates as a confusing zero through the caller's
+     * weighted blend.
+     */
+    fun ratio(a: String, b: String): Float {
+        if (a == b) return 1f
+        val maxLength = maxOf(a.length, b.length)
+        if (maxLength == 0) return 1f
+        return 1f - levenshtein(a, b).toFloat() / maxLength
+    }
+
+    /**
+     * The best [ratio] between the shorter string and any equal-length window of the longer one.
+     *
+     * This is what catches a title that is a *subtitle* of another — `"berserk"` inside
+     * `"berserk deluxe edition"` scores 1.0 here and about 0.32 under [ratio], because plain edit
+     * distance charges for every character of the extra words.
+     */
+    fun partialRatio(a: String, b: String): Float {
+        if (a.isEmpty() || b.isEmpty()) return if (a == b) 1f else 0f
+        val (shorter, longer) = if (a.length <= b.length) a to b else b to a
+        if (shorter.length == longer.length) return ratio(shorter, longer)
+
+        var best = 0f
+        for (start in 0..(longer.length - shorter.length)) {
+            val window = longer.substring(start, start + shorter.length)
+            best = maxOf(best, ratio(shorter, window))
+            if (best == 1f) return 1f
+        }
+        return best
+    }
+
+    /**
+     * Compares the two strings as *sets of words*, so order and duplication stop mattering.
+     *
+     * Following FuzzyWuzzy's construction: build the sorted intersection of the token sets and the
+     * two sorted remainders, then take the best ratio among intersection-vs-each-full-string and
+     * the two full strings against each other. The intersection comparisons are what make a title
+     * that contains all of another's words score highly regardless of arrangement.
+     */
+    fun tokenSetRatio(a: String, b: String): Float {
+        val tokensA = a.split(WHITESPACE).filter { it.isNotEmpty() }.toSortedSet()
+        val tokensB = b.split(WHITESPACE).filter { it.isNotEmpty() }.toSortedSet()
+        if (tokensA.isEmpty() && tokensB.isEmpty()) return 1f
+        if (tokensA.isEmpty() || tokensB.isEmpty()) return 0f
+
+        val intersection = tokensA.intersect(tokensB).joinToString(" ")
+        val restOfA = (tokensA - tokensB).joinToString(" ")
+        val restOfB = (tokensB - tokensA).joinToString(" ")
+
+        val combinedA = "$intersection $restOfA".trim()
+        val combinedB = "$intersection $restOfB".trim()
+
+        return maxOf(
+            ratio(intersection, combinedA),
+            ratio(intersection, combinedB),
+            ratio(combinedA, combinedB),
+        )
+    }
+
+    /**
+     * Levenshtein edit distance.
+     *
+     * Two rows rather than a full matrix: the recurrence only ever reads the previous row, and a
+     * title pair is small enough that the allocation, not the arithmetic, dominates.
+     */
+    fun levenshtein(a: String, b: String): Int {
+        if (a == b) return 0
+        if (a.isEmpty()) return b.length
+        if (b.isEmpty()) return a.length
+
+        var previous = IntArray(b.length + 1) { it }
+        var current = IntArray(b.length + 1)
+
+        for (i in 1..a.length) {
+            current[0] = i
+            for (j in 1..b.length) {
+                val substitution = previous[j - 1] + if (a[i - 1] == b[j - 1]) 0 else 1
+                current[j] = minOf(current[j - 1] + 1, previous[j] + 1, substitution)
+            }
+            val swap = previous
+            previous = current
+            current = swap
+        }
+        return previous[b.length]
+    }
+
+    private val WHITESPACE = Regex("""\s+""")
+}

--- a/domain/src/test/java/app/otakureader/domain/usecase/metadata/MatchAniListMediaUseCaseTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/usecase/metadata/MatchAniListMediaUseCaseTest.kt
@@ -1,0 +1,206 @@
+package app.otakureader.domain.usecase.metadata
+
+import app.otakureader.domain.model.AniListMediaCandidate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Drives the matcher from a table of cases that actually occur, rather than from invented strings.
+ *
+ * The bar for each case is "would a human looking at these two titles say they are the same manga",
+ * and the matcher has to agree. Cases where a human would say *no* matter more than the easy
+ * agreements, so the sequel cases below are the ones to keep working.
+ */
+class MatchAniListMediaUseCaseTest {
+
+    private val match = MatchAniListMediaUseCase()
+
+    private fun candidate(
+        id: Long,
+        romaji: String = "",
+        english: String? = null,
+        native: String? = null,
+        synonyms: List<String> = emptyList(),
+    ) = AniListMediaCandidate(id, romaji, english, native, synonyms)
+
+    @Test
+    fun `an exact romaji title wins`() {
+        val result = match(
+            sourceTitle = "Berserk",
+            candidates = listOf(candidate(1, romaji = "Berserk"), candidate(2, romaji = "Bastard")),
+        )
+
+        assertEquals(1L, result!!.candidate.mediaId)
+        assertTrue(result.confident)
+    }
+
+    @Test
+    fun `the english title matches when the source uses romaji`() {
+        // The everyday case: sources name things in romaji, AniList's English title is a
+        // translation with no characters in common beyond "Hero".
+        val result = match(
+            sourceTitle = "Boku no Hero Academia",
+            candidates = listOf(
+                candidate(1, romaji = "Kimetsu no Yaiba", english = "Demon Slayer"),
+                candidate(2, romaji = "Boku no Hero Academia", english = "My Hero Academia"),
+            ),
+        )
+
+        assertEquals(2L, result!!.candidate.mediaId)
+        assertTrue(result.confident)
+    }
+
+    @Test
+    fun `a synonym matches when neither main title does`() {
+        val result = match(
+            sourceTitle = "OPM",
+            candidates = listOf(
+                candidate(1, romaji = "One Punch-Man", english = "One-Punch Man", synonyms = listOf("OPM")),
+                candidate(2, romaji = "Onepunch-Man Gaiden"),
+            ),
+        )
+
+        assertEquals(1L, result!!.candidate.mediaId)
+    }
+
+    /**
+     * The case the season adjustment exists for, and the one a pure string measure gets wrong.
+     *
+     * These two titles differ by one token out of six. Without the season term the sequel scores
+     * about as well as the original, and which one wins comes down to search-result order — while
+     * they are different entries with different chapter counts, so the user sees their progress
+     * land on the wrong one.
+     */
+    @Test
+    fun `a season 2 source title does not match the season 1 entry`() {
+        val result = match(
+            sourceTitle = "Kaguya-sama: Love is War Season 2",
+            candidates = listOf(
+                candidate(1, romaji = "Kaguya-sama wa Kokurasetai", english = "Kaguya-sama: Love is War"),
+                candidate(2, english = "Kaguya-sama: Love is War Season 2"),
+            ),
+        )
+
+        assertEquals(2L, result!!.candidate.mediaId)
+    }
+
+    @Test
+    fun `an unmarked source title prefers the unmarked entry over a sequel`() {
+        val result = match(
+            sourceTitle = "Overlord",
+            candidates = listOf(
+                candidate(1, romaji = "Overlord 2"),
+                candidate(2, romaji = "Overlord"),
+            ),
+        )
+
+        assertEquals(2L, result!!.candidate.mediaId)
+    }
+
+    @Test
+    fun `the ordinal season form is understood too`() {
+        // "2nd Season" is as common as "Season 2" in AniList's own titles.
+        val result = match(
+            sourceTitle = "Shingeki no Kyojin 2nd Season",
+            candidates = listOf(
+                candidate(1, romaji = "Shingeki no Kyojin"),
+                candidate(2, romaji = "Shingeki no Kyojin 2nd Season"),
+            ),
+        )
+
+        assertEquals(2L, result!!.candidate.mediaId)
+    }
+
+    @Test
+    fun `punctuation and spacing differences still match`() {
+        val result = match(
+            sourceTitle = "Re:Zero kara Hajimeru Isekai Seikatsu",
+            candidates = listOf(
+                candidate(1, romaji = "ReZero kara Hajimeru Isekai Seikatsu"),
+                candidate(2, romaji = "Tensei Shitara Slime Datta Ken"),
+            ),
+        )
+
+        assertEquals(1L, result!!.candidate.mediaId)
+        assertTrue(result.confident)
+    }
+
+    @Test
+    fun `a subtitle on the candidate does not prevent a match`() {
+        // The distractor is a different manga, not a typo of the same one. An earlier version of
+        // this test used "Bersek" as the distractor, which a human would also call Berserk — so
+        // whichever way it resolved, the test proved nothing about edition suffixes.
+        val result = match(
+            sourceTitle = "Berserk",
+            candidates = listOf(candidate(1, english = "Berserk: Deluxe Edition"), candidate(2, romaji = "Bastard!!")),
+        )
+
+        assertEquals(1L, result!!.candidate.mediaId)
+        assertTrue(result.confident)
+    }
+
+    @Test
+    fun `placeholder titles are ignored rather than matched against each other`() {
+        // Sources emit "?" for a missing localized name. Two of them are a perfect string match
+        // and a completely meaningless one.
+        val result = match(
+            sourceTitle = "Vinland Saga",
+            candidates = listOf(
+                candidate(1, romaji = "?", english = "?"),
+                candidate(2, romaji = "Vinland Saga"),
+            ),
+        )
+
+        assertEquals(2L, result!!.candidate.mediaId)
+    }
+
+    @Test
+    fun `an alternative title matches when the source title does not`() {
+        // This is the manual-override path: the user has told us what this manga is really called.
+        val result = match(
+            sourceTitle = "Zzzz Unknown Release",
+            alternativeTitles = listOf("Vagabond"),
+            candidates = listOf(candidate(1, romaji = "Berserk"), candidate(2, romaji = "Vagabond")),
+        )
+
+        assertEquals(2L, result!!.candidate.mediaId)
+    }
+
+    @Test
+    fun `an unrelated title still returns the best candidate but not as confident`() {
+        // Never returning null for a non-empty candidate list is deliberate — the caller shows a
+        // picker, and "here is my best guess, marked uncertain" beats an empty screen. The flag is
+        // what keeps a guess from being written to the manga row as a confirmed match.
+        val result = match(
+            sourceTitle = "Completely Unrelated Manga Title",
+            candidates = listOf(candidate(1, romaji = "Berserk")),
+        )
+
+        assertEquals(1L, result!!.candidate.mediaId)
+        assertFalse(result.confident)
+    }
+
+    @Test
+    fun `no candidates yields null`() {
+        assertNull(match(sourceTitle = "Berserk", candidates = emptyList()))
+    }
+
+    @Test
+    fun `a blank source title with no alternatives yields null`() {
+        // Rather than matching everything equally badly and picking arbitrarily.
+        assertNull(match(sourceTitle = "   ", candidates = listOf(candidate(1, romaji = "Berserk"))))
+    }
+
+    @Test
+    fun `a candidate with no usable titles scores zero rather than throwing`() {
+        val result = match(
+            sourceTitle = "Berserk",
+            candidates = listOf(candidate(1), candidate(2, romaji = "Berserk")),
+        )
+
+        assertEquals(2L, result!!.candidate.mediaId)
+    }
+}

--- a/domain/src/test/java/app/otakureader/domain/usecase/metadata/MatchAniListMediaUseCaseTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/usecase/metadata/MatchAniListMediaUseCaseTest.kt
@@ -183,6 +183,75 @@ class MatchAniListMediaUseCaseTest {
         assertFalse(result.confident)
     }
 
+    /**
+     * A season stated only in an override has to count.
+     *
+     * The season used to be read from `sourceTitle` alone. So when the source name is junk — which
+     * is the whole reason an override exists — the season term was silently switched off, the
+     * entry and its sequel tied on base score (normalization strips the marker from both), and the
+     * winner fell to search order. Every target title now carries its own season.
+     */
+    @Test
+    fun `a season stated in an alternative title disambiguates the sequel`() {
+        val result = match(
+            sourceTitle = "kaguya raw v2 scan",
+            alternativeTitles = listOf("Kaguya-sama: Love is War Season 2"),
+            candidates = listOf(
+                candidate(1, english = "Kaguya-sama: Love is War"),
+                candidate(2, english = "Kaguya-sama: Love is War Season 2"),
+            ),
+        )
+
+        assertEquals(2L, result!!.candidate.mediaId)
+    }
+
+    /**
+     * The season that counts is the one on the title that matched.
+     *
+     * The adjustment used to be computed once per candidate, from the first of its titles stating
+     * any season. An entry whose romaji says one season and whose english says another was then
+     * judged by whichever came first in the list, even when the *other* title was the exact match.
+     * Asserting the score rather than the winner, because that is where the difference shows:
+     * under the old rule the romaji's season 5 disagreed with the target's 2 and cost 0.3.
+     */
+    @Test
+    fun `the season comes from the matched title, not from a sibling title`() {
+        val result = match(
+            sourceTitle = "Overlord Season 2",
+            candidates = listOf(
+                candidate(1, romaji = "Overlord Season 5", english = "Overlord Season 2"),
+            ),
+        )
+
+        assertEquals(1f, result!!.score)
+        assertTrue(result.confident)
+    }
+
+    @Test
+    fun `a trailing volume number is not read as a season`() {
+        // "Berserk Vol 3" is the same manga as "Berserk". Reading the 3 as a season would put a
+        // 0.3 penalty on the correct entry, which is worse than having no season signal at all.
+        val result = match(
+            sourceTitle = "Berserk Vol 3",
+            candidates = listOf(candidate(1, romaji = "Berserk"), candidate(2, romaji = "Bastard!!")),
+        )
+
+        assertEquals(1L, result!!.candidate.mediaId)
+        assertTrue(result.confident)
+    }
+
+    @Test
+    fun `a lowercase placeholder is filtered too`() {
+        // The check used to be case-sensitive, so "n/a" slipped past "N/A" and could match another
+        // placeholder perfectly.
+        val result = match(
+            sourceTitle = "Vinland Saga",
+            candidates = listOf(candidate(1, romaji = "n/a", english = "n/a"), candidate(2, romaji = "Vinland Saga")),
+        )
+
+        assertEquals(2L, result!!.candidate.mediaId)
+    }
+
     @Test
     fun `no candidates yields null`() {
         assertNull(match(sourceTitle = "Berserk", candidates = emptyList()))

--- a/domain/src/test/java/app/otakureader/domain/util/StringSimilarityTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/util/StringSimilarityTest.kt
@@ -1,0 +1,138 @@
+package app.otakureader.domain.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Each measure is tested on the case it exists for and on the case it is blind to.
+ *
+ * Testing only the agreements would leave three interchangeable-looking functions with no evidence
+ * that any of them earns its place in the blend — and the blend's weights are only defensible if
+ * the measures genuinely disagree.
+ */
+class StringSimilarityTest {
+
+    // ── ratio ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `identical strings are 1`() {
+        assertEquals(1f, StringSimilarity.ratio("berserk", "berserk"))
+    }
+
+    @Test
+    fun `two empty strings are identical, not maximally different`() {
+        // 0.0 here would propagate through the caller's weighted blend as a confusing zero for
+        // input that is, in fact, equal.
+        assertEquals(1f, StringSimilarity.ratio("", ""))
+    }
+
+    @Test
+    fun `one empty string shares nothing`() {
+        assertEquals(0f, StringSimilarity.ratio("", "berserk"))
+    }
+
+    @Test
+    fun `a single typo costs one edit out of the length`() {
+        // "bersek" vs "berserk": one insertion over a max length of 7.
+        assertEquals(1f - 1f / 7f, StringSimilarity.ratio("bersek", "berserk"), 0.0001f)
+    }
+
+    @Test
+    fun `ratio is blind to word order`() {
+        // The case tokenSetRatio exists to cover: same words, rearranged, and plain edit distance
+        // charges for nearly every character.
+        assertTrue(StringSimilarity.ratio("love is war", "war is love") < 0.6f)
+    }
+
+    // ── partialRatio ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `a title contained in a longer one scores 1`() {
+        assertEquals(1f, StringSimilarity.partialRatio("berserk", "berserk deluxe edition"))
+    }
+
+    @Test
+    fun `the contained match is found anywhere, not only at the start`() {
+        assertEquals(1f, StringSimilarity.partialRatio("berserk", "the complete berserk archive"))
+    }
+
+    @Test
+    fun `partialRatio is symmetric in its arguments`() {
+        assertEquals(
+            StringSimilarity.partialRatio("berserk", "berserk deluxe edition"),
+            StringSimilarity.partialRatio("berserk deluxe edition", "berserk"),
+        )
+    }
+
+    @Test
+    fun `containment scores far higher under partialRatio than under ratio`() {
+        // This gap is the whole reason both are in the blend. Asserting each in isolation would
+        // not show that they disagree, which is the property that matters.
+        val a = "berserk"
+        val b = "berserk deluxe edition"
+        assertTrue(StringSimilarity.partialRatio(a, b) - StringSimilarity.ratio(a, b) > 0.5f)
+    }
+
+    // ── tokenSetRatio ────────────────────────────────────────────────────────
+
+    @Test
+    fun `reordered words score 1`() {
+        assertEquals(1f, StringSimilarity.tokenSetRatio("love is war", "war is love"))
+    }
+
+    @Test
+    fun `a superset of words still scores 1`() {
+        // Every token of the shorter title is present, so the sorted intersection equals the
+        // shorter string exactly.
+        assertEquals(1f, StringSimilarity.tokenSetRatio("hero academia", "boku no hero academia"))
+    }
+
+    @Test
+    fun `repeated words do not change the result`() {
+        assertEquals(
+            StringSimilarity.tokenSetRatio("hero academia", "boku no hero academia"),
+            StringSimilarity.tokenSetRatio("hero hero academia", "boku no hero academia academia"),
+        )
+    }
+
+    @Test
+    fun `tokenSetRatio is blind to a typo inside a token`() {
+        // The case ratio covers and this one does not: no token matches exactly, so the sets are
+        // disjoint even though a human reads them as the same words.
+        assertTrue(StringSimilarity.tokenSetRatio("berserk", "bersek") < 0.9f)
+        assertTrue(StringSimilarity.ratio("berserk", "bersek") > 0.8f)
+    }
+
+    @Test
+    fun `disjoint word sets score low`() {
+        assertTrue(StringSimilarity.tokenSetRatio("berserk", "vagabond") < 0.5f)
+    }
+
+    // ── levenshtein ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `levenshtein counts single edits of each kind`() {
+        assertEquals(0, StringSimilarity.levenshtein("kitten", "kitten"))
+        assertEquals(1, StringSimilarity.levenshtein("kitten", "sitten")) // substitution
+        assertEquals(1, StringSimilarity.levenshtein("kitten", "kitteng")) // insertion
+        assertEquals(1, StringSimilarity.levenshtein("kitten", "kiten")) // deletion
+        assertEquals(3, StringSimilarity.levenshtein("kitten", "sitting")) // the textbook case
+    }
+
+    @Test
+    fun `levenshtein against an empty string is the other length`() {
+        assertEquals(7, StringSimilarity.levenshtein("", "berserk"))
+        assertEquals(7, StringSimilarity.levenshtein("berserk", ""))
+    }
+
+    @Test
+    fun `levenshtein is symmetric`() {
+        // The two-row implementation writes into a rolling buffer, which is where an
+        // asymmetry would show up if the row swap were wrong.
+        assertEquals(
+            StringSimilarity.levenshtein("kaguya sama", "kaguyasama wa"),
+            StringSimilarity.levenshtein("kaguyasama wa", "kaguya sama"),
+        )
+    }
+}


### PR DESCRIPTION
First slice of Stage 5b, after Stage 5a completed in #1236. This is the piece the whole metadata layer depends on: deciding **which** AniList entry a manga from a source actually is. The fetch, the Room cache and the details-screen sections follow in their own PRs.

## Why this needs scoring at all

There is no identifier in common between a source and AniList — only strings a human would recognise as the same work:

| A source calls it | AniList calls it |
|---|---|
| `Boku no Hero Academia` | `My Hero Academia` (english) |
| `僕のヒーローアカデミア` | `Boku no Hero Academia` (romaji) |
| `Berserk (Official Colored)` | `Berserk` |
| `OPM` | `One-Punch Man`, synonym `OPM` |

So every candidate is scored against **every** title the target is known by, and the best takes it — not one title at a time, which would let a weak match on an early title beat a strong match on a later one purely by ordering.

## Scoring

```
0.4 · tokenSetRatio  +  0.3 · partialRatio  +  0.3 · ratio      ± seasonWeight
```

Three measures because each is blind to what the others catch:

| Measure | Good at | Blind to |
|---|---|---|
| `ratio` | typos | word reordering; one title being a subset of another |
| `partialRatio` | `Berserk` inside `Berserk: Deluxe Edition` | reordering |
| `tokenSetRatio` | reordering, extra words | a typo *inside* a token |

The `StringSimilarity` tests assert those **disagreements**, not just the agreements. Three interchangeable-looking functions with no evidence they differ wouldn't justify the weights.

These follow the shape of FuzzyWuzzy's measures but the base is Levenshtein-normalized rather than `SequenceMatcher`'s matching-blocks ratio. Said plainly in the KDoc, because calling it "fuzzywuzzy's algorithm" would invite someone to port a threshold from a Python project and find it behaves differently.

## Two things found by reading the code instead of following the plan

### `TitleNormalizer` already exists — and `normalize()` strips a trailing `season N`

Correct for its own purpose, and a hard constraint here. Extracting a season *after* normalizing would find nothing in any title, the sequel handling would never fire, and the code would look like it worked. So seasons are read from the **raw** title.

**That reached further than the extraction, and cost me a failing test to discover.** Because normalization removes the season marker, `Kaguya-sama: Love is War` and `Kaguya-sama: Love is War Season 2` normalize to the *identical* string — both score a base of 1.0, and the season term is the only thing separating them. My first version then:

- clamped the score to `[0, 1]` before ranking, which erased exactly that term, and
- early-exited on the first candidate scoring ≥ 0.98, returning whichever the search listed first.

So the season adjustment — the entire reason sequels are handled — could never break the tie it exists to break. Ranking is now on the unclamped score with **no early exit**; the clamp applies only to the reported value. Deleting the early exit made the method shorter, and the candidate list is one search page, so it was never worth much.

This is the failure this repo's checklist calls #1, caught by a test rather than by review: the comment described sequel handling, the code implemented most of it.

### `SearchMigrationTargetsUseCase` already had a private Levenshtein

Doing the same `1 - distance / maxLength` arithmetic. Extracted to `StringSimilarity` rather than written a second time — two implementations in one module drift apart, because the second gets written from the same *description* rather than the same code, and the divergence surfaces as two features disagreeing about whether two titles are the same manga. The migration use case now delegates, and its existing tests still pass.

## What `ArchitectureTest` caught

The two new data classes were top-level in the usecase package; the repo enforces that domain data classes live in `domain/model`. Moved. Worth noting the rule exists and works — it failed the build before review saw it.

## Design decisions worth flagging

- **A non-empty candidate list never returns null.** The caller shows a picker, and "best guess, marked uncertain" beats an empty screen. `AniListMatch.confident` is what keeps a guess out of the manga row as a confirmed `anilistId`.
- **An unknown season is neutral, not "season 1".** Most titles carry no marker, so treating absence as 1 would penalise every unmarked title against every sequel — making the common case worse to handle the rare one.
- **Placeholder titles (`?`, `??`, `-`, `N/A`) are dropped.** Sources really do emit these for a missing localized name, and two of them are a *perfect* string match that means nothing.

## Verification

`./gradlew :app:assembleDebug testDebugUnitTest detekt ktlintCheck` → **BUILD SUCCESSFUL**. All 281 `:domain` tests pass, including the pre-existing migration suite against the shared Levenshtein.

The matcher's tests are a fixture table of cases that actually occur — romaji vs english, synonym-only matches, `Season 2` and `2nd Season`, `Re:Zero` vs `ReZero`, edition subtitles, placeholder titles, the manual-override path, and the cases that should *not* match.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UoEui2mCCcqArdhyQyFwnR)_

## Summary by Sourcery

Introduce an AniList media title matcher that selects the best AniList entry for a source manga using blended string similarity and season-aware scoring, and centralize string similarity utilities for reuse.

New Features:
- Add AniListMediaCandidate and AniListMatch domain models to represent AniList search results and matching outcomes.
- Implement MatchAniListMediaUseCase to choose the best AniList media for a given source title and optional alternative titles, with confidence scoring.

Enhancements:
- Extract shared string similarity logic into a new StringSimilarity utility, providing ratio, partialRatio, tokenSetRatio, and Levenshtein functions.
- Update SearchMigrationTargetsUseCase to use the shared StringSimilarity.ratio utility instead of a private Levenshtein implementation.

Tests:
- Add comprehensive tests for MatchAniListMediaUseCase covering real-world title matching scenarios, including romaji vs English, synonyms, seasons, punctuation differences, placeholders, and manual overrides.
- Add StringSimilarityTest to validate the behavior and tradeoffs of ratio, partialRatio, tokenSetRatio, and Levenshtein across their intended and blind-spot cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an AniList title matcher that scores candidates across all known titles using blended similarity and season-aware tie-breaking. Centralizes string similarity and fixes season handling by attaching the season to the title that states it.

- **New Features**
  - `MatchAniListMediaUseCase` blends 0.4 tokenSetRatio + 0.3 partialRatio + 0.3 ratio with ±0.3 season; ranks on unclamped score; reads season from raw titles; heavy-normalized fallback; returns best with `confident`.
  - Introduces `StringSimilarity` (`ratio`, `partialRatio`, `tokenSetRatio`, shared `levenshtein`); `SearchMigrationTargetsUseCase` now delegates. Adds `AniListMediaCandidate`/`AniListMatch` and focused tests.

- **Bug Fixes**
  - Season is tied to the matched title and applied per (target, candidate) pair; seasons in `alternativeTitles` now count.
  - Ignore unit-qualified trailing numbers (e.g., "Vol 3") as seasons; placeholder filtering is case-insensitive; avoid double normalization.

<sup>Written for commit 258543184ec2fb169fdfa3931f990ea398ca3139. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HeartlessVeteran2/Otaku-Reader/pull/1237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

