### PR TITLE
Search AniList for a manga's media id, and score the results

### DIFF
--- a/data/src/main/java/app/otakureader/data/di/RepositoryModule.kt
+++ b/data/src/main/java/app/otakureader/data/di/RepositoryModule.kt
@@ -66,6 +66,8 @@ import app.otakureader.domain.scheduler.ExtensionUpdateScheduler
 import app.otakureader.domain.scheduler.LibraryUpdateScheduler
 import app.otakureader.domain.scheduler.ReminderScheduler
 import app.otakureader.data.metadata.AniListMetadataRepository
+import app.otakureader.data.metadata.AniListSearchRepositoryImpl
+import app.otakureader.domain.repository.AniListSearchRepository
 import app.otakureader.domain.repository.MangaMetadataRepository
 import app.otakureader.domain.repository.UpdateErrorRepository
 import app.otakureader.domain.repository.UpdateRunSummaryRepository
@@ -200,6 +202,9 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun bindMangaMetadataRepository(impl: AniListMetadataRepository): MangaMetadataRepository
+
+    @Binds
+    abstract fun bindAniListSearchRepository(impl: AniListSearchRepositoryImpl): AniListSearchRepository
 
     companion object {
         @Provides

--- a/data/src/main/java/app/otakureader/data/metadata/AniListMetadataApi.kt
+++ b/data/src/main/java/app/otakureader/data/metadata/AniListMetadataApi.kt
@@ -19,6 +19,16 @@ import javax.inject.Inject
 interface AniListMetadataService {
     @POST("graphql")
     suspend fun query(@Body body: MetadataGraphQlQuery): MetadataResponse
+
+    /**
+     * Same endpoint, different response type.
+     *
+     * Retrofit picks the deserializer from the declared return type, so a search cannot reuse
+     * [query] without making `MetadataResponse` cover both shapes — every field nullable, and a
+     * missing `Media` indistinguishable from a missing `Page`.
+     */
+    @POST("graphql")
+    suspend fun search(@Body body: MetadataGraphQlQuery): SearchResponse
 }
 
 @kotlinx.serialization.Serializable
@@ -48,4 +58,30 @@ class AniListMetadataApi @Inject constructor(
                 variables = buildJsonObject { put("id", anilistId) },
             )
         )
+
+    /**
+     * Search AniList for manga whose title resembles [title].
+     *
+     * [perPage] is capped rather than taken on trust: AniList's own maximum is 50, and the matcher
+     * gains nothing from a long tail — it scores every candidate, so a hundred near-misses only
+     * costs time and bandwidth to reject.
+     */
+    suspend fun searchMedia(title: String, perPage: Int = DEFAULT_PER_PAGE): SearchResponse =
+        service.search(
+            MetadataGraphQlQuery(
+                query = SEARCH_QUERY,
+                variables = buildJsonObject {
+                    put("search", title)
+                    put("perPage", perPage.coerceIn(1, MAX_PER_PAGE))
+                },
+            )
+        )
+
+    companion object {
+        /** Enough for the right entry to be present; short enough that scoring stays cheap. */
+        const val DEFAULT_PER_PAGE = 10
+
+        /** AniList rejects anything above this. */
+        const val MAX_PER_PAGE = 50
+    }
 }

--- a/data/src/main/java/app/otakureader/data/metadata/AniListMetadataQuery.kt
+++ b/data/src/main/java/app/otakureader/data/metadata/AniListMetadataQuery.kt
@@ -115,3 +115,57 @@ data class MetadataTitle(
     val native: String? = null,
     val userPreferred: String? = null,
 )
+
+/**
+ * Title search, used to find which AniList media a source manga corresponds to.
+ *
+ * ### Why this is not `AniListTracker.search`
+ *
+ * The tracker already has a search, and it is the wrong shape twice over. It asks only for
+ * `title { romaji english }`, while the matcher scores against **every** name a work is known by —
+ * dropping `native` and `synonyms` throws away the evidence that resolves a Japanese-titled source
+ * against an English AniList entry. And it returns `TrackEntry`, a *tracking* record, so using it
+ * here would mean inventing a fake list entry for a manga the user does not track — which is the
+ * exact case this exists to serve.
+ *
+ * ### Only what the matcher reads
+ *
+ * No cover, no format, no dates. [app.otakureader.domain.model.AniListMediaCandidate] holds titles
+ * and nothing else, so anything more would be fetched, parsed, and dropped. The wrong-match picker
+ * will need a cover and a year to be usable by a human; that slice extends the query and the
+ * candidate model together, where there is a consumer to justify each field.
+ */
+internal const val SEARCH_QUERY = """
+    query (${'$'}search: String, ${'$'}perPage: Int) {
+      Page(perPage: ${'$'}perPage) {
+        media(search: ${'$'}search, type: MANGA) {
+          id
+          title { romaji english native }
+          synonyms
+        }
+      }
+    }
+"""
+
+@Serializable
+data class SearchResponse(
+    val data: SearchData? = null,
+    val errors: List<MetadataError> = emptyList(),
+)
+
+@Serializable
+data class SearchData(
+    @SerialName("Page") val page: SearchPage? = null,
+)
+
+@Serializable
+data class SearchPage(
+    val media: List<SearchMedia> = emptyList(),
+)
+
+@Serializable
+data class SearchMedia(
+    val id: Long = 0,
+    val title: MetadataTitle? = null,
+    val synonyms: List<String> = emptyList(),
+)

