### PR TITLE
Fix the source-key round-trip so a library manga can reach its source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,36 @@ LibraryViewModel.kt — @HiltViewModel, produces StateFlow<LibraryState>
 LibraryScreen.kt    — stateless composable consuming state
 ```
 
+### Source Identity — Two Ids, One Direction
+
+A source has a **string id** (`MangaSource.id`) and every manga row stores a **`Long` key**
+(`Manga.sourceId`). The key is `id.toSourceId()`, which is `id.hashCode().toLong()`.
+
+**Hashing is one-way.** `manga.sourceId.toString()` is the decimal of a hash and matches no
+source's id — it is *not* a way back. To go from a key to a source, search the loaded sources:
+
+```kotlin
+sourceRepository.getSourceByKey(manga.sourceId)          // the MangaSource
+sourceRepository.resolveSourceId(manga.sourceId)         // its string id, for a source call
+```
+
+Getting this wrong is the highest-impact bug the project has had. `getSource(manga.sourceId.toString())`
+was in reading, library update, recommendations, migration, the details screen, prefetch and
+download-ahead; all of them failed with "Source not found" for every library entry, and the
+details header's source name was permanently blank. Three *different* wrong conventions were in
+use at once (`toSourceId()`, `toLongOrNull()`, and the raw `ExtensionSource.id`), which is why
+some manga worked and others didn't depending on which screen added them. Fixed across the repo;
+`getSourceByKey` also matches the legacy `toLongOrNull()` rows, because a `Long` on disk carries
+no record of which convention wrote it and so no migration can tell them apart.
+
+Two things are deliberately *not* this key:
+
+- **`resolveDownloadFolderName`** returns the numeric key as a string and consults no source. Every
+  download on disk is already filed under the number, so resolving a display name would orphan
+  them. Changing it is a data migration — see #1256.
+- **`Route.SourceListing.sourceId`** is already the string id. Browse never went through the key,
+  which is why browsing worked while reading from the library did not.
+
 ### Clean Architecture Layer Rules
 
 | Layer | Contains | Rules |
@@ -472,12 +502,13 @@ A claim about a library's published versions was taken from a search API that on
 2. **Room DAO not connected** — DAO not injected into repo, repo not injected into UseCase. Trace the chain.
 3. **MVI state not updating UI** — `StateFlow` not collected in Compose, or reducer emitting same reference. Use `copy()`.
 4. **Extension loader failures** — ClassLoader issue, missing permission, or interface mismatch with Tachiyomi API.
-5. **Gradle dependency conflicts** — Version mismatches between Compose BOM, Kotlin, Hilt, or KSP. Check `libs.versions.toml` first.
-6. **Navigation crashes** — Missing destination, wrong argument type in NavGraph, or missing `@Serializable` on route class.
-7. **Coroutine scope leaks** — `GlobalScope` used instead of `viewModelScope` or `lifecycleScope`. Always use structured concurrency.
-8. **Stale undo from concurrent batches** — Guard the undo handler: `if (pendingBatchIds != incomingIds) return`.
-9. **Flow recreated on recomposition** — Wrap with `remember(key) { flow }` when derived from a `@Singleton` injected dependency.
-10. **Room migration FK violations** — Recreating a table (to DROP a column) while child tables have FK references to it causes `SQLITE_CONSTRAINT_FOREIGNKEY`. Wrap the CREATE/INSERT/DROP/RENAME block with `PRAGMA foreign_keys = OFF` before and `PRAGMA foreign_keys = ON` after.
+5. **"Source not found" for a library manga** — someone passed `manga.sourceId.toString()` where a source id was wanted. Use `getSourceByKey` / `resolveSourceId`. See *Source Identity* above.
+6. **Gradle dependency conflicts** — Version mismatches between Compose BOM, Kotlin, Hilt, or KSP. Check `libs.versions.toml` first.
+7. **Navigation crashes** — Missing destination, wrong argument type in NavGraph, or missing `@Serializable` on route class.
+8. **Coroutine scope leaks** — `GlobalScope` used instead of `viewModelScope` or `lifecycleScope`. Always use structured concurrency.
+9. **Stale undo from concurrent batches** — Guard the undo handler: `if (pendingBatchIds != incomingIds) return`.
+10. **Flow recreated on recomposition** — Wrap with `remember(key) { flow }` when derived from a `@Singleton` injected dependency.
+11. **Room migration FK violations** — Recreating a table (to DROP a column) while child tables have FK references to it causes `SQLITE_CONSTRAINT_FOREIGNKEY`. Wrap the CREATE/INSERT/DROP/RENAME block with `PRAGMA foreign_keys = OFF` before and `PRAGMA foreign_keys = ON` after.
 
 ---
 

--- a/data/src/main/java/app/otakureader/data/download/DownloadManager.kt
+++ b/data/src/main/java/app/otakureader/data/download/DownloadManager.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import app.otakureader.core.common.network.NetworkMonitor
 import app.otakureader.core.common.network.NetworkType
 import app.otakureader.core.database.dao.DownloadQueueDao
+import app.otakureader.core.database.dao.MangaDao
 import app.otakureader.core.database.entity.DownloadQueueEntity
 import app.otakureader.core.preferences.CbzEncryptionStore
 import app.otakureader.core.preferences.DownloadPreferences
@@ -13,7 +14,6 @@ import app.otakureader.domain.model.DownloadItem
 import app.otakureader.domain.model.DownloadPriority
 import app.otakureader.domain.model.DownloadStatus
 import app.otakureader.domain.repository.ChapterRepository
-import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.repository.resolveSourceId
 import app.otakureader.sourceapi.SourceChapter
@@ -79,11 +79,11 @@ class DownloadManager @Inject constructor(
     private val downloadQueueDao: DownloadQueueDao,
     private val chapterRepository: ChapterRepository,
     private val sourceRepository: SourceRepository,
-    // There is a cycle here — DownloadRepositoryImpl injects this class, MangaRepositoryImpl
-    // injects DownloadRepository — but MangaRepositoryImpl already holds its end as a
-    // `dagger.Lazy`, which breaks it. This can stay eager only because of that; making that one
-    // eager would fail the build here, not there.
-    private val mangaRepository: MangaRepository,
+    // The DAO rather than MangaRepository: DownloadRepositoryImpl injects this class and
+    // MangaRepositoryImpl injects DownloadRepository, so going through the repository would
+    // close a cycle that only compiles because of a `dagger.Lazy` on the far side of it. The
+    // DAO has no such edges, and this class already takes DownloadQueueDao directly.
+    private val mangaDao: MangaDao,
     @param:ApplicationScope private val scope: CoroutineScope
 ) {
     private val mutex = Mutex()
@@ -733,7 +733,7 @@ class DownloadManager @Inject constructor(
         // resolved to an empty list and went straight to FAILED. The source is a property of the
         // manga, so it is resolved from the manga's key.
         val manga = try {
-            mangaRepository.getMangaById(request.mangaId)
+            mangaDao.getMangaById(request.mangaId)
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/data/src/main/java/app/otakureader/data/download/DownloadManager.kt
+++ b/data/src/main/java/app/otakureader/data/download/DownloadManager.kt
@@ -13,7 +13,9 @@ import app.otakureader.domain.model.DownloadItem
 import app.otakureader.domain.model.DownloadPriority
 import app.otakureader.domain.model.DownloadStatus
 import app.otakureader.domain.repository.ChapterRepository
+import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.SourceRepository
+import app.otakureader.domain.repository.resolveSourceId
 import app.otakureader.sourceapi.SourceChapter
 import app.otakureader.core.common.di.ApplicationScope
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -77,6 +79,11 @@ class DownloadManager @Inject constructor(
     private val downloadQueueDao: DownloadQueueDao,
     private val chapterRepository: ChapterRepository,
     private val sourceRepository: SourceRepository,
+    // There is a cycle here — DownloadRepositoryImpl injects this class, MangaRepositoryImpl
+    // injects DownloadRepository — but MangaRepositoryImpl already holds its end as a
+    // `dagger.Lazy`, which breaks it. This can stay eager only because of that; making that one
+    // eager would fail the build here, not there.
+    private val mangaRepository: MangaRepository,
     @param:ApplicationScope private val scope: CoroutineScope
 ) {
     private val mutex = Mutex()
@@ -721,7 +728,24 @@ class DownloadManager @Inject constructor(
             chapterNumber = chapter.chapterNumber,
             scanlator = chapter.scanlator ?: "",
         )
-        return sourceRepository.getPageList(request.sourceName, sourceChapter)
+        // `request.sourceName` is the download *folder* name, not a source id — passing it here
+        // meant this lookup never found a source, so any download enqueued without page URLs
+        // resolved to an empty list and went straight to FAILED. The source is a property of the
+        // manga, so it is resolved from the manga's key.
+        val manga = try {
+            mangaRepository.getMangaById(request.mangaId)
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w(TAG, "resolvePageUrls: manga lookup failed", e)
+            null
+        }
+        val sourceId = manga?.let { sourceRepository.resolveSourceId(it.sourceId) }
+        if (sourceId == null) {
+            Log.w(TAG, "resolvePageUrls: no source for manga ${request.mangaId}")
+            return emptyList()
+        }
+        return sourceRepository.getPageList(sourceId, sourceChapter)
             .onFailure { e ->
                 Log.w(TAG, "resolvePageUrls: source failed for chapter ${request.chapterId}", e)
             }

--- a/data/src/main/java/app/otakureader/data/repository/DownloadRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/DownloadRepositoryImpl.kt
@@ -12,8 +12,7 @@ import app.otakureader.domain.model.DownloadItem
 import app.otakureader.domain.model.OrphanScanResult
 import app.otakureader.domain.model.ReindexResult
 import app.otakureader.domain.repository.DownloadRepository
-import app.otakureader.domain.repository.SourceRepository
-import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.downloadFolderNameFor
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import javax.inject.Inject
@@ -31,7 +30,6 @@ class DownloadRepositoryImpl @Inject constructor(
     private val downloadManager: DownloadManager,
     private val mangaDao: MangaDao,
     private val chapterDao: ChapterDao,
-    private val sourceRepository: SourceRepository,
     @param:ApplicationScope private val scope: CoroutineScope
 ) : DownloadRepository {
 
@@ -241,7 +239,7 @@ class DownloadRepositoryImpl @Inject constructor(
      * cleaning up the downloaded files.
      *
      * The directory path is derived from the same folder-name resolution used when the
-     * download was originally created: [resolveDownloadFolderName] / sanitize(title) /
+     * download was originally created: [downloadFolderNameFor] / sanitize(title) /
      * sanitize(name). This must stay in lockstep with every enqueue/delete call site — a
      * mismatch here would make every real download look "orphaned" and get deleted by
      * [deleteOrphanedDownloads].
@@ -258,7 +256,7 @@ class DownloadRepositoryImpl @Inject constructor(
         val sourceNameById = mangaById.values
             .map { it.sourceId }
             .distinct()
-            .associateWith { sourceRepository.resolveDownloadFolderName(it) }
+            .associateWith { downloadFolderNameFor(it) }
         val expectedPaths = buildSet<String> {
             for (chapter in chapterDao.getAllChaptersOnce()) {
                 val manga = mangaById[chapter.mangaId] ?: continue
@@ -316,7 +314,7 @@ class DownloadRepositoryImpl @Inject constructor(
             ?.mapNotNull { it.name.toLongOrNull() }
             ?: return@withContext 0
         val resolvedNames = candidateIds.associate { id ->
-            id.toString() to sourceRepository.resolveDownloadFolderName(id)
+            id.toString() to downloadFolderNameFor(id)
         }
         DownloadProvider.migrateSourceFolderNames(rootDir, resolvedNames)
     }

--- a/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/MangaRepositoryImpl.kt
@@ -11,8 +11,7 @@ import app.otakureader.domain.model.ContentRating
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.repository.MangaRepository
-import app.otakureader.domain.repository.SourceRepository
-import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.downloadFolderNameFor
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import kotlinx.coroutines.Dispatchers
@@ -33,7 +32,6 @@ class MangaRepositoryImpl @Inject constructor(
     private val mangaCategoryDao: MangaCategoryDao,
     private val altSourceDao: MangaAlternativeSourceDao,
     private val downloadRepository: dagger.Lazy<app.otakureader.domain.repository.DownloadRepository>,
-    private val sourceRepository: SourceRepository,
 ) : MangaRepository {
 
     override fun getLibraryManga(): Flow<List<Manga>> {
@@ -164,7 +162,7 @@ class MangaRepositoryImpl @Inject constructor(
         val chapters = chapterDao.getChaptersByMangaId(mangaId).first()
 
         // Delete downloads for each chapter
-        val sourceName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
+        val sourceName = downloadFolderNameFor(manga.sourceId)
         val mangaTitle = manga.title
 
         chapters.forEach { chapterEntity ->

--- a/data/src/main/java/app/otakureader/data/repository/RecommendationRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/RecommendationRepositoryImpl.kt
@@ -9,6 +9,7 @@ import app.otakureader.domain.model.Recommendation
 import app.otakureader.domain.repository.RecommendationRepository
 import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.repository.resolveSourceId
+import app.otakureader.sourceapi.toSourceId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.encodeToString
@@ -81,11 +82,24 @@ class RecommendationRepositoryImpl @Inject constructor(
         // keys, so each has to be resolved back to a real source id — stringifying the key
         // produced a hash's decimal that matched nothing, and `toLongOrNull` on it then discarded
         // whatever came back, so this loop never seeded a single candidate.
-        val sourceKeys = libraryManga.map { it.sourceId }.distinct().take(MAX_SOURCES_TO_SEED)
+        //
+        // The cap is applied *after* resolving, not before: a key whose extension is uninstalled
+        // can never be seeded from, and letting it consume one of the slots would mean a library
+        // whose first few sources are gone seeds nothing while installed sources further down
+        // the list are never reached.
+        //
+        // The key kept is the *canonical* one derived from the resolved source id, not the one
+        // the library row happened to hold: a legacy row's key would otherwise be copied onto
+        // brand-new candidate rows, so the same source would end up written under two keys and
+        // later adds would not recognise the candidate as already present.
+        val resolved = libraryManga.map { it.sourceId }.distinct()
+            .mapNotNull { key -> sourceRepository.resolveSourceId(key) }
+            .distinct()
+            .take(MAX_SOURCES_TO_SEED)
+            .map { it.toSourceId() to it }
         val now = System.currentTimeMillis()
         val toInsert = mutableListOf<MangaEntity>()
-        for (sourceId in sourceKeys) {
-            val sourceIdStr = sourceRepository.resolveSourceId(sourceId) ?: continue
+        for ((sourceId, sourceIdStr) in resolved) {
             sourceRepository.getPopularManga(sourceIdStr, page = 1)
                 .getOrNull()
                 ?.mangas

--- a/data/src/main/java/app/otakureader/data/repository/RecommendationRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/RecommendationRepositoryImpl.kt
@@ -8,6 +8,7 @@ import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.Recommendation
 import app.otakureader.domain.repository.RecommendationRepository
 import app.otakureader.domain.repository.SourceRepository
+import app.otakureader.domain.repository.resolveSourceId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.encodeToString
@@ -76,11 +77,15 @@ class RecommendationRepositoryImpl @Inject constructor(
     }
 
     private suspend fun seedCandidatesFromSources(libraryManga: List<Manga>) {
-        val sourceIds = libraryManga.map { it.sourceId.toString() }.distinct().take(MAX_SOURCES_TO_SEED)
+        // Seed from the sources the user's own library came from. These are the stored `Long`
+        // keys, so each has to be resolved back to a real source id — stringifying the key
+        // produced a hash's decimal that matched nothing, and `toLongOrNull` on it then discarded
+        // whatever came back, so this loop never seeded a single candidate.
+        val sourceKeys = libraryManga.map { it.sourceId }.distinct().take(MAX_SOURCES_TO_SEED)
         val now = System.currentTimeMillis()
         val toInsert = mutableListOf<MangaEntity>()
-        for (sourceIdStr in sourceIds) {
-            val sourceId = sourceIdStr.toLongOrNull() ?: continue
+        for (sourceId in sourceKeys) {
+            val sourceIdStr = sourceRepository.resolveSourceId(sourceId) ?: continue
             sourceRepository.getPopularManga(sourceIdStr, page = 1)
                 .getOrNull()
                 ?.mangas

--- a/data/src/main/java/app/otakureader/data/repository/RecommendationRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/RecommendationRepositoryImpl.kt
@@ -83,27 +83,41 @@ class RecommendationRepositoryImpl @Inject constructor(
         // produced a hash's decimal that matched nothing, and `toLongOrNull` on it then discarded
         // whatever came back, so this loop never seeded a single candidate.
         //
+        // Resolved once per distinct key rather than once per manga: a large library holds many
+        // rows but few sources.
+        val resolvedByKey = libraryManga.map { it.sourceId }.distinct()
+            .mapNotNull { key -> sourceRepository.resolveSourceId(key)?.let { key to it } }
+            .toMap()
+
+        // What the user already owns, grouped by the *resolved* source rather than by the raw
+        // key. That indirection is the point: a candidate row is written under the canonical key,
+        // so a legacy library row holding the parsed key would not collide with it on the
+        // (sourceId, url) unique index, and `insertIfNotExists` would happily add a second,
+        // non-favourite copy of a manga the user already has — which then gets recommended back
+        // to them. Comparing through the resolved source recognises the row either way.
+        val ownedUrls = mutableMapOf<String, MutableSet<String>>()
+        libraryManga.forEach { manga ->
+            val sourceIdStr = resolvedByKey[manga.sourceId] ?: return@forEach
+            ownedUrls.getOrPut(sourceIdStr) { mutableSetOf() }.add(manga.url)
+        }
+
         // The cap is applied *after* resolving, not before: a key whose extension is uninstalled
         // can never be seeded from, and letting it consume one of the slots would mean a library
         // whose first few sources are gone seeds nothing while installed sources further down
         // the list are never reached.
-        //
-        // The key kept is the *canonical* one derived from the resolved source id, not the one
-        // the library row happened to hold: a legacy row's key would otherwise be copied onto
-        // brand-new candidate rows, so the same source would end up written under two keys and
-        // later adds would not recognise the candidate as already present.
-        val resolved = libraryManga.map { it.sourceId }.distinct()
-            .mapNotNull { key -> sourceRepository.resolveSourceId(key) }
-            .distinct()
-            .take(MAX_SOURCES_TO_SEED)
-            .map { it.toSourceId() to it }
+        val seedSources = resolvedByKey.values.distinct().take(MAX_SOURCES_TO_SEED)
         val now = System.currentTimeMillis()
         val toInsert = mutableListOf<MangaEntity>()
-        for ((sourceId, sourceIdStr) in resolved) {
+        for (sourceIdStr in seedSources) {
+            // The canonical key, not whichever one the library row happened to hold: every new
+            // row this app writes uses the canonical convention, and seeding a legacy key would
+            // spread it to manga that never had it.
+            val sourceId = sourceIdStr.toSourceId()
+            val owned = ownedUrls[sourceIdStr].orEmpty()
             sourceRepository.getPopularManga(sourceIdStr, page = 1)
                 .getOrNull()
                 ?.mangas
-                ?.filter { !it.genre.isNullOrBlank() }
+                ?.filter { !it.genre.isNullOrBlank() && it.url !in owned }
                 ?.mapTo(toInsert) { sm ->
                     MangaEntity(
                         id = 0,

--- a/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
@@ -12,12 +12,12 @@ import app.otakureader.core.tachiyomi.health.SourceHealthMonitor
 import app.otakureader.core.tachiyomi.local.LocalSource
 import app.otakureader.domain.repository.ExtensionManagementRepository
 import app.otakureader.domain.repository.SourceRepository
+import app.otakureader.domain.repository.associateBySourceKey
 import app.otakureader.sourceapi.FilterList
 import app.otakureader.sourceapi.MangaPage
 import app.otakureader.sourceapi.MangaSource
 import app.otakureader.sourceapi.SourceChapter
 import app.otakureader.sourceapi.SourceManga
-import app.otakureader.sourceapi.toSourceId
 import app.otakureader.core.common.di.ApplicationScope
 import app.otakureader.core.common.network.PageImageHeaders
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -171,21 +171,15 @@ class SourceRepositoryImpl @Inject constructor(
     /**
      * Reverses [toSourceId] by searching the loaded sources, because hashing is one-way.
      *
-     * The second pass exists because two conventions for deriving the key were in use when manga
-     * rows were written, and a `Long` on disk carries no record of which produced it:
-     * [toSourceId] (the canonical one) and a plain `toLongOrNull()` parse, which
-     * `SourceMangaDetailViewModel` used. Rows written the second way are indistinguishable from
-     * hashed ones after the fact, so they cannot be repaired by a migration — they can only be
-     * matched by also trying that rule here. New rows are always [toSourceId]; this pass is for
-     * libraries built before that was true.
-     *
-     * The canonical rule is tried first so a hypothetical source matching both cannot shadow it.
+     * Delegates to [associateBySourceKey] rather than restating the rule. That rule has two parts
+     * — the canonical [toSourceId] hash, plus a legacy `toLongOrNull()` parse that
+     * `SourceMangaDetailViewModel` once wrote, indistinguishable from a hash on disk and so
+     * unrepairable by migration — and it is also used to index sources by key elsewhere. Written
+     * out twice, the two copies agreed on every key owned by one source but disagreed on which
+     * source won a collision, and nothing would have caught them drifting further apart.
      */
-    override suspend fun getSourceByKey(key: Long): MangaSource? {
-        val sources = _sources.value
-        return sources.find { it.id.toSourceId() == key }
-            ?: sources.find { it.id.toLongOrNull() == key }
-    }
+    override suspend fun getSourceByKey(key: Long): MangaSource? =
+        _sources.value.associateBySourceKey { it.id }[key]
 
     /**
      * Helper to perform a source health check and return a failure Result when unhealthy.

--- a/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
+++ b/data/src/main/java/app/otakureader/data/repository/SourceRepositoryImpl.kt
@@ -17,6 +17,7 @@ import app.otakureader.sourceapi.MangaPage
 import app.otakureader.sourceapi.MangaSource
 import app.otakureader.sourceapi.SourceChapter
 import app.otakureader.sourceapi.SourceManga
+import app.otakureader.sourceapi.toSourceId
 import app.otakureader.core.common.di.ApplicationScope
 import app.otakureader.core.common.network.PageImageHeaders
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -165,6 +166,25 @@ class SourceRepositoryImpl @Inject constructor(
 
     override suspend fun getSource(sourceId: String): MangaSource? {
         return _sources.value.find { it.id == sourceId }
+    }
+
+    /**
+     * Reverses [toSourceId] by searching the loaded sources, because hashing is one-way.
+     *
+     * The second pass exists because two conventions for deriving the key were in use when manga
+     * rows were written, and a `Long` on disk carries no record of which produced it:
+     * [toSourceId] (the canonical one) and a plain `toLongOrNull()` parse, which
+     * `SourceMangaDetailViewModel` used. Rows written the second way are indistinguishable from
+     * hashed ones after the fact, so they cannot be repaired by a migration — they can only be
+     * matched by also trying that rule here. New rows are always [toSourceId]; this pass is for
+     * libraries built before that was true.
+     *
+     * The canonical rule is tried first so a hypothetical source matching both cannot shadow it.
+     */
+    override suspend fun getSourceByKey(key: Long): MangaSource? {
+        val sources = _sources.value
+        return sources.find { it.id.toSourceId() == key }
+            ?: sources.find { it.id.toLongOrNull() == key }
     }
 
     /**

--- a/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
@@ -28,7 +28,7 @@ import app.otakureader.domain.model.Manga
 import app.otakureader.domain.repository.FeedRepository
 import app.otakureader.domain.repository.SourceRepository
 import java.time.Instant
-import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.downloadFolderNameFor
 import app.otakureader.domain.usecase.GetLibraryMangaUseCase
 import app.otakureader.domain.usecase.UpdateLibraryMangaUseCase
 import dagger.assisted.Assisted
@@ -305,7 +305,7 @@ class LibraryUpdateWorker @AssistedInject constructor(
                 .sortedByDescending { it.chapterNumber }
                 .take(safeLimit)
 
-            val sourceName = sourceRepository.resolveDownloadFolderName(sourceId)
+            val sourceName = downloadFolderNameFor(sourceId)
 
             for (chapter in chapters) {
                 // Enqueue with empty pageUrls - DownloadManager will handle fetching them later

--- a/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/LibraryUpdateWorker.kt
@@ -351,7 +351,7 @@ class LibraryUpdateWorker @AssistedInject constructor(
      * that reports 0 for an undated chapter would otherwise pin that row to 1970 and bury it.
      */
     private suspend fun recordFeedItems(manga: Manga, newChapters: List<Chapter>) {
-        val sourceName = sourceRepository.getSource(manga.sourceId.toString())?.name
+        val sourceName = sourceRepository.getSourceByKey(manga.sourceId)?.name
             ?: manga.sourceId.toString()
         val now = Instant.now()
         feedRepository.addFeedItems(

--- a/data/src/main/java/app/otakureader/data/worker/RecordReadingHistoryWorker.kt
+++ b/data/src/main/java/app/otakureader/data/worker/RecordReadingHistoryWorker.kt
@@ -16,8 +16,7 @@ import app.otakureader.domain.download.selectChapterToDeleteAfterRead
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.MangaRepository
-import app.otakureader.domain.repository.SourceRepository
-import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.downloadFolderNameFor
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CancellationException
@@ -44,7 +43,6 @@ class RecordReadingHistoryWorker @AssistedInject constructor(
     private val downloadPreferences: DownloadPreferences,
     private val downloadRepository: DownloadRepository,
     private val mangaRepository: MangaRepository,
-    private val sourceRepository: SourceRepository,
 ) : CoroutineWorker(context, workerParams) {
 
     override suspend fun doWork(): Result {
@@ -129,7 +127,7 @@ class RecordReadingHistoryWorker @AssistedInject constructor(
                 slots = slots,
             )
         } ?: return
-        val downloadFolderName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
+        val downloadFolderName = downloadFolderNameFor(manga.sourceId)
         if (!downloadRepository.isChapterDownloaded(downloadFolderName, manga.title, chapter.name)) return
 
         downloadRepository.deleteChapterDownload(

--- a/data/src/test/java/app/otakureader/data/download/DownloadManagerTest.kt
+++ b/data/src/test/java/app/otakureader/data/download/DownloadManagerTest.kt
@@ -10,7 +10,7 @@ import app.otakureader.domain.model.DownloadStatus
 import app.otakureader.domain.model.DownloadPriority
 import app.otakureader.domain.model.Chapter
 import app.otakureader.domain.repository.ChapterRepository
-import app.otakureader.domain.repository.MangaRepository
+import app.otakureader.core.database.dao.MangaDao
 import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.sourceapi.Page
 import io.mockk.coEvery
@@ -46,7 +46,7 @@ class DownloadManagerTest {
     private lateinit var downloadQueueDao: DownloadQueueDao
     private lateinit var chapterRepository: ChapterRepository
     private lateinit var sourceRepository: SourceRepository
-    private lateinit var mangaRepository: MangaRepository
+    private lateinit var mangaDao: MangaDao
     private lateinit var downloadManager: DownloadManager
 
     private val testRequest = ChapterDownloadRequest(
@@ -86,7 +86,7 @@ class DownloadManagerTest {
         // tests override these stubs to exercise the successful-resolution path.
         chapterRepository = mockk { coEvery { getChapterById(any()) } returns null }
         sourceRepository = mockk(relaxed = true)
-        mangaRepository = mockk(relaxed = true)
+        mangaDao = mockk(relaxed = true)
 
         downloadManager = DownloadManager(
             context,
@@ -97,7 +97,7 @@ class DownloadManagerTest {
             downloadQueueDao,
             chapterRepository,
             sourceRepository,
-            mangaRepository,
+            mangaDao,
             TestScope(testDispatcher)
         )
     }
@@ -437,6 +437,27 @@ class DownloadManagerTest {
     // -------------------------------------------------------------------------
 
     @Test
+    fun `enqueue with empty pageUrls fails cleanly when no source owns the manga's key`() =
+        runTest(testDispatcher) {
+            coEvery { chapterRepository.getChapterById(testRequest.chapterId) } returns Chapter(
+                id = testRequest.chapterId,
+                mangaId = testRequest.mangaId,
+                url = "/chapter/1",
+                name = testRequest.chapterTitle,
+            )
+            coEvery { mangaDao.getMangaById(testRequest.mangaId) } returns mockk(relaxed = true) {
+                every { sourceId } returns SOURCE_KEY
+            }
+            coEvery { sourceRepository.getSourceByKey(SOURCE_KEY) } returns null
+
+            downloadManager.enqueue(testRequest.copy(pageUrls = emptyList()))
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { sourceRepository.getPageList(any(), any()) }
+            coVerify(exactly = 0) { downloader.downloadPage(any(), any()) }
+        }
+
+    @Test
     fun `enqueue with empty pageUrls resolves pages from the source and downloads`() = runTest(testDispatcher) {
         // Given - the chapter exists and the source returns a page list
         coEvery { chapterRepository.getChapterById(testRequest.chapterId) } returns Chapter(
@@ -445,7 +466,17 @@ class DownloadManagerTest {
             url = "/chapter/1",
             name = testRequest.chapterTitle,
         )
-        coEvery { sourceRepository.getPageList(any(), any()) } returns Result.success(
+        // The source is resolved from the manga's stored key, not from `request.sourceName` —
+        // that is the download folder name. Stubbed concretely rather than left to the relaxed
+        // mock, which hands back a source whose id is "" and would let this pass without the
+        // resolution working at all.
+        coEvery { mangaDao.getMangaById(testRequest.mangaId) } returns mockk(relaxed = true) {
+            every { sourceId } returns SOURCE_KEY
+        }
+        coEvery { sourceRepository.getSourceByKey(SOURCE_KEY) } returns mockk(relaxed = true) {
+            every { id } returns RESOLVED_SOURCE_ID
+        }
+        coEvery { sourceRepository.getPageList(RESOLVED_SOURCE_ID, any()) } returns Result.success(
             listOf(Page(index = 0, imageUrl = "https://example.com/resolved-page1.jpg"))
         )
 
@@ -455,6 +486,8 @@ class DownloadManagerTest {
 
         // Then - pages were resolved, downloaded, and persisted for restore
         coVerify { downloader.downloadPage("https://example.com/resolved-page1.jpg", any()) }
+        // The folder name is not a source id; passing it as one is the bug this guards.
+        coVerify(exactly = 0) { sourceRepository.getPageList(testRequest.sourceName, any()) }
         coVerify { downloadQueueDao.updatePageUrls(testRequest.chapterId, any()) }
     }
 
@@ -865,5 +898,12 @@ class DownloadManagerTest {
         assertEquals(1, downloads.size)
         assertEquals(DownloadStatus.FAILED, downloads[0].status)
     }
-}
 
+    private companion object {
+        /** The hashed key a manga row stores. */
+        const val SOURCE_KEY = -1874553621L
+
+        /** The source's own id, which is what a source call needs. */
+        const val RESOLVED_SOURCE_ID = "2499283573021220255"
+    }
+}

--- a/data/src/test/java/app/otakureader/data/download/DownloadManagerTest.kt
+++ b/data/src/test/java/app/otakureader/data/download/DownloadManagerTest.kt
@@ -10,6 +10,7 @@ import app.otakureader.domain.model.DownloadStatus
 import app.otakureader.domain.model.DownloadPriority
 import app.otakureader.domain.model.Chapter
 import app.otakureader.domain.repository.ChapterRepository
+import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.sourceapi.Page
 import io.mockk.coEvery
@@ -45,6 +46,7 @@ class DownloadManagerTest {
     private lateinit var downloadQueueDao: DownloadQueueDao
     private lateinit var chapterRepository: ChapterRepository
     private lateinit var sourceRepository: SourceRepository
+    private lateinit var mangaRepository: MangaRepository
     private lateinit var downloadManager: DownloadManager
 
     private val testRequest = ChapterDownloadRequest(
@@ -84,6 +86,7 @@ class DownloadManagerTest {
         // tests override these stubs to exercise the successful-resolution path.
         chapterRepository = mockk { coEvery { getChapterById(any()) } returns null }
         sourceRepository = mockk(relaxed = true)
+        mangaRepository = mockk(relaxed = true)
 
         downloadManager = DownloadManager(
             context,
@@ -94,6 +97,7 @@ class DownloadManagerTest {
             downloadQueueDao,
             chapterRepository,
             sourceRepository,
+            mangaRepository,
             TestScope(testDispatcher)
         )
     }

--- a/data/src/test/java/app/otakureader/data/download/DownloadManagerTest.kt
+++ b/data/src/test/java/app/otakureader/data/download/DownloadManagerTest.kt
@@ -455,6 +455,10 @@ class DownloadManagerTest {
 
             coVerify(exactly = 0) { sourceRepository.getPageList(any(), any()) }
             coVerify(exactly = 0) { downloader.downloadPage(any(), any()) }
+            // The terminal state matters as much as the absent calls: "fails cleanly" means the
+            // item is visible and retryable as FAILED, not parked in QUEUED forever. Without
+            // this the test would pass on a regression that simply stalls the download.
+            assertEquals(DownloadStatus.FAILED, downloadManager.downloads.first().first().status)
         }
 
     @Test

--- a/data/src/test/java/app/otakureader/data/repository/MangaRepositoryImplTest.kt
+++ b/data/src/test/java/app/otakureader/data/repository/MangaRepositoryImplTest.kt
@@ -8,7 +8,6 @@ import app.otakureader.core.database.entity.MangaEntity
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.repository.DownloadRepository
-import app.otakureader.domain.repository.SourceRepository
 import app.cash.turbine.test
 import dagger.Lazy
 import io.mockk.coEvery
@@ -31,7 +30,6 @@ class MangaRepositoryImplTest {
     private lateinit var mangaCategoryDao: MangaCategoryDao
     private lateinit var altSourceDao: MangaAlternativeSourceDao
     private lateinit var downloadRepository: Lazy<DownloadRepository>
-    private lateinit var sourceRepository: SourceRepository
     private lateinit var repository: MangaRepositoryImpl
 
     private fun makeEntity(
@@ -57,7 +55,6 @@ class MangaRepositoryImplTest {
         mangaCategoryDao = mockk()
         altSourceDao = mockk()
         downloadRepository = mockk()
-        sourceRepository = mockk(relaxed = true)
         repository = MangaRepositoryImpl(
             context = mockk(relaxed = true),
             mangaDao = mangaDao,
@@ -65,7 +62,6 @@ class MangaRepositoryImplTest {
             mangaCategoryDao = mangaCategoryDao,
             altSourceDao = altSourceDao,
             downloadRepository = downloadRepository,
-            sourceRepository = sourceRepository,
         )
     }
 

--- a/data/src/test/java/app/otakureader/data/repository/RecommendationRepositoryImplTest.kt
+++ b/data/src/test/java/app/otakureader/data/repository/RecommendationRepositoryImplTest.kt
@@ -1,0 +1,125 @@
+package app.otakureader.data.repository
+
+import app.otakureader.core.database.dao.MangaDao
+import app.otakureader.core.database.dao.RecommendationDao
+import app.otakureader.core.database.entity.MangaEntity
+import app.otakureader.domain.model.Manga
+import app.otakureader.domain.repository.SourceRepository
+import app.otakureader.sourceapi.MangaPage
+import app.otakureader.sourceapi.SourceManga
+import app.otakureader.sourceapi.toSourceId
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Covers candidate seeding, which is the part that touches source keys.
+ *
+ * Seeding was dead before the key round-trip was fixed: it stringified each library row's hashed
+ * key, got a decimal that matched no source, and then discarded whatever came back. Every test
+ * here would have failed against that version.
+ */
+class RecommendationRepositoryImplTest {
+
+    private lateinit var recommendationDao: RecommendationDao
+    private lateinit var mangaDao: MangaDao
+    private lateinit var sourceRepository: SourceRepository
+    private lateinit var repository: RecommendationRepositoryImpl
+
+    @Before
+    fun setUp() {
+        recommendationDao = mockk(relaxed = true)
+        mangaDao = mockk(relaxed = true)
+        sourceRepository = mockk(relaxed = true)
+        coEvery { mangaDao.getRecommendationCandidates(any()) } returns emptyList()
+        repository = RecommendationRepositoryImpl(recommendationDao, mangaDao, sourceRepository)
+    }
+
+    /**
+     * The user's own manga must not come back as a recommendation.
+     *
+     * The trap is that the library row here is a *legacy* one — it stores the parsed key, while a
+     * freshly seeded candidate is written under the canonical hashed key. The two therefore do
+     * not collide on the `(sourceId, url)` unique index, so `insertIfNotExists` would insert a
+     * second, non-favourite copy, and nothing downstream filters it: the library exclusion is by
+     * row id, and the new row has a different one.
+     */
+    @Test
+    fun `a manga already in the library is not seeded again under the canonical key`() = runTest {
+        val legacyKey = SOURCE_ID.toLong()
+        val library = libraryOf(sourceKey = legacyKey, ownedUrl = "/manga/owned")
+        stubSource(legacyKey)
+        coEvery { sourceRepository.getPopularManga(SOURCE_ID, 1) } returns Result.success(
+            MangaPage(
+                mangas = listOf(
+                    SourceManga(url = "/manga/owned", title = "Owned", genre = "Action"),
+                    SourceManga(url = "/manga/fresh", title = "Fresh", genre = "Action"),
+                ),
+                hasNextPage = false,
+            )
+        )
+
+        repository.refreshRecommendations(library)
+
+        val inserted = slot<List<MangaEntity>>()
+        coVerify { mangaDao.insertIfNotExists(capture(inserted)) }
+        assertEquals(listOf("/manga/fresh"), inserted.captured.map { it.url })
+        // And what does get seeded carries the canonical key, so later adds recognise it.
+        assertEquals(SOURCE_ID.toSourceId(), inserted.captured.single().sourceId)
+    }
+
+    /**
+     * `MAX_SOURCES_TO_SEED` is 5. Six library sources where the first five cannot be resolved
+     * used to mean nothing was seeded at all, because the cap was applied to raw keys before
+     * anything checked whether they led anywhere.
+     */
+    @Test
+    fun `unresolvable sources do not consume the seed budget`() = runTest {
+        val deadKeys = (1L..5L).toList()
+        val liveKey = SOURCE_ID.toLong()
+        val library = deadKeys.flatMap { key -> libraryOf(sourceKey = key, ownedUrl = "/dead$key") } +
+            libraryOf(sourceKey = liveKey, ownedUrl = "/manga/owned")
+        deadKeys.forEach { coEvery { sourceRepository.getSourceByKey(it) } returns null }
+        stubSource(liveKey)
+        coEvery { sourceRepository.getPopularManga(SOURCE_ID, 1) } returns Result.success(
+            MangaPage(listOf(SourceManga(url = "/manga/fresh", title = "Fresh", genre = "Action")), false)
+        )
+
+        repository.refreshRecommendations(library)
+
+        val inserted = slot<List<MangaEntity>>()
+        coVerify { mangaDao.insertIfNotExists(capture(inserted)) }
+        assertTrue(inserted.captured.isNotEmpty())
+    }
+
+    private fun stubSource(key: Long) {
+        coEvery { sourceRepository.getSourceByKey(key) } returns mockk(relaxed = true) {
+            every { id } returns SOURCE_ID
+        }
+    }
+
+    /** [MIN_LIBRARY_SIZE] is 5, so every fixture needs at least that many rows to get past it. */
+    private fun libraryOf(sourceKey: Long, ownedUrl: String): List<Manga> =
+        (0 until 5).map { index ->
+            Manga(
+                id = sourceKey * 100 + index,
+                sourceId = sourceKey,
+                url = if (index == 0) ownedUrl else "$ownedUrl-$index",
+                title = "Owned $sourceKey-$index",
+                genre = listOf("Action"),
+                favorite = true,
+            )
+        }
+
+    private companion object {
+        /** An APK extension's id: a Tachiyomi Long, stringified. */
+        const val SOURCE_ID = "2499283573021220255"
+    }
+}

--- a/data/src/test/java/app/otakureader/data/repository/SourceRepositoryImplTest.kt
+++ b/data/src/test/java/app/otakureader/data/repository/SourceRepositoryImplTest.kt
@@ -15,6 +15,7 @@ import app.otakureader.domain.repository.ExtensionManagementRepository
 import app.otakureader.sourceapi.MangaPage
 import app.otakureader.sourceapi.MangaSource
 import app.otakureader.sourceapi.SourceManga
+import app.otakureader.domain.repository.associateBySourceKey
 import app.otakureader.sourceapi.toSourceId
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.online.HttpSource
@@ -536,6 +537,29 @@ class SourceRepositoryImplTest {
         repository.injectSourcesForTesting(listOf(source))
 
         assertEquals(source, repository.getSourceByKey(APK_SOURCE_ID.toLong()))
+    }
+
+    /**
+     * A genuine `String.hashCode()` collision, not a contrived one: `"Aa"` and `"BB"` both hash
+     * to 2112. Two installed sources whose ids collide therefore claim the same canonical key,
+     * and something has to decide which one wins.
+     *
+     * The value asserted here is not that a particular source wins — either would be defensible —
+     * but that `getSourceByKey` and `associateBySourceKey` agree. They used to be written out
+     * separately and disagreed exactly here: a linear `find` returns the first match in list
+     * order while a map built with `put` keeps the last. Same key, two different sources,
+     * depending on which path asked.
+     */
+    @Test
+    fun getSourceByKey_agreesWithTheKeyIndexOnAGenuinelyCollidingKey() = runTest {
+        val first = makeFakeSource(id = "Aa", name = "First")
+        val second = makeFakeSource(id = "BB", name = "Second")
+        val key = "Aa".toSourceId()
+        assertEquals(key, "BB".toSourceId())
+        repository.injectSourcesForTesting(listOf(first, second))
+
+        val viaIndex = listOf(first, second).associateBySourceKey { it.id }[key]
+        assertEquals(viaIndex, repository.getSourceByKey(key))
     }
 
     /**

--- a/data/src/test/java/app/otakureader/data/repository/SourceRepositoryImplTest.kt
+++ b/data/src/test/java/app/otakureader/data/repository/SourceRepositoryImplTest.kt
@@ -15,6 +15,7 @@ import app.otakureader.domain.repository.ExtensionManagementRepository
 import app.otakureader.sourceapi.MangaPage
 import app.otakureader.sourceapi.MangaSource
 import app.otakureader.sourceapi.SourceManga
+import app.otakureader.sourceapi.toSourceId
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.online.HttpSource
 import io.mockk.coEvery
@@ -492,6 +493,74 @@ class SourceRepositoryImplTest {
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // getSourceByKey – reversing the hashed key stored on manga rows
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * The bug this guards: a manga row stores `source.id.toSourceId()`, and every read-back used
+     * to do `getSource(manga.sourceId.toString())` — comparing the hash's decimal against the
+     * source's real id, which never matches. Reading, updating and recommending all failed with
+     * "Source not found" for every library entry.
+     *
+     * The source id used here is the numeric form an APK extension actually has, because that is
+     * the case where stringifying *looks* plausible.
+     */
+    @Test
+    fun getSourceByKey_findsTheSourceThatProducedTheKey() = runTest {
+        val source = makeFakeSource(id = APK_SOURCE_ID, name = "MangaDex")
+        repository.injectSourcesForTesting(listOf(source))
+
+        assertEquals(source, repository.getSourceByKey(APK_SOURCE_ID.toSourceId()))
+        // The value the old code passed. It has to miss, or the test above proves nothing.
+        assertNull(repository.getSource(APK_SOURCE_ID.toSourceId().toString()))
+    }
+
+    @Test
+    fun getSourceByKey_findsSourcesWhoseIdIsNotNumeric() = runTest {
+        val local = makeFakeSource(id = "local", name = "Local")
+        val js = makeFakeSource(id = "en.somejssource", name = "Some JS Source")
+        repository.injectSourcesForTesting(listOf(local, js))
+
+        assertEquals(local, repository.getSourceByKey("local".toSourceId()))
+        assertEquals(js, repository.getSourceByKey("en.somejssource".toSourceId()))
+    }
+
+    /**
+     * Rows written before the key convention was uniform hold `id.toLongOrNull()` instead. They
+     * are indistinguishable from hashed rows on disk, so the only way to keep those libraries
+     * working is to match them here too.
+     */
+    @Test
+    fun getSourceByKey_alsoMatchesLegacyRowsThatStoredTheParsedId() = runTest {
+        val source = makeFakeSource(id = APK_SOURCE_ID, name = "MangaDex")
+        repository.injectSourcesForTesting(listOf(source))
+
+        assertEquals(source, repository.getSourceByKey(APK_SOURCE_ID.toLong()))
+    }
+
+    /**
+     * With both rules in play two different sources can claim one key. The canonical rule has to
+     * win, otherwise a legacy match could shadow a source that genuinely owns the key today.
+     */
+    @Test
+    fun getSourceByKey_prefersTheCanonicalRuleWhenBothMatch() = runTest {
+        val canonical = makeFakeSource(id = "en.canonical", name = "Canonical")
+        val key = "en.canonical".toSourceId()
+        val legacy = makeFakeSource(id = key.toString(), name = "Legacy")
+        // Legacy first in the list, so ordering cannot be what decides it.
+        repository.injectSourcesForTesting(listOf(legacy, canonical))
+
+        assertEquals(canonical, repository.getSourceByKey(key))
+    }
+
+    @Test
+    fun getSourceByKey_returnsNullWhenNoSourceOwnsTheKey() = runTest {
+        repository.injectSourcesForTesting(listOf(makeFakeSource(id = "en.one", name = "One")))
+
+        assertNull(repository.getSourceByKey("en.two".toSourceId()))
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // getPopularManga / getLatestUpdates / searchManga – error propagation
     // ──────────────────────────────────────────────────────────────────────
 
@@ -712,5 +781,10 @@ class SourceRepositoryImplTest {
         // Here we mock the preference flows to return safe defaults.
         every { localSourcePreferences.localSourceDirectory } returns kotlinx.coroutines.flow.flowOf("/tmp/local")
         every { localSourcePreferences.allowLocalSourceHiddenFolders } returns kotlinx.coroutines.flow.flowOf(false)
+    }
+
+    private companion object {
+        /** The shape an APK extension's id actually has: a Tachiyomi Long, stringified. */
+        const val APK_SOURCE_ID = "2499283573021220255"
     }
 }

--- a/data/src/test/java/app/otakureader/data/worker/LibraryUpdateWorkerTest.kt
+++ b/data/src/test/java/app/otakureader/data/worker/LibraryUpdateWorkerTest.kt
@@ -231,7 +231,7 @@ class LibraryUpdateWorkerTest {
     fun `new chapters are recorded in the feed`() = runTest {
         coEvery { getLibraryManga() } returns flowOf(listOf(testManga1))
         coEvery { updateLibraryManga(testManga1) } returns Result.success(newChapters(2))
-        coEvery { sourceRepository.getSource(testManga1.sourceId.toString()) } returns
+        coEvery { sourceRepository.getSourceByKey(testManga1.sourceId) } returns
             mockk { every { name } returns "MangaDex" }
 
         worker.doWork()
@@ -264,7 +264,7 @@ class LibraryUpdateWorkerTest {
     fun `a chapter from an uninstalled source still reaches the feed`() = runTest {
         coEvery { getLibraryManga() } returns flowOf(listOf(testManga1))
         coEvery { updateLibraryManga(testManga1) } returns Result.success(newChapters(1))
-        coEvery { sourceRepository.getSource(any()) } returns null
+        coEvery { sourceRepository.getSourceByKey(any()) } returns null
 
         worker.doWork()
 

--- a/data/src/test/java/app/otakureader/data/worker/RecordReadingHistoryWorkerTest.kt
+++ b/data/src/test/java/app/otakureader/data/worker/RecordReadingHistoryWorkerTest.kt
@@ -11,7 +11,6 @@ import app.otakureader.domain.model.Manga
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.MangaRepository
-import app.otakureader.domain.repository.SourceRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -46,7 +45,6 @@ class RecordReadingHistoryWorkerTest {
     private lateinit var downloadPreferences: DownloadPreferences
     private lateinit var downloadRepository: DownloadRepository
     private lateinit var mangaRepository: MangaRepository
-    private lateinit var sourceRepository: SourceRepository
 
     private val mangaId = 1L
     private val chapterId = 10L
@@ -69,7 +67,6 @@ class RecordReadingHistoryWorkerTest {
             downloadPreferences,
             downloadRepository,
             mangaRepository,
-            sourceRepository,
         )
     }
 
@@ -82,7 +79,6 @@ class RecordReadingHistoryWorkerTest {
         downloadPreferences = mockk()
         downloadRepository = mockk()
         mangaRepository = mockk()
-        sourceRepository = mockk(relaxed = true)
 
         coEvery { chapterRepository.recordHistory(any(), any(), any()) } just runs
         coEvery { chapterRepository.updateChapterProgress(any<Long>(), any<Boolean>(), any<Int>()) } just runs
@@ -90,9 +86,6 @@ class RecordReadingHistoryWorkerTest {
         coEvery { chapterRepository.getChapterById(chapterId) } returns testChapter
         coEvery { downloadRepository.isChapterDownloaded(any(), any(), any()) } returns true
         coEvery { downloadRepository.deleteChapterDownload(any(), any(), any(), any()) } just runs
-        // No installed source for this fixture id — resolveDownloadFolderName falls back to the
-        // numeric sourceId string.
-        coEvery { sourceRepository.getSource(any()) } returns null
         // Default: immediate delete-after-read (slots = 0).
         every { downloadPreferences.removeAfterReadSlots } returns flowOf(0)
     }

--- a/domain/src/main/java/app/otakureader/domain/repository/SourceRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/SourceRepository.kt
@@ -3,6 +3,7 @@ package app.otakureader.domain.repository
 import app.otakureader.sourceapi.FilterList
 import app.otakureader.sourceapi.MangaPage
 import app.otakureader.sourceapi.MangaSource
+import app.otakureader.sourceapi.toSourceId
 import app.otakureader.sourceapi.SourceChapter
 import app.otakureader.sourceapi.SourceManga
 import kotlinx.coroutines.flow.Flow
@@ -90,17 +91,38 @@ interface SourceRepository {
 suspend fun SourceRepository.resolveSourceId(key: Long): String? = getSourceByKey(key)?.id
 
 /**
+ * Indexes [this] by every `Long` key a manga row might hold for it.
+ *
+ * The rule has to match [SourceRepository.getSourceByKey], including its precedence: legacy
+ * parsed keys are written first so the canonical hashed key overwrites them on a collision. A
+ * map built from the canonical key alone would leave legacy rows unmatched here while
+ * `getSourceByKey` still resolved them — the same source reachable one way and not the other.
+ *
+ * [id] extracts the source's string id, because callers index different types: `MangaSource`
+ * holds it directly, `ExtensionSource` holds the raw Tachiyomi `Long` that has to be stringified
+ * first.
+ */
+fun <T> Iterable<T>.associateBySourceKey(id: (T) -> String): Map<Long, T> {
+    val items = this
+    return buildMap {
+        // Named receiver: inside buildMap a bare `forEach` binds to the map being built, not to
+        // the iterable being indexed.
+        items.forEach { item -> id(item).toLongOrNull()?.let { key -> put(key, item) } }
+        items.forEach { item -> put(id(item).toSourceId(), item) }
+    }
+}
+
+/**
  * The on-disk folder name used for a manga's downloads: the numeric source key, as a string.
  *
- * This deliberately does *not* resolve the source's display name. It used to try
- * (`getSource(sourceId.toString())?.name`), but that lookup compared a hashed key's decimal
- * against a source's real id and so could never match — every download on every device is
- * already filed under the number. Making the name resolve now would point every read at a
- * folder that does not exist, orphaning downloaded chapters. Switching to display names is a
- * migration, not an edit; see #1256.
+ * Not a [SourceRepository] extension, because it consults no source and pretending otherwise
+ * implied a dependency that does not exist. It used to be one — `getSource(sourceId.toString())
+ * ?.name` — but that lookup compared a hashed key's decimal against a source's real id and so
+ * could never match. Every download on every device is already filed under the number, so making
+ * the name resolve now would point every read at a folder that does not exist, orphaning
+ * downloaded chapters. Switching to display names is a migration, not an edit; see #1256.
  *
  * Every download enqueue/read/delete call site must resolve through this so they all agree on
  * the same folder — never build a download path from a raw sourceId directly.
  */
-@Suppress("UnusedReceiverParameter")
-suspend fun SourceRepository.resolveDownloadFolderName(sourceId: Long): String = sourceId.toString()
+fun downloadFolderNameFor(sourceId: Long): String = sourceId.toString()

--- a/domain/src/main/java/app/otakureader/domain/repository/SourceRepository.kt
+++ b/domain/src/main/java/app/otakureader/domain/repository/SourceRepository.kt
@@ -23,6 +23,17 @@ interface SourceRepository {
     suspend fun getSource(sourceId: String): MangaSource?
 
     /**
+     * Get a source by the `Long` key that manga rows store in `Manga.sourceId`.
+     *
+     * That key is produced by [app.otakureader.sourceapi.toSourceId], which hashes the source's
+     * string id — so it cannot be turned back into an id by stringifying it. The reverse has to
+     * be a search over the loaded sources, which is what this does.
+     *
+     * Use this, never `getSource(manga.sourceId.toString())`.
+     */
+    suspend fun getSourceByKey(key: Long): MangaSource?
+
+    /**
      * Get popular manga from a source
      */
     suspend fun getPopularManga(sourceId: String, page: Int): Result<MangaPage>
@@ -69,11 +80,27 @@ interface SourceRepository {
 }
 
 /**
- * Resolves the on-disk folder name used for a manga's downloads: the source's actual display
- * name (e.g. "MangaDex") when the source can be looked up, falling back to the numeric
- * [sourceId] string when it can't (e.g. its extension was uninstalled). Every download
- * enqueue/read/delete call site must resolve through this so they all agree on the same
- * folder — never build a download path from a raw sourceId directly.
+ * Resolves the string id a source call needs from the `Long` key stored on a manga row, or null
+ * when no loaded source owns that key (its extension is uninstalled, or it hasn't loaded yet).
+ *
+ * Every source call takes the string id; every manga row holds the `Long`. This is the only
+ * correct bridge between them — see [SourceRepository.getSourceByKey] for why stringifying the
+ * key does not work.
  */
-suspend fun SourceRepository.resolveDownloadFolderName(sourceId: Long): String =
-    getSource(sourceId.toString())?.name ?: sourceId.toString()
+suspend fun SourceRepository.resolveSourceId(key: Long): String? = getSourceByKey(key)?.id
+
+/**
+ * The on-disk folder name used for a manga's downloads: the numeric source key, as a string.
+ *
+ * This deliberately does *not* resolve the source's display name. It used to try
+ * (`getSource(sourceId.toString())?.name`), but that lookup compared a hashed key's decimal
+ * against a source's real id and so could never match — every download on every device is
+ * already filed under the number. Making the name resolve now would point every read at a
+ * folder that does not exist, orphaning downloaded chapters. Switching to display names is a
+ * migration, not an edit; see #1256.
+ *
+ * Every download enqueue/read/delete call site must resolve through this so they all agree on
+ * the same folder — never build a download path from a raw sourceId directly.
+ */
+@Suppress("UnusedReceiverParameter")
+suspend fun SourceRepository.resolveDownloadFolderName(sourceId: Long): String = sourceId.toString()

--- a/domain/src/main/java/app/otakureader/domain/usecase/UpdateLibraryMangaUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/UpdateLibraryMangaUseCase.kt
@@ -4,6 +4,7 @@ import app.otakureader.domain.model.Chapter
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.SourceRepository
+import app.otakureader.domain.repository.resolveSourceId
 import app.otakureader.sourceapi.SourceChapter
 import app.otakureader.sourceapi.SourceManga
 import kotlinx.coroutines.CancellationException
@@ -33,9 +34,17 @@ class UpdateLibraryMangaUseCase @Inject constructor(
             // Convert domain Manga to SourceManga
             val sourceManga = manga.toSourceManga()
 
+            // `manga.sourceId` is a hash of the source's string id, so it has to be resolved back
+            // through the loaded sources — stringifying it yields the hash's decimal, which
+            // matches no source and made every library update fail with "Source not found".
+            val sourceId = sourceRepository.resolveSourceId(manga.sourceId)
+                ?: return Result.failure(
+                    IllegalStateException("Source not found for manga ${manga.id}")
+                )
+
             // Fetch chapter list from source
             val chaptersResult = sourceRepository.getChapterList(
-                sourceId = manga.sourceId.toString(),
+                sourceId = sourceId,
                 manga = sourceManga
             )
 

--- a/domain/src/main/java/app/otakureader/domain/usecase/migration/MigrateMangaUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/migration/MigrateMangaUseCase.kt
@@ -13,6 +13,7 @@ import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.resolveSourceId
 import app.otakureader.domain.tracking.TrackRepository
 import app.otakureader.sourceapi.SourceChapter
 import app.otakureader.sourceapi.SourceManga
@@ -77,13 +78,18 @@ class MigrateMangaUseCase @Inject constructor(
                 thumbnailUrl = targetCandidate.thumbnailUrl
             )
 
+            val targetSourceId = sourceRepository.resolveSourceId(targetCandidate.sourceId)
+                ?: return Result.failure(
+                    IllegalStateException("Target source not found: ${targetCandidate.sourceId}")
+                )
+
             val detailsResult = sourceRepository.getMangaDetails(
-                sourceId = targetCandidate.sourceId.toString(),
+                sourceId = targetSourceId,
                 manga = sourceMangaForFetch
             )
 
             val chaptersResult = sourceRepository.getChapterList(
-                sourceId = targetCandidate.sourceId.toString(),
+                sourceId = targetSourceId,
                 manga = sourceMangaForFetch
             )
 

--- a/domain/src/main/java/app/otakureader/domain/usecase/migration/MigrateMangaUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/migration/MigrateMangaUseCase.kt
@@ -12,7 +12,7 @@ import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.SourceRepository
-import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.downloadFolderNameFor
 import app.otakureader.domain.repository.resolveSourceId
 import app.otakureader.domain.tracking.TrackRepository
 import app.otakureader.sourceapi.SourceChapter
@@ -50,6 +50,14 @@ class MigrateMangaUseCase @Inject constructor(
         flags: Set<MigrationFlag> = MigrationFlag.entries.toSet()
     ): Result<MigrationResult> {
         return try {
+            // Resolved before anything is written. Doing it after the insert below would leave a
+            // library row for a source that cannot be reached — a target entry that can never be
+            // initialised and that the user did not ask to keep.
+            val targetSourceId = sourceRepository.resolveSourceId(targetCandidate.sourceId)
+                ?: return Result.failure(
+                    IllegalStateException("Target source not found: ${targetCandidate.sourceId}")
+                )
+
             // Check if target manga already exists in library
             val existingTarget = mangaRepository.getMangaBySourceAndUrl(
                 sourceId = targetCandidate.sourceId,
@@ -77,11 +85,6 @@ class MigrateMangaUseCase @Inject constructor(
                 title = targetCandidate.title,
                 thumbnailUrl = targetCandidate.thumbnailUrl
             )
-
-            val targetSourceId = sourceRepository.resolveSourceId(targetCandidate.sourceId)
-                ?: return Result.failure(
-                    IllegalStateException("Target source not found: ${targetCandidate.sourceId}")
-                )
 
             val detailsResult = sourceRepository.getMangaDetails(
                 sourceId = targetSourceId,
@@ -255,9 +258,9 @@ class MigrateMangaUseCase @Inject constructor(
             .associateBy { it.chapterNumber }
 
         // Source names for download migration
-        val fromSourceName = sourceRepository.resolveDownloadFolderName(sourceManga.sourceId)
+        val fromSourceName = downloadFolderNameFor(sourceManga.sourceId)
         val fromMangaTitle = sourceManga.title
-        val toSourceName = sourceRepository.resolveDownloadFolderName(targetManga.sourceId)
+        val toSourceName = downloadFolderNameFor(targetManga.sourceId)
         val toMangaTitle = targetManga.title
 
         // Insert target chapters with matched reading progress

--- a/domain/src/main/java/app/otakureader/domain/usecase/migration/SearchMigrationTargetsUseCase.kt
+++ b/domain/src/main/java/app/otakureader/domain/usecase/migration/SearchMigrationTargetsUseCase.kt
@@ -4,6 +4,7 @@ import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.model.MigrationCandidate
 import app.otakureader.domain.repository.SourceRepository
+import app.otakureader.domain.repository.resolveSourceId
 import app.otakureader.domain.util.StringSimilarity
 import app.otakureader.domain.util.TitleNormalizer
 import app.otakureader.sourceapi.SourceManga
@@ -35,9 +36,14 @@ class SearchMigrationTargetsUseCase @Inject constructor(
         targetSourceId: Long
     ): Result<List<MigrationCandidate>> {
         return try {
+            val targetSource = sourceRepository.resolveSourceId(targetSourceId)
+                ?: return Result.failure(
+                    IllegalStateException("Target source not found: $targetSourceId")
+                )
+
             // Search in the target source using the manga title
             val searchResult = sourceRepository.searchManga(
-                sourceId = targetSourceId.toString(),
+                sourceId = targetSource,
                 query = sourceManga.title,
                 page = 1
             )

--- a/domain/src/test/java/app/otakureader/domain/repository/SourceRepositoryExtTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/repository/SourceRepositoryExtTest.kt
@@ -2,10 +2,12 @@ package app.otakureader.domain.repository
 
 import app.otakureader.sourceapi.MangaSource
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class SourceRepositoryExtTest {
@@ -13,17 +15,38 @@ class SourceRepositoryExtTest {
     private val sourceRepository: SourceRepository = mockk()
 
     @Test
-    fun `resolveDownloadFolderName returns the source display name when resolvable`() = runTest {
-        val source = mockk<MangaSource> { every { name } returns "MangaDex" }
-        coEvery { sourceRepository.getSource("1943584017") } returns source
+    fun `resolveSourceId returns the source's own string id, not the stringified key`() = runTest {
+        val source = mockk<MangaSource> { every { id } returns "2499283573021220255" }
+        coEvery { sourceRepository.getSourceByKey(SOURCE_KEY) } returns source
 
-        assertEquals("MangaDex", sourceRepository.resolveDownloadFolderName(1943584017L))
+        assertEquals("2499283573021220255", sourceRepository.resolveSourceId(SOURCE_KEY))
     }
 
     @Test
-    fun `resolveDownloadFolderName falls back to the numeric sourceId when unresolvable`() = runTest {
-        coEvery { sourceRepository.getSource("1943584017") } returns null
+    fun `resolveSourceId returns null when no loaded source owns the key`() = runTest {
+        coEvery { sourceRepository.getSourceByKey(SOURCE_KEY) } returns null
 
+        assertNull(sourceRepository.resolveSourceId(SOURCE_KEY))
+    }
+
+    /**
+     * The folder name is the numeric key and nothing else — see the KDoc on
+     * [resolveDownloadFolderName]. Downloads on disk are already filed under it, so resolving a
+     * display name here would point every read at a directory that does not exist.
+     *
+     * This asserts the *absence* of a lookup, not just the returned string, because a version
+     * that looked the source up and happened to miss would return the same value while being one
+     * successful lookup away from orphaning every download.
+     */
+    @Test
+    fun `resolveDownloadFolderName is the numeric key and consults no source`() = runTest {
         assertEquals("1943584017", sourceRepository.resolveDownloadFolderName(1943584017L))
+
+        coVerify(exactly = 0) { sourceRepository.getSource(any()) }
+        coVerify(exactly = 0) { sourceRepository.getSourceByKey(any()) }
+    }
+
+    private companion object {
+        const val SOURCE_KEY = -1874553621L
     }
 }

--- a/domain/src/test/java/app/otakureader/domain/repository/SourceRepositoryExtTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/repository/SourceRepositoryExtTest.kt
@@ -1,6 +1,7 @@
 package app.otakureader.domain.repository
 
 import app.otakureader.sourceapi.MangaSource
+import app.otakureader.sourceapi.toSourceId
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -16,10 +17,10 @@ class SourceRepositoryExtTest {
 
     @Test
     fun `resolveSourceId returns the source's own string id, not the stringified key`() = runTest {
-        val source = mockk<MangaSource> { every { id } returns "2499283573021220255" }
+        val source = mockk<MangaSource> { every { id } returns APK_SOURCE_ID }
         coEvery { sourceRepository.getSourceByKey(SOURCE_KEY) } returns source
 
-        assertEquals("2499283573021220255", sourceRepository.resolveSourceId(SOURCE_KEY))
+        assertEquals(APK_SOURCE_ID, sourceRepository.resolveSourceId(SOURCE_KEY))
     }
 
     @Test
@@ -31,7 +32,7 @@ class SourceRepositoryExtTest {
 
     /**
      * The folder name is the numeric key and nothing else — see the KDoc on
-     * [resolveDownloadFolderName]. Downloads on disk are already filed under it, so resolving a
+     * [downloadFolderNameFor]. Downloads on disk are already filed under it, so resolving a
      * display name here would point every read at a directory that does not exist.
      *
      * This asserts the *absence* of a lookup, not just the returned string, because a version
@@ -39,14 +40,61 @@ class SourceRepositoryExtTest {
      * successful lookup away from orphaning every download.
      */
     @Test
-    fun `resolveDownloadFolderName is the numeric key and consults no source`() = runTest {
-        assertEquals("1943584017", sourceRepository.resolveDownloadFolderName(1943584017L))
+    fun `downloadFolderNameFor is the numeric key and consults no source`() = runTest {
+        assertEquals("1943584017", downloadFolderNameFor(1943584017L))
 
         coVerify(exactly = 0) { sourceRepository.getSource(any()) }
         coVerify(exactly = 0) { sourceRepository.getSourceByKey(any()) }
     }
 
+    // ── associateBySourceKey ──────────────────────────────────────────────────
+    //
+    // This rule has to stay identical to SourceRepositoryImpl.getSourceByKey. A map that indexed
+    // only the canonical key would leave legacy rows unresolved here while getSourceByKey still
+    // matched them — the same source reachable one way and not the other, which is how the
+    // library ended up with blank source names in the first place.
+
+    @Test
+    fun `associateBySourceKey indexes by the canonical hashed key`() {
+        val map = listOf(APK_SOURCE_ID, "local").associateBySourceKey { it }
+
+        assertEquals(APK_SOURCE_ID, map[APK_SOURCE_ID.toSourceId()])
+        assertEquals("local", map["local".toSourceId()])
+    }
+
+    @Test
+    fun `associateBySourceKey also indexes the legacy parsed key`() {
+        val map = listOf(APK_SOURCE_ID).associateBySourceKey { it }
+
+        assertEquals(APK_SOURCE_ID, map[APK_SOURCE_ID.toLong()])
+    }
+
+    /**
+     * Same collision precedence as `getSourceByKey`: the source that genuinely owns the key today
+     * must win over one that only matches it under the legacy rule. Ordering must not decide it,
+     * so the legacy entry is deliberately first in the list.
+     */
+    @Test
+    fun `associateBySourceKey prefers the canonical owner when both rules match one key`() {
+        val canonical = "en.canonical"
+        val key = canonical.toSourceId()
+        val legacy = key.toString()
+
+        val map = listOf(legacy, canonical).associateBySourceKey { it }
+
+        assertEquals(canonical, map[key])
+    }
+
+    @Test
+    fun `associateBySourceKey has no entry for a key no source owns`() {
+        val map = listOf("en.one").associateBySourceKey { it }
+
+        assertNull(map["en.two".toSourceId()])
+    }
+
     private companion object {
+        /** The shape an APK extension's id actually has: a Tachiyomi Long, stringified. */
+        const val APK_SOURCE_ID = "2499283573021220255"
         const val SOURCE_KEY = -1874553621L
     }
 }

--- a/domain/src/test/java/app/otakureader/domain/usecase/UpdateLibraryMangaUseCaseTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/usecase/UpdateLibraryMangaUseCaseTest.kt
@@ -41,7 +41,34 @@ class UpdateLibraryMangaUseCaseTest {
     fun setUp() {
         chapterRepository = mockk()
         sourceRepository = mockk()
+        // The manga row stores a hashed key; the use case has to turn it back into the source's
+        // real string id before it can ask the source for anything.
+        coEvery { sourceRepository.getSourceByKey(1L) } returns mockk {
+            every { id } returns SOURCE_STRING_ID
+        }
         useCase = UpdateLibraryMangaUseCase(chapterRepository, sourceRepository)
+    }
+
+    @Test
+    fun `invoke asks the source by its resolved string id, not the stringified key`() = runTest {
+        coEvery { sourceRepository.getChapterList(any(), any()) } returns Result.success(emptyList())
+        every { chapterRepository.getChaptersByMangaId(1L) } returns flowOf(emptyList())
+
+        useCase(testManga)
+
+        // "1" — the key stringified — is what the code used to pass, and it matches no source.
+        coVerify(exactly = 0) { sourceRepository.getChapterList("1", any()) }
+        coVerify { sourceRepository.getChapterList(SOURCE_STRING_ID, any()) }
+    }
+
+    @Test
+    fun `invoke fails when no loaded source owns the manga's key`() = runTest {
+        coEvery { sourceRepository.getSourceByKey(1L) } returns null
+
+        val result = useCase(testManga)
+
+        assertTrue(result.isFailure)
+        coVerify(exactly = 0) { sourceRepository.getChapterList(any(), any()) }
     }
 
     @Test
@@ -118,5 +145,9 @@ class UpdateLibraryMangaUseCaseTest {
 
         assertTrue(result.isSuccess)
         assertEquals(0, result.getOrNull()?.size)
+    }
+
+    private companion object {
+        const val SOURCE_STRING_ID = "2499283573021220255"
     }
 }

--- a/domain/src/test/java/app/otakureader/domain/usecase/migration/SearchMigrationTargetsUseCaseTest.kt
+++ b/domain/src/test/java/app/otakureader/domain/usecase/migration/SearchMigrationTargetsUseCaseTest.kt
@@ -6,6 +6,7 @@ import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.sourceapi.MangaPage
 import app.otakureader.sourceapi.SourceManga
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -21,7 +22,22 @@ class SearchMigrationTargetsUseCaseTest {
     @Before
     fun setup() {
         sourceRepository = mockk()
+        // Target sources are chosen by their canonical `Long` key; the search itself needs the
+        // source's real string id, which only a lookup can produce. Deliberately not "1" — if the
+        // use case went back to stringifying the key, every test here would stop matching.
+        coEvery { sourceRepository.getSourceByKey(TARGET_SOURCE_KEY) } returns mockk {
+            every { id } returns TARGET_SOURCE_ID
+        }
         useCase = SearchMigrationTargetsUseCase(sourceRepository)
+    }
+
+    @Test
+    fun `returns failure when no loaded source owns the target key`() = runTest {
+        coEvery { sourceRepository.getSourceByKey(TARGET_SOURCE_KEY) } returns null
+
+        val result = useCase(createTestManga(title = "One Piece"), TARGET_SOURCE_KEY)
+
+        assertTrue(result.isFailure)
     }
 
     @Test
@@ -31,11 +47,11 @@ class SearchMigrationTargetsUseCaseTest {
         val targetManga = createTestSourceManga(title = "One Piece")
 
         coEvery {
-            sourceRepository.searchManga("1", "One Piece", 1)
+            sourceRepository.searchManga(TARGET_SOURCE_ID, "One Piece", 1)
         } returns Result.success(MangaPage(listOf(targetManga), false))
 
         // When
-        val result = useCase(sourceManga, 1L)
+        val result = useCase(sourceManga, TARGET_SOURCE_KEY)
 
         // Then
         assertTrue(result.isSuccess)
@@ -52,11 +68,11 @@ class SearchMigrationTargetsUseCaseTest {
         val targetManga = createTestSourceManga(title = "Tokyo Ghoul")
 
         coEvery {
-            sourceRepository.searchManga("1", "Tokyo Ghoul (2011)", 1)
+            sourceRepository.searchManga(TARGET_SOURCE_ID, "Tokyo Ghoul (2011)", 1)
         } returns Result.success(MangaPage(listOf(targetManga), false))
 
         // When
-        val result = useCase(sourceManga, 1L)
+        val result = useCase(sourceManga, TARGET_SOURCE_KEY)
 
         // Then
         assertTrue(result.isSuccess)
@@ -73,11 +89,11 @@ class SearchMigrationTargetsUseCaseTest {
         val targetManga = createTestSourceManga(title = "My Hero Academia")
 
         coEvery {
-            sourceRepository.searchManga("1", "Boku no Hero Academia", 1)
+            sourceRepository.searchManga(TARGET_SOURCE_ID, "Boku no Hero Academia", 1)
         } returns Result.success(MangaPage(listOf(targetManga), false))
 
         // When
-        val result = useCase(sourceManga, 1L)
+        val result = useCase(sourceManga, TARGET_SOURCE_KEY)
 
         // Then
         assertTrue(result.isSuccess)
@@ -104,11 +120,11 @@ class SearchMigrationTargetsUseCaseTest {
         )
 
         coEvery {
-            sourceRepository.searchManga("1", "One Piece", 1)
+            sourceRepository.searchManga(TARGET_SOURCE_ID, "One Piece", 1)
         } returns Result.success(MangaPage(listOf(targetManga1, targetManga2), false))
 
         // When
-        val result = useCase(sourceManga, 1L)
+        val result = useCase(sourceManga, TARGET_SOURCE_KEY)
 
         // Then
         assertTrue(result.isSuccess)
@@ -136,11 +152,11 @@ class SearchMigrationTargetsUseCaseTest {
         )
 
         coEvery {
-            sourceRepository.searchManga("1", "One Piece", 1)
+            sourceRepository.searchManga(TARGET_SOURCE_ID, "One Piece", 1)
         } returns Result.success(MangaPage(listOf(targetManga1, targetManga2), false))
 
         // When
-        val result = useCase(sourceManga, 1L)
+        val result = useCase(sourceManga, TARGET_SOURCE_KEY)
 
         // Then
         assertTrue(result.isSuccess)
@@ -157,11 +173,11 @@ class SearchMigrationTargetsUseCaseTest {
         val targetManga = createTestSourceManga(title = "Seven Deadly Sins")
 
         coEvery {
-            sourceRepository.searchManga("1", "The Seven Deadly Sins", 1)
+            sourceRepository.searchManga(TARGET_SOURCE_ID, "The Seven Deadly Sins", 1)
         } returns Result.success(MangaPage(listOf(targetManga), false))
 
         // When
-        val result = useCase(sourceManga, 1L)
+        val result = useCase(sourceManga, TARGET_SOURCE_KEY)
 
         // Then
         assertTrue(result.isSuccess)
@@ -198,11 +214,11 @@ class SearchMigrationTargetsUseCaseTest {
         )
 
         coEvery {
-            sourceRepository.searchManga("1", "One Piece", 1)
+            sourceRepository.searchManga(TARGET_SOURCE_ID, "One Piece", 1)
         } returns Result.success(MangaPage(listOf(poorMatch, perfectMatch, goodMatch), false))
 
         // When
-        val result = useCase(sourceManga, 1L)
+        val result = useCase(sourceManga, TARGET_SOURCE_KEY)
 
         // Then
         assertTrue(result.isSuccess)
@@ -224,11 +240,11 @@ class SearchMigrationTargetsUseCaseTest {
         val sourceManga = createTestManga(title = "Nonexistent Manga")
 
         coEvery {
-            sourceRepository.searchManga("1", "Nonexistent Manga", 1)
+            sourceRepository.searchManga(TARGET_SOURCE_ID, "Nonexistent Manga", 1)
         } returns Result.success(MangaPage(emptyList(), false))
 
         // When
-        val result = useCase(sourceManga, 1L)
+        val result = useCase(sourceManga, TARGET_SOURCE_KEY)
 
         // Then
         assertTrue(result.isSuccess)
@@ -242,11 +258,11 @@ class SearchMigrationTargetsUseCaseTest {
         val exception = Exception("Network error")
 
         coEvery {
-            sourceRepository.searchManga("1", "Some Manga", 1)
+            sourceRepository.searchManga(TARGET_SOURCE_ID, "Some Manga", 1)
         } returns Result.failure(exception)
 
         // When
-        val result = useCase(sourceManga, 1L)
+        val result = useCase(sourceManga, TARGET_SOURCE_KEY)
 
         // Then
         assertTrue(result.isFailure)
@@ -259,11 +275,11 @@ class SearchMigrationTargetsUseCaseTest {
         val targetManga = createTestSourceManga(title = "Hunter x Hunter")
 
         coEvery {
-            sourceRepository.searchManga("1", "Hunter×Hunter", 1)
+            sourceRepository.searchManga(TARGET_SOURCE_ID, "Hunter×Hunter", 1)
         } returns Result.success(MangaPage(listOf(targetManga), false))
 
         // When
-        val result = useCase(sourceManga, 1L)
+        val result = useCase(sourceManga, TARGET_SOURCE_KEY)
 
         // Then
         assertTrue(result.isSuccess)
@@ -300,4 +316,9 @@ class SearchMigrationTargetsUseCaseTest {
         author = author,
         genre = genre
     )
+
+    private companion object {
+        const val TARGET_SOURCE_KEY = 1L
+        const val TARGET_SOURCE_ID = "2499283573021220255"
+    }
 }

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -41,7 +41,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import app.otakureader.domain.repository.SourceRepository
-import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.downloadFolderNameFor
 import app.otakureader.domain.repository.resolveSourceId
 import app.otakureader.domain.tracking.TrackRepository
 import app.otakureader.domain.tracking.Tracker
@@ -1070,7 +1070,7 @@ class DetailsViewModel @Inject constructor(
             val manga = _state.value.manga
             val chapters = _state.value.chapters.filter { selectedIds.contains(it.id) }
             val mangaTitle = manga?.title ?: "Manga"
-            val sourceName = manga?.sourceId?.let { sourceRepository.resolveDownloadFolderName(it) } ?: ""
+            val sourceName = manga?.sourceId?.let { downloadFolderNameFor(it) } ?: ""
 
             val enqueuedCount = try {
                 enqueueChapters(chapters, sourceName, mangaTitle)
@@ -1095,7 +1095,7 @@ class DetailsViewModel @Inject constructor(
             val chapters = _state.value.chapters.filter { selectedIds.contains(it.id) }
 
             if (manga != null) {
-                val sourceName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
+                val sourceName = downloadFolderNameFor(manga.sourceId)
                 chapters.forEach { chapter ->
                     downloadRepository.deleteChapterDownload(
                         chapterId = chapter.id,
@@ -1176,7 +1176,7 @@ class DetailsViewModel @Inject constructor(
             val chapter = _state.value.chapters.firstOrNull { it.id == chapterId }
             val manga = _state.value.manga
             val mangaTitle = manga?.title ?: "Manga"
-            val sourceName = manga?.sourceId?.let { sourceRepository.resolveDownloadFolderName(it) } ?: ""
+            val sourceName = manga?.sourceId?.let { downloadFolderNameFor(it) } ?: ""
 
             if (chapter != null) {
                 try {
@@ -1202,7 +1202,7 @@ class DetailsViewModel @Inject constructor(
     private fun downloadAllChapters(unreadOnly: Boolean) {
         viewModelScope.launch {
             val manga = _state.value.manga ?: return@launch
-            val sourceName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
+            val sourceName = downloadFolderNameFor(manga.sourceId)
             val chapters = if (unreadOnly) {
                 _state.value.chapters.filter { !it.read }
             } else {
@@ -1270,7 +1270,7 @@ class DetailsViewModel @Inject constructor(
                 } else {
                     downloadRepository.deleteChapterDownload(
                         chapterId = chapterId,
-                        sourceName = sourceRepository.resolveDownloadFolderName(manga.sourceId),
+                        sourceName = downloadFolderNameFor(manga.sourceId),
                         mangaTitle = manga.title,
                         chapterTitle = chapter.name
                     )
@@ -1293,7 +1293,7 @@ class DetailsViewModel @Inject constructor(
                 return@launch
             }
             downloadRepository.exportChapterAsCbz(
-                sourceName = sourceRepository.resolveDownloadFolderName(manga.sourceId),
+                sourceName = downloadFolderNameFor(manga.sourceId),
                 mangaTitle = manga.title,
                 chapterTitle = chapter.name
             ).fold(
@@ -1364,7 +1364,7 @@ class DetailsViewModel @Inject constructor(
             val manga = _state.value.manga ?: return@launch
             _effect.send(
                 DetailsContract.Effect.OpenDownloadFolder(
-                    sourceName = sourceRepository.resolveDownloadFolderName(manga.sourceId),
+                    sourceName = downloadFolderNameFor(manga.sourceId),
                     mangaTitle = manga.title,
                 )
             )
@@ -1384,7 +1384,7 @@ class DetailsViewModel @Inject constructor(
                 return@launch
             }
             var cleared = 0
-            val sourceName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
+            val sourceName = downloadFolderNameFor(manga.sourceId)
             downloadedChapters.forEach { chapter ->
                 try {
                     downloadRepository.deleteChapterDownload(

--- a/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
+++ b/feature/details/src/main/java/app/otakureader/feature/details/DetailsViewModel.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.resolveSourceId
 import app.otakureader.domain.tracking.TrackRepository
 import app.otakureader.domain.tracking.Tracker
 import app.otakureader.domain.usecase.metadata.ResolveAniListMediaUseCase
@@ -259,8 +260,9 @@ class DetailsViewModel @Inject constructor(
     private fun onSourceClick() {
         viewModelScope.launch {
             val manga = _state.value.manga ?: return@launch
+            val sourceId = sourceRepository.resolveSourceId(manga.sourceId) ?: return@launch
             _effect.send(
-                DetailsContract.Effect.NavigateToSourceSearch(sourceId = manga.sourceId.toString(), query = "")
+                DetailsContract.Effect.NavigateToSourceSearch(sourceId = sourceId, query = "")
             )
         }
     }
@@ -269,7 +271,7 @@ class DetailsViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 val manga = mangaRepository.getMangaById(mangaId) ?: return@launch
-                val source = sourceRepository.getSource(manga.sourceId.toString())
+                val source = sourceRepository.getSourceByKey(manga.sourceId)
                 _state.update { it.copy(sourceName = source?.name) }
             } catch (e: CancellationException) {
                 throw e
@@ -295,9 +297,10 @@ class DetailsViewModel @Inject constructor(
     private fun searchGenreInSource(genre: String) {
         viewModelScope.launch {
             val manga = _state.value.manga ?: return@launch
+            val sourceId = sourceRepository.resolveSourceId(manga.sourceId) ?: return@launch
             _effect.send(
                 DetailsContract.Effect.NavigateToSourceSearch(
-                    sourceId = manga.sourceId.toString(),
+                    sourceId = sourceId,
                     query = genre,
                 )
             )
@@ -571,7 +574,7 @@ class DetailsViewModel @Inject constructor(
                 val fullUrl = if (manga.url.startsWith("http")) {
                     manga.url
                 } else {
-                    val source = sourceRepository.getSource(manga.sourceId.toString()) ?: return@launch
+                    val source = sourceRepository.getSourceByKey(manga.sourceId) ?: return@launch
                     val baseUrl = source.baseUrl.trimEnd('/')
                     if (baseUrl.isEmpty()) return@launch
                     "$baseUrl/${manga.url.removePrefix("/")}"
@@ -683,7 +686,9 @@ class DetailsViewModel @Inject constructor(
                             )
 
                             // Use repository instead of calling source directly (#587)
-                            val pages = sourceRepository.getPageList(manga.sourceId.toString(), sourceChapter)
+                            val sourceId = sourceRepository.resolveSourceId(manga.sourceId)
+                                ?: return@async
+                            val pages = sourceRepository.getPageList(sourceId, sourceChapter)
                                 .getOrNull() ?: return@async
                             if (pages.isNotEmpty()) {
                                 val firstPageUrl = pages.first().imageUrl
@@ -1648,7 +1653,11 @@ class DetailsViewModel @Inject constructor(
                 )
 
                 // Use repository to respect caching and abstraction layers (#587)
-                val pages = sourceRepository.getPageList(manga.sourceId.toString(), sourceChapter)
+                val sourceId = sourceRepository.resolveSourceId(manga.sourceId) ?: run {
+                    _effect.send(DetailsContract.Effect.ShowError("Source not available"))
+                    return@launch
+                }
+                val pages = sourceRepository.getPageList(sourceId, sourceChapter)
                     .getOrElse {
                         _effect.send(DetailsContract.Effect.ShowError("Source not available"))
                         return@launch
@@ -1697,7 +1706,7 @@ class DetailsViewModel @Inject constructor(
             _state.update { it.copy(isLoadingSourceSuggestions = true, sourceSuggestionsError = null) }
 
             try {
-                val source = sourceRepository.getSource(manga.sourceId.toString())
+                val source = sourceRepository.getSourceByKey(manga.sourceId)
                 if (source == null) {
                     _state.update {
                         it.copy(
@@ -1716,7 +1725,7 @@ class DetailsViewModel @Inject constructor(
                 val reason = if (author != null) "Same author" else "From ${source.name}"
 
                 val result = sourceRepository.searchManga(
-                    sourceId = manga.sourceId.toString(),
+                    sourceId = source.id,
                     query = query,
                     page = 1,
                 )

--- a/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
+++ b/feature/details/src/test/java/app/otakureader/feature/details/DetailsViewModelTest.kt
@@ -165,6 +165,12 @@ class DetailsViewModelTest {
 
     private fun setUpDefaultMocks() {
         stubManga(sampleManga)
+        // The manga row's `sourceId` is a hashed key. Every source call resolves it back through
+        // the repository first, so the id asserted below is the source's own — deliberately not
+        // `sampleManga.sourceId.toString()`, which is what the code used to pass and what matches
+        // no installed source.
+        coEvery { sourceRepository.getSourceByKey(sampleManga.sourceId) } returns
+            mockk(relaxed = true) { every { id } returns SAMPLE_SOURCE_ID }
         every { chapterRepository.getChaptersByMangaId(mangaId) } returns flowOf(sampleChapters)
         every { mangaRepository.isFavorite(mangaId) } returns flowOf(false)
         every { downloadRepository.observeDownloads() } returns flowOf(emptyList())
@@ -202,7 +208,7 @@ class DetailsViewModelTest {
         setUpDefaultMocks()
         val source = mockk<app.otakureader.sourceapi.MangaSource>(relaxed = true)
         every { source.name } returns "MangaDex"
-        coEvery { sourceRepository.getSource(sampleManga.sourceId.toString()) } returns source
+        coEvery { sourceRepository.getSourceByKey(sampleManga.sourceId) } returns source
 
         val viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
@@ -896,7 +902,7 @@ class DetailsViewModelTest {
             val effect = awaitItem()
             assertTrue(effect is DetailsContract.Effect.NavigateToSourceSearch)
             val navigate = effect as DetailsContract.Effect.NavigateToSourceSearch
-            assertEquals(sampleManga.sourceId.toString(), navigate.sourceId)
+            assertEquals(SAMPLE_SOURCE_ID, navigate.sourceId)
             assertEquals("", navigate.query)
         }
     }
@@ -1045,7 +1051,7 @@ class DetailsViewModelTest {
         setUpDefaultMocks()
         val source = mockk<app.otakureader.sourceapi.MangaSource>(relaxed = true)
         every { source.baseUrl } returns "https://example.com"
-        coEvery { sourceRepository.getSource(sampleManga.sourceId.toString()) } returns source
+        coEvery { sourceRepository.getSourceByKey(sampleManga.sourceId) } returns source
 
         val viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
@@ -1758,5 +1764,7 @@ class DetailsViewModelTest {
     private companion object {
         /** Long enough that a fetch left running would obviously outlive the one that replaced it. */
         const val SLOW_FETCH_MS = 5_000L
+
+        const val SAMPLE_SOURCE_ID = "2499283573021220255"
     }
 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryMangaGrid.kt
@@ -90,9 +90,15 @@ private object LibraryListRowDefaults {
     const val TitleMaxLines = 2
 }
 
-/** Returns true when a manga item belongs to the manhwa/webtoon content type. */
+/**
+ * Returns true when a manga item belongs to the manhwa/webtoon content type.
+ *
+ * Matched against the source's *name*. It used to read `sourceId.toString()`, which is a decimal
+ * number — no number contains the word "webtoon", so the Manhwa tab was always empty and the
+ * Manga tab always held everything.
+ */
 internal fun isManhwa(manga: LibraryMangaItem): Boolean {
-    val src = manga.sourceId.toString().lowercase()
+    val src = manga.sourceName.lowercase()
     return src.contains("manhwa") || src.contains("webtoon") ||
         src.contains("korean") || src.contains("toon") || src.contains("naver")
 }

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -25,8 +25,8 @@ import app.otakureader.core.extension.domain.repository.ExtensionRepository
 import app.otakureader.domain.repository.EhFavoritesRepository
 import app.otakureader.domain.repository.PageBookmarkRepository
 import app.otakureader.domain.repository.SourceRepository
-import app.otakureader.domain.repository.resolveDownloadFolderName
-import app.otakureader.sourceapi.toSourceId
+import app.otakureader.domain.repository.associateBySourceKey
+import app.otakureader.domain.repository.downloadFolderNameFor
 import app.otakureader.domain.usecase.SyncEhFavoritesUseCase
 import app.otakureader.domain.usecase.SyncLibraryUseCase
 import app.otakureader.domain.usecase.downloads.ReindexDownloadsUseCase
@@ -582,7 +582,7 @@ class LibraryViewModel @Inject constructor(
     }
 
     /**
-     * Keyed by the same canonical key a manga row stores, not by [ExtensionSource.id].
+     * Keyed by the same keys a manga row can store, not by [ExtensionSource.id].
      *
      * `ExtensionSource.id` is the raw Tachiyomi source id; the key on a manga row is that id
      * stringified and hashed, which is what `TachiyomiSourceAdapter` exposes as its `id` and what
@@ -591,8 +591,9 @@ class LibraryViewModel @Inject constructor(
      */
     private suspend fun buildSourceIconUrlMap(): Map<Long, String?> =
         extensionRepository.getInstalledExtensions().first()
-            .flatMap { ext -> ext.sources.map { src -> src.id.toString().toSourceId() to ext.iconUrl } }
-            .toMap()
+            .flatMap { ext -> ext.sources.map { src -> src to ext.iconUrl } }
+            .associateBySourceKey { (src, _) -> src.id.toString() }
+            .mapValues { (_, entry) -> entry.second }
 
     private fun loadLibrary() {
         val isRefreshing = _state.value.mangaList.isNotEmpty()
@@ -603,15 +604,14 @@ class LibraryViewModel @Inject constructor(
                 coroutineScope {
                     // Build source metadata (name + lang) lookup in parallel
                     val sourceMetaDeferred = async {
+                        // Indexed by every key a manga row can hold, matching getSourceByKey.
+                        // This used to parse the id as a number and nothing else, which both
+                        // dropped every non-numeric source and, for numeric ones, produced a key
+                        // no manga row uses — so `sourceName` came back blank for the whole
+                        // library and "group by source" showed numbers.
                         sourceRepository.getSources().first()
-                            .associate { source ->
-                                // Keyed by the canonical key. Parsing the id as a number instead
-                                // both dropped every non-numeric source and, for numeric ones,
-                                // produced a key no manga row uses — so `sourceName` came back
-                                // blank for the whole library and "group by source" showed
-                                // numbers.
-                                source.id.toSourceId() to Pair(source.name, source.lang)
-                            }
+                            .associateBySourceKey { it.id }
+                            .mapValues { (_, source) -> Pair(source.name, source.lang) }
                     }
 
                     val sourceIconUrlDeferred = async { buildSourceIconUrlMap() }
@@ -625,7 +625,7 @@ class LibraryViewModel @Inject constructor(
                     // filesystem walk for the whole library instead of a per-manga check
                     val mangaKeysDeferred = async {
                         mangaList.associate { manga ->
-                            manga.id to (sourceRepository.resolveDownloadFolderName(manga.sourceId) to manga.title)
+                            manga.id to (downloadFolderNameFor(manga.sourceId) to manga.title)
                         }
                     }
 
@@ -871,7 +871,7 @@ class LibraryViewModel @Inject constructor(
                 // Must match the folder-name resolution used everywhere else; a mismatch here
                 // stores files under a path isChapterDownloaded()/deleteChapterDownload() would
                 // never find when checking under the resolved name.
-                val sourceName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
+                val sourceName = downloadFolderNameFor(manga.sourceId)
                 chapters.filter { !it.read }.forEach { chapter ->
                     downloadRepository.enqueueChapter(
                         mangaId = mangaId,

--- a/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/LibraryViewModel.kt
@@ -26,6 +26,7 @@ import app.otakureader.domain.repository.EhFavoritesRepository
 import app.otakureader.domain.repository.PageBookmarkRepository
 import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.sourceapi.toSourceId
 import app.otakureader.domain.usecase.SyncEhFavoritesUseCase
 import app.otakureader.domain.usecase.SyncLibraryUseCase
 import app.otakureader.domain.usecase.downloads.ReindexDownloadsUseCase
@@ -580,9 +581,17 @@ class LibraryViewModel @Inject constructor(
             .launchIn(viewModelScope)
     }
 
+    /**
+     * Keyed by the same canonical key a manga row stores, not by [ExtensionSource.id].
+     *
+     * `ExtensionSource.id` is the raw Tachiyomi source id; the key on a manga row is that id
+     * stringified and hashed, which is what `TachiyomiSourceAdapter` exposes as its `id` and what
+     * `toSourceId` then derives. Keying by the raw id meant no library entry ever matched, so no
+     * source icons were shown.
+     */
     private suspend fun buildSourceIconUrlMap(): Map<Long, String?> =
         extensionRepository.getInstalledExtensions().first()
-            .flatMap { ext -> ext.sources.map { src -> src.id to ext.iconUrl } }
+            .flatMap { ext -> ext.sources.map { src -> src.id.toString().toSourceId() to ext.iconUrl } }
             .toMap()
 
     private fun loadLibrary() {
@@ -595,10 +604,14 @@ class LibraryViewModel @Inject constructor(
                     // Build source metadata (name + lang) lookup in parallel
                     val sourceMetaDeferred = async {
                         sourceRepository.getSources().first()
-                            .mapNotNull { source ->
-                                source.id.toLongOrNull()?.let { id -> id to Pair(source.name, source.lang) }
+                            .associate { source ->
+                                // Keyed by the canonical key. Parsing the id as a number instead
+                                // both dropped every non-numeric source and, for numeric ones,
+                                // produced a key no manga row uses — so `sourceName` came back
+                                // blank for the whole library and "group by source" showed
+                                // numbers.
+                                source.id.toSourceId() to Pair(source.name, source.lang)
                             }
-                            .toMap()
                     }
 
                     val sourceIconUrlDeferred = async { buildSourceIconUrlMap() }

--- a/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.SourceRepository
-import app.otakureader.sourceapi.toSourceId
+import app.otakureader.domain.repository.associateBySourceKey
 import app.otakureader.domain.usecase.FillMissingChaptersUseCase
 import app.otakureader.domain.usecase.LinkAlternativeSourceUseCase
 import app.otakureader.domain.usecase.MergeDuplicateMangaUseCase
@@ -82,13 +82,11 @@ class MergeDuplicatesViewModel @Inject constructor(
     private fun observeSourceNames() {
         sourceRepository.getSources()
             .onEach { sources ->
-                val names = sources.associate { source ->
-                    // The canonical key, matching what manga rows store. This used to parse the
-                    // id as a number and only fall back to hashing when that failed, so numeric
-                    // (APK) sources were keyed one way and everything else another — and the
-                    // numeric ones, which are most of them, never matched a manga row at all.
-                    source.id.toSourceId() to source.name
-                }
+                // Indexed by every key a manga row can hold, matching getSourceByKey. This used
+                // to parse the id as a number and only fall back to hashing when that failed, so
+                // numeric (APK) sources were keyed one way and everything else another — and the
+                // numeric ones, which are most of them, never matched a manga row at all.
+                val names = sources.associateBySourceKey { it.id }.mapValues { (_, s) -> s.name }
                 _state.update { it.copy(sourceNames = names) }
             }
             .launchIn(viewModelScope)

--- a/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesViewModel.kt
+++ b/feature/library/src/main/java/app/otakureader/feature/library/MergeDuplicatesViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.SourceRepository
+import app.otakureader.sourceapi.toSourceId
 import app.otakureader.domain.usecase.FillMissingChaptersUseCase
 import app.otakureader.domain.usecase.LinkAlternativeSourceUseCase
 import app.otakureader.domain.usecase.MergeDuplicateMangaUseCase
@@ -82,9 +83,11 @@ class MergeDuplicatesViewModel @Inject constructor(
         sourceRepository.getSources()
             .onEach { sources ->
                 val names = sources.associate { source ->
-                    // MangaSource.id is the Long source ID serialized to String
-                    val id = source.id.toLongOrNull() ?: return@associate source.id.hashCode().toLong() to source.name
-                    id to source.name
+                    // The canonical key, matching what manga rows store. This used to parse the
+                    // id as a number and only fall back to hashing when that failed, so numeric
+                    // (APK) sources were keyed one way and everything else another — and the
+                    // numeric ones, which are most of them, never matched a manga row at all.
+                    source.id.toSourceId() to source.name
                 }
                 _state.update { it.copy(sourceNames = names) }
             }

--- a/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/app/otakureader/feature/library/LibraryViewModelTest.kt
@@ -7,6 +7,7 @@ import app.otakureader.core.preferences.ReadingGoalPreferences
 import app.otakureader.domain.model.Chapter
 import app.otakureader.domain.model.ContinueReadingItem
 import app.otakureader.domain.model.Manga
+import app.otakureader.sourceapi.toSourceId
 import app.otakureader.domain.model.ReadingGoal
 import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.model.ReadingList
@@ -235,7 +236,16 @@ class LibraryViewModelTest {
 
     @Test
     fun loadLibrary_populatesSourceIconUrl_fromInstalledExtensions() = runTest {
-        every { getLibraryManga() } returns flowOf(sampleMangas)
+        // A manga row stores the *canonical* key — the extension's source id stringified and
+        // hashed, matching what `TachiyomiSourceAdapter` exposes. Keying the icon map by the raw
+        // `ExtensionSource.id` instead meant no row ever matched and no icons were shown.
+        val installedKey = INSTALLED_SOURCE_ID.toString().toSourceId()
+        val uninstalledKey = "99".toSourceId()
+        every { getLibraryManga() } returns flowOf(
+            sampleMangas.mapIndexed { index, manga ->
+                manga.copy(sourceId = if (index == 1) uninstalledKey else installedKey)
+            }
+        )
         val testIconUrl = "https://test.icon/source10.png"
         val fakeExtension = app.otakureader.core.extension.domain.model.Extension(
             id = 1L,
@@ -245,7 +255,7 @@ class LibraryViewModelTest {
             versionName = "1.0",
             sources = listOf(
                 app.otakureader.core.extension.domain.model.ExtensionSource(
-                    id = 10L,
+                    id = INSTALLED_SOURCE_ID,
                     name = "Test Source",
                     lang = "en",
                     baseUrl = "https://example.com",
@@ -264,14 +274,13 @@ class LibraryViewModelTest {
         val viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
 
-        // sourceId 10 → icon URL from the extension
-        viewModel.state.value.mangaList
-            .filter { it.sourceId == 10L }
-            .forEach { assertEquals(testIconUrl, it.sourceIconUrl) }
-        // sourceId 20 → no matching extension, so null
-        viewModel.state.value.mangaList
-            .filter { it.sourceId == 20L }
-            .forEach { assertNull(it.sourceIconUrl) }
+        val matched = viewModel.state.value.mangaList.filter { it.sourceId == installedKey }
+        val unmatched = viewModel.state.value.mangaList.filter { it.sourceId == uninstalledKey }
+        // Both non-empty, or "every entry has the right icon" would hold vacuously.
+        assertTrue(matched.isNotEmpty())
+        assertTrue(unmatched.isNotEmpty())
+        matched.forEach { assertEquals(testIconUrl, it.sourceIconUrl) }
+        unmatched.forEach { assertNull(it.sourceIconUrl) }
     }
 
     @Test
@@ -1055,5 +1064,10 @@ class LibraryViewModelTest {
         // Falls back to alphabetical: Bleach, Naruto, One Piece
         val titles = viewModel.state.value.mangaList.map { it.title }
         assertEquals(listOf("Bleach", "Naruto", "One Piece"), titles)
+    }
+
+    private companion object {
+        /** Matches the raw Tachiyomi id an installed extension reports. */
+        const val INSTALLED_SOURCE_ID = 10L
     }
 }

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationViewModel.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationViewModel.kt
@@ -8,6 +8,7 @@ import app.otakureader.domain.model.MigrationMode
 import app.otakureader.domain.model.MigrationStatus
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.SourceRepository
+import app.otakureader.sourceapi.toSourceId
 import app.otakureader.domain.usecase.migration.MigrateMangaUseCase
 import app.otakureader.domain.usecase.migration.SearchMigrationTargetsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -68,7 +69,11 @@ class MigrationViewModel @Inject constructor(
                 val sourcesFlow = sourceRepository.getSources()
                 val sources = sourcesFlow.first().map { source ->
                     SourceItem(
-                        id = source.id.toLongOrNull() ?: 0L,
+                        // The canonical key, same as every manga row stores. Parsing the id as a
+                        // number instead mapped every non-numeric source — the local source, all
+                        // JS sources — onto 0L, so they shared one list key and only one of them
+                        // was selectable.
+                        id = source.id.toSourceId(),
                         name = source.name,
                         lang = source.lang
                     )

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/SmartDownloadTrigger.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/SmartDownloadTrigger.kt
@@ -8,8 +8,7 @@ import app.otakureader.domain.model.SmartDownloadRule
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.MangaRepository
-import app.otakureader.domain.repository.SourceRepository
-import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.downloadFolderNameFor
 import app.otakureader.core.common.di.ApplicationScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
@@ -33,7 +32,6 @@ class SmartDownloadTrigger @Inject constructor(
     private val mangaRepository: MangaRepository,
     private val chapterRepository: ChapterRepository,
     private val downloadRepository: DownloadRepository,
-    private val sourceRepository: SourceRepository,
     private val networkMonitor: NetworkMonitor,
     @param:ApplicationScope private val scope: CoroutineScope,
 ) {
@@ -73,7 +71,7 @@ class SmartDownloadTrigger @Inject constructor(
                 .filter { !it.read }
                 .take(rule.chaptersAhead)
 
-            val sourceName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
+            val sourceName = downloadFolderNameFor(manga.sourceId)
             for (chapter in toDownload) {
                 downloadRepository.enqueueChapter(
                     mangaId = mangaId,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/prefetch/AdaptiveChapterPrefetcher.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/prefetch/AdaptiveChapterPrefetcher.kt
@@ -5,6 +5,7 @@ import app.otakureader.domain.model.Chapter
 import app.otakureader.domain.model.PrefetchStrategy
 import app.otakureader.domain.model.ReadingBehavior
 import app.otakureader.domain.repository.ChapterRepository
+import app.otakureader.domain.repository.resolveSourceId
 import app.otakureader.feature.reader.model.ReaderPage
 import coil3.ImageLoader
 import coil3.request.ImageRequest
@@ -77,7 +78,8 @@ class AdaptiveChapterPrefetcher @Inject constructor(
      * @param strategy Prefetch strategy
      * @param behavior User reading behavior
      * @param scope Coroutine scope for launching prefetch jobs
-     * @param sourceId Source ID string for the manga (used to fetch page URLs)
+     * @param sourceKey The manga row's `sourceId` — a hashed key, resolved back to a real
+     *   source id inside the prefetch job. Null skips chapter prefetching.
      */
     fun prefetchAdjacentChapters(
         currentChapterId: Long,
@@ -87,29 +89,32 @@ class AdaptiveChapterPrefetcher @Inject constructor(
         strategy: PrefetchStrategy,
         behavior: ReadingBehavior,
         scope: CoroutineScope,
-        sourceId: String? = null
+        sourceKey: Long? = null
     ) {
         // Check if we should prefetch next chapter
         if (strategy.shouldPrefetchNextChapter(currentPage, totalPages, behavior)) {
-            prefetchNextChapter(currentChapterId, mangaId, scope, sourceId)
+            prefetchNextChapter(currentChapterId, mangaId, scope, sourceKey)
         }
 
         // Check if we should prefetch previous chapter
         if (strategy.shouldPrefetchPreviousChapter(currentPage, behavior)) {
-            prefetchPreviousChapter(currentChapterId, mangaId, scope, sourceId)
+            prefetchPreviousChapter(currentChapterId, mangaId, scope, sourceKey)
         }
     }
 
     /**
      * Prefetches the first few pages of the next chapter.
      */
-    private fun prefetchNextChapter(currentChapterId: Long, mangaId: Long, scope: CoroutineScope, sourceId: String?) {
+    private fun prefetchNextChapter(currentChapterId: Long, mangaId: Long, scope: CoroutineScope, sourceKey: Long?) {
         nextChapterPrefetchJob?.cancel()
 
-        if (sourceId == null) return
+        if (sourceKey == null) return
 
         nextChapterPrefetchJob = scope.launch {
             try {
+                // Resolving has to happen here rather than at the call site: it suspends, and
+                // the caller hands us the hashed key that the manga row stores.
+                val sourceId = sourceRepository.resolveSourceId(sourceKey) ?: return@launch
                 // Get all chapters for this manga
                 val chapters = chapterRepository.getChaptersByMangaIdSync(mangaId)
 
@@ -143,13 +148,16 @@ class AdaptiveChapterPrefetcher @Inject constructor(
     /**
      * Prefetches the last few pages of the previous chapter.
      */
-    private fun prefetchPreviousChapter(currentChapterId: Long, mangaId: Long, scope: CoroutineScope, sourceId: String?) {
+    private fun prefetchPreviousChapter(currentChapterId: Long, mangaId: Long, scope: CoroutineScope, sourceKey: Long?) {
         previousChapterPrefetchJob?.cancel()
 
-        if (sourceId == null) return
+        if (sourceKey == null) return
 
         previousChapterPrefetchJob = scope.launch {
             try {
+                // Resolving has to happen here rather than at the call site: it suspends, and
+                // the caller hands us the hashed key that the manga row stores.
+                val sourceId = sourceRepository.resolveSourceId(sourceKey) ?: return@launch
                 // Get all chapters for this manga
                 val chapters = chapterRepository.getChaptersByMangaIdSync(mangaId)
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderChapterLoaderDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderChapterLoaderDelegate.kt
@@ -6,6 +6,8 @@ import app.otakureader.domain.model.Manga
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.SourceRepository
+import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.resolveSourceId
 import app.otakureader.feature.reader.model.ReaderPage
 import app.otakureader.sourceapi.SourceChapter
 import javax.inject.Inject
@@ -70,7 +72,15 @@ class ReaderChapterLoaderDelegate @Inject constructor(
         manga: Manga,
         chapter: Chapter,
     ): List<ReaderPage> {
-        val sourceId = manga.sourceId.toString()
+        // Two different strings, deliberately. `sourceId` addresses the *source* and must be
+        // resolved back from the hashed key on the manga row; `downloadFolderName` addresses the
+        // *download directory*. They happened to be the same value while the resolution was
+        // broken, which is why one variable was doing both jobs — and why fixing the source
+        // lookup alone would have pointed the reader at a folder that does not exist.
+        val sourceId = checkNotNull(sourceRepository.resolveSourceId(manga.sourceId)) {
+            "Source not found for manga ${manga.id}"
+        }
+        val downloadFolderName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
         val sourceChapter = SourceChapter(
             url = chapter.url,
             name = chapter.name,
@@ -83,7 +93,7 @@ class ReaderChapterLoaderDelegate @Inject constructor(
                 index = index,
                 imageUrl = pageLoader.resolveUrl(
                     page.imageUrl.orEmpty(),
-                    sourceId,
+                    downloadFolderName,
                     manga.title,
                     chapter.name,
                     index,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderChapterLoaderDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderChapterLoaderDelegate.kt
@@ -6,7 +6,7 @@ import app.otakureader.domain.model.Manga
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.SourceRepository
-import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.downloadFolderNameFor
 import app.otakureader.domain.repository.resolveSourceId
 import app.otakureader.feature.reader.model.ReaderPage
 import app.otakureader.sourceapi.SourceChapter
@@ -47,10 +47,15 @@ class ReaderChapterLoaderDelegate @Inject constructor(
                 ?: return Result.NotFound("Chapter not found")
             val manga = mangaRepository.getMangaById(mangaId)
                 ?: return Result.NotFound("Manga not found")
+            // An extension can be uninstalled while its manga stay in the library, so this is a
+            // normal outcome rather than a fault — same shape as the two lookups above.
+            val sourceId = sourceRepository.resolveSourceId(manga.sourceId)
+                ?: return Result.NotFound("Source not found")
 
             val pages = fetchPagesFromSource(
                 manga = manga,
                 chapter = chapter,
+                sourceId = sourceId,
             )
             Result.Success(manga = manga, chapter = chapter, pages = pages)
         } catch (e: kotlinx.coroutines.CancellationException) {
@@ -71,16 +76,14 @@ class ReaderChapterLoaderDelegate @Inject constructor(
     private suspend fun fetchPagesFromSource(
         manga: Manga,
         chapter: Chapter,
+        sourceId: String,
     ): List<ReaderPage> {
-        // Two different strings, deliberately. `sourceId` addresses the *source* and must be
+        // Two different strings, deliberately. [sourceId] addresses the *source* and had to be
         // resolved back from the hashed key on the manga row; `downloadFolderName` addresses the
         // *download directory*. They happened to be the same value while the resolution was
         // broken, which is why one variable was doing both jobs — and why fixing the source
         // lookup alone would have pointed the reader at a folder that does not exist.
-        val sourceId = checkNotNull(sourceRepository.resolveSourceId(manga.sourceId)) {
-            "Source not found for manga ${manga.id}"
-        }
-        val downloadFolderName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
+        val downloadFolderName = downloadFolderNameFor(manga.sourceId)
         val sourceChapter = SourceChapter(
             url = chapter.url,
             name = chapter.name,

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDeleteAfterReadDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDeleteAfterReadDelegate.kt
@@ -7,8 +7,7 @@ import app.otakureader.domain.download.selectChapterToDeleteAfterRead
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.MangaRepository
-import app.otakureader.domain.repository.SourceRepository
-import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.downloadFolderNameFor
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
 
@@ -24,7 +23,6 @@ import kotlinx.coroutines.flow.first
 class ReaderDeleteAfterReadDelegate @Inject constructor(
     private val downloadPreferences: DownloadPreferences,
     private val downloadRepository: DownloadRepository,
-    private val sourceRepository: SourceRepository,
     private val chapterRepository: ChapterRepository,
     private val mangaRepository: MangaRepository,
 ) {
@@ -48,7 +46,7 @@ class ReaderDeleteAfterReadDelegate @Inject constructor(
                 slots = slots,
             )
         } ?: return
-        val downloadFolderName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
+        val downloadFolderName = downloadFolderNameFor(manga.sourceId)
         if (!downloadRepository.isChapterDownloaded(downloadFolderName, manga.title, chapter.name)) return
 
         downloadRepository.deleteChapterDownload(

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDownloadAheadDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDownloadAheadDelegate.kt
@@ -9,7 +9,7 @@ import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.SourceRepository
-import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.downloadFolderNameFor
 import app.otakureader.domain.repository.resolveSourceId
 import app.otakureader.core.preferences.DownloadPreferences
 import app.otakureader.sourceapi.Page
@@ -30,7 +30,7 @@ class ReaderDownloadAheadDelegate @Inject constructor(
 ) {
     suspend fun enqueueCurrentChapter(manga: Manga, chapter: Chapter): Boolean {
         val sourceIdString = sourceRepository.resolveSourceId(manga.sourceId) ?: return false
-        val downloadFolderName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
+        val downloadFolderName = downloadFolderNameFor(manga.sourceId)
         val existingDownloads = downloadRepository.observeDownloads().first()
         if (existingDownloads.any { it.chapterId == chapter.id }) return false
         if (downloadRepository.isChapterDownloaded(downloadFolderName, manga.title, chapter.name)) return false
@@ -39,7 +39,7 @@ class ReaderDownloadAheadDelegate @Inject constructor(
 
     suspend fun isChapterDownloaded(manga: Manga, chapter: Chapter): Boolean =
         downloadRepository.isChapterDownloaded(
-            sourceRepository.resolveDownloadFolderName(manga.sourceId),
+            downloadFolderNameFor(manga.sourceId),
             manga.title,
             chapter.name,
         )
@@ -69,7 +69,7 @@ class ReaderDownloadAheadDelegate @Inject constructor(
 
             val manga = getCurrentManga() ?: mangaRepository.getMangaById(mangaId) ?: return@launch
             val sourceIdString = sourceRepository.resolveSourceId(manga.sourceId) ?: return@launch
-            val downloadFolderName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
+            val downloadFolderName = downloadFolderNameFor(manga.sourceId)
             val existingDownloads = downloadRepository.observeDownloads().first()
 
             val endIndex = minOf(currentIndex + downloadAheadChapters, chapters.size - 1)

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDownloadAheadDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderDownloadAheadDelegate.kt
@@ -10,6 +10,7 @@ import app.otakureader.domain.repository.DownloadRepository
 import app.otakureader.domain.repository.MangaRepository
 import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.resolveSourceId
 import app.otakureader.core.preferences.DownloadPreferences
 import app.otakureader.sourceapi.Page
 import app.otakureader.sourceapi.SourceChapter
@@ -28,7 +29,7 @@ class ReaderDownloadAheadDelegate @Inject constructor(
     private val mangaRepository: MangaRepository,
 ) {
     suspend fun enqueueCurrentChapter(manga: Manga, chapter: Chapter): Boolean {
-        val sourceIdString = manga.sourceId.toString()
+        val sourceIdString = sourceRepository.resolveSourceId(manga.sourceId) ?: return false
         val downloadFolderName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
         val existingDownloads = downloadRepository.observeDownloads().first()
         if (existingDownloads.any { it.chapterId == chapter.id }) return false
@@ -67,7 +68,7 @@ class ReaderDownloadAheadDelegate @Inject constructor(
             if (currentIndex == -1 || currentIndex >= chapters.size - 1) return@launch
 
             val manga = getCurrentManga() ?: mangaRepository.getMangaById(mangaId) ?: return@launch
-            val sourceIdString = manga.sourceId.toString()
+            val sourceIdString = sourceRepository.resolveSourceId(manga.sourceId) ?: return@launch
             val downloadFolderName = sourceRepository.resolveDownloadFolderName(manga.sourceId)
             val existingDownloads = downloadRepository.observeDownloads().first()
 

--- a/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderPrefetchDelegate.kt
+++ b/feature/reader/src/main/java/app/otakureader/feature/reader/viewmodel/delegate/ReaderPrefetchDelegate.kt
@@ -65,7 +65,7 @@ class ReaderPrefetchDelegate @Inject constructor(
                         strategy = cachedPrefetchStrategy,
                         behavior = behavior,
                         scope = scope,
-                        sourceId = currentManga?.sourceId?.toString(),
+                        sourceKey = currentManga?.sourceId,
                     )
                 }
             } else {

--- a/feature/reader/src/test/java/app/otakureader/feature/reader/ReaderViewModelTest.kt
+++ b/feature/reader/src/test/java/app/otakureader/feature/reader/ReaderViewModelTest.kt
@@ -74,7 +74,17 @@ class ReaderViewModelTest {
     private val mangaId = 1L
     private val chapterId = 10L
     private val testSourceId = 99L
+
+    /**
+     * The download folder name, which is the numeric key and stays so — see
+     * `resolveDownloadFolderName`. Deliberately different from [testResolvedSourceId]: the two
+     * were the same string while source resolution was broken, and one variable was doing both
+     * jobs.
+     */
     private val testSourceIdString = testSourceId.toString()
+
+    /** What the source itself is called, i.e. what a source call has to be given. */
+    private val testResolvedSourceId = "2499283573021220255"
 
     private lateinit var context: Context
     private lateinit var mangaRepository: MangaRepository
@@ -613,12 +623,20 @@ class ReaderViewModelTest {
         coEvery { chapterRepository.updateChapterProgress(any<Long>(), any<Boolean>(), any<Int>()) } just runs
         coEvery { downloadRepository.isChapterDownloaded(any(), any(), any()) } returns true
         coEvery { downloadRepository.deleteChapterDownload(any(), any(), any(), any()) } just runs
-        // sourceRepository is a relaxed mock — an unstubbed getSource() call returns a relaxed
-        // Source mock (not null), whose .name resolves to "" instead of falling through to the
-        // numeric sourceId fallback that resolveDownloadFolderName() expects. Stub it explicitly
-        // so the folder name resolves to testSourceIdString, matching the other fixtures in this
-        // file that already do this for the same reason.
-        coEvery { sourceRepository.getSource(testSourceIdString) } returns null
+        stubSourceResolution()
+    }
+
+    /**
+     * Makes the fixture's [testSourceId] resolve to a real source.
+     *
+     * `sourceRepository` is a relaxed mock, so an unstubbed `getSourceByKey` returns a relaxed
+     * `MangaSource` whose `id` and `name` are both `""` — which is not null, so nothing falls
+     * through to a sensible default and every source call goes to the empty-string source.
+     */
+    private fun stubSourceResolution() {
+        coEvery { sourceRepository.getSourceByKey(testSourceId) } returns mockk(relaxed = true) {
+            every { id } returns testResolvedSourceId
+        }
     }
 
     // These exercise the live in-session path (the debounced auto-save in saveCurrentProgress(),
@@ -900,12 +918,10 @@ class ReaderViewModelTest {
         every { downloadPreferences.downloadAheadWhileReading } returns flowOf(1)
         every { downloadPreferences.downloadAheadOnlyOnWifi } returns flowOf(false)
         every { downloadRepository.observeDownloads() } returns flowOf(emptyList())
-        // No installed source for this fixture id, so the download folder name falls back to
-        // the numeric sourceId string, matching testSourceIdString below.
-        coEvery { sourceRepository.getSource(testSourceIdString) } returns null
+        stubSourceResolution()
         coEvery {
             sourceRepository.getPageList(
-                testSourceIdString,
+                testResolvedSourceId,
                 match { it.url == nextChapter.url && it.name == nextChapter.name }
             )
         } returns Result.success(
@@ -974,9 +990,10 @@ class ReaderViewModelTest {
         every { downloadPreferences.downloadAheadWhileReading } returns flowOf(1)
         every { downloadPreferences.downloadAheadOnlyOnWifi } returns flowOf(false)
         every { downloadRepository.observeDownloads() } returns flowOf(emptyList())
+        stubSourceResolution()
         coEvery {
             sourceRepository.getPageList(
-                testSourceIdString,
+                testResolvedSourceId,
                 match { it.url == nextChapter.url && it.name == nextChapter.name }
             )
         } returns Result.failure(IllegalStateException("Network failed"))

--- a/feature/reader/src/test/java/app/otakureader/feature/reader/ReaderViewModelTest.kt
+++ b/feature/reader/src/test/java/app/otakureader/feature/reader/ReaderViewModelTest.kt
@@ -77,7 +77,7 @@ class ReaderViewModelTest {
 
     /**
      * The download folder name, which is the numeric key and stays so — see
-     * `resolveDownloadFolderName`. Deliberately different from [testResolvedSourceId]: the two
+     * `downloadFolderNameFor`. Deliberately different from [testResolvedSourceId]: the two
      * were the same string while source resolution was broken, and one variable was doing both
      * jobs.
      */
@@ -285,7 +285,6 @@ class ReaderViewModelTest {
             deleteAfterReadDelegate = ReaderDeleteAfterReadDelegate(
                 downloadPreferences = downloadPreferences,
                 downloadRepository = downloadRepository,
-                sourceRepository = sourceRepository,
                 chapterRepository = chapterRepository,
                 mangaRepository = mangaRepository,
             ),

--- a/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
+++ b/feature/updates/src/main/java/app/otakureader/feature/updates/UpdatesViewModel.kt
@@ -7,9 +7,8 @@ import app.otakureader.core.preferences.GeneralPreferences
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.model.DownloadBlockedException
 import app.otakureader.domain.repository.DownloadRepository
-import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.repository.UpdateErrorRepository
-import app.otakureader.domain.repository.resolveDownloadFolderName
+import app.otakureader.domain.repository.downloadFolderNameFor
 import app.otakureader.domain.scheduler.LibraryUpdateScheduler
 import app.otakureader.domain.usecase.GetLastUpdateRunSummaryUseCase
 import app.otakureader.domain.usecase.GetLibraryMangaUseCase
@@ -41,7 +40,6 @@ class UpdatesViewModel @Inject constructor(
     private val downloadRepository: DownloadRepository,
     private val chapterRepository: ChapterRepository,
     private val libraryUpdateScheduler: LibraryUpdateScheduler,
-    private val sourceRepository: SourceRepository,
     private val updateErrorRepository: UpdateErrorRepository,
 ) : ViewModel() {
 
@@ -183,7 +181,7 @@ class UpdatesViewModel @Inject constructor(
                     chapterId = chapterId,
                     mangaTitle = update.manga.title,
                     chapterTitle = update.chapter.name,
-                    sourceName = sourceRepository.resolveDownloadFolderName(update.manga.sourceId)
+                    sourceName = downloadFolderNameFor(update.manga.sourceId)
                 )
             }.onSuccess {
                 _effect.send(UpdatesEffect.ShowSnackbar(
@@ -215,7 +213,7 @@ class UpdatesViewModel @Inject constructor(
                         chapterId = update.chapter.id,
                         mangaTitle = update.manga.title,
                         chapterTitle = update.chapter.name,
-                        sourceName = sourceRepository.resolveDownloadFolderName(update.manga.sourceId)
+                        sourceName = downloadFolderNameFor(update.manga.sourceId)
                     )
                 }.onSuccess { successCount++ }.onFailure { e ->
                     if (e is DownloadBlockedException) blockedByDataSaver = true
@@ -394,7 +392,7 @@ class UpdatesViewModel @Inject constructor(
                         mangaId = manga.id,
                         title = manga.title,
                         thumbnailUrl = manga.thumbnailUrl,
-                        sourceName = sourceRepository.resolveDownloadFolderName(manga.sourceId),
+                        sourceName = downloadFolderNameFor(manga.sourceId),
                         lastChecked = 0L
                     )
                 }

--- a/feature/updates/src/test/java/app/otakureader/feature/updates/UpdatesViewModelTest.kt
+++ b/feature/updates/src/test/java/app/otakureader/feature/updates/UpdatesViewModelTest.kt
@@ -9,7 +9,6 @@ import app.otakureader.domain.model.MangaStatus
 import app.otakureader.domain.model.MangaUpdate
 import app.otakureader.domain.repository.ChapterRepository
 import app.otakureader.domain.repository.DownloadRepository
-import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.repository.UpdateErrorRepository
 import app.otakureader.domain.scheduler.LibraryUpdateScheduler
 import app.otakureader.domain.usecase.GetLastUpdateRunSummaryUseCase
@@ -49,7 +48,6 @@ class UpdatesViewModelTest {
     private lateinit var downloadRepository: DownloadRepository
     private lateinit var chapterRepository: ChapterRepository
     private lateinit var libraryUpdateScheduler: LibraryUpdateScheduler
-    private lateinit var sourceRepository: SourceRepository
     private lateinit var updateErrorRepository: UpdateErrorRepository
     private lateinit var context: Context
 
@@ -77,7 +75,6 @@ class UpdatesViewModelTest {
         downloadRepository = mockk(relaxed = true)
         chapterRepository = mockk(relaxed = true)
         libraryUpdateScheduler = mockk(relaxed = true)
-        sourceRepository = mockk(relaxed = true)
         updateErrorRepository = mockk(relaxed = true) {
             every { observeErrors() } returns flowOf(emptyList())
         }
@@ -99,7 +96,6 @@ class UpdatesViewModelTest {
             downloadRepository,
             chapterRepository,
             libraryUpdateScheduler,
-            sourceRepository,
             updateErrorRepository,
         )
     }


### PR DESCRIPTION
Found while starting the feed source picker (#1251) — the picker hashes user-typed text into a source id, and chasing *why* that was wrong led here.

## The bug, in one line

A manga row stores `MangaSource.id.hashCode().toLong()`. Every read-back does `manga.sourceId.toString()`. **Hashing is one-way** — that string is the decimal of a hash, and it matches no source's id.

## What that means in practice

`SourceRepositoryImpl.getSource` is `_sources.value.find { it.id == sourceId }`, so the lookup misses, and `getPageList` / `getChapterList` return `Result.failure(IllegalArgumentException("Source not found: …"))`. That call pattern was in:

| Where | Symptom |
|---|---|
| `UpdateLibraryMangaUseCase` | library update finds no chapters, ever |
| `ReaderChapterLoaderDelegate` | reading any chapter that isn't already downloaded fails |
| `RecommendationRepositoryImpl` | candidate pool is always empty |
| `MigrateMangaUseCase` / `SearchMigrationTargetsUseCase` | migration can't reach the target source |
| `DetailsViewModel` ×7 | blank source name, no page thumbnails, no suggestions, broken tag→search |
| `AdaptiveChapterPrefetcher`, `ReaderDownloadAheadDelegate` | prefetch and download-ahead silently no-op |

Verified rather than assumed — a five-line `javac` probe over the three id shapes the app actually produces:

```
2499283573021220255 -> key -1874553621 -> reverse "-1874553621" matches id? false   (APK extension)
local               -> key   103145323 -> reverse "103145323"   matches id? false   (LocalSource)
en.mangadex         -> key  1639958408 -> reverse "1639958408"  matches id? false   (JS source)
```

**Browse was never affected**, which is why the app looked half-working: `Route.SourceListing.sourceId` is already a `String`, so browsing carries the real id and never goes through the key. Everything reached *from the library* went through it.

## The fix

Hashing can't be inverted, so the reverse has to be a search:

```kotlin
suspend fun getSourceByKey(key: Long): MangaSource?        // on SourceRepository
suspend fun SourceRepository.resolveSourceId(key: Long): String?
```

Every call site converted.

### Why `getSourceByKey` tries two rules

There were **three** conventions in the code for turning a source id into a `Long`, all live at once:

- `toSourceId()` — hash. `AddMangaToLibraryUseCase`, the main add-to-library path.
- `toLongOrNull()` — parse. `SourceMangaDetailViewModel`, reached by tapping a search result.
- the raw `ExtensionSource.id`. The library's icon map.

So whether a manga worked depended on which screen added it. Going forward everything writes the canonical `toSourceId()` key, but rows already on disk are just `Long`s — nothing records which rule wrote them, so a migration cannot separate them. `getSourceByKey` therefore tries the canonical rule and falls back to the parse, canonical first so a legacy match can't shadow a source that genuinely owns the key today. There's a test for exactly that collision.

## Four more instances of the same confusion, fixed here

- **Library source name and language** were keyed by `source.id.toLongOrNull()`, so `sourceName` was `""` for every entry — which is why "group by source" showed numbers.
- **Library source icons** were keyed by the raw `ExtensionSource.id`; the canonical key is that id *stringified and hashed* (`TachiyomiSourceAdapter.id` is `tachiyomiSource.id.toString()`). No entry ever matched, so no icons.
- **Migration** mapped every non-numeric source (`local`, every JS source) onto `0L`, so they collided on one `LazyColumn` key.
- **`isManhwa`** did `manga.sourceId.toString().lowercase().contains("webtoon")` — searching a decimal number for a word. The Manhwa tab was permanently empty.
- **`DownloadManager.resolvePageUrls`** passed `request.sourceName` — the download *folder* name — as a source id, so any download enqueued without page URLs resolved to an empty list and went straight to `FAILED`.

## What is deliberately *not* fixed

`resolveDownloadFolderName` used to be `getSource(sourceId.toString())?.name ?: sourceId.toString()`, with a KDoc promising the display name. It never resolved, so **every download on every device is filed under the number**.

Making it resolve now would point every download *read* at `Downloads/MangaDex/…` while the files sit in `Downloads/-1874553621/…` — chapters already on disk would vanish from the app. The broken lookup was load-bearing. It's now `= sourceId.toString()`, which is what it always did, with a KDoc that says so and a test asserting it consults *no* source, so nobody "fixes" it back by accident. Doing it properly is a filesystem migration: **#1256**.

The same trap bit `ReaderChapterLoaderDelegate`, where one variable was feeding both `getPageList` (wants a source id) and `PageLoader.resolveUrl` (wants a folder name). They were the same string only because resolution was broken; they're now two variables, so fixing #1256 later can't silently break the reader.

## Tests

New:
- `getSourceByKey` — finds the source that produced the key, for numeric and non-numeric ids; matches legacy parsed rows; prefers the canonical rule on collision; null when nothing owns the key. The first of those also asserts `getSource(key.toString())` **misses**, or it would prove nothing.
- `UpdateLibraryMangaUseCase` — asks by the resolved id, explicitly `coVerify(exactly = 0)` on the stringified key; fails when nothing owns the key.
- `SearchMigrationTargetsUseCase` — fails when the target key doesn't resolve.
- `resolveDownloadFolderName is the numeric key and consults no source`.

Rewritten, and worth flagging: `SourceRepositoryExtTest` previously asserted `resolveDownloadFolderName` returns the display name — and passed, because it stubbed `getSource("1943584017")` to return a source. Nothing in production ever registers a source under that id. A green test asserting behaviour the app has never had.

Each new guard was checked by mutation with `--rerun-tasks`: reverting the resolution, deleting the legacy pass, swapping the rule precedence, and making the folder name resolve again each fail exactly the test that names them.

`:app:assembleDebug`, `testDebugUnitTest`, `:domain:test`, `detekt`, `ktlintCheck` — all green.

`CLAUDE.md` gains a *Source Identity* section under Architecture and a new Common Bug Areas entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoEui2mCCcqArdhyQyFwnR)_

## Summary by Sourcery

Ensure library and reader flows resolve sources from the hashed Long keys stored on manga rows instead of stringified hashes, and document the two-step source identity model.

Bug Fixes:
- Fix source lookups that passed manga.sourceId.toString() by resolving the real string source id via getSourceByKey/resolveSourceId, restoring library updates, reading, migration, recommendations, and suggestions for library manga.
- Correct download page URL resolution to derive the source from the manga’s key rather than the download folder name, so downloads enqueued without page URLs can be resolved.
- Keep download folder names as the numeric key string to avoid orphaning existing on-disk downloads while clarifying this behavior in tests and docs.
- Fix library source name, language, icon, migration target ids, and manhwa detection by consistently keying on the canonical hashed source key instead of mixed raw/parsed ids, so grouping and UI filters behave correctly.

Enhancements:
- Add getSourceByKey and resolveSourceId helpers to bridge between hashed Long keys on manga rows and string source ids, including support for legacy rows written with numeric ids.
- Refine prefetching, download-ahead, migration, and worker logic to use resolved source ids and clearer separation between source ids and download folder names.
- Expand architecture docs with a Source Identity section and update common bug guidance around source-related issues.

Tests:
- Add comprehensive tests for getSourceByKey and resolveSourceId behavior, including legacy numeric rows and collision precedence.
- Strengthen tests for update-library, migration target search, download folder naming, reader behavior, library icons, and library updates to assert correct source resolution and to guard against regressions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the source key round-trip so library manga can reach their source again, centralizes the key rule, and restores reading, updates, migration, recommendations, prefetch, and download-ahead. Also stops recommending manga you already own while keeping download folders stable.

- **Bug Fixes**
  - Added `SourceRepository.getSourceByKey` and `resolveSourceId`; all call sites now resolve the real source id instead of passing a stringified hash.
  - Centralized key indexing in `associateBySourceKey`; `getSourceByKey` now delegates to it for one rule and consistent collision handling (canonical hash first, with legacy parse fallback).
  - Recommendations seed only from resolved sources, apply the cap after resolving, persist the canonical key, and exclude manga already in the user’s library.
  - `DownloadManager` resolves the source from the manga via `MangaDao` and uses the resolved id for page lists; downloads from an unresolvable source now move to FAILED instead of stalling; the folder name is never used as a source id.
  - `Reader` returns `Result.NotFound` when a source can’t be resolved and keeps source id separate from the download folder name.
  - Library source names, icons, migration lists, filters, and Manhwa tab detection now key off the canonical source key, fixing empty values and wrong grouping across the app.
  - Tests cover key reversal, collision precedence, recommendation seeding (including owned-manga exclusion), and assert the folder name is never used as a source id.

- **Migration**
  - No data migration. `downloadFolderNameFor` always returns the numeric key string to keep existing downloads visible; switching to display names is tracked in #1256.

<sup>Written for commit d82d59e5d87c3ba2513f6b0d1d191fb88e958c4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HeartlessVeteran2/Otaku-Reader/pull/1257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