--- a/data/src/main/java/app/otakureader/data/metadata/AniListSearchRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/metadata/AniListSearchRepositoryImpl.kt
@@ -19,6 +19,11 @@ class AniListSearchRepositoryImpl @Inject constructor(
         // A blank or placeholder title cannot match anything, and sending it would spend a request
         // against the rate limit to be told so. Sources really do emit "?" and "??" for a missing
         // localized title — see PlaceholderTitles.
+        //
+        // This returns success-with-nothing rather than a failure on purpose: the caller should
+        // move on to the next title, which is exactly what an empty result already means to it.
+        // Note that it makes "empty" mean "no candidates", not "AniList had none" — see the
+        // interface docs.
         if (!PlaceholderTitles.isMeaningful(title)) return Result.success(emptyList())
 
         return try {
@@ -30,7 +35,18 @@ class AniListSearchRepositoryImpl @Inject constructor(
             response.errors.firstOrNull()?.let {
                 return Result.failure(AniListMetadataException(it.message))
             }
-            Result.success(response.data?.page?.media.orEmpty().map { it.toCandidate() })
+            // A missing `Page` is not an empty page. `media: []` means AniList looked and found
+            // nothing — a normal outcome that must let the cascade try the next title. A null
+            // `data` or `Page` means the response was not the shape the query asked for, and
+            // advancing on that would make four malformed requests where one already failed,
+            // which is the same reasoning that makes ResolveAniListMediaUseCase abort on failure.
+            // `refreshMetadata` already draws this line for a missing `Media`; search was the
+            // inconsistent one.
+            val page = response.data?.page
+                ?: return Result.failure(
+                    AniListMetadataException("AniList returned no result page for \"$title\"")
+                )
+            Result.success(page.media.map { it.toCandidate() })
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/data/src/main/java/app/otakureader/data/metadata/AniListSearchRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/metadata/AniListSearchRepositoryImpl.kt
@@ -1,0 +1,59 @@
+package app.otakureader.data.metadata
+
+import app.otakureader.domain.model.AniListMediaCandidate
+import app.otakureader.domain.repository.AniListSearchRepository
+import app.otakureader.domain.util.PlaceholderTitles
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
+
+/**
+ * AniList title search, mapped down to what the matcher scores against.
+ */
+@Singleton
+class AniListSearchRepositoryImpl @Inject constructor(
+    private val api: AniListMetadataApi,
+) : AniListSearchRepository {
+
+    override suspend fun searchMedia(title: String): Result<List<AniListMediaCandidate>> {
+        // A blank or placeholder title cannot match anything, and sending it would spend a request
+        // against the rate limit to be told so. Sources really do emit "?" and "??" for a missing
+        // localized title — see PlaceholderTitles.
+        if (!PlaceholderTitles.isMeaningful(title)) return Result.success(emptyList())
+
+        return try {
+            val response = api.searchMedia(title)
+            // Errors before data, as everywhere else against this endpoint: GraphQL answers a
+            // rejected document with HTTP 200, and can return `data` and `errors` together when one
+            // resolver fails. Without this a refused search is indistinguishable from a search that
+            // genuinely found nothing.
+            response.errors.firstOrNull()?.let {
+                return Result.failure(AniListMetadataException(it.message))
+            }
+            Result.success(response.data?.page?.media.orEmpty().map { it.toCandidate() })
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}
+
+/**
+ * Keeps only meaningful titles, so a placeholder never becomes evidence.
+ *
+ * This matters more than it looks: two placeholders match each other perfectly, so an entry whose
+ * native title is `"?"` would score 1.0 against a source whose title is also `"?"`. The romaji field
+ * is non-null on the candidate model, so an entry with no usable romaji falls back to an empty
+ * string and simply contributes nothing to scoring rather than contributing noise.
+ */
+private fun SearchMedia.toCandidate(): AniListMediaCandidate {
+    fun String?.meaningful(): String? = this?.takeIf { PlaceholderTitles.isMeaningful(it) }
+    return AniListMediaCandidate(
+        mediaId = id,
+        romaji = title?.romaji.meaningful().orEmpty(),
+        english = title?.english.meaningful(),
+        native = title?.native.meaningful(),
+        synonyms = synonyms.filter { PlaceholderTitles.isMeaningful(it) },
+    )
+}

--- a/data/src/test/java/app/otakureader/data/metadata/AniListSearchRepositoryImplTest.kt
+++ b/data/src/test/java/app/otakureader/data/metadata/AniListSearchRepositoryImplTest.kt
@@ -1,0 +1,127 @@
+package app.otakureader.data.metadata
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AniListSearchRepositoryImplTest {
+
+    private val api: AniListMetadataApi = mockk()
+    private val repository = AniListSearchRepositoryImpl(api)
+
+    private fun searchResponse(vararg media: SearchMedia) =
+        SearchResponse(data = SearchData(page = SearchPage(media = media.toList())))
+
+    @Test
+    fun `maps every title form onto the candidate`() = runTest {
+        coEvery { api.searchMedia("Berserk") } returns searchResponse(
+            SearchMedia(
+                id = 30002L,
+                title = MetadataTitle(romaji = "Berserk", english = "Berserk", native = "ベルセルク"),
+                synonyms = listOf("Berserk Deluxe Edition"),
+            )
+        )
+
+        val candidate = repository.searchMedia("Berserk").getOrThrow().single()
+
+        // All four forms matter — the matcher scores against every one of them, and dropping
+        // `native` is what makes a Japanese-titled source fail to resolve.
+        assertEquals(30002L, candidate.mediaId)
+        assertEquals("Berserk", candidate.romaji)
+        assertEquals("Berserk", candidate.english)
+        assertEquals("ベルセルク", candidate.native)
+        assertEquals(listOf("Berserk Deluxe Edition"), candidate.synonyms)
+    }
+
+    @Test
+    fun `strips placeholder titles so they cannot become evidence`() = runTest {
+        coEvery { api.searchMedia(any()) } returns searchResponse(
+            SearchMedia(
+                id = 1L,
+                title = MetadataTitle(romaji = "Real Title", english = "?", native = "??"),
+                synonyms = listOf("??", "Genuine Synonym"),
+            )
+        )
+
+        val candidate = repository.searchMedia("Real Title").getOrThrow().single()
+
+        // Two placeholders match each other perfectly, so leaving them in would let an entry whose
+        // english title is "?" score 1.0 against a source whose title is also "?".
+        assertEquals("Real Title", candidate.romaji)
+        assertEquals(null, candidate.english)
+        assertEquals(null, candidate.native)
+        assertEquals(listOf("Genuine Synonym"), candidate.synonyms)
+    }
+
+    @Test
+    fun `an entry with no usable romaji contributes an empty string rather than a placeholder`() = runTest {
+        coEvery { api.searchMedia(any()) } returns searchResponse(
+            SearchMedia(id = 1L, title = MetadataTitle(romaji = "?", english = "Real English"))
+        )
+
+        val candidate = repository.searchMedia("Real English").getOrThrow().single()
+
+        assertEquals("", candidate.romaji)
+        assertEquals("Real English", candidate.english)
+    }
+
+    @Test
+    fun `a GraphQL error is a failure even though the transport succeeded`() = runTest {
+        // AniList answers a rejected document with HTTP 200, so Retrofit throws nothing. Without
+        // the errors-first check a refused search is indistinguishable from an empty one.
+        coEvery { api.searchMedia(any()) } returns SearchResponse(
+            data = null,
+            errors = listOf(MetadataError("Invalid token")),
+        )
+
+        val result = repository.searchMedia("Berserk")
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AniListMetadataException)
+    }
+
+    @Test
+    fun `errors are checked before data, since GraphQL can return both`() = runTest {
+        coEvery { api.searchMedia(any()) } returns SearchResponse(
+            data = SearchData(page = SearchPage(media = listOf(SearchMedia(id = 1L)))),
+            errors = listOf(MetadataError("partial resolver failure")),
+        )
+
+        assertTrue(repository.searchMedia("Berserk").isFailure)
+    }
+
+    @Test
+    fun `no results is a success, not a failure`() = runTest {
+        coEvery { api.searchMedia(any()) } returns searchResponse()
+
+        val result = repository.searchMedia("Some Obscure Doujin")
+
+        // A long-tail source title genuinely absent from AniList is a normal outcome; reporting it
+        // as an error would make the caller abort a cascade that should continue.
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    @Test
+    fun `a placeholder query never reaches the network`() = runTest {
+        val result = repository.searchMedia("??")
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+        coVerify(exactly = 0) { api.searchMedia(any()) }
+    }
+
+    @Test
+    fun `a thrown transport error becomes a failure rather than escaping`() = runTest {
+        coEvery { api.searchMedia(any()) } throws java.io.IOException("no route to host")
+
+        val result = repository.searchMedia("Berserk")
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is java.io.IOException)
+    }
+}

--- a/data/src/test/java/app/otakureader/data/metadata/AniListSearchRepositoryImplTest.kt
+++ b/data/src/test/java/app/otakureader/data/metadata/AniListSearchRepositoryImplTest.kt
@@ -107,6 +107,39 @@ class AniListSearchRepositoryImplTest {
     }
 
     @Test
+    fun `a response with no page is a failure, not an empty search`() = runTest {
+        // "AniList found nothing" and "AniList did not answer the question asked" must stay
+        // distinguishable: the cascade advances on the first and aborts on the second, so calling
+        // a malformed response empty would make four malformed requests where one already failed.
+        coEvery { api.searchMedia(any()) } returns SearchResponse(data = SearchData(page = null))
+
+        val result = repository.searchMedia("Berserk")
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is AniListMetadataException)
+    }
+
+    @Test
+    fun `a response with no data at all is a failure`() = runTest {
+        coEvery { api.searchMedia(any()) } returns SearchResponse(data = null)
+
+        assertTrue(repository.searchMedia("Berserk").isFailure)
+    }
+
+    @Test
+    fun `an empty media list is still a success`() = runTest {
+        // The other side of the same line: `media: []` means AniList looked and found nothing,
+        // which is a normal outcome the cascade must be allowed to move past.
+        coEvery { api.searchMedia(any()) } returns
+            SearchResponse(data = SearchData(page = SearchPage(media = emptyList())))
+
+        val result = repository.searchMedia("Some Obscure Doujin")
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    @Test
     fun `a placeholder query never reaches the network`() = runTest {
         val result = repository.searchMedia("??")
 

--- a/domain/src/main/java/app/otakureader/domain/repository/AniListSearchRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/AniListSearchRepository.kt
@@ -1,0 +1,32 @@
+package app.otakureader.domain.repository
+
+import app.otakureader.domain.model.AniListMediaCandidate
+
+/**
+ * Searches AniList for media that might correspond to a local manga.
+ *
+ * ### Separate from [MangaMetadataRepository] on purpose
+ *
+ * That one owns a *cache*: it reads Room, writes Room, and has a TTL. This one owns no state at
+ * all — every call is a network round trip, nothing is stored, and there is nothing to observe.
+ * Folding them together would put a method with none of the offline-first guarantees the metadata
+ * repository documents behind the same interface that makes them.
+ *
+ * The two are still wired to the same Retrofit instance, so a search inherits the rate limiter and
+ * certificate pinning without restating either.
+ */
+interface AniListSearchRepository {
+
+    /**
+     * Candidates whose title resembles [title], best-effort and unranked.
+     *
+     * Ranking is [app.otakureader.domain.usecase.metadata.MatchAniListMediaUseCase]'s job — AniList
+     * orders by its own relevance, which knows nothing about the alternative titles the local
+     * record carries.
+     *
+     * @return the candidates, or a failure carrying why the search did not happen. An empty list is
+     *   a success: AniList genuinely has nothing under that name, which is a normal outcome for a
+     *   long-tail source title and must not be reported as an error.
+     */
+    suspend fun searchMedia(title: String): Result<List<AniListMediaCandidate>>
+}

--- a/domain/src/main/java/app/otakureader/domain/repository/AniListSearchRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/AniListSearchRepository.kt
@@ -24,9 +24,18 @@ interface AniListSearchRepository {
      * orders by its own relevance, which knows nothing about the alternative titles the local
      * record carries.
      *
-     * @return the candidates, or a failure carrying why the search did not happen. An empty list is
-     *   a success: AniList genuinely has nothing under that name, which is a normal outcome for a
-     *   long-tail source title and must not be reported as an error.
+     * @return the candidates, or a failure carrying why the search did not happen.
+     *
+     * An empty list means **no candidates**, and deliberately does not say why. It covers two
+     * paths: AniList looked and had nothing under that name — normal for a long-tail source title,
+     * and not an error — and the title being unusable enough that it was never sent, which
+     * implementations may short-circuit locally rather than spend a request against the rate limit
+     * to be told the same thing. Callers treat both identically (move on to the next title), so
+     * naming only the first would be a claim the contract does not keep.
+     *
+     * A malformed response is a **failure**, not an empty list. "AniList found nothing" and
+     * "AniList did not answer the question asked" have to stay distinguishable, because the caller
+     * advances on the first and aborts on the second.
      */
     suspend fun searchMedia(title: String): Result<List<AniListMediaCandidate>>
 }

--- a/domain/src/main/java/app/otakureader/domain/usecase/metadata/ResolveAniListMediaUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/metadata/ResolveAniListMediaUseCase.kt
@@ -1,0 +1,93 @@
+package app.otakureader.domain.usecase.metadata
+
+import app.otakureader.domain.model.AniListMatch
+import app.otakureader.domain.repository.AniListSearchRepository
+import app.otakureader.domain.util.PlaceholderTitles
+import javax.inject.Inject
+
+/**
+ * Finds which AniList media a source manga is, by searching and then scoring the results.
+ *
+ * [MatchAniListMediaUseCase] is a pure function over candidates it is handed; this is the half that
+ * decides *what to search for* and hands them over. Keeping them apart is what lets the matcher stay
+ * driven by a fixture table with no network in sight.
+ *
+ * ### Why searching more than once is necessary
+ *
+ * AniList's search is a text index, not a matcher. A source that names a work
+ * `"Boku no Hero Academia (Official Colored)"` returns nothing at all — there is no entry by that
+ * name — and no amount of clever scoring rescues an empty candidate list. So when a search comes
+ * back empty the next known title is tried, which is exactly the case a manual override or a
+ * previously-cached synonym set exists to repair.
+ *
+ * ### Why it stops at the first search that returns anything
+ *
+ * Merging results from every title would give the matcher more to choose from, and cost a request
+ * per title against a rate limit this app has to wait out — up to 90 seconds per response when
+ * AniList is throttling (#1236). One extra request to rescue a failed search is worth it; three
+ * more to slightly widen an already-populated candidate list is not.
+ *
+ * Note that stopping early costs nothing in *matching* quality: whichever search produced the
+ * candidates, they are scored against the whole title set, so a candidate found via a synonym is
+ * still judged on how well it matches the source title.
+ *
+ * ### A failed search aborts the cascade
+ *
+ * Only an *empty* result advances to the next title. A failure means the request did not complete —
+ * no network, or AniList refused the document — and the next title would fail the same way. Retrying
+ * it three more times would turn one dead request into four, which is precisely what the rate-limit
+ * interceptor exists to prevent.
+ */
+class ResolveAniListMediaUseCase @Inject constructor(
+    private val searchRepository: AniListSearchRepository,
+    private val matchMedia: MatchAniListMediaUseCase,
+) {
+
+    /**
+     * @param sourceTitle the title as the source names it — searched first, and always scored.
+     * @param alternativeTitles other names known locally, used both as fallback search terms and as
+     *   additional scoring targets.
+     * @return the best match, `null` when no search produced any candidate, or a failure when a
+     *   search could not be completed.
+     */
+    suspend operator fun invoke(
+        sourceTitle: String,
+        alternativeTitles: List<String> = emptyList(),
+    ): Result<AniListMatch?> {
+        val searchTerms = (listOf(sourceTitle) + alternativeTitles)
+            .map { it.trim() }
+            .filter { PlaceholderTitles.isMeaningful(it) }
+            // Case-insensitively distinct: a source title that differs from a synonym only in
+            // capitalisation would otherwise spend a second request to receive the same page.
+            .distinctBy { it.lowercase() }
+            .take(MAX_SEARCH_ATTEMPTS)
+
+        if (searchTerms.isEmpty()) return Result.success(null)
+
+        for (term in searchTerms) {
+            val candidates = searchRepository.searchMedia(term)
+                .getOrElse { return Result.failure(it) }
+            if (candidates.isEmpty()) continue
+
+            return Result.success(
+                matchMedia(
+                    sourceTitle = sourceTitle,
+                    alternativeTitles = alternativeTitles,
+                    candidates = candidates,
+                )
+            )
+        }
+        return Result.success(null)
+    }
+
+    companion object {
+        /**
+         * How many titles are searched before giving up.
+         *
+         * Four covers the shapes that actually occur — a source title plus an english, romaji and
+         * native alternative — without letting a manga with twenty cached synonyms issue twenty
+         * requests.
+         */
+        const val MAX_SEARCH_ATTEMPTS = 4
+    }
+}

--- a/domain/src/main/java/app/otakureader/domain/usecase/metadata/ResolveAniListMediaUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/metadata/ResolveAniListMediaUseCase.kt
@@ -59,6 +59,11 @@ class ResolveAniListMediaUseCase @Inject constructor(
             .filter { PlaceholderTitles.isMeaningful(it) }
             // Case-insensitively distinct: a source title that differs from a synonym only in
             // capitalisation would otherwise spend a second request to receive the same page.
+            //
+            // The no-argument `lowercase()` is already locale-invariant — Kotlin defines it as the
+            // invariant-locale mapping, which is exactly why it replaced `toLowerCase()`. Passing
+            // `Locale.ROOT` explicitly would be a no-op, and passing `Locale.getDefault()` would
+            // introduce the Turkish dotless-i bug rather than avoid it.
             .distinctBy { it.lowercase() }
             .take(MAX_SEARCH_ATTEMPTS)
 

--- a/domain/src/test/java/app/otakureader/domain/usecase/metadata/ResolveAniListMediaUseCaseTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/usecase/metadata/ResolveAniListMediaUseCaseTest.kt
@@ -1,0 +1,151 @@
+package app.otakureader.domain.usecase.metadata
+
+import app.otakureader.domain.model.AniListMediaCandidate
+import app.otakureader.domain.repository.AniListSearchRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the half of matching that the matcher's own test cannot: which titles get searched, in what
+ * order, and when the cascade stops.
+ */
+class ResolveAniListMediaUseCaseTest {
+
+    private val searchRepository: AniListSearchRepository = mockk()
+    private val resolve = ResolveAniListMediaUseCase(searchRepository, MatchAniListMediaUseCase())
+
+    private fun candidate(
+        id: Long,
+        romaji: String = "",
+        english: String? = null,
+    ) = AniListMediaCandidate(id, romaji, english)
+
+    @Test
+    fun `searches the source title first and matches against its results`() = runTest {
+        coEvery { searchRepository.searchMedia("Berserk") } returns
+            Result.success(listOf(candidate(2L, romaji = "Berserk")))
+
+        val match = resolve("Berserk").getOrThrow()
+
+        assertEquals(2L, match?.candidate?.mediaId)
+        assertTrue(match!!.confident)
+        coVerify(exactly = 1) { searchRepository.searchMedia("Berserk") }
+    }
+
+    @Test
+    fun `falls through to an alternative title when the first search finds nothing`() = runTest {
+        // The case this exists for: AniList has no entry called "Boku no Hero Academia (Official
+        // Colored)", so the source's own title returns an empty page and no scoring can rescue it.
+        coEvery { searchRepository.searchMedia("Boku no Hero Academia (Official Colored)") } returns
+            Result.success(emptyList())
+        coEvery { searchRepository.searchMedia("My Hero Academia") } returns
+            Result.success(listOf(candidate(31706L, romaji = "Boku no Hero Academia", english = "My Hero Academia")))
+
+        val match = resolve(
+            sourceTitle = "Boku no Hero Academia (Official Colored)",
+            alternativeTitles = listOf("My Hero Academia"),
+        ).getOrThrow()
+
+        assertEquals(31706L, match?.candidate?.mediaId)
+    }
+
+    @Test
+    fun `stops searching as soon as a search returns candidates`() = runTest {
+        coEvery { searchRepository.searchMedia("Berserk") } returns
+            Result.success(listOf(candidate(2L, romaji = "Berserk")))
+
+        resolve(sourceTitle = "Berserk", alternativeTitles = listOf("Berserk Deluxe", "ベルセルク"))
+
+        // Widening an already-populated candidate list is not worth a request against a rate limit
+        // that can hold a response for 90 seconds.
+        coVerify(exactly = 0) { searchRepository.searchMedia("Berserk Deluxe") }
+        coVerify(exactly = 0) { searchRepository.searchMedia("ベルセルク") }
+    }
+
+    @Test
+    fun `a failed search aborts the cascade instead of retrying the next title`() = runTest {
+        coEvery { searchRepository.searchMedia("Berserk") } returns
+            Result.failure(IllegalStateException("offline"))
+
+        val result = resolve(sourceTitle = "Berserk", alternativeTitles = listOf("ベルセルク"))
+
+        assertTrue(result.isFailure)
+        // A dead request would be dead for the next title too; turning one into four is what the
+        // rate-limit interceptor exists to prevent.
+        coVerify(exactly = 0) { searchRepository.searchMedia("ベルセルク") }
+    }
+
+    @Test
+    fun `every title is scored even when a later one produced the candidates`() = runTest {
+        // "Kaguya-sama" finds nothing; the native title does. The candidates must still be judged
+        // against the source title, or a search term that happens to be vague would decide the
+        // match on its own.
+        coEvery { searchRepository.searchMedia("Kaguya-sama wa Kokurasetai Season 2") } returns
+            Result.success(emptyList())
+        coEvery { searchRepository.searchMedia("かぐや様は告らせたい") } returns Result.success(
+            listOf(
+                candidate(1L, romaji = "Kaguya-sama wa Kokurasetai"),
+                candidate(2L, romaji = "Kaguya-sama wa Kokurasetai Season 2"),
+            )
+        )
+
+        val match = resolve(
+            sourceTitle = "Kaguya-sama wa Kokurasetai Season 2",
+            alternativeTitles = listOf("かぐや様は告らせたい"),
+        ).getOrThrow()
+
+        assertEquals(2L, match?.candidate?.mediaId)
+    }
+
+    @Test
+    fun `returns null rather than a failure when no title finds anything`() = runTest {
+        coEvery { searchRepository.searchMedia(any()) } returns Result.success(emptyList())
+
+        val result = resolve(sourceTitle = "Some Obscure Doujin", alternativeTitles = listOf("Another Name"))
+
+        // AniList genuinely having nothing is a normal outcome, not an error.
+        assertTrue(result.isSuccess)
+        assertNull(result.getOrThrow())
+    }
+
+    @Test
+    fun `never searches more than MAX_SEARCH_ATTEMPTS titles`() = runTest {
+        coEvery { searchRepository.searchMedia(any()) } returns Result.success(emptyList())
+
+        resolve(
+            sourceTitle = "T0",
+            alternativeTitles = listOf("T1", "T2", "T3", "T4", "T5"),
+        )
+
+        coVerify(exactly = ResolveAniListMediaUseCase.MAX_SEARCH_ATTEMPTS) {
+            searchRepository.searchMedia(any())
+        }
+        coVerify(exactly = 0) { searchRepository.searchMedia("T4") }
+    }
+
+    @Test
+    fun `skips placeholder and duplicate titles without spending a request on them`() = runTest {
+        coEvery { searchRepository.searchMedia(any()) } returns Result.success(emptyList())
+
+        resolve(sourceTitle = "Berserk", alternativeTitles = listOf("?", "??", "  ", "berserk", "BERSERK"))
+
+        // "?" and "??" are what sources emit for a missing localized title, and the three casings
+        // of Berserk would all return the same page.
+        coVerify(exactly = 1) { searchRepository.searchMedia(any()) }
+    }
+
+    @Test
+    fun `returns null when the manga has no meaningful title at all`() = runTest {
+        val result = resolve(sourceTitle = "?", alternativeTitles = listOf("  "))
+
+        assertTrue(result.isSuccess)
+        assertNull(result.getOrThrow())
+        coVerify(exactly = 0) { searchRepository.searchMedia(any()) }
+    }
+}


### PR DESCRIPTION
Stage 5b slice 4a. #1239 gave the details screen AniList metadata, but only for manga the user **already tracks on AniList** — the media id came from the AniList `TrackEntry.remoteId`, and an untracked manga has none. `MatchAniListMediaUseCase` (#1237) has been able to pick the right entry since the day it landed; nothing has ever handed it any candidates to pick from. This is the half that finds them.

## Why the tracker's existing search couldn't be reused

`AniListTracker.search` already exists, and it's the wrong shape twice over:

- **It asks only for `title { romaji english }`.** The matcher scores against *every* name a work is known by, so dropping `native` and `synonyms` throws away exactly the evidence that resolves a Japanese-titled source against an English AniList entry.
- **It returns `TrackEntry`** — a *tracking* record. Using it here would mean fabricating a list entry for a manga the user doesn't track, which is precisely the case this exists to serve.

So the search lives on the metadata API instead. That endpoint is unauthenticated (it needs to work for users who never logged into AniList) and already inherits the rate-limit interceptor and certificate pinning from the shared Retrofit instance, so neither had to be restated.

## The cascade, and why it stops early

AniList's search is a text index, not a matcher. A source that names a work `"Boku no Hero Academia (Official Colored)"` returns an empty page — there is no entry by that name — and no amount of clever scoring rescues an empty candidate list. So when a search finds nothing, the next known title is tried.

It **stops at the first search that returns anything.** Merging results from every title would widen the candidate list at the cost of one request per title against a limit that can hold a response for up to 90 seconds (#1236). One extra request to rescue a failed search is worth it; three more to slightly widen an already-populated list is not.

Stopping early costs nothing in *match* quality, and that's worth being precise about: whichever search produced the candidates, they're scored against the **whole** title set, so a candidate found via a synonym is still judged on how well it matches the source title. There's a test that pins this — the source title finds nothing, the native title finds two candidates, and the sequel-vs-original distinction is still decided by the source title's season marker.

Only an **empty** result advances to the next title. A failure aborts the cascade: a dead request would be dead for the next title too, and turning one into four is what the rate-limit interceptor exists to prevent.

## Shape

`AniListSearchRepository` is its own domain interface rather than a method on `MangaMetadataRepository`. That one owns a cache — Room reads, Room writes, a TTL, and offline-first guarantees it documents in as many words. This one owns no state at all: every call is a round trip and there's nothing to observe. Putting a method with none of those guarantees behind the interface that makes them seemed like the wrong trade.

Placeholder handling is at the boundary, reusing `PlaceholderTitles` (#1238). Sources emit `"?"` and `"??"` for a missing localized title, and **two placeholders match each other perfectly** — an entry whose english title is `"?"` would otherwise score 1.0 against a source whose title is also `"?"`.

## Scope

Search and match only. Nothing is persisted, no UI changes.

Where a confirmed `anilistId` lives is a schema decision I'd rather make deliberately than in passing — it's a migration, the least reversible thing in this app — and the wrong-match picker needs it in the same breath. Both are the next slice; I've asked about the storage shape separately.

## Verification

`:app:assembleDebug`, `testDebugUnitTest`, `:domain:test`, `detekt`, `ktlintCheck` — all green. 17 new tests (9 on the cascade, 8 on the mapping and error handling). The errors-first GraphQL check was confirmed to fail two tests when removed; the cascade's stop-early and abort-on-failure rules each have a test that constructs the case where the rule actually bites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoEui2mCCcqArdhyQyFwnR)_

## Summary by Sourcery

Implement AniList title search and resolution for untracked manga by querying AniList metadata, mapping results into media candidates, and orchestrating multi-title searches before scoring matches.

New Features:
- Add AniListSearchRepository domain interface and AniListSearchRepositoryImpl to perform AniList title searches for manga and return media candidates.
- Introduce ResolveAniListMediaUseCase to search AniList across multiple meaningful titles and select the best matching media using existing matching logic.

Enhancements:
- Extend AniList metadata GraphQL schema and API with a dedicated search query and response model tailored for title-based media lookup, including placeholder-aware mapping.
- Limit AniList search attempts and per-page results, skip placeholder or duplicate titles, and treat empty results as a normal outcome to respect rate limits and improve robustness.

Tests:
- Add unit tests for ResolveAniListMediaUseCase covering search cascade behavior, stopping conditions, failure handling, and placeholder title scenarios.
- Add unit tests for AniListSearchRepositoryImpl validating GraphQL error handling, candidate mapping, placeholder stripping, and transport error propagation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AniList title search and candidate scoring to resolve a manga’s media id when it isn’t tracked yet. Searches the metadata API with source and alternative titles, stops at the first non-empty result, then scores to pick the best match.

- **New Features**
  - Added `AniListMetadataApi.searchMedia` GraphQL query (romaji/english/native/synonyms; per-page capped).
  - Implemented `AniListSearchRepository` and `AniListSearchRepositoryImpl` to map results to `AniListMediaCandidate`, strip placeholder titles, de-duplicate titles case-insensitively with locale-invariant `lowercase()`, and fail fast on GraphQL errors.
  - Added `ResolveAniListMediaUseCase` to try titles in order, stop at first non-empty result, abort on failure, limit to 4 attempts, and score with `MatchAniListMediaUseCase`.
  - Bound `AniListSearchRepository` in `RepositoryModule`. 20 tests cover cascade behavior, mapping, and error handling.

- **Bug Fixes**
  - Treat malformed AniList search responses (no `data` or no `Page`) as failures, not empty results; only `media: []` is a successful “no candidates” outcome. Updated interface docs and tests.

<sup>Written for commit 1fd2692673d5e96d903fc3dc0efded06d60d511d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HeartlessVeteran2/Otaku-Reader/pull/1240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

