### PR TITLE
Run Mangayomi JavaScript extensions unmodified

### DIFF
--- a/.claude/skills/extension-system/SKILL.md
+++ b/.claude/skills/extension-system/SKILL.md
@@ -67,9 +67,16 @@ JsSource : MangaSource
 
 The prelude cannot be unit-tested from the JVM — QuickJS is an Android artifact. `JsPreludeTest` guards packaging and global names only. Behaviour is covered by `tools/js-prelude-harness/`, a Node harness reproducing `QuickJsHost.call`. Check a failing site with `curl` before suspecting the code.
 
-## APK extensions (`core/extension/`, `core/tachiyomi-compat/`) — retiring
+## APK extensions (`core/extension/`, `core/tachiyomi-compat/`) — partly retiring
 
-Still present, still loading; not where new work goes. `core/extension` also holds the shared `Extension`/`ExtensionSource` models the JavaScript path currently reuses, so those move before the module is deleted.
+Still present, still loading; not where new work goes.
+
+**Neither module can simply be deleted.** Both mix APK-only machinery with things the rest of the app depends on:
+
+- `core/extension` holds the `Extension`/`ExtensionSource`/`InstallStatus` models, the repository contracts, the blocklist and `JsExtensionBackend` — used by the JavaScript path and the browse UI.
+- `core/tachiyomi-compat` holds **`LocalSource`** (local manga folders — a shipped feature, wired into settings, navigation and preferences) and **`SourceHealthMonitor`** (which wraps *every* source call, JavaScript included), plus the `eu.kanade.tachiyomi.network` classes that `OtakuReaderApplication` initialises at startup.
+
+Extract those first, then delete the Tachiyomi `Source`/`CatalogueSource`/`HttpSource` surface and the loader. Confirm with `grep -rn "import eu\.kanade\.tachiyomi" --include=*.kt .` that the only remaining consumers live inside the retiring modules.
 
 The security properties that applied here still apply to the JavaScript path and are worth carrying forward:
 

--- a/.claude/skills/extension-system/SKILL.md
+++ b/.claude/skills/extension-system/SKILL.md
@@ -1,64 +1,82 @@
 # Extension System Patterns
 
-## Overview
-Extensions are the core value proposition — access to 2000+ manga sources. They are dynamically loaded APKs that implement interfaces from the `source-api` module.
+## Direction
 
-## Extension Types
-1. **Remote extensions** — Downloaded from Keiyoushi or Komikku repos
-2. **Private extensions** — Sideloaded by user, auto-trusted
-3. **Shared extensions** — Sideloaded but must pass `TrustedSignatureStore` validation
+**The APK backend is being retired. JavaScript sources from the Mangayomi ecosystem are the future.**
 
-## Key Interfaces
+This file previously documented only the Tachiyomi APK path and stated that its compatibility must never be broken. That rule is no longer in force — see the *Extension System* section of `CLAUDE.md`, which is the authority. Do not treat removal of APK code as a regression.
+
+It also described a `Source` interface that never existed in this repository. The real contract is `MangaSource`, below. Anything you remember from the old version of this file should be re-checked against the code.
+
+## The seam
+
+`MangaSource` (in `source-api/`) is the only source contract the rest of the app knows. The reader, library, downloads, migration and every domain use-case speak it, so a backend is **one implementation of one interface**.
+
 ```kotlin
-// Every extension implements this
-interface Source {
-    val id: Long
+interface MangaSource {
+    val id: String          // string id; Manga.sourceId is id.toSourceId() — one-way, see CLAUDE.md
     val name: String
     val lang: String
-    suspend fun getMangaList(page: Int, query: String?): MangasPage
-    suspend fun getMangaDetails(manga: Manga): Manga
-    suspend fun getChapterList(manga: Manga): List<Chapter>
-    suspend fun getPageList(chapter: Chapter): List<Page>
-}
+    val baseUrl: String
+    val isNsfw: Boolean
 
-// Extensions may also implement
-interface ConfigurableSource : Source {
-    fun setupPreferenceScreen(screen: PreferenceScreen)
-}
-```
-
-## Extension Loader Flow
-1. `ExtensionLoader` scans for APKs in extension directory
-2. Validates APK signature against `TrustedSignatureStore`
-3. Loads DEX and instantiates source classes via reflection
-4. Wraps in `Extension` model with metadata
-
-## Trust Model
-```kotlin
-// From ExtensionLoader
-when (val trustResult = checkTrust(apkFile)) {
-    is TrustResult.Trusted -> loadExtension()
-    is TrustResult.Untrusted -> markAsUntrusted() // User must approve
-    is TrustResult.NotInstalled -> showInstallPrompt()
+    suspend fun fetchPopularManga(page: Int): MangaPage
+    suspend fun fetchLatestUpdates(page: Int): MangaPage
+    suspend fun fetchSearchManga(page: Int, query: String, filters: FilterList): MangaPage
+    suspend fun fetchMangaDetails(manga: SourceManga): SourceManga
+    suspend fun fetchChapterList(manga: SourceManga): List<SourceChapter>
+    suspend fun fetchPageList(chapter: SourceChapter): List<Page>
 }
 ```
 
-## Extension API Versioning
-- `source-api` defines the contract
-- Extensions compiled against a specific API version
-- Forward compatibility maintained where possible
-- Breaking changes bump API version and require extension updates
+Check the actual file before relying on this — it is reproduced here for orientation, not as a spec.
 
-## Adding New Extension Features
-When modifying the extension system:
-1. Update `source-api` interfaces first
-2. Provide default implementations for backward compatibility
-3. Update `ExtensionLoader` to handle new metadata
-4. Test with both Keiyoushi and Komikku repo extensions
-5. Update extension API version if breaking
+## JavaScript sources (`core/js-runtime/`)
 
-## Security Rules
-- Never execute extension code on the main thread
-- Extension network calls go through app's OkHttp (respects user proxy/vpn)
-- Extension storage is sandboxed — they can't access app's internal data
-- Always validate signatures before loading — never trust unsigned shared extensions
+```
+Mangayomi extension (unmodified, from index.json)
+   │  new Client() / new Document(html) / doc.selectFirst(s)?.text
+   ▼
+prelude.js            ← compatibility layer, written in JavaScript on purpose
+   │  Client.get(...) / Document.parse(html) → integer handle
+   ▼
+QuickJsHost bindings  ← flat, primitives only
+   │  JsProtocol JSON over a process boundary
+   ▼
+JsSource : MangaSource
+```
+
+### Flow
+
+1. `JsExtensionRemoteDataSource` fetches the repository index — `/js/index.json` if served, otherwise `/index.json` (which is where Mangayomi publishes).
+2. Entries are filtered to manga, to `sourceCodeLanguage == 1` (JavaScript, not Dart), and to a non-blank `sourceCodeUrl`.
+3. `downloadScript` fetches the `.js` over HTTPS only, size-bounded.
+4. `JsSourceStore` writes manifest and script as **one document**, so a single atomic rename is the whole update.
+5. `QuickJsHost` evaluates the source config global, then `prelude.js`, then the script, then the invocation.
+
+### Rules
+
+- **Extensions run unmodified.** If a published source fails, the runtime is wrong, not the source.
+- **The compatibility layer stays in JavaScript.** Having Kotlin bindings hand objects to JS would defeat the isolation the handle design exists for.
+- **`MProvider` must exist before the script is evaluated** — `extends` resolves at class-definition time, so a missing base fails the whole script.
+- **Release every parsed document in a `finally`.** The pool caps at 32 and the host refuses rather than evicts.
+- **Preferences: stored wins, declared default (`getSourcePreferences()`) is the fallback.** Sources routinely read a preference nobody has set.
+- **Verify against real sources.** The Mangayomi contributing guide says `getLatest`; all 18 sampled published sources define `getLatestUpdates`.
+
+### Testing
+
+The prelude cannot be unit-tested from the JVM — QuickJS is an Android artifact. `JsPreludeTest` guards packaging and global names only. Behaviour is covered by `tools/js-prelude-harness/`, a Node harness reproducing `QuickJsHost.call`. Check a failing site with `curl` before suspecting the code.
+
+## APK extensions (`core/extension/`, `core/tachiyomi-compat/`) — retiring
+
+Still present, still loading; not where new work goes. `core/extension` also holds the shared `Extension`/`ExtensionSource` models the JavaScript path currently reuses, so those move before the module is deleted.
+
+The security properties that applied here still apply to the JavaScript path and are worth carrying forward:
+
+- Source code never runs on the main thread.
+- Source network calls go through the app's shared OkHttp client, so certificate pinning, the cookie jar, rate limiting and the user's proxy/VPN all apply.
+- Sources cannot reach app data. For JavaScript this is stronger than it was for APKs: a QuickJS context starts with no I/O at all, capability arrives only through the globals `QuickJsHost` installs, and the sidecar process runs under a permission-less UID.
+
+## Before removing the APK path
+
+Read *Source Identity → The backend switch runs straight into this* in `CLAUDE.md`. Mangayomi ids are not Tachiyomi ids and `Manga.sourceId` is a one-way hash, so every library row would point at a source that no longer exists. A guided migration (reusing `feature/migration/`) and a resolution for orphaned downloads (#1256) must ship with the removal, not after it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,11 @@ This file is the AI assistant reference for the Otaku Reader codebase. Read it b
 
 ## What This Project Is
 
-Otaku Reader is a production-grade Android manga reader built entirely in Kotlin and Jetpack Compose by a solo developer. It is a clean-architecture alternative to Mihon/Tachiyomi that inherits the Tachiyomi extension ecosystem. The app is feature-complete: all 35 parity issues, the hardening batch, and the post-beta polish pass have shipped.
+Otaku Reader is a production-grade Android manga reader built entirely in Kotlin and Jetpack Compose by a solo developer. It is a clean-architecture alternative to Mihon/Tachiyomi. The feature set is complete: all 35 parity issues, the hardening batch, and the post-beta polish pass have shipped.
 
-**Status:** All phases shipped. Alpha (2026-05-25) → Beta parity (#926–#958) → Hardening (#1090–#1099) → P3 polish (#1114) → Post-P3 additions: QR library sharing (#1110/#1125), update-errors screen (#1119), stats improvements (#1122), in-chapter download button (#1127), page bookmarks + collections (PR #1130, merged 2026-06-20) → Komikku-parity deferred-gaps batch (issue #1192, 7 PRs #1197/#1202–#1207, merged 2026-07-05 → 2026-07-06 — statistics Trackers card, settings wiring batch, keep-last-N delete-after-read, onboarding storage step, dedicated Update Errors screen, configurable migration options + custom-cover migration, selective backup/restore; remaining deferred items spun out to #1208). **Current phase: cutting v1.0.0 release tag.** Project website: https://heartless-veteran.github.io/Otaku-Reader/ — VitePress landing page, download with live version lookup, docs, FAQ, auto-synced changelog. Deployed from `website/` via `pages.yml`.
+**The source system is mid-rebuild.** The app is moving off dynamically-loaded Tachiyomi APK extensions and onto **JavaScript sources from the Mangayomi ecosystem**, run by QuickJS in an isolated sidecar process. This is the single largest active change in the codebase and it reverses a rule this file previously called non-negotiable — read *Extension System* before touching anything source-related.
+
+**Status:** All phases shipped. Alpha (2026-05-25) → Beta parity (#926–#958) → Hardening (#1090–#1099) → P3 polish (#1114) → Post-P3 additions: QR library sharing (#1110/#1125), update-errors screen (#1119), stats improvements (#1122), in-chapter download button (#1127), page bookmarks + collections (PR #1130, merged 2026-06-20) → Komikku-parity deferred-gaps batch (issue #1192, 7 PRs #1197/#1202–#1207, merged 2026-07-05 → 2026-07-06 — statistics Trackers card, settings wiring batch, keep-last-N delete-after-read, onboarding storage step, dedicated Update Errors screen, configurable migration options + custom-cover migration, selective backup/restore; remaining deferred items spun out to #1208). **Current phase: the JavaScript source-system rebuild (see *Extension System*). The v1.0.0 tag waits on it** — cutting a 1.0 on the APK backend that is about to be removed would ship a release whose sources stop working on the next update. Project website: https://heartless-veteran.github.io/Otaku-Reader/ — VitePress landing page, download with live version lookup, docs, FAQ, auto-synced changelog. Deployed from `website/` via `pages.yml`.
 
 **The developer is newer to Kotlin. Always explain what was wrong and why a fix works — never drop solutions without context.**
 
@@ -21,20 +23,24 @@ Otaku-Reader/
 ├── app/                    # Application entry point, Navigation host, Widgets, DI root
 ├── domain/                 # Pure business logic — UseCases, Repository interfaces
 ├── data/                   # Repository implementations, WorkManager workers, Backup/Sync
-├── source-api/             # Tachiyomi extension API contracts (pure Kotlin/Java interfaces)
-├── server/                 # Self-hosted Ktor sync server (optional, separate repo)
+├── source-api/             # The MangaSource contract every backend implements (pure Kotlin)
 ├── baselineprofile/        # Baseline profile generation for app startup performance
 ├── website/                # VitePress project site, deployed to GitHub Pages by pages.yml
 ├── build-logic/            # Gradle convention plugins
+├── tools/
+│   ├── extension-smoke-test/   # Live-network source loading check (manual only, never gates a PR)
+│   └── js-prelude-harness/     # Node harness running real JS extensions against prelude.js
 ├── core/
 │   ├── common/             # Shared utilities, Palette API, coroutine helpers
-│   ├── database/           # Room entities, DAOs, migrations (current schema v42)
+│   ├── database/           # Room entities, DAOs, migrations (current schema v45)
 │   ├── network/            # OkHttp + Retrofit + Kotlinx Serialization setup
 │   ├── preferences/        # DataStore preferences, encrypted credential storage
 │   ├── ui/                 # Shared Compose components, Material 3 theme, Coil integration
 │   ├── navigation/         # Type-safe Compose Navigation routing
-│   ├── extension/          # Dynamic APK classloading for Tachiyomi extensions
-│   ├── tachiyomi-compat/   # RxJava 1.x stubs and Tachiyomi interface bridges
+│   ├── js-runtime/         # JavaScript sources: QuickJS sidecar, JsProtocol, prelude.js  ← the future
+│   ├── webview/            # WebView host (Cloudflare challenges, OAuth flows)
+│   ├── extension/          # APK classloading — RETIRING, see Extension System
+│   ├── tachiyomi-compat/   # RxJava 1.x stubs — RETIRING, see Extension System
 │   └── discord/            # Discord Rich Presence (native, no external library)
 └── feature/
     ├── library/            # Main manga collection, categories, filtering
@@ -51,8 +57,11 @@ Otaku-Reader/
     ├── about/              # About screen, credits, version info
     ├── opds/               # OPDS catalog support (Komga/Kavita)
     ├── feed/               # Recommendations and activity feed
+    ├── webview/            # WebView screen (Cloudflare challenges, tracker OAuth)
     └── more/               # Bottom nav "More" section
 ```
+
+There is **no `server/` module** in this repository. It was listed here for a long time and does not exist — the self-hosted Ktor sync server lives in its own repo.
 
 ---
 
@@ -125,7 +134,7 @@ Otaku-Reader/
 - Auto-update schedule: interval, wifi-only
 - Tracker auth management
 - Extension management (install/uninstall/trust)
-- Backup: export and import (native format + Tachiyomi import), with selective per-category backup/restore (`BackupOptions`, PR #1207)
+- Backup: export and import (native format + Tachiyomi import), with selective per-category backup/restore (`BackupOptions`, PR #1207). `BackupData` is plain versioned JSON (currently v4), which is why it is also the app's data-portability story — anything that needs to read a user's library outside this codebase reads that, not the Room database. **Tachiyomi import carries the same source-id hazard as the backend switch**: an imported backup names Tachiyomi sources, so once the APK path is gone those entries land pointing at sources that do not exist and need the same migration recourse (see *Source Identity*).
 
 ### More tab (`feature/more/`)
 - Bookmarks screen: page-level bookmarks, collection filtering, multi-select, export (PR #1130)
@@ -217,6 +226,15 @@ Two things are deliberately *not* this key:
 - **`Route.SourceListing.sourceId`** is already the string id. Browse never went through the key,
   which is why browsing worked while reading from the library did not.
 
+#### The backend switch runs straight into this
+
+Retiring the APK backend is **not** a code-only change, and this is the section that says why. A Mangayomi source's id is not its Tachiyomi equivalent, and `Manga.sourceId` is `id.hashCode().toLong()` — one-way. So on the day the APK sources go, **every existing library row points at a source that no longer exists**, which reproduces the exact "Source not found" failure described above, across the entire library at once, for every user.
+
+Two things must ship *with* the removal, not after it:
+
+- **A guided library migration.** Reuse `feature/migration/` — the wizard already does source-to-source entry migration. This is the recourse; do not write a new one.
+- **A decision on downloads.** `downloadFolderNameFor(sourceId)` files every downloaded chapter under the numeric key, so re-pointing an entry at a new source orphans its files on disk. Tracked as #1256; it has to be resolved as part of this work.
+
 ### Clean Architecture Layer Rules
 
 | Layer | Contains | Rules |
@@ -244,20 +262,50 @@ Two things are deliberately *not* this key:
 - Migrations must be explicit. **Never use `fallbackToDestructiveMigration()` in production.**
 - Entities are separate from domain models. Always write and use mapper functions.
 - For DAO tests, use in-memory Room databases. **Migrations are tested with `MigrationTestHelper`** in `core/database/src/test/.../DatabaseMigrationTest.kt` — this file used to say not to, which was simply wrong about the code. `runMigrationsAndValidate` against the exported schema is the assertion that catches a column-type mismatch, and that class of bug fails *only on upgrade*, never on a fresh install.
-- Current schema version: **v44** (adds `relations` and `externalLinks` to `manga_metadata`, same JSON-text encoding as v43. Relations are filtered to `type == MANGA` at the mapper boundary — AniList returns anime adaptations among a manga's relations and this app has no anime surface, so such a tile could only do nothing when tapped. External links are filtered to `http`/`https` **twice**: once in the repository, deciding what is worth caching, and again in `ExternalLinkChips` before a URL becomes an Intent, because a row cached by an older build or restored from a backup never passed through today's mapper.) v43 added `characters` and `staff` to `manga_metadata` — the cast and credits carousels. Stored as **JSON text via a `kotlinx.serialization` TypeConverter**, not as the parallel delimited columns the tag fields use: a person has four fields and there are two such lists, so the delimited encoding would mean eight columns and eight chances for the length invariant to slip. `DatabaseConverters.fromPersonList` returns an empty list on a parse failure rather than throwing — safe *only* because this table is a disposable cache with a re-fetchable upstream; do not copy that to a table that owns its data. Both columns declare `@ColumnInfo(defaultValue = "[]")`, which must match the migration's `DEFAULT '[]'` or Room's validation fails on upgrade only.) v42 added `manga_anilist_link` — which AniList media a manga is, keyed by `mangaId`, `ON DELETE CASCADE` from `manga`, with a `userConfirmed` flag that auto-matching must never overwrite). Deliberately a second table rather than reusing `manga_metadata.anilistId`: the metadata row is a disposable 7-day cache — a fetch overwrites it wholesale, and one happens as soon as it goes stale or the AniList id changes — and a user's manual correction has to outlive it. v41 added `manga_metadata` — cached AniList metadata for the details screen, keyed by `mangaId`, `ON DELETE CASCADE` from `manga`, refreshed against a 7-day TTL). v40 added `update_errors` (per-manga current-unresolved library update failures, keyed by `mangaId`, replaced on each new failure and cleared on the manga's next successful update).
+- Current schema version: **v45** (dedupes `feed_items` and adds a unique index on `(mangaId, chapterId)`, from #1253. The dedupe has to run *before* the index is created or the `CREATE UNIQUE INDEX` fails on any database that already holds duplicate rows — which is every database that ran a library update under the previous build. Note the interaction with `FeedBuilderBottomSheet` described under the Feed screen: `insertFeedSource` is `OnConflictStrategy.REPLACE` against a unique index, so a re-add silently resets the user's row.) v44 added `relations` and `externalLinks` to `manga_metadata`, same JSON-text encoding as v43. Relations are filtered to `type == MANGA` at the mapper boundary — AniList returns anime adaptations among a manga's relations and this app has no anime surface, so such a tile could only do nothing when tapped. External links are filtered to `http`/`https` **twice**: once in the repository, deciding what is worth caching, and again in `ExternalLinkChips` before a URL becomes an Intent, because a row cached by an older build or restored from a backup never passed through today's mapper.) v43 added `characters` and `staff` to `manga_metadata` — the cast and credits carousels. Stored as **JSON text via a `kotlinx.serialization` TypeConverter**, not as the parallel delimited columns the tag fields use: a person has four fields and there are two such lists, so the delimited encoding would mean eight columns and eight chances for the length invariant to slip. `DatabaseConverters.fromPersonList` returns an empty list on a parse failure rather than throwing — safe *only* because this table is a disposable cache with a re-fetchable upstream; do not copy that to a table that owns its data. Both columns declare `@ColumnInfo(defaultValue = "[]")`, which must match the migration's `DEFAULT '[]'` or Room's validation fails on upgrade only.) v42 added `manga_anilist_link` — which AniList media a manga is, keyed by `mangaId`, `ON DELETE CASCADE` from `manga`, with a `userConfirmed` flag that auto-matching must never overwrite). Deliberately a second table rather than reusing `manga_metadata.anilistId`: the metadata row is a disposable 7-day cache — a fetch overwrites it wholesale, and one happens as soon as it goes stale or the AniList id changes — and a user's manual correction has to outlive it. v41 added `manga_metadata` — cached AniList metadata for the details screen, keyed by `mangaId`, `ON DELETE CASCADE` from `manga`, refreshed against a 7-day TTL). v40 added `update_errors` (per-manga current-unresolved library update failures, keyed by `mangaId`, replaced on each new failure and cleared on the manga's next successful update).
 - **SQLite cannot `DROP COLUMN`** — to remove a column, CREATE TABLE new → INSERT INTO SELECT (omit removed column) → DROP TABLE old → RENAME new. When child tables have FK references to the table being recreated, wrap the entire block with `PRAGMA foreign_keys = OFF` (before) and `PRAGMA foreign_keys = ON` (after) to prevent `SQLITE_CONSTRAINT_FOREIGNKEY` on the DROP step.
 
 ---
 
-## Extension System — Non-Negotiable
+## Extension System — Being Rebuilt on JavaScript
 
-**Tachiyomi extension compatibility must never be broken.**
+**The APK backend is being retired. JavaScript sources are the future of this app, and the target ecosystem is Mangayomi.**
 
-Extensions load dynamically as APKs with classloader isolation. The interfaces in `source-api/` and `core/tachiyomi-compat/` must match the Tachiyomi/Mihon extension API exactly — this gives Otaku Reader access to 500+ community-maintained sources without any changes to those extensions.
+This reverses what this file said until 2026-08-17. The old rule — *"Tachiyomi extension compatibility must never be broken"* — is **no longer in force**. It was removed deliberately, not by accident. Do not reinstate it, and do not treat the removal of APK code as a regression to revert.
 
-- Do not modify interface signatures in `source-api/`.
-- Do not change or remove the Tachiyomi RxJava 1.x stubs in `core/tachiyomi-compat/`.
-- Reference the Komikku fork in the same GitHub org when uncertain about the extension API.
+### Why the direction changed
+
+Mangayomi publishes its sources in **both JavaScript and Dart** (`/javascript` and `/dart` in `kodjodevf/mangayomi-extensions`, with separate contributing guides). The JavaScript half needs no Dart runtime, so Kotlin can consume it directly — no Flutter port, no `d4rt`, no platform channel. That makes a single cross-backend source model reachable without giving up the language the app is written in.
+
+### The seam
+
+`MangaSource` (in `source-api/`) is the only contract the rest of the app knows. The reader, library, downloads, migration and every domain use-case speak it, so **a backend is one implementation of one interface**, not a change to any of them. `source-api/` stays. It is no longer "the Tachiyomi API" — it is this app's own source contract.
+
+### Current state
+
+| Module | Status |
+|---|---|
+| `core/js-runtime/` | **The backend going forward.** QuickJS in a sidecar process, behind the `JsProtocol` JSON wire format. |
+| `source-api/` | **Keep.** The `MangaSource` seam. |
+| `core/extension/` | Retiring — APK loader, classloader, signature verifier, trust store, install receiver (~4,200 LOC). Still holds the shared `Extension`/`ExtensionSource` models the JS path uses; those move before the module goes. |
+| `core/tachiyomi-compat/` | Retiring — RxJava 1.x stubs (~3,450 LOC). Nothing but the APK path uses these. |
+
+### Rules for the JavaScript backend
+
+- **Extensions run unmodified.** Anything a published Mangayomi source needs is the app's job to provide, not the source's job to change. If a real source fails, fix the runtime.
+- **`prelude.js` is the compatibility layer**, and it is written in JavaScript on purpose. `QuickJsHost` installs flat, primitives-only bindings so no host object reference ever crosses into JS; extensions expect an object API (`new Client()`, `new Document(html)`, `doc.selectFirst(s)?.text`). Rebuilding that in JS keeps the isolation property. **Do not "simplify" this by having the Kotlin bindings hand out objects** — that trades the boundary away for the same result.
+- **`MProvider` must exist before the extension script is evaluated.** Extensions name it in an `extends` clause, which resolves at class-definition time, so its absence fails the entire script rather than one method. This was broken for the whole life of the JS backend: `buildInvocation` referenced `MProvider` in a comment and nothing ever defined it.
+- **Release every parsed document.** The handle pool caps at 32 and the host *refuses* rather than evicts. A selector that returns without releasing only fails against a page with enough rows to exhaust the pool, which is exactly the size of input a test does not use.
+- **Preferences: stored value wins, declared default is the fallback.** Sources read preferences the user has never set — a mirror or base-URL override is near-universal — and ship the working value as that preference's declared default in `getSourcePreferences()`. Reading the declared default lazily (rather than seeding a copy at install) is what lets a source's *updated* default reach a user who never touched the setting.
+- **Verify against real sources, not against the docs.** The Mangayomi contributing guide documents `getLatest`; every one of 18 sampled published sources defines `getLatestUpdates`. See the harness below.
+
+### Testing the JavaScript runtime
+
+The prelude **cannot be unit-tested from the JVM** — QuickJS ships as an Android artifact, so there is no engine to evaluate it in. `JsPreludeTest` therefore only guards packaging and the published global names.
+
+Behaviour is covered by **`tools/js-prelude-harness/`**, a Node harness that reproduces `QuickJsHost.call` exactly (same binding signatures, same handle discipline, same 32-document cap, cheerio in place of Jsoup) and runs real extensions off the live index. It is deliberately not a Gradle module and never gates a PR, because it needs live network and third-party sites.
+
+When a source misbehaves, **check the site with `curl` before suspecting this code.** In the sweep that validated the layer, every hard failure was external: a Cloudflare interstitial, a site that had moved domain since its extension was published, an upstream error, and a proxy block.
 
 ---
 
@@ -473,8 +521,12 @@ These are not hypotheticals. Each one shipped in this repo, passed local tests, 
 | "Writing the manifest last means a half-finished install is invisible" | True for a fresh install, false for an update — where both files already exist |
 | A test docstring: "locks the precedence rule down" | The test would have passed with the rule inverted |
 | "Per-source scoping is a security boundary" | Those credentials were written to disk in cleartext |
+| "The extension declares `class DefaultExtension extends MProvider`" | `MProvider` was never defined anywhere — the comment was the only mention of it in the repository, so every extension failed at script evaluation |
+| "Mirrors the Mangayomi index shape… those sources work here unmodified" | The field *names* matched; `id` and `itemType` were numbers where the DTO wanted strings, and nothing read `sourceCodeLanguage`, so the index decoded to nothing or fed Dart files to a JavaScript engine |
 
 **The check:** after writing a comment that asserts a property, re-read the code as if you had not written it and ask whether it actually has that property in *every* path — not just the one you had in mind. If the comment says "always" or "never", find the case where it doesn't.
+
+**A sharper version of the same check, learned from the two rows above:** when a comment claims compatibility with something external — an index format, an extension API, a published contract — go and read the external thing. Both of those claims were written by someone reasoning about the format from memory, and both were *nearly* right, which is why they survived review. Fetching the actual `index.json` and 18 actual extensions took minutes and falsified both. See also checklist item 4.
 
 ### 2. Single-threaded reasoning about concurrent code
 
@@ -501,7 +553,7 @@ A claim about a library's published versions was taken from a search API that on
 1. **Hilt binding errors** — Missing `@Provides`, wrong scope, missing `@InstallIn`. Check the DI module before assuming the ViewModel is wrong.
 2. **Room DAO not connected** — DAO not injected into repo, repo not injected into UseCase. Trace the chain.
 3. **MVI state not updating UI** — `StateFlow` not collected in Compose, or reducer emitting same reference. Use `copy()`.
-4. **Extension loader failures** — ClassLoader issue, missing permission, or interface mismatch with Tachiyomi API.
+4. **JavaScript source failures** — check the site with `curl` first; most are Cloudflare, a moved domain, or the site being down. Then check, in order: is `MProvider` defined (a missing global fails the whole script, not one method); is the source reading a preference nobody set (declared defaults come from `getSourcePreferences()`); did a selector path leak a document handle. Reproduce with `tools/js-prelude-harness/`. *(APK loader failures — ClassLoader, permissions, interface mismatch — still exist while `core/extension` does, but that path is being removed and is not where new work goes.)*
 5. **"Source not found" for a library manga** — someone passed `manga.sourceId.toString()` where a source id was wanted. Use `getSourceByKey` / `resolveSourceId`. See *Source Identity* above.
 6. **Gradle dependency conflicts** — Version mismatches between Compose BOM, Kotlin, Hilt, or KSP. Check `libs.versions.toml` first.
 7. **Navigation crashes** — Missing destination, wrong argument type in NavGraph, or missing `@Serializable` on route class.
@@ -527,7 +579,9 @@ A claim about a library's published versions was taken from a search API that on
 
 ## What NOT To Do
 
-- **Do not break Tachiyomi extension compatibility** — this is the most critical constraint.
+- **Do not reinstate the Tachiyomi APK backend.** This used to be the most critical constraint in this file and is now the opposite: the APK path is being retired in favour of JavaScript sources. See *Extension System*.
+- **Do not edit an extension to make it work.** Published sources run unmodified; a failure is the runtime's to fix.
+- **Do not let the Kotlin JS bindings hand host objects to JavaScript** — the compatibility layer belongs in `prelude.js`, which is what keeps the boundary primitives-only.
 - **Do not implement AI features in core** — AI features belong in the separate Otaku-Reader-AI repo.
 - **Do not add Firebase analytics or crash tooling** unless explicitly requested.
 - **Do not use `fallbackToDestructiveMigration()`** in Room database setup.
@@ -553,6 +607,8 @@ A claim about a library's published versions was taken from a search API that on
 
 CodeQL runs through GitHub's **default setup** — there is no workflow file for it, so a failing `Analyze (java-kotlin)` check cannot be debugged from `.github/workflows/`.
 
+**Third-party checks that are not gates.** A PR also shows `CodeFactor`, `sourcery-ai` and `submit-gradle`, none of which come from `.github/workflows/` and none of which are required. CodeFactor in particular reports issue *counts* on the check and renders the detail only in a client-side page, so its findings cannot be read from the API — open the linked page in a browser. Do not block on these; the required set is the `ci.yml` jobs listed above.
+
 **Removed (do not re-add):**
 - `build.yml` and `build_preview.yml` both ran `assembleDebug`, so every PR built the app three times for one artifact. That work is consolidated into `ci.yml`'s `assemble` job, which also posts the preview-APK comment (updating it in place instead of adding one per push).
 - `label.yml` — low value, and it used the `pull_request_target` trigger, which runs with a write-scoped token against untrusted fork code.
@@ -570,7 +626,17 @@ CI uses JDK 21. Gradle setup/caching is handled by `gradle/actions/setup-gradle`
 
 - Solo developer, veteran background, newer to Kotlin — explain fixes, don't just drop code.
 - Multi-agent workflow: Claude (architecture + debugging), Copilot (day-to-day), Gemini Code Assist, Kimi Claw (bulk GitHub tasks).
-- **Current priority: the source-system rebuild + AniList metadata backbone.** Stage 5a (AniList tracker correctness) shipped in #1232/#1234/#1235/#1236; Stage 5b is in progress. The v1.0.0 tag waits on that work.
+- **Current priority: the JavaScript source-system rebuild.** The AniList metadata backbone is done — Stage 5a shipped in #1232/#1234/#1235/#1236, and the details-screen metadata layer in #1238–#1250. The v1.0.0 tag waits on the source rebuild.
+
+  Where it stands:
+
+  | Milestone | State |
+  |---|---|
+  | 1. Run Mangayomi JS extensions unmodified | Shipped — PR #1262 (`prelude.js`, `MProvider`, real-index decoding, declared preference defaults) |
+  | 2. Retire `core/extension` + `core/tachiyomi-compat` | Not started (~7,700 LOC to remove) |
+  | 3. Library migration + the downloads decision (#1256) | Not started — **must ship with milestone 2**, see *Source Identity* |
+
+  Milestone 1 is verified against real sources but is not the same as "the ecosystem works": only ~114 of the 363 entries in the Mangayomi index are JavaScript. Source coverage relative to the current APK set is an open question and should be measured before milestone 2 commits.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,8 +287,20 @@ Mangayomi publishes its sources in **both JavaScript and Dart** (`/javascript` a
 |---|---|
 | `core/js-runtime/` | **The backend going forward.** QuickJS in a sidecar process, behind the `JsProtocol` JSON wire format. |
 | `source-api/` | **Keep.** The `MangaSource` seam. |
-| `core/extension/` | Retiring — APK loader, classloader, signature verifier, trust store, install receiver (~4,200 LOC). Still holds the shared `Extension`/`ExtensionSource` models the JS path uses; those move before the module goes. |
-| `core/tachiyomi-compat/` | Retiring — RxJava 1.x stubs (~3,450 LOC). Nothing but the APK path uses these. |
+| `core/extension/` | **Partly** retiring — the APK loader, classloader, signature verifier, trust store, installer and install receiver go. It also holds the `Extension`/`ExtensionSource`/`InstallStatus` models, the `ExtensionRepository`/`ExtensionRepoRepository` contracts, the blocklist and the `JsExtensionBackend` interface — **all of which the JavaScript path and the browse UI use**. Those stay; gut the module rather than deleting it. |
+| `core/tachiyomi-compat/` | **Partly** retiring. The `eu.kanade.tachiyomi.source.*` surface (the Tachiyomi `Source`/`CatalogueSource`/`HttpSource` API and its RxJava-facing models) and the `compat/Tachiyomi*Adapter` classes go with the APK loader. **Three things in it must survive and be extracted first** — see below. |
+
+#### What must be extracted before either module is deleted
+
+An earlier version of this table said "nothing but the APK path uses these". That was wrong, and deleting on that basis would have removed a shipped feature:
+
+| Survivor | Currently at | Why it stays |
+|---|---|---|
+| `LocalSource` | `core/tachiyomi/local/` | **Local manga folders — a shipped feature.** Wired into `feature/settings` (`LocalSourceBrowserScreen`), `core/navigation` (`Route`), `core/preferences` (`LocalSourcePreferences`) and the app's NavHost. Nothing to do with APKs. |
+| `SourceHealthMonitor` | `core/tachiyomi/health/` | `SourceRepositoryImpl` routes **every** source call through it, JavaScript included — `JsSource`'s own comment relies on this for hung or broken scripts. |
+| `eu.kanade.tachiyomi.network.*` | `NetworkHelper`, `RateLimitInterceptor`, `AndroidCookieJar`, progress bodies | `OtakuReaderApplication` initialises `NetworkHelper` at startup. Check each class for live use before assuming it goes with the APK path. |
+
+So the sequence is **extract, then delete** — never delete first. Verify with `grep -rn "import eu\.kanade\.tachiyomi" --include=*.kt .` and confirm the only remaining consumers are inside the two retiring modules.
 
 ### Rules for the JavaScript backend
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,9 +296,9 @@ An earlier version of this table said "nothing but the APK path uses these". Tha
 
 | Survivor | Currently at | Why it stays |
 |---|---|---|
-| `LocalSource` | `core/tachiyomi/local/` | **Local manga folders — a shipped feature.** Wired into `feature/settings` (`LocalSourceBrowserScreen`), `core/navigation` (`Route`), `core/preferences` (`LocalSourcePreferences`) and the app's NavHost. Nothing to do with APKs. |
-| `SourceHealthMonitor` | `core/tachiyomi/health/` | `SourceRepositoryImpl` routes **every** source call through it, JavaScript included — `JsSource`'s own comment relies on this for hung or broken scripts. |
-| `eu.kanade.tachiyomi.network.*` | `NetworkHelper`, `RateLimitInterceptor`, `AndroidCookieJar`, progress bodies | `OtakuReaderApplication` initialises `NetworkHelper` at startup. Check each class for live use before assuming it goes with the APK path. |
+| `LocalSource` | `core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/local/` | **Local manga folders — a shipped feature.** Wired into `feature/settings` (`LocalSourceBrowserScreen`), `core/navigation` (`Route`), `core/preferences` (`LocalSourcePreferences`) and the app's NavHost. Nothing to do with APKs. |
+| `SourceHealthMonitor` | `core/tachiyomi-compat/src/main/java/app/otakureader/core/tachiyomi/health/` | `SourceRepositoryImpl` routes **every** source call through it, JavaScript included — `JsSource`'s own comment relies on this for hung or broken scripts. |
+| `eu.kanade.tachiyomi.network.*` | `core/tachiyomi-compat/src/main/java/eu/kanade/tachiyomi/network/` — `NetworkHelper`, `RateLimitInterceptor`, `AndroidCookieJar`, progress bodies | `OtakuReaderApplication` initialises `NetworkHelper` at startup. Check each class for live use before assuming it goes with the APK path. |
 
 So the sequence is **extract, then delete** — never delete first. Verify with `grep -rn "import eu\.kanade\.tachiyomi" --include=*.kt .` and confirm the only remaining consumers are inside the two retiring modules.
 

--- a/core/extension/src/main/java/app/otakureader/core/extension/domain/model/Extension.kt
+++ b/core/extension/src/main/java/app/otakureader/core/extension/domain/model/Extension.kt
@@ -128,7 +128,15 @@ data class ExtensionSource(
     
     /** Base URL for the source */
     val baseUrl: String,
-    
+
+    /**
+     * API host, when the source has one distinct from [baseUrl]. Empty for scraping sources.
+     *
+     * Only JavaScript sources populate this — an APK extension builds its own requests in Kotlin
+     * and never exposes such a URL to the app.
+     */
+    val apiUrl: String = "",
+
     /** Whether this source supports search */
     val supportsSearch: Boolean = true,
     

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/engine/JsPrelude.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/engine/JsPrelude.kt
@@ -1,0 +1,32 @@
+package app.otakureader.core.js.engine
+
+/**
+ * The Mangayomi compatibility layer, loaded from `resources/js/prelude.js`.
+ *
+ * Held as a Java resource rather than an Android asset so that it can be read with no [android
+ * .content.Context]. [QuickJsHost] is constructed with a config, a script and an HTTP callback and
+ * nothing else, and threading a Context through it purely to reach an asset would put an Android
+ * dependency into the one part of this module that is otherwise plain Kotlin — and therefore the
+ * one part that a JVM unit test can exercise directly.
+ *
+ * Read once and cached: the file is a few kilobytes, but a source's page-list call is preceded by
+ * a detail call and a search, and re-reading a stream per call for a constant is waste that grows
+ * with how heavily a source is used.
+ */
+internal object JsPrelude {
+
+    private const val RESOURCE_PATH = "/js/prelude.js"
+
+    /**
+     * Fails loudly if the resource is missing.
+     *
+     * A packaging mistake that dropped this file would otherwise surface as every extension
+     * failing with `ReferenceError: MProvider is not defined` — an error that names the script and
+     * implicates the source, when the fault is entirely in the app's own build.
+     */
+    val source: String by lazy {
+        requireNotNull(JsPrelude::class.java.getResourceAsStream(RESOURCE_PATH)) {
+            "Missing $RESOURCE_PATH — the JavaScript compatibility prelude was not packaged"
+        }.use { it.readBytes().decodeToString() }
+    }
+}

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/engine/QuickJsHost.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/engine/QuickJsHost.kt
@@ -237,11 +237,26 @@ internal class QuickJsHost(
                 val html = args.getOrNull(0) as? String ?: return@function ""
                 Jsoup.parse(html).text()
             }
+            /**
+             * The attribute exactly as written.
+             *
+             * This used to resolve every attribute through `absUrl`, with a comment explaining
+             * that relative hrefs want resolving — true of an href, and applied to *all* names.
+             * Jsoup's `absUrl` resolves any string against the base URI, so a title read with
+             * `attr("title")` came back as `https://site/…` with the title as its path. Sources
+             * read titles, alt text and data-* fields this way constantly, so they were being
+             * handed URLs where they expected text. Use [absAttr] when a URL is what is wanted.
+             */
             function("attr") { args ->
                 val html = args.getOrNull(0) as? String ?: return@function ""
                 val name = args.getOrNull(1) as? String ?: return@function ""
-                // absUrl resolves relative hrefs against the source's baseUrl, which is what
-                // essentially every extension actually wants from an href or src.
+                Jsoup.parse(html, config.baseUrl).body().children().firstOrNull()
+                    ?.attr(name).orEmpty()
+            }
+            /** The attribute resolved against the source's base URL, for href/src and the like. */
+            function("absAttr") { args ->
+                val html = args.getOrNull(0) as? String ?: return@function ""
+                val name = args.getOrNull(1) as? String ?: return@function ""
                 val element = Jsoup.parse(html, config.baseUrl).body().children().firstOrNull()
                 element?.absUrl(name).takeUnless { it.isNullOrEmpty() }
                     ?: element?.attr(name).orEmpty()

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/engine/QuickJsHost.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/engine/QuickJsHost.kt
@@ -299,6 +299,18 @@ internal class QuickJsHost(
      * be a snapshot that silently stopped matching after the first write.
      */
     private fun sourceConfigGlobal(): String {
+        // Two encodings, one runtime JSON layer — they are not the same kind of step, and reading
+        // them as two semantic layers is the obvious misreading.
+        //
+        //   1. the config object  -> JSON text            `{"id":"x","baseUrl":"https://…"}`
+        //   2. that JSON text     -> a JS string literal  `"{\"id\":\"x\",…}"`
+        //
+        // Step 2 is source-code quoting, not data. The JavaScript parser undoes it while
+        // evaluating the assignment, so at runtime the global holds a *string* of JSON and the
+        // prelude's single `JSON.parse` yields the object. Parsing twice would throw on the
+        // resulting object; emitting the manifest bare would drop the quoting that keeps a quote
+        // or backslash in a source's name from terminating the literal and changing the program —
+        // the same reasoning [buildInvocation] applies to call arguments.
         val manifest = JsProtocol.json.encodeToString(config.copy(preferences = emptyMap()))
         return "globalThis.__otakuSourceConfig = ${JsProtocol.json.encodeToString(manifest)};"
     }

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/engine/QuickJsHost.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/engine/QuickJsHost.kt
@@ -112,6 +112,15 @@ internal class QuickJsHost(
 
             installGlobals(engine)
 
+            // Order matters in both directions. The prelude captures the host namespaces
+            // installed above and then shadows their names with the class-shaped API extensions
+            // expect, so it cannot run before `installGlobals`. It defines `MProvider`, which
+            // every extension names in its `extends` clause, so it must run before the script is
+            // evaluated — a class declaration resolves its base at definition time, not at call
+            // time, and a missing base fails the whole script rather than one method.
+            engine.evaluate<Any?>(sourceConfigGlobal())
+            engine.evaluate<Any?>(JsPrelude.source)
+
             // The result is pushed out through a binding rather than taken from the
             // evaluation's return value.
             //
@@ -172,7 +181,17 @@ internal class QuickJsHost(
             ?.entries
             ?.mapNotNull { (k, v) ->
                 val key = k as? String ?: return@mapNotNull null
-                key to v.toString()
+                // Drop the header rather than stringifying a null into it.
+                //
+                // Sources build header maps from preferences that frequently have no value yet —
+                // `{"user-agent": this.getPreference("custom_user_agent")}` is the common shape,
+                // and on a fresh install that preference is unset. `Any?.toString()` renders that
+                // as the four characters `null`, so the request goes out claiming a User-Agent of
+                // "null": worse than sending none, because it defeats the default the shared
+                // OkHttp client would otherwise have supplied and it is a value some sites
+                // fingerprint on.
+                val value = v ?: return@mapNotNull null
+                key to value.toString()
             }
             ?.toMap()
             .orEmpty()
@@ -263,6 +282,25 @@ internal class QuickJsHost(
                 null
             }
         }
+    }
+
+    /**
+     * Publish this source's own manifest as a JSON literal for the prelude to read.
+     *
+     * Extensions reach for `this.source.baseUrl`, `this.source.apiUrl` and `this.source.lang`
+     * throughout — an API-backed source builds essentially every request from `apiUrl`. Handing
+     * the config over as text rather than as a binding keeps the rule that only primitives cross
+     * the boundary, and encoding it with the serializer rather than by concatenation means a
+     * quote or backslash in a source name cannot terminate the literal and change the program
+     * being evaluated, which is the same reasoning [buildInvocation] applies to call arguments.
+     *
+     * Preferences are deliberately excluded: they are reachable through `SharedPreferences`,
+     * which routes writes back to the main process, whereas a copy pasted into this object would
+     * be a snapshot that silently stopped matching after the first write.
+     */
+    private fun sourceConfigGlobal(): String {
+        val manifest = JsProtocol.json.encodeToString(config.copy(preferences = emptyMap()))
+        return "globalThis.__otakuSourceConfig = ${JsProtocol.json.encodeToString(manifest)};"
     }
 
     /**

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/protocol/JsProtocol.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/protocol/JsProtocol.kt
@@ -47,6 +47,16 @@ data class JsSourceConfig(
     val name: String,
     val baseUrl: String,
     val lang: String,
+    /**
+     * The source's API host, when it has one distinct from [baseUrl].
+     *
+     * Defaulted to empty rather than made non-null because the index leaves it blank for every
+     * scraping source, which is most of them. Sources that *do* set it build essentially every
+     * request from `this.source.apiUrl`, so an omitted value here is not a cosmetic gap — it
+     * produces requests to `undefined/manga?...` that fail as ordinary HTTP errors and give no
+     * hint that the manifest was the problem.
+     */
+    val apiUrl: String = "",
     val isNsfw: Boolean = false,
     /** Persisted source preferences, exposed to the script as the `SharedPreferences` global. */
     val preferences: Map<String, String> = emptyMap(),

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionBackendImpl.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionBackendImpl.kt
@@ -41,6 +41,7 @@ class JsExtensionBackendImpl @Inject constructor(
                 id = extension.pkgName,
                 name = extension.name,
                 baseUrl = extension.sources.firstOrNull()?.baseUrl ?: extension.repoUrl.orEmpty(),
+                apiUrl = extension.sources.firstOrNull()?.apiUrl.orEmpty(),
                 lang = extension.lang,
                 isNsfw = extension.isNsfw,
             ),

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
@@ -368,12 +368,17 @@ class JsExtensionRemoteDataSource @Inject constructor(
 
         return httpClient.newCall(Request.Builder().url(indexUrl).build()).execute().use { response ->
             // 404 is the one status that means "this repository does not offer this path", which
-            // is an answer rather than a fault. Every other status is a fault.
-            if (response.code == HTTP_NOT_FOUND) {
-                throw JsExtensionNotFoundException("No index at $indexUrl")
-            }
+            // is an answer rather than a fault. Every other unsuccessful status is a fault.
+            //
+            // Selected then thrown, rather than thrown from two branches, to stay within detekt's
+            // ThrowsCount limit — and it reads better as one decision about what an unsuccessful
+            // response means.
             if (!response.isSuccessful) {
-                throw JsExtensionFetchException("HTTP ${response.code} fetching $indexUrl")
+                throw if (response.code == HTTP_NOT_FOUND) {
+                    JsExtensionNotFoundException("No index at $indexUrl")
+                } else {
+                    JsExtensionFetchException("HTTP ${response.code} fetching $indexUrl")
+                }
             }
             val responseBody = response.body
                 ?: throw JsExtensionFetchException("Empty index body from $indexUrl")

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
@@ -7,8 +7,16 @@ import app.otakureader.core.extension.domain.model.InstallStatus
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonPrimitive
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.ResponseBody
@@ -17,36 +25,132 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
+ * Renders whatever JSON primitive appears in a field as its string form.
+ *
+ * The published indexes disagree on the type of two fields that matter. Mangayomi's writes `id`
+ * and `itemType` as **numbers**; the Sora-style indexes write them as **strings**. Both are
+ * legitimate and neither is going to change, so the reader has to accept either.
+ *
+ * Done with a serializer rather than by switching the parser to `isLenient` because leniency is
+ * global: it would also start accepting unquoted keys and values everywhere else in the document,
+ * which is a much larger promise to make about a file fetched from an arbitrary remote host. This
+ * widens exactly the two fields that need widening.
+ */
+private object FlexibleStringSerializer : KSerializer<String> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("FlexibleString", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): String {
+        val element = (decoder as JsonDecoder).decodeJsonElement()
+        // `content` is the primitive's text regardless of whether it was quoted, so a numeric id
+        // arrives as its decimal — which is stable, and is what the string-typed indexes publish
+        // for the same source anyway.
+        return (element as? JsonPrimitive)?.content.orEmpty()
+    }
+
+    override fun serialize(encoder: Encoder, value: String) = encoder.encodeString(value)
+}
+
+/**
  * One entry in a repository's JavaScript source index.
  *
- * Mirrors the Mangayomi/Sora index shape, which is what the existing community JavaScript
- * sources are published against. Following it rather than inventing a format means those sources
- * work here unmodified — the same reasoning that keeps the Tachiyomi APK contract intact.
+ * Mirrors the Mangayomi/Sora index shape, which is what the existing community JavaScript sources
+ * are published against.
+ *
+ * **This claim was previously wider than the code.** The field *names* matched, but three of the
+ * types did not, and each failure was silent in a different way against the real Mangayomi index:
+ * `id` and `itemType` are numbers there, so every entry either failed to decode or survived
+ * decoding and was then dropped by an `itemType == "manga"` comparison that a numeric `0` can
+ * never satisfy; and nothing read `sourceCodeLanguage`, so the 249 Dart entries that share the
+ * index with the 114 JavaScript ones would have been downloaded and handed to the JS engine.
  */
 @Serializable
 internal data class JsExtensionDto(
+    @Serializable(with = FlexibleStringSerializer::class)
     val id: String,
     val name: String,
     val baseUrl: String,
     val lang: String,
-    /** Where the `.js` itself lives. Relative paths resolve against the repository base. */
-    val sourceCodeUrl: String,
+    /**
+     * The source's API host, when it keeps one separate from [baseUrl].
+     *
+     * Blank for scraping sources, which is most of them, and set for roughly a quarter of the
+     * index. Sources that set it build nearly every request from it, so dropping the field on the
+     * floor makes those sources fail as ordinary HTTP errors against `undefined/...`.
+     */
+    val apiUrl: String = "",
+    /** Where the source code lives. Relative paths resolve against the repository base. */
+    val sourceCodeUrl: String = "",
     val version: String = "1.0.0",
-    /** Monotonic build number, used for update detection. */
-    val versionCode: Int = 1,
+    /**
+     * Monotonic build number.
+     *
+     * Absent from every entry of the Mangayomi index — use [effectiveVersionCode], never this
+     * field directly. Kept because the Sora-style indexes do publish it.
+     */
+    val versionCode: Int = 0,
     val iconUrl: String? = null,
     val isNsfw: Boolean = false,
     val hasCloudflare: Boolean = false,
     /**
-     * `manga`, `novel`, or `anime` in the wild.
+     * Which language the source is written in: `0` Dart, `1` JavaScript.
      *
-     * Only `manga` entries are surfaced today — see the filter in `fetchIndex`. Absent means
-     * manga, which is what the overwhelming majority of index entries omit it for.
+     * Defaults to JavaScript because a repository that serves *only* JavaScript omits the field
+     * entirely — that is the shape this reader was originally written against — and defaulting to
+     * Dart would silently empty every such repository.
      */
+    val sourceCodeLanguage: Int = LANGUAGE_JAVASCRIPT,
+    /**
+     * `manga`, `novel` or `anime` — as a name in some indexes, as an ordinal in others.
+     *
+     * Only manga entries are surfaced today; see the filter in `fetchIndex`. Absent means manga,
+     * which is what the overwhelming majority of index entries omit it for.
+     */
+    @Serializable(with = FlexibleStringSerializer::class)
     val itemType: String = ITEM_TYPE_MANGA,
 ) {
+    /** True when this entry is a manga source, under either spelling of the field. */
+    val isManga: Boolean
+        get() = itemType.equals(ITEM_TYPE_MANGA, ignoreCase = true) ||
+            itemType == ITEM_TYPE_MANGA_ORDINAL
+
+    val isJavaScript: Boolean
+        get() = sourceCodeLanguage == LANGUAGE_JAVASCRIPT
+
+    /**
+     * A comparable build number, derived from [version] when the index omits [versionCode].
+     *
+     * Update detection and the duplicate-entry tiebreak both order by this. With the raw field the
+     * Mangayomi index pins every source at the same number, which does not fail loudly — it just
+     * means an installed source is never seen to have a newer release, and the user quietly stays
+     * on whatever version they first installed forever.
+     *
+     * Segments are packed rather than summed so that ordering follows precedence: 1.0.0 must beat
+     * 0.9.9, which a sum gets wrong. Three segments of two digits covers the published range;
+     * anything wider saturates rather than wrapping into a lower-looking number.
+     */
+    val effectiveVersionCode: Int
+        get() {
+            if (versionCode > 0) return versionCode
+            val parts = version.split('.', '-', '+')
+            var packed = 0
+            for (index in 0 until VERSION_SEGMENTS) {
+                val segment = parts.getOrNull(index)?.takeWhile(Char::isDigit)?.toIntOrNull() ?: 0
+                packed = packed * VERSION_SEGMENT_RADIX + segment.coerceIn(0, VERSION_SEGMENT_RADIX - 1)
+            }
+            return packed
+        }
+
     internal companion object {
         const val ITEM_TYPE_MANGA = "manga"
+
+        /** Mangayomi writes the item type as an ordinal, where manga is 0. */
+        const val ITEM_TYPE_MANGA_ORDINAL = "0"
+
+        const val LANGUAGE_JAVASCRIPT = 1
+
+        private const val VERSION_SEGMENTS = 3
+        private const val VERSION_SEGMENT_RADIX = 100
     }
 }
 
@@ -103,7 +207,30 @@ class JsExtensionRemoteDataSource @Inject constructor(
     }
 
     internal companion object {
-        const val INDEX_PATH = "/js/index.json"
+        /**
+         * The dedicated JavaScript index.
+         *
+         * A repository serving this path means JavaScript unambiguously, so anything that goes
+         * wrong after a successful fetch — a malformed document, a truncated body — is a real
+         * fault worth reporting to the user.
+         */
+        const val DEDICATED_INDEX_PATH = "/js/index.json"
+
+        /**
+         * The combined index, tried only when [DEDICATED_INDEX_PATH] is not served.
+         *
+         * The Mangayomi repository — the ecosystem this backend exists to consume — publishes one
+         * index here covering both its Dart and its JavaScript sources, and serves nothing at the
+         * dedicated path. Without this fallback the single largest supplier of JavaScript sources
+         * reports itself as a repository with no sources.
+         *
+         * **Failures here are swallowed, unlike the dedicated path.** This is the same filename
+         * the APK backend reads, so a Keiyoushi-style repository answers it with an index of a
+         * completely different shape. That is not a fault: it is the ordinary, expected answer
+         * from a repository that serves only APKs, and reporting it would put an error in front
+         * of every user about a backend they are using correctly.
+         */
+        const val COMBINED_INDEX_PATH = "/index.json"
 
         /**
          * Ceiling on a downloaded script.
@@ -166,11 +293,58 @@ class JsExtensionRemoteDataSource @Inject constructor(
         )
     }
 
+    /**
+     * The repository's JavaScript sources, from whichever index it publishes.
+     *
+     * The two paths are handled asymmetrically on purpose — see the notes on the constants.
+     * Precisely:
+     *
+     * - dedicated path **not served** → fall through, silently;
+     * - dedicated path served but **unreadable** → throws, because a repository publishing that
+     *   path has declared itself a JavaScript repository and a broken index there is a real fault;
+     * - combined path **not served** → throws, because a repository answering neither path
+     *   publishes no index at all;
+     * - combined path served but **unreadable** → empty, because that filename is shared with the
+     *   APK backend and an index of a foreign shape is the expected answer from an APK-only
+     *   repository.
+     */
     private fun fetchIndex(baseUrl: String): List<Extension> {
-        val indexUrl = baseUrl + INDEX_PATH
+        val dedicated = try {
+            fetchIndexBody(baseUrl + DEDICATED_INDEX_PATH)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            // Not served. Deliberately not chained into anything reported later: for every
+            // repository that reaches the next line this is the same uninformative 404 about a
+            // path the repository never claimed to have.
+            null
+        }
+
+        // Served, so its content is authoritative — a malformed document here is a real fault and
+        // this parse is allowed to throw.
+        if (dedicated != null) return parseIndex(dedicated, baseUrl)
+
+        // Not served, so try the combined index. Failing to *fetch* one still propagates: a
+        // repository that answers neither path serves no index at all, which is what the caller
+        // records as this repository's failure.
+        val combined = fetchIndexBody(baseUrl + COMBINED_INDEX_PATH)
+
+        return try {
+            parseIndex(combined, baseUrl)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            // Fetched but unreadable. This filename is shared with the APK backend, so an index
+            // of a shape this reader does not understand is the ordinary answer from an APK-only
+            // repository — not a fault, and not something to put in front of the user.
+            emptyList()
+        }
+    }
+
+    private fun fetchIndexBody(indexUrl: String): String {
         requireHttps(indexUrl)
 
-        val body = httpClient.newCall(Request.Builder().url(indexUrl).build()).execute().use { response ->
+        return httpClient.newCall(Request.Builder().url(indexUrl).build()).execute().use { response ->
             if (!response.isSuccessful) {
                 throw JsExtensionFetchException("HTTP ${response.code} fetching $indexUrl")
             }
@@ -181,7 +355,9 @@ class JsExtensionRemoteDataSource @Inject constructor(
             // during source discovery, before a single script had been downloaded.
             responseBody.readBounded(MAX_INDEX_BYTES, "Index at $indexUrl")
         }
+    }
 
+    private fun parseIndex(body: String, baseUrl: String): List<Extension> {
         return json.decodeFromString<List<JsExtensionDto>>(body)
             // Only manga sources are surfaced. `JsSource` implements the manga contract, so a
             // novel or anime entry would install cleanly and then fail on every read — an entry
@@ -192,7 +368,22 @@ class JsExtensionRemoteDataSource @Inject constructor(
             // explain, and nothing is lost, because these sources could not work anyway. Stage 7
             // adds the novel runtime and relaxes this filter in the same change that makes the
             // entries usable.
-            .filter { it.itemType.equals(JsExtensionDto.ITEM_TYPE_MANGA, ignoreCase = true) }
+            .filter { it.isManga }
+            // Only JavaScript. The Mangayomi index lists Dart and JavaScript sources together —
+            // Dart is in fact the majority — and a Dart file handed to QuickJS does not fail at
+            // install time. It downloads, stores and registers exactly like a working source, and
+            // then throws a syntax error on the user's first browse, naming the script rather
+            // than the reason it could never have run.
+            //
+            // This does mean reading a field to decide what an entry is, which the note on the
+            // index paths argues against for whole *indexes*. The reasoning does not carry over:
+            // that argument is about guessing which backend a file belongs to, and this is the
+            // index's own explicit, documented discriminator for its own entries.
+            .filter { it.isJavaScript }
+            // A blank URL is an entry there is nothing to download for. It reaches here when a
+            // repository serves an index of a different shape whose other fields happen to
+            // overlap, which decodes into mostly-default DTOs rather than failing outright.
+            .filter { it.sourceCodeUrl.isNotBlank() }
             .map { it.toDomain(baseUrl) }
     }
 
@@ -264,7 +455,9 @@ private fun JsExtensionDto.toDomain(repoUrl: String): Extension = Extension(
     id = id.toStableId(),
     pkgName = id,
     name = name,
-    versionCode = versionCode,
+    // Derived, not the raw field — the Mangayomi index publishes no versionCode at all, and the
+    // raw default would make every source look permanently up to date.
+    versionCode = effectiveVersionCode,
     versionName = version,
     sources = listOf(
         ExtensionSource(
@@ -273,6 +466,7 @@ private fun JsExtensionDto.toDomain(repoUrl: String): Extension = Extension(
             lang = lang,
             // The site the source scrapes — NOT the repository it was listed in.
             baseUrl = baseUrl,
+            apiUrl = apiUrl,
         )
     ),
     status = InstallStatus.AVAILABLE,

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
@@ -126,19 +126,24 @@ internal data class JsExtensionDto(
      * on whatever version they first installed forever.
      *
      * Segments are packed rather than summed so that ordering follows precedence: 1.0.0 must beat
-     * 0.9.9, which a sum gets wrong. Three segments of two digits covers the published range;
-     * anything wider saturates rather than wrapping into a lower-looking number.
+     * 0.9.9, which a sum gets wrong.
+     *
+     * The radix is 1000, not 100, and the arithmetic runs in `Long`. A two-digit radix looks
+     * sufficient against today's published versions but fails quietly the first time a segment
+     * reaches 100: 0.100.0 and 0.99.0 would clamp to the same number, so a real update would never
+     * be offered. Saturating the final value rather than each segment keeps ordering monotonic all
+     * the way up to the clamp instead of flattening at every position.
      */
     val effectiveVersionCode: Int
         get() {
             if (versionCode > 0) return versionCode
             val parts = version.split('.', '-', '+')
-            var packed = 0
+            var packed = 0L
             for (index in 0 until VERSION_SEGMENTS) {
-                val segment = parts.getOrNull(index)?.takeWhile(Char::isDigit)?.toIntOrNull() ?: 0
-                packed = packed * VERSION_SEGMENT_RADIX + segment.coerceIn(0, VERSION_SEGMENT_RADIX - 1)
+                val segment = parts.getOrNull(index)?.takeWhile(Char::isDigit)?.toLongOrNull() ?: 0L
+                packed = packed * VERSION_SEGMENT_RADIX + segment.coerceAtMost(VERSION_SEGMENT_RADIX - 1)
             }
-            return packed
+            return packed.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
         }
 
     internal companion object {
@@ -150,7 +155,7 @@ internal data class JsExtensionDto(
         const val LANGUAGE_JAVASCRIPT = 1
 
         private const val VERSION_SEGMENTS = 3
-        private const val VERSION_SEGMENT_RADIX = 100
+        private const val VERSION_SEGMENT_RADIX = 1000L
     }
 }
 
@@ -252,6 +257,8 @@ class JsExtensionRemoteDataSource @Inject constructor(
 
         /** Only https:// is accepted, matching the guard `ExtensionInstaller` applies to APKs. */
         const val HTTPS_PREFIX = "https://"
+
+        const val HTTP_NOT_FOUND = 404
     }
 
     /**
@@ -269,7 +276,10 @@ class JsExtensionRemoteDataSource @Inject constructor(
         val extensions = repoUrls.flatMap { rawUrl ->
             val baseUrl = rawUrl.trimEnd('/')
             runCatching { fetchIndex(baseUrl) }
-                .onSuccess { servedAnyIndex = true }
+                // Only a repository that actually served a JavaScript index counts. An APK-only
+                // repository succeeds here with an empty result, and flagging that as "served"
+                // would let one such repository mask every other repository's genuine failure.
+                .onSuccess { if (it.servedJsIndex) servedAnyIndex = true }
                 .onFailure { error ->
                     if (error is CancellationException) throw error
                     android.util.Log.w("JsExtensionRemoteDS", "No JS index at $baseUrl: ${error.message}")
@@ -278,7 +288,7 @@ class JsExtensionRemoteDataSource @Inject constructor(
                     // backend the user is not using and cannot act on.
                     if (firstFailure == null) firstFailure = error
                 }
-                .getOrDefault(emptyList())
+                .getOrNull()?.extensions.orEmpty()
         }
 
         JsExtensionFetch(
@@ -294,57 +304,74 @@ class JsExtensionRemoteDataSource @Inject constructor(
     }
 
     /**
-     * The repository's JavaScript sources, from whichever index it publishes.
+     * The repository's JavaScript sources, and whether it actually served a JavaScript index.
      *
-     * The two paths are handled asymmetrically on purpose — see the notes on the constants.
-     * Precisely:
+     * Both halves matter and they are not interchangeable. `JsExtensionBackend` already documents
+     * why `servedAnyIndex` is carried rather than inferred from `extensions.isEmpty()`: a
+     * repository that served an index listing no manga sources and one that served nothing are
+     * different answers, and `ExtensionRemoteDataSource` uses the distinction to decide whether a
+     * round of failures is worth reporting. Returning a bare empty list for an APK-only
+     * repository collapsed them, which would report a failed refresh as a successful empty one.
      *
-     * - dedicated path **not served** → fall through, silently;
-     * - dedicated path served but **unreadable** → throws, because a repository publishing that
-     *   path has declared itself a JavaScript repository and a broken index there is a real fault;
-     * - combined path **not served** → throws, because a repository answering neither path
-     *   publishes no index at all;
-     * - combined path served but **unreadable** → empty, because that filename is shared with the
-     *   APK backend and an index of a foreign shape is the expected answer from an APK-only
-     *   repository.
+     * The paths are handled asymmetrically on purpose — see the notes on the constants. Precisely:
+     *
+     * - dedicated path **absent** (404) → fall through to the combined path, silently;
+     * - dedicated path **broken** (any other transport or body failure) → throws, because a
+     *   repository publishing that path has declared itself a JavaScript repository and its index
+     *   being unreachable is a real fault that the combined endpoint must not paper over;
+     * - dedicated path served but **unreadable** → throws, same reasoning;
+     * - combined path **absent** (404) → empty and not counted as served. A repository answering
+     *   neither path is almost always an APK-only one publishing `index.min.json` and nothing
+     *   else, which is not a fault and must not be reported;
+     * - combined path **broken** (any other failure) → throws;
+     * - combined path served but **unreadable** → empty *and not counted as served*, because that
+     *   filename is shared with the APK backend and a foreign index is the expected answer from an
+     *   APK-only repository.
      */
-    private fun fetchIndex(baseUrl: String): List<Extension> {
-        val dedicated = try {
-            fetchIndexBody(baseUrl + DEDICATED_INDEX_PATH)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            // Not served. Deliberately not chained into anything reported later: for every
-            // repository that reaches the next line this is the same uninformative 404 about a
-            // path the repository never claimed to have.
-            null
-        }
+    private fun fetchIndex(baseUrl: String): IndexResult {
+        // Null only for a genuine 404. Anything else — a 500, a timeout, an oversized body —
+        // propagates, so a broken JavaScript index cannot be hidden behind the combined endpoint.
+        val dedicated = fetchIndexBodyOrNull(baseUrl + DEDICATED_INDEX_PATH)
 
-        // Served, so its content is authoritative — a malformed document here is a real fault and
-        // this parse is allowed to throw.
-        if (dedicated != null) return parseIndex(dedicated, baseUrl)
+        // Served, so its content is authoritative and this parse is allowed to throw.
+        if (dedicated != null) return IndexResult(parseIndex(dedicated, baseUrl), servedJsIndex = true)
 
-        // Not served, so try the combined index. Failing to *fetch* one still propagates: a
-        // repository that answers neither path serves no index at all, which is what the caller
-        // records as this repository's failure.
-        val combined = fetchIndexBody(baseUrl + COMBINED_INDEX_PATH)
+        // A 404 here too is an answer, not a fault: the APK backend documents `index.min.json` as
+        // the common third-party format with `index.json` only as its fallback, so a repository
+        // serving min-only answers neither path this reader asks for. Reporting that would put an
+        // error in front of every user with such a repository configured. Any other failure — a
+        // 500, a timeout, an oversized body — still propagates.
+        val combined = fetchIndexBodyOrNull(baseUrl + COMBINED_INDEX_PATH)
+            ?: return IndexResult(emptyList(), servedJsIndex = false)
 
         return try {
-            parseIndex(combined, baseUrl)
+            IndexResult(parseIndex(combined, baseUrl), servedJsIndex = true)
         } catch (e: CancellationException) {
             throw e
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            // Fetched but unreadable. This filename is shared with the APK backend, so an index
-            // of a shape this reader does not understand is the ordinary answer from an APK-only
-            // repository — not a fault, and not something to put in front of the user.
-            emptyList()
+            // Fetched but unreadable: the ordinary answer from an APK-only repository. Not a
+            // fault, and deliberately not counted as having served a JavaScript index.
+            IndexResult(emptyList(), servedJsIndex = false)
         }
     }
+
+    /** The body, or null when the path is genuinely absent. Every other failure propagates. */
+    private fun fetchIndexBodyOrNull(indexUrl: String): String? =
+        try {
+            fetchIndexBody(indexUrl)
+        } catch (e: JsExtensionNotFoundException) {
+            null
+        }
 
     private fun fetchIndexBody(indexUrl: String): String {
         requireHttps(indexUrl)
 
         return httpClient.newCall(Request.Builder().url(indexUrl).build()).execute().use { response ->
+            // 404 is the one status that means "this repository does not offer this path", which
+            // is an answer rather than a fault. Every other status is a fault.
+            if (response.code == HTTP_NOT_FOUND) {
+                throw JsExtensionNotFoundException("No index at $indexUrl")
+            }
             if (!response.isSuccessful) {
                 throw JsExtensionFetchException("HTTP ${response.code} fetching $indexUrl")
             }
@@ -380,10 +407,17 @@ class JsExtensionRemoteDataSource @Inject constructor(
             // that argument is about guessing which backend a file belongs to, and this is the
             // index's own explicit, documented discriminator for its own entries.
             .filter { it.isJavaScript }
-            // A blank URL is an entry there is nothing to download for. It reaches here when a
-            // repository serves an index of a different shape whose other fields happen to
-            // overlap, which decodes into mostly-default DTOs rather than failing outright.
-            .filter { it.sourceCodeUrl.isNotBlank() }
+            // A blank URL is an entry there is nothing to download for, and a blank id is one
+            // that cannot own its stored preferences or be uninstalled by name. Both reach here
+            // when a repository serves an index of a different shape whose other fields happen to
+            // overlap, which decodes into mostly-default DTOs rather than failing outright — and
+            // when `id` arrives as an object or array, which the flexible serializer renders as
+            // empty rather than throwing.
+            //
+            // Dropped here rather than rejected in the serializer on purpose: throwing mid-decode
+            // fails the entire document, so one malformed entry would cost the user every source
+            // that repository offers.
+            .filter { it.sourceCodeUrl.isNotBlank() && it.id.isNotBlank() }
             .map { it.toDomain(baseUrl) }
     }
 
@@ -424,6 +458,25 @@ class JsExtensionRemoteDataSource @Inject constructor(
 
 /** Thrown when a repository index or script cannot be fetched or parsed. */
 class JsExtensionFetchException(message: String) : RuntimeException(message)
+
+/**
+ * The repository does not offer this path at all — a 404, not a fault.
+ *
+ * A distinct type rather than a status check at the call site, so that "absent" and "broken" can
+ * never be collapsed by a `catch (Exception)` that was only meant to handle the first.
+ */
+class JsExtensionNotFoundException(message: String) : RuntimeException(message)
+
+/**
+ * What one repository yielded, and whether it served a JavaScript index at all.
+ *
+ * The flag is not derivable from `extensions.isEmpty()` — an index listing no manga sources and a
+ * foreign index this reader cannot read both produce an empty list and mean opposite things.
+ */
+private data class IndexResult(
+    val extensions: List<Extension>,
+    val servedJsIndex: Boolean,
+)
 
 /**
  * Read a body, refusing it if it exceeds [limit].

--- a/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
+++ b/core/js-runtime/src/main/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSource.kt
@@ -130,9 +130,18 @@ internal data class JsExtensionDto(
      *
      * The radix is 1000, not 100, and the arithmetic runs in `Long`. A two-digit radix looks
      * sufficient against today's published versions but fails quietly the first time a segment
-     * reaches 100: 0.100.0 and 0.99.0 would clamp to the same number, so a real update would never
-     * be offered. Saturating the final value rather than each segment keeps ordering monotonic all
-     * the way up to the clamp instead of flattening at every position.
+     * reaches 100: 0.100.0 and 0.99.0 would collapse to the same number, so a real update would
+     * never be offered.
+     *
+     * Each segment is clamped to the radix rather than allowed to carry, and that is the deliberate
+     * half of the trade: a carry would let a large minor outrank a major bump — 0.1000.0 beating
+     * 1.0.0 — and precedence is the whole property this ordering exists to preserve. The cost is
+     * that two versions differing only past `.999` in one position stop being distinguishable,
+     * three orders of magnitude beyond anything the index publishes.
+     *
+     * Three clamped segments cannot exceed 999_999_999, so the final `coerceAtMost` never fires as
+     * this is configured. It is there so that widening [VERSION_SEGMENTS] or the radix later cannot
+     * silently start handing back negative version codes on the `Int` narrowing.
      */
     val effectiveVersionCode: Int
         get() {

--- a/core/js-runtime/src/main/resources/js/prelude.js
+++ b/core/js-runtime/src/main/resources/js/prelude.js
@@ -182,11 +182,12 @@
                 return this.html;
             }
         },
-        innerHtml: {
-            get: function () {
-                return this.html;
-            }
-        },
+        // No `innerHtml`. An element here is represented by the outer HTML the host returned, so
+        // the obvious implementation returns the wrapping tag as well as its contents — an
+        // extension asking for a node's contents would silently receive malformed markup, which
+        // is worse than the property being absent, because absence throws where it is used.
+        // Nothing in the published sources sampled for this layer reads it. If one does, give it
+        // a real host binding rather than approximating it here.
         getHref: {
             get: function () {
                 return this.attr('href');

--- a/core/js-runtime/src/main/resources/js/prelude.js
+++ b/core/js-runtime/src/main/resources/js/prelude.js
@@ -350,6 +350,41 @@
      * yields the default rather than throwing: a corrupt preference should degrade the source to
      * its defaults, not make it unusable with no way for the user to reset it.
      */
+    /**
+     * Coerce a preference value to the type the caller's default implies.
+     *
+     * Applied to declared defaults as well as stored ones, and that is the point. The host stores
+     * strings, and an extension declares an `editTextPreference` default as a string too — so
+     * `getInt(key, 0)` against a declared "5" used to return the *string* "5" where the identical
+     * value, once the user had touched the setting, returned the number 5. A source doing
+     * arithmetic on it got "5" + 1 = "51", and only for users who had never opened the settings
+     * screen: the exact population the declared-default fallback exists to serve.
+     *
+     * Values that already carry a type are passed through. A `multiSelectListPreference` declares
+     * an array and a switch declares a boolean; re-parsing those would be a second guess at
+     * something already known.
+     */
+    function coerce(value, defaultValue) {
+        if (typeof value !== 'string') {
+            return value;
+        }
+        if (defaultValue !== null && typeof defaultValue === 'object') {
+            try {
+                return JSON.parse(value);
+            } catch (e) {
+                return defaultValue;
+            }
+        }
+        if (typeof defaultValue === 'boolean') {
+            return value === 'true';
+        }
+        if (typeof defaultValue === 'number') {
+            var parsed = Number(value);
+            return isNaN(parsed) ? defaultValue : parsed;
+        }
+        return value;
+    }
+
     MSharedPreferences.prototype.get = function (key, defaultValue) {
         var stored = hostPreferences.get(key);
         if (stored === null || stored === undefined) {
@@ -359,25 +394,11 @@
             // just a type hint written at the call site.
             var declared = defaultFor(key);
             if (declared !== undefined) {
-                return declared;
+                return coerce(declared, defaultValue);
             }
             return defaultValue === undefined ? null : defaultValue;
         }
-        if (defaultValue !== null && typeof defaultValue === 'object') {
-            try {
-                return JSON.parse(stored);
-            } catch (e) {
-                return defaultValue;
-            }
-        }
-        if (typeof defaultValue === 'boolean') {
-            return stored === 'true';
-        }
-        if (typeof defaultValue === 'number') {
-            var parsed = Number(stored);
-            return isNaN(parsed) ? defaultValue : parsed;
-        }
-        return stored;
+        return coerce(stored, defaultValue);
     };
 
     MSharedPreferences.prototype.set = function (key, value) {

--- a/core/js-runtime/src/main/resources/js/prelude.js
+++ b/core/js-runtime/src/main/resources/js/prelude.js
@@ -37,9 +37,12 @@
     var hostDocument = global.Document;
     var hostPreferences = global.SharedPreferences;
 
-    // Injected by QuickJsHost as a JSON literal. Extensions read `this.source.baseUrl`,
-    // `this.source.apiUrl` and `this.source.lang` constantly, so an absent config is a broken
-    // source rather than a degraded one.
+    // Injected by QuickJsHost as a JS string literal holding JSON, so exactly one parse is
+    // correct: the JavaScript parser already removed the source-level quoting while evaluating
+    // the assignment. Parsing twice throws.
+    //
+    // Extensions read `this.source.baseUrl`, `this.source.apiUrl` and `this.source.lang`
+    // constantly, so an absent config is a broken source rather than a degraded one.
     var sourceConfig = global.__otakuSourceConfig
         ? JSON.parse(global.__otakuSourceConfig)
         : {};

--- a/core/js-runtime/src/main/resources/js/prelude.js
+++ b/core/js-runtime/src/main/resources/js/prelude.js
@@ -84,7 +84,13 @@
     };
 
     MClient.prototype.post = function (url, headers, body) {
-        return hostClient.post(url, headers || {}, body === undefined ? null : body).then(decodeResponse);
+        // Serialise object bodies. The host binding reads the body with `as? String`, so a JS
+        // object arrives as a Map, fails the cast, and becomes null — the request then goes out
+        // with no payload at all and the source sees an unexplained empty response. Sources that
+        // already encoded their body pass a string, which is forwarded untouched.
+        var payload = body === undefined || body === null ? null
+            : (typeof body === 'string' ? body : JSON.stringify(body));
+        return hostClient.post(url, headers || {}, payload).then(decodeResponse);
     };
 
     /** Some sources build a request descriptor instead of calling get/post directly. */
@@ -144,14 +150,29 @@
         var found = withHandle(this.html, function (handle) {
             return hostDocument.selectFirst(handle, selector);
         });
-        // Null rather than an empty element: extensions write `el.selectFirst(s)?.text`, and the
-        // optional chain is the only thing standing between a missing node and a thrown error.
-        // Returning an empty MElement would make every miss look like an empty string instead.
-        return found === null || found === undefined ? null : new MElement(found);
+        // An empty element on a miss, never null.
+        //
+        // An earlier version returned null, reasoning that sources guard with
+        // `el.selectFirst(s)?.text`. Measured against the published sources, that is the minority:
+        // 38 call sites read a property straight off the result with no optional chain, against 17
+        // that guard. Returning null makes a missed selector throw and take the whole source down,
+        // where an empty element degrades to an empty string — and a source that fails to find one
+        // optional field should not stop returning the other twenty.
+        //
+        // The cost is that `?? fallback` after a miss now sees "" rather than nullish and keeps
+        // the empty string. That is the lesser failure, and it matches what sources are written
+        // against.
+        return new MElement(found === null || found === undefined ? '' : found);
     };
 
     MElement.prototype.attr = function (name) {
+        // Raw, as written. Mangayomi's `attr` is not URL-aware; `getHref`/`getSrc` are.
         return hostDocument.attr(this.html, name);
+    };
+
+    /** The attribute resolved against the source's base URL. */
+    MElement.prototype.absAttr = function (name) {
+        return hostDocument.absAttr(this.html, name);
     };
 
     MElement.prototype.getAttribute = function (name) {
@@ -190,12 +211,12 @@
         // a real host binding rather than approximating it here.
         getHref: {
             get: function () {
-                return this.attr('href');
+                return this.absAttr('href');
             }
         },
         getSrc: {
             get: function () {
-                return this.attr('src');
+                return this.absAttr('src');
             }
         },
         /**
@@ -338,10 +359,14 @@
     };
 
     MSharedPreferences.prototype.set = function (key, value) {
-        hostPreferences.set(
-            key,
-            value !== null && typeof value === 'object' ? JSON.stringify(value) : String(value)
-        );
+        // Nullish writes store an empty string, mirroring the Kotlin binding's
+        // `?.toString().orEmpty()`. `String(null)` would persist the four characters "null", which
+        // then reads back as a set value and permanently shadows both the extension's declared
+        // default and the caller's — a source writing a not-yet-computed value would poison that
+        // preference for good.
+        var stored = value === null || value === undefined ? ''
+            : (typeof value === 'object' ? JSON.stringify(value) : String(value));
+        hostPreferences.set(key, stored);
     };
 
     MSharedPreferences.prototype.getString = function (key, defaultValue) {

--- a/core/js-runtime/src/main/resources/js/prelude.js
+++ b/core/js-runtime/src/main/resources/js/prelude.js
@@ -226,9 +226,9 @@
          * one name at a time and adding a bulk binding would mean a Kotlin change for something
          * the published sources use almost exclusively on JSON payloads rather than on DOM nodes.
          *
-         * Values are returned raw. Unlike `attr()`, which resolves against the source base URL,
-         * a relative href read from here stays relative — use `attr('href')` when an absolute URL
-         * is what is wanted.
+         * Values are returned exactly as the tag spells them, which is also what `attr()` does —
+         * neither resolves a relative URL. `getHref`/`getSrc` (and `absAttr`) are the resolving
+         * accessors; reach for one of those when an absolute URL is what is wanted.
          */
         attributes: {
             get: function () {
@@ -359,14 +359,22 @@
     };
 
     MSharedPreferences.prototype.set = function (key, value) {
-        // Nullish writes store an empty string, mirroring the Kotlin binding's
-        // `?.toString().orEmpty()`. `String(null)` would persist the four characters "null", which
-        // then reads back as a set value and permanently shadows both the extension's declared
-        // default and the caller's — a source writing a not-yet-computed value would poison that
-        // preference for good.
-        var stored = value === null || value === undefined ? ''
-            : (typeof value === 'object' ? JSON.stringify(value) : String(value));
-        hostPreferences.set(key, stored);
+        // A nullish write is dropped rather than stored.
+        //
+        // The host has no `remove`, so every write is a write of *something*: `String(null)`
+        // persists the four characters "null", and the empty string the Kotlin binding's
+        // `?.toString().orEmpty()` produces is no better — both read back as a value that is set,
+        // which permanently shadows the extension's declared default with no way for a user to
+        // undo it short of reinstalling the source. Sources reach this path by accident, writing a
+        // value they have not computed yet, not by deciding the preference should be blank; a
+        // source that means blank passes `''` and that still stores.
+        //
+        // This is a deliberate divergence from the host binding, and the only one in this file.
+        // The binding keeps its own coercion as a floor for any caller that is not the prelude.
+        if (value === null || value === undefined) {
+            return;
+        }
+        hostPreferences.set(key, typeof value === 'object' ? JSON.stringify(value) : String(value));
     };
 
     MSharedPreferences.prototype.getString = function (key, defaultValue) {

--- a/core/js-runtime/src/main/resources/js/prelude.js
+++ b/core/js-runtime/src/main/resources/js/prelude.js
@@ -279,38 +279,60 @@
      * updated default — a moved mirror domain, say — reach a user who never touched the setting,
      * while still never overriding a choice the user did make.
      */
+    /**
+     * The value one declaration entry carries, or `undefined` if it declares none.
+     *
+     * Split out from the cache below so each half stays readable on its own: this is the part that
+     * knows the four shapes Mangayomi's preference declarations take, and it is where a fifth one
+     * would be added.
+     */
+    function declaredValueOf(entry) {
+        if (entry.editTextPreference) {
+            return entry.editTextPreference.value;
+        }
+        if (entry.listPreference) {
+            // A list declares its default as an index into entryValues, not as a value — except
+            // when it also carries an explicit `value`, which wins.
+            var list = entry.listPreference;
+            if (list.value !== undefined) {
+                return list.value;
+            }
+            var values = list.entryValues || [];
+            return values[typeof list.valueIndex === 'number' ? list.valueIndex : 0];
+        }
+        if (entry.multiSelectListPreference) {
+            return entry.multiSelectListPreference.values || [];
+        }
+        var toggle = entry.switchPreferenceCompat || entry.checkBoxPreference;
+        return toggle ? toggle.value : undefined;
+    }
+
+    function loadDeclaredDefaults() {
+        var out = {};
+        try {
+            var declared = currentProvider && typeof currentProvider.getSourcePreferences === 'function'
+                ? currentProvider.getSourcePreferences()
+                : [];
+            for (var i = 0; i < declared.length; i++) {
+                var entry = declared[i];
+                if (!entry || !entry.key) { continue; }
+                var value = declaredValueOf(entry);
+                if (value !== undefined) {
+                    out[entry.key] = value;
+                }
+            }
+        } catch (e) {
+            // A source whose preference declaration throws still has to be usable for everything
+            // that does not depend on a preference. Discard the partial map rather than keeping
+            // it: a half-read declaration would answer some keys and silently not others.
+            return {};
+        }
+        return out;
+    }
+
     function defaultFor(key) {
         if (declaredDefaults === null) {
-            declaredDefaults = {};
-            try {
-                var declared = currentProvider && typeof currentProvider.getSourcePreferences === 'function'
-                    ? currentProvider.getSourcePreferences()
-                    : [];
-                for (var i = 0; i < declared.length; i++) {
-                    var entry = declared[i];
-                    if (!entry || !entry.key) { continue; }
-                    var edit = entry.editTextPreference;
-                    var list = entry.listPreference;
-                    var multi = entry.multiSelectListPreference;
-                    var toggle = entry.switchPreferenceCompat || entry.checkBoxPreference;
-                    if (edit) {
-                        declaredDefaults[entry.key] = edit.value;
-                    } else if (list) {
-                        // The default is an index into entryValues, not a value itself.
-                        var values = list.entryValues || [];
-                        var chosen = typeof list.valueIndex === 'number' ? list.valueIndex : 0;
-                        declaredDefaults[entry.key] = list.value !== undefined ? list.value : values[chosen];
-                    } else if (multi) {
-                        declaredDefaults[entry.key] = multi.values || [];
-                    } else if (toggle) {
-                        declaredDefaults[entry.key] = toggle.value;
-                    }
-                }
-            } catch (e) {
-                // A source whose preference declaration throws still has to be usable for
-                // everything that does not depend on a preference.
-                declaredDefaults = {};
-            }
+            declaredDefaults = loadDeclaredDefaults();
         }
         return Object.prototype.hasOwnProperty.call(declaredDefaults, key)
             ? declaredDefaults[key]

--- a/core/js-runtime/src/main/resources/js/prelude.js
+++ b/core/js-runtime/src/main/resources/js/prelude.js
@@ -1,0 +1,422 @@
+/*
+ * Mangayomi compatibility prelude.
+ *
+ * Evaluated by QuickJsHost immediately before every extension script, in the same context.
+ *
+ * ### Why this file exists
+ *
+ * Community JavaScript sources are published against the Mangayomi runtime, which hands scripts
+ * an object-oriented API: `new Client()`, `new Document(html)`, `new SharedPreferences()`, and a
+ * `MProvider` base class that every extension extends. QuickJsHost deliberately installs
+ * something different — flat namespaces whose arguments and returns are all primitives, so no
+ * host object reference ever crosses into JavaScript.
+ *
+ * Both designs are right for their own reasons, and this file is the adapter between them. It
+ * runs entirely in JavaScript, so the Kotlin boundary keeps passing primitives only and the
+ * isolation property QuickJsHost documents is preserved exactly: the element objects below wrap
+ * strings and integers that the host produced, never a Jsoup node.
+ *
+ * The alternative — teaching the Kotlin bindings to hand out objects — would have traded that
+ * property away for the same result.
+ *
+ * ### The one rule to preserve when editing
+ *
+ * `Document.parse` allocates a handle from a pool capped at MAX_LIVE_DOCUMENTS (32), and the host
+ * *refuses* rather than evicts once the cap is hit. A selector call on an element therefore parses
+ * and releases inside the same function, in a `finally`. Holding a handle across an `await` — or
+ * forgetting the `finally` on a throwing path — turns a page of 20 results into a hard failure
+ * that only appears against real-sized data.
+ */
+(function (global) {
+    'use strict';
+
+    // The host bindings, captured before the classes below shadow them. After this point the
+    // names `Client`, `Document` and `SharedPreferences` refer to the compatibility classes, so
+    // these locals are the only remaining way to reach the host.
+    var hostClient = global.Client;
+    var hostDocument = global.Document;
+    var hostPreferences = global.SharedPreferences;
+
+    // Injected by QuickJsHost as a JSON literal. Extensions read `this.source.baseUrl`,
+    // `this.source.apiUrl` and `this.source.lang` constantly, so an absent config is a broken
+    // source rather than a degraded one.
+    var sourceConfig = global.__otakuSourceConfig
+        ? JSON.parse(global.__otakuSourceConfig)
+        : {};
+
+    // ---------------------------------------------------------------------------------------
+    // HTTP
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * The response shape Mangayomi extensions expect.
+     *
+     * `statusCode` rather than the host's `code`: extensions branch on `res.statusCode`, and a
+     * missing property would read as `undefined` and compare falsely against every number
+     * instead of failing loudly.
+     */
+    function MResponse(raw) {
+        this.body = typeof raw.body === 'string' ? raw.body : '';
+        this.statusCode = typeof raw.code === 'number' ? raw.code : 0;
+        this.headers = raw.headers || {};
+        this.ok = !!raw.ok;
+        this.error = raw.error === undefined ? null : raw.error;
+    }
+
+    function decodeResponse(payload) {
+        // The host returns the serialized JsHttpResponse. A non-JSON body would mean the bridge
+        // itself failed, which is not something a source can handle, so let the parse throw.
+        return new MResponse(JSON.parse(payload));
+    }
+
+    function MClient() {
+        // Mangayomi's constructor accepts an options bag that only configures redirect and
+        // cookie behaviour. Both are owned by the app's shared OkHttp client here — that is the
+        // entire point of routing source traffic through it — so the argument is accepted and
+        // ignored rather than rejected, which would fail sources that pass one out of habit.
+    }
+
+    MClient.prototype.get = function (url, headers) {
+        return hostClient.get(url, headers || {}).then(decodeResponse);
+    };
+
+    MClient.prototype.post = function (url, headers, body) {
+        return hostClient.post(url, headers || {}, body === undefined ? null : body).then(decodeResponse);
+    };
+
+    /** Some sources build a request descriptor instead of calling get/post directly. */
+    MClient.prototype.request = function (options) {
+        var opts = options || {};
+        var method = (opts.method || 'GET').toUpperCase();
+        if (method === 'POST') {
+            return this.post(opts.url, opts.headers, opts.body);
+        }
+        return this.get(opts.url, opts.headers);
+    };
+
+    // ---------------------------------------------------------------------------------------
+    // HTML
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * One node, represented by its outer HTML.
+     *
+     * A document and an element are the same type here, because the host's selector functions
+     * take HTML in and give HTML back — there is no separate document identity to model. That
+     * also makes `new Document(html)` and the result of `selectFirst` interchangeable, which is
+     * what extensions assume when they pass a selected node to a helper that selects again.
+     */
+    function MElement(html) {
+        this.html = typeof html === 'string' ? html : '';
+    }
+
+    /**
+     * Run `fn` against a freshly parsed handle and release it before returning.
+     *
+     * The `finally` is load-bearing: a selector that throws must still release, or the handle
+     * pool leaks one slot per failure and the source dies at the 32nd with an error naming
+     * documents rather than the selector that actually broke.
+     */
+    function withHandle(html, fn) {
+        var handle = hostDocument.parse(html);
+        try {
+            return fn(handle);
+        } finally {
+            hostDocument.release(handle);
+        }
+    }
+
+    MElement.prototype.select = function (selector) {
+        var found = withHandle(this.html, function (handle) {
+            return hostDocument.select(handle, selector);
+        });
+        var out = [];
+        for (var i = 0; i < found.length; i++) {
+            out.push(new MElement(found[i]));
+        }
+        return out;
+    };
+
+    MElement.prototype.selectFirst = function (selector) {
+        var found = withHandle(this.html, function (handle) {
+            return hostDocument.selectFirst(handle, selector);
+        });
+        // Null rather than an empty element: extensions write `el.selectFirst(s)?.text`, and the
+        // optional chain is the only thing standing between a missing node and a thrown error.
+        // Returning an empty MElement would make every miss look like an empty string instead.
+        return found === null || found === undefined ? null : new MElement(found);
+    };
+
+    MElement.prototype.attr = function (name) {
+        return hostDocument.attr(this.html, name);
+    };
+
+    MElement.prototype.getAttribute = function (name) {
+        return this.attr(name);
+    };
+
+    MElement.prototype.selectAll = function (selector) {
+        return this.select(selector);
+    };
+
+    MElement.prototype.toString = function () {
+        return this.html;
+    };
+
+    Object.defineProperties(MElement.prototype, {
+        // `text`, `html` and `outerHtml` are properties, not methods — verified against the
+        // published sources, which write `el.selectFirst(s)?.text` with no call parentheses.
+        // Defining them as functions would silently yield a function object that stringifies to
+        // its own source code, which is the kind of failure that reaches a user as garbled titles
+        // rather than an error.
+        text: {
+            get: function () {
+                return hostDocument.text(this.html);
+            }
+        },
+        outerHtml: {
+            get: function () {
+                return this.html;
+            }
+        },
+        innerHtml: {
+            get: function () {
+                return this.html;
+            }
+        },
+        getHref: {
+            get: function () {
+                return this.attr('href');
+            }
+        },
+        getSrc: {
+            get: function () {
+                return this.attr('src');
+            }
+        },
+        /**
+         * Attributes of this node's opening tag.
+         *
+         * Read off the tag text rather than from Jsoup, because the host exposes attributes only
+         * one name at a time and adding a bulk binding would mean a Kotlin change for something
+         * the published sources use almost exclusively on JSON payloads rather than on DOM nodes.
+         *
+         * Values are returned raw. Unlike `attr()`, which resolves against the source base URL,
+         * a relative href read from here stays relative — use `attr('href')` when an absolute URL
+         * is what is wanted.
+         */
+        attributes: {
+            get: function () {
+                var out = {};
+                var openingTag = /<[a-zA-Z][^\s/>]*((?:\s+[^\s=/>]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'>]+))?)*)/.exec(this.html);
+                if (!openingTag) {
+                    return out;
+                }
+                var pattern = /([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+)))?/g;
+                var match;
+                while ((match = pattern.exec(openingTag[1])) !== null) {
+                    var value = match[2];
+                    if (value === undefined) { value = match[3]; }
+                    if (value === undefined) { value = match[4]; }
+                    out[match[1]] = value === undefined ? '' : value;
+                }
+                return out;
+            }
+        }
+    });
+
+    // ---------------------------------------------------------------------------------------
+    // Preferences
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * The most recently constructed provider, used only to reach `getSourcePreferences()`.
+     *
+     * Set by the MProvider constructor, which the invocation runs before it calls any method, so
+     * this is populated by the time a source can ask for a preference.
+     */
+    var currentProvider = null;
+    var declaredDefaults = null;
+
+    /**
+     * Default values the extension declares for its own preferences.
+     *
+     * Sources routinely read a preference the user has never set — the near-universal case is a
+     * mirror or base-URL override, `new SharedPreferences().get("overrideBaseUrl1")` — and the
+     * extension supplies the working value as that preference's declared default. Without this,
+     * such a source builds every request against `null/...` and fails completely at browse time
+     * rather than degrading.
+     *
+     * Resolved lazily and cached: `getSourcePreferences()` is a plain constructor of literals, but
+     * it is called once per preference read otherwise, and a source can read one per result row.
+     *
+     * A stored value always wins over a declared one. That ordering is what makes a source's
+     * updated default — a moved mirror domain, say — reach a user who never touched the setting,
+     * while still never overriding a choice the user did make.
+     */
+    function defaultFor(key) {
+        if (declaredDefaults === null) {
+            declaredDefaults = {};
+            try {
+                var declared = currentProvider && typeof currentProvider.getSourcePreferences === 'function'
+                    ? currentProvider.getSourcePreferences()
+                    : [];
+                for (var i = 0; i < declared.length; i++) {
+                    var entry = declared[i];
+                    if (!entry || !entry.key) { continue; }
+                    var edit = entry.editTextPreference;
+                    var list = entry.listPreference;
+                    var multi = entry.multiSelectListPreference;
+                    var toggle = entry.switchPreferenceCompat || entry.checkBoxPreference;
+                    if (edit) {
+                        declaredDefaults[entry.key] = edit.value;
+                    } else if (list) {
+                        // The default is an index into entryValues, not a value itself.
+                        var values = list.entryValues || [];
+                        var chosen = typeof list.valueIndex === 'number' ? list.valueIndex : 0;
+                        declaredDefaults[entry.key] = list.value !== undefined ? list.value : values[chosen];
+                    } else if (multi) {
+                        declaredDefaults[entry.key] = multi.values || [];
+                    } else if (toggle) {
+                        declaredDefaults[entry.key] = toggle.value;
+                    }
+                }
+            } catch (e) {
+                // A source whose preference declaration throws still has to be usable for
+                // everything that does not depend on a preference.
+                declaredDefaults = {};
+            }
+        }
+        return Object.prototype.hasOwnProperty.call(declaredDefaults, key)
+            ? declaredDefaults[key]
+            : undefined;
+    }
+
+    function MSharedPreferences() {}
+
+    /**
+     * Read a stored preference, falling back to `defaultValue`.
+     *
+     * The host stores strings only. When the caller's default is an array or object the stored
+     * text is JSON-decoded, because sources keep multi-select preferences — enabled languages,
+     * selected categories — as lists and then call `.join()` on what comes back. A decode failure
+     * yields the default rather than throwing: a corrupt preference should degrade the source to
+     * its defaults, not make it unusable with no way for the user to reset it.
+     */
+    MSharedPreferences.prototype.get = function (key, defaultValue) {
+        var stored = hostPreferences.get(key);
+        if (stored === null || stored === undefined) {
+            // Nothing stored: fall back to what the extension declared, then to what the caller
+            // asked for. The declared value comes first because it is the source's own statement
+            // of what the setting means when untouched, whereas the caller's argument is usually
+            // just a type hint written at the call site.
+            var declared = defaultFor(key);
+            if (declared !== undefined) {
+                return declared;
+            }
+            return defaultValue === undefined ? null : defaultValue;
+        }
+        if (defaultValue !== null && typeof defaultValue === 'object') {
+            try {
+                return JSON.parse(stored);
+            } catch (e) {
+                return defaultValue;
+            }
+        }
+        if (typeof defaultValue === 'boolean') {
+            return stored === 'true';
+        }
+        if (typeof defaultValue === 'number') {
+            var parsed = Number(stored);
+            return isNaN(parsed) ? defaultValue : parsed;
+        }
+        return stored;
+    };
+
+    MSharedPreferences.prototype.set = function (key, value) {
+        hostPreferences.set(
+            key,
+            value !== null && typeof value === 'object' ? JSON.stringify(value) : String(value)
+        );
+    };
+
+    MSharedPreferences.prototype.getString = function (key, defaultValue) {
+        return this.get(key, defaultValue === undefined ? '' : defaultValue);
+    };
+    MSharedPreferences.prototype.getBool = function (key, defaultValue) {
+        return this.get(key, defaultValue === undefined ? false : defaultValue);
+    };
+    MSharedPreferences.prototype.getInt = function (key, defaultValue) {
+        return this.get(key, defaultValue === undefined ? 0 : defaultValue);
+    };
+    MSharedPreferences.prototype.getStringList = function (key, defaultValue) {
+        return this.get(key, defaultValue === undefined ? [] : defaultValue);
+    };
+    MSharedPreferences.prototype.setString = function (key, value) { this.set(key, value); };
+    MSharedPreferences.prototype.setBool = function (key, value) { this.set(key, value); };
+    MSharedPreferences.prototype.setInt = function (key, value) { this.set(key, value); };
+    MSharedPreferences.prototype.setStringList = function (key, value) { this.set(key, value); };
+
+    // ---------------------------------------------------------------------------------------
+    // The base class every extension extends
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * `class DefaultExtension extends MProvider` is the published contract, so this name must
+     * exist before the extension script is evaluated — not before it is *called*. A missing
+     * `MProvider` fails at class-definition time with a ReferenceError, which is why the prelude
+     * is evaluated ahead of the script rather than folded into the invocation.
+     */
+    function MProvider() {
+        this.source = sourceConfig;
+        this.client = new MClient();
+        this.preferences = new MSharedPreferences();
+        // Publish this instance so `new SharedPreferences()` — which sources construct standalone,
+        // with no reference to the provider — can still reach the declared preference defaults.
+        currentProvider = this;
+        declaredDefaults = null;
+    }
+
+    MProvider.prototype.getPreference = function (key, defaultValue) {
+        return this.preferences.get(key, defaultValue);
+    };
+
+    MProvider.prototype.setPreference = function (key, value) {
+        this.preferences.set(key, value);
+    };
+
+    /**
+     * Default request headers.
+     *
+     * Most sources override this. The base returns an empty object rather than inventing a
+     * User-Agent, because the app's shared OkHttp client already sets one and a value chosen here
+     * would silently override it for exactly the sources that did not ask for anything.
+     */
+    MProvider.prototype.getHeaders = function () {
+        return {};
+    };
+
+    MProvider.prototype.getBaseUrl = function () {
+        return sourceConfig.baseUrl || '';
+    };
+
+    /** Sources that expose no filters still get called for them; an empty list is the answer. */
+    MProvider.prototype.getFilterList = function () {
+        return [];
+    };
+
+    MProvider.prototype.getSourcePreferences = function () {
+        return [];
+    };
+
+    // ---------------------------------------------------------------------------------------
+    // Publish
+    // ---------------------------------------------------------------------------------------
+
+    global.Client = MClient;
+    global.Document = MElement;
+    global.Element = MElement;
+    global.SharedPreferences = MSharedPreferences;
+    global.MProvider = MProvider;
+    global.MResponse = MResponse;
+})(globalThis);

--- a/core/js-runtime/src/test/java/app/otakureader/core/js/engine/JsPreludeTest.kt
+++ b/core/js-runtime/src/test/java/app/otakureader/core/js/engine/JsPreludeTest.kt
@@ -56,17 +56,44 @@ class JsPreludeTest {
             .substringAfter("function withHandle(")
             .substringBefore("MElement.prototype.select")
 
-        // Position, not mere presence. Asserting only that both tokens appear would still pass if
-        // the release were moved out of the `finally` into the normal path — which is exactly the
-        // regression this test exists to catch, since the happy path releases either way and only
-        // the throwing path leaks.
-        val finallyAt = withHandle.indexOf("finally {")
-        val releaseAt = withHandle.indexOf("hostDocument.release(handle)")
-
+        val finallyAt = withHandle.indexOf(FINALLY)
         assertTrue("withHandle no longer has a finally block", finallyAt >= 0)
+
+        // The release must sit inside the finally *body*, not merely somewhere after the keyword.
+        // An earlier version of this test compared raw indices, which would have passed with the
+        // release moved below the closing brace — and that is precisely the regression it exists
+        // to catch, since the happy path releases either way and only the throwing path leaks.
+        val body = blockBodyAt(withHandle, finallyAt + FINALLY.length - 1)
+
         assertTrue(
             "hostDocument.release(handle) must sit inside the finally block",
-            releaseAt > finallyAt,
+            body.contains(RELEASE),
         )
+    }
+
+    /**
+     * The text between the brace at [openBraceIndex] and its match.
+     *
+     * Brace counting, not `substringBefore("}")`: the finally body is one statement today, and a
+     * naive scan to the first `}` would keep passing while quietly stopping at the wrong place the
+     * moment anyone wraps the release in a guard.
+     */
+    private fun blockBodyAt(source: String, openBraceIndex: Int): String {
+        var depth = 0
+        for (index in openBraceIndex until source.length) {
+            when (source[index]) {
+                '{' -> depth++
+                '}' -> {
+                    depth--
+                    if (depth == 0) return source.substring(openBraceIndex + 1, index)
+                }
+            }
+        }
+        return ""
+    }
+
+    private companion object {
+        const val FINALLY = "finally {"
+        const val RELEASE = "hostDocument.release(handle)"
     }
 }

--- a/core/js-runtime/src/test/java/app/otakureader/core/js/engine/JsPreludeTest.kt
+++ b/core/js-runtime/src/test/java/app/otakureader/core/js/engine/JsPreludeTest.kt
@@ -56,9 +56,17 @@ class JsPreludeTest {
             .substringAfter("function withHandle(")
             .substringBefore("MElement.prototype.select")
 
+        // Position, not mere presence. Asserting only that both tokens appear would still pass if
+        // the release were moved out of the `finally` into the normal path — which is exactly the
+        // regression this test exists to catch, since the happy path releases either way and only
+        // the throwing path leaks.
+        val finallyAt = withHandle.indexOf("finally {")
+        val releaseAt = withHandle.indexOf("hostDocument.release(handle)")
+
+        assertTrue("withHandle no longer has a finally block", finallyAt >= 0)
         assertTrue(
-            "withHandle must release its handle in a finally block",
-            withHandle.contains("finally") && withHandle.contains("hostDocument.release(handle)"),
+            "hostDocument.release(handle) must sit inside the finally block",
+            releaseAt > finallyAt,
         )
     }
 }

--- a/core/js-runtime/src/test/java/app/otakureader/core/js/engine/JsPreludeTest.kt
+++ b/core/js-runtime/src/test/java/app/otakureader/core/js/engine/JsPreludeTest.kt
@@ -1,0 +1,64 @@
+package app.otakureader.core.js.engine
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the packaging of the compatibility prelude and the names it is required to publish.
+ *
+ * The prelude's *behaviour* cannot be exercised here: QuickJS ships as an Android artifact, so
+ * there is no engine to evaluate it in from a JVM unit test. What this file can do is catch the
+ * two failures that would otherwise reach a user as a broken source with a misleading message —
+ * the resource not being packaged at all, and a rename that quietly drops one of the globals the
+ * published extensions name.
+ *
+ * Both are worth a test precisely because neither fails at build time.
+ */
+class JsPreludeTest {
+
+    @Test
+    fun `the prelude is packaged and readable as a resource`() {
+        // Missing packaging would surface as every extension failing with "MProvider is not
+        // defined" — an error that names the script and implicates the source, when the fault is
+        // entirely in this app's own build.
+        assertTrue("the prelude resource is empty", JsPrelude.source.isNotEmpty())
+    }
+
+    @Test
+    fun `the prelude publishes every global the published extensions rely on`() {
+        // Each of these was verified against the JavaScript sources in the Mangayomi index rather
+        // than taken from its contributing guide, which disagrees with the code in at least one
+        // place. `MProvider` is the one with the worst failure mode: extensions name it in an
+        // `extends` clause, which resolves when the class is *defined*, so its absence fails the
+        // whole script rather than the one method that needed it.
+        val required = listOf(
+            "global.MProvider = MProvider;",
+            "global.Client = MClient;",
+            "global.Document = MElement;",
+            "global.SharedPreferences = MSharedPreferences;",
+        )
+
+        val missing = required.filterNot { JsPrelude.source.contains(it) }
+
+        assertTrue("the prelude no longer publishes: $missing", missing.isEmpty())
+    }
+
+    @Test
+    fun `every parsed document is released on the path that throws`() {
+        // The handle pool is capped and the host refuses rather than evicts once it is full, so a
+        // selector that throws without releasing leaks one slot per failure until the source dies
+        // with an error about documents rather than about the selector that actually broke.
+        //
+        // Asserting on the `finally` is crude, but the alternative is no coverage at all: the
+        // leak only manifests against a page with enough rows to exhaust 32 handles, which is
+        // exactly the size of input a unit test does not use.
+        val withHandle = JsPrelude.source
+            .substringAfter("function withHandle(")
+            .substringBefore("MElement.prototype.select")
+
+        assertTrue(
+            "withHandle must release its handle in a finally block",
+            withHandle.contains("finally") && withHandle.contains("hostDocument.release(handle)"),
+        )
+    }
+}

--- a/core/js-runtime/src/test/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSourceTest.kt
+++ b/core/js-runtime/src/test/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSourceTest.kt
@@ -146,7 +146,7 @@ class JsExtensionRemoteDataSourceTest {
     }
 
     @Test
-    fun `a repository serving neither index path contributes nothing`() = runTest {
+    fun `a repository serving neither index path stays silent`() = runTest {
         // Both paths are tried, so both have to be answered. Enqueuing only one would leave the
         // second request waiting on an empty dispatcher until the client's read timeout, which
         // makes the test slow and — worse — pass for a reason unrelated to what it claims.
@@ -156,10 +156,26 @@ class JsExtensionRemoteDataSourceTest {
         val result = dataSource.fetchAvailable(listOf(baseUrl()))
 
         assertTrue(result.extensions.isEmpty())
-        // Answering neither path means the repository publishes no index at all, which is a real
-        // failure. The APK-only case — a foreign index served at the shared path — is the one that
-        // stays silent, and is covered separately below.
+        // This is the *common* case, not a fault: the APK backend reads `index.min.json` first and
+        // documents it as the usual third-party format, so a min-only repository answers neither
+        // path this reader asks for. Reporting it would put an error in front of every user with
+        // such a repository configured, about a backend they are using correctly.
+        assertNull(result.firstFailure)
+    }
+
+    @Test
+    fun `a broken dedicated index is reported rather than hidden by the combined one`() = runTest {
+        // 500, not 404 — the distinction is the whole point. A repository publishing
+        // /js/index.json has declared itself a JavaScript repository, so its index being
+        // unreachable is a real fault; falling through to the combined path would let a
+        // successfully-parsed APK index there bury it and report the refresh as fine.
+        server.enqueue(MockResponse().setResponseCode(500))
+
+        val result = dataSource.fetchAvailable(listOf(baseUrl()))
+
         assertNotNull(result.firstFailure)
+        // And the combined path must never have been asked: one request, to the dedicated path.
+        assertEquals(1, server.requestCount)
     }
 
     @Test
@@ -354,7 +370,8 @@ class JsExtensionRemoteDataSourceTest {
         // The Mangayomi index carries no versionCode at all. Falling back to a constant would
         // leave every installed source looking permanently up to date, so it is derived from the
         // version string — and the derivation has to order by segment precedence, not by sum.
-        // 1.0.0 against 0.9.9 is the case that tells those two rules apart: they sum identically.
+        // 1.0.0 against 0.9.9 tells those two rules apart: summing the segments gives 1 and 18, so
+        // a sum ranks the older build higher, while packing gives 1_000_000 and 9_009 — correct.
         val older = JsExtensionDto(id = "a", name = "a", baseUrl = "u", lang = "en", version = "0.9.9")
         val newer = JsExtensionDto(id = "a", name = "a", baseUrl = "u", lang = "en", version = "1.0.0")
 

--- a/core/js-runtime/src/test/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSourceTest.kt
+++ b/core/js-runtime/src/test/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSourceTest.kt
@@ -146,19 +146,29 @@ class JsExtensionRemoteDataSourceTest {
     }
 
     @Test
-    fun `a repository with no javascript index contributes nothing without failing`() = runTest {
+    fun `a repository serving neither index path contributes nothing`() = runTest {
+        // Both paths are tried, so both have to be answered. Enqueuing only one would leave the
+        // second request waiting on an empty dispatcher until the client's read timeout, which
+        // makes the test slow and — worse — pass for a reason unrelated to what it claims.
+        server.enqueue(MockResponse().setResponseCode(404))
         server.enqueue(MockResponse().setResponseCode(404))
 
-        val extensions = dataSource.fetchAvailable(listOf(baseUrl())).extensions
+        val result = dataSource.fetchAvailable(listOf(baseUrl()))
 
-        // Most repositories serve only APKs. That is a normal answer, not an error — throwing
-        // here would turn the common case into a user-visible failure.
-        assertTrue(extensions.isEmpty())
+        assertTrue(result.extensions.isEmpty())
+        // Answering neither path means the repository publishes no index at all, which is a real
+        // failure. The APK-only case — a foreign index served at the shared path — is the one that
+        // stays silent, and is covered separately below.
+        assertNotNull(result.firstFailure)
     }
 
     @Test
     fun `one unreachable repository does not suppress another`() = runTest {
-        // Two repos, first 404s. Both are read in order, so the enqueue order matches.
+        // The first repository answers neither path, so it consumes two responses before the
+        // second repository is reached. Getting this wrong is not a visible failure: the second
+        // repository would silently receive the first one's index and the assertion would still
+        // hold, which is precisely the kind of green-but-meaningless test worth avoiding.
+        server.enqueue(MockResponse().setResponseCode(500))
         server.enqueue(MockResponse().setResponseCode(500))
         server.enqueue(MockResponse().setBody(indexBody("survivor", "Survivor")))
 
@@ -247,5 +257,156 @@ class JsExtensionRemoteDataSourceTest {
         // whole and then fails somewhere inside the engine, far from its cause.
         assertNotNull(error)
         assertTrue("expected a fetch failure, got $error", error is JsExtensionFetchException)
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // The real Mangayomi index shape
+    //
+    // Every entry below is copied from https://kodjodevf.github.io/mangayomi-extensions/index.json
+    // with only the URLs pointed at the test server. The types are the point: `id` and `itemType`
+    // are JSON *numbers* there, and `sourceCodeLanguage` distinguishes the Dart majority from the
+    // JavaScript sources this backend can actually run.
+    // -----------------------------------------------------------------------------------------
+
+    /** One JavaScript manga source and one Dart one, exactly as the live index writes them. */
+    private fun mangayomiIndexBody() = """
+        [
+          {
+            "name": "JavaScript Source",
+            "id": 652112892,
+            "baseUrl": "https://js.example.test",
+            "lang": "en",
+            "iconUrl": "https://icons.example.test/js.png",
+            "isNsfw": false,
+            "hasCloudflare": false,
+            "sourceCodeUrl": "js/real.js",
+            "apiUrl": "https://api.example.test",
+            "version": "0.0.35",
+            "isManga": true,
+            "itemType": 0,
+            "sourceCodeLanguage": 1
+          },
+          {
+            "name": "Dart Source",
+            "id": 638504049,
+            "baseUrl": "https://dart.example.test",
+            "lang": "en",
+            "isNsfw": false,
+            "hasCloudflare": false,
+            "sourceCodeUrl": "dart/manga/multisrc/madara/madara.dart",
+            "apiUrl": "",
+            "version": "0.1.3",
+            "isManga": true,
+            "itemType": 0,
+            "sourceCodeLanguage": 0
+          }
+        ]
+    """.trimIndent()
+
+    @Test
+    fun `the live Mangayomi index decodes despite numeric id and itemType`() = runTest {
+        server.enqueue(MockResponse().setBody(mangayomiIndexBody()))
+
+        val result = dataSource.fetchAvailable(listOf(baseUrl()))
+
+        // Before this was fixed the decode threw on `id` and, had it not, the numeric `itemType`
+        // could never equal "manga" and the whole index would have filtered down to nothing. Both
+        // failures look identical from outside — a repository that reports no sources — so assert
+        // on the surviving entry rather than merely on the absence of an exception.
+        assertNull(result.firstFailure)
+        val extension = result.extensions.single()
+        assertEquals("652112892", extension.pkgName)
+        assertEquals("JavaScript Source", extension.name)
+    }
+
+    @Test
+    fun `Dart entries sharing the index are dropped`() = runTest {
+        server.enqueue(MockResponse().setBody(mangayomiIndexBody()))
+
+        val result = dataSource.fetchAvailable(listOf(baseUrl()))
+
+        // The rule that actually bites: both entries are manga, both are `itemType` 0, and they
+        // differ only by `sourceCodeLanguage`. A test with one entry would pass with the filter
+        // deleted. A Dart file that survived here would download, install and register exactly
+        // like a working source, and fail only when the user first browsed it.
+        assertEquals(1, result.extensions.size)
+        assertTrue(
+            "a Dart source reached the installable list: ${result.extensions.map { it.name }}",
+            result.extensions.none { it.name == "Dart Source" },
+        )
+    }
+
+    @Test
+    fun `apiUrl survives onto the source so API-backed extensions can build requests`() = runTest {
+        server.enqueue(MockResponse().setBody(mangayomiIndexBody()))
+
+        val source = dataSource.fetchAvailable(listOf(baseUrl())).extensions.single().sources.single()
+
+        // Sources that set apiUrl build essentially every request from it. Dropping the field
+        // produces requests against "undefined/..." that fail as ordinary HTTP errors, which
+        // gives no hint that the manifest was the problem.
+        assertEquals("https://api.example.test", source.apiUrl)
+        assertEquals("https://js.example.test", source.baseUrl)
+    }
+
+    @Test
+    fun `a version is ordered by precedence when the index publishes no versionCode`() = runTest {
+        // The Mangayomi index carries no versionCode at all. Falling back to a constant would
+        // leave every installed source looking permanently up to date, so it is derived from the
+        // version string — and the derivation has to order by segment precedence, not by sum.
+        // 1.0.0 against 0.9.9 is the case that tells those two rules apart: they sum identically.
+        val older = JsExtensionDto(id = "a", name = "a", baseUrl = "u", lang = "en", version = "0.9.9")
+        val newer = JsExtensionDto(id = "a", name = "a", baseUrl = "u", lang = "en", version = "1.0.0")
+
+        assertTrue(
+            "1.0.0 (${newer.effectiveVersionCode}) must outrank 0.9.9 (${older.effectiveVersionCode})",
+            newer.effectiveVersionCode > older.effectiveVersionCode,
+        )
+    }
+
+    @Test
+    fun `an explicit versionCode still wins over the derived one`() = runTest {
+        val explicit = JsExtensionDto(
+            id = "a", name = "a", baseUrl = "u", lang = "en", version = "0.0.1", versionCode = 77,
+        )
+
+        assertEquals(77, explicit.effectiveVersionCode)
+    }
+
+    @Test
+    fun `a repository serving only an APK index contributes nothing without reporting a failure`() = runTest {
+        // No /js/index.json...
+        server.enqueue(MockResponse().setResponseCode(404))
+        // ...and an /index.json in the APK backend's shape, which this reader cannot read.
+        server.enqueue(
+            MockResponse().setBody(
+                """[{"name":"Some APK","pkg":"eu.kanade.tachiyomi.en.some","apk":"some.apk","lang":"en","code":14}]""",
+            ),
+        )
+
+        val result = dataSource.fetchAvailable(listOf(baseUrl()))
+
+        // The state that matters is the *absence* of a reported failure. That filename is shared
+        // with the APK backend, so a foreign index there is the ordinary answer from an APK-only
+        // repository — surfacing it would put an error in front of every user who has Keiyoushi
+        // configured and is using it correctly.
+        assertEquals(emptyList<String>(), result.extensions.map { it.name })
+        assertNull(result.firstFailure)
+    }
+
+    @Test
+    fun `the combined index is only consulted when the dedicated one is absent`() = runTest {
+        server.enqueue(MockResponse().setBody(mangayomiIndexBody()))
+
+        dataSource.fetchAvailable(listOf(baseUrl()))
+
+        // One request, to the dedicated path. Asserting the request count is what stops this from
+        // silently becoming "always fetch both", which would double the traffic of every refresh
+        // against every configured repository.
+        assertEquals(1, server.requestCount)
+        assertEquals(
+            JsExtensionRemoteDataSource.DEDICATED_INDEX_PATH,
+            server.takeRequest().path,
+        )
     }
 }

--- a/core/js-runtime/src/test/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSourceTest.kt
+++ b/core/js-runtime/src/test/java/app/otakureader/core/js/remote/JsExtensionRemoteDataSourceTest.kt
@@ -180,11 +180,14 @@ class JsExtensionRemoteDataSourceTest {
 
     @Test
     fun `one unreachable repository does not suppress another`() = runTest {
-        // The first repository answers neither path, so it consumes two responses before the
-        // second repository is reached. Getting this wrong is not a visible failure: the second
-        // repository would silently receive the first one's index and the assertion would still
-        // hold, which is precisely the kind of green-but-meaningless test worth avoiding.
-        server.enqueue(MockResponse().setResponseCode(500))
+        // One response each. A 500 on the dedicated path is a fault, not an absence, so it stops
+        // there rather than falling through to the combined path — the first repository consumes
+        // exactly one response and the second gets its own index.
+        //
+        // This is worth stating because the count is invisible until it is wrong: an earlier
+        // version of this test enqueued two responses for the first repository, and once the
+        // fallthrough narrowed to 404 only, the second repository silently received the leftover
+        // 500 instead of its index. The assertion below is what caught it.
         server.enqueue(MockResponse().setResponseCode(500))
         server.enqueue(MockResponse().setBody(indexBody("survivor", "Survivor")))
 

--- a/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
+++ b/feature/browse/src/main/java/app/otakureader/feature/browse/BrowseScreen.kt
@@ -340,7 +340,9 @@ fun BrowseScreen(
                     BrowseTab.MIGRATE -> {
                         val migVm: MigrationEntryViewModel = hiltViewModel()
                         val migState by migVm.state.collectAsStateWithLifecycle()
-                        val migFiltered = remember(migState.mangaList, migState.searchQuery) {
+                        // Keyed on the whole state — see the note in MigrationEntryScreen. Keying
+                        // on individual fields broke here too when showOnlyStranded was added.
+                        val migFiltered = remember(migState) {
                             migVm.filteredList(migState)
                         }
                         LaunchedEffect(migVm) {

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryMvi.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryMvi.kt
@@ -13,15 +13,28 @@ data class MigrationEntryState(
     val searchQuery: String = "",
     /** Narrows the list to entries whose source no longer resolves. */
     val showOnlyStranded: Boolean = false,
+    /**
+     * Whether the source inventory has actually loaded.
+     *
+     * Until it has, nothing can be called stranded: the repository's source list is a StateFlow
+     * seeded empty, so the first emission resolves every key to nothing. Treating that as an
+     * answer would show the whole library as broken and invite the user to migrate all of it.
+     *
+     * Held separately from the items rather than inferred from them, because "every entry is
+     * stranded" and "sources have not loaded" look identical in the list and want opposite
+     * treatment.
+     */
+    val sourcesKnown: Boolean = false,
     val error: String? = null
 ) {
     /**
-     * Entries no loaded source can serve.
+     * Entries no loaded source can serve — zero until the inventory is known.
      *
-     * Derived rather than stored so it cannot drift from [mangaList] — the count and the list it
-     * describes are always computed from the same snapshot.
+     * Derived rather than stored so it cannot drift from [mangaList], and gated on
+     * [sourcesKnown] so the banner and its actions stay hidden while the answer is still
+     * unknown rather than briefly claiming the library is broken.
      */
-    val strandedCount: Int get() = mangaList.count { it.isStranded }
+    val strandedCount: Int get() = if (sourcesKnown) mangaList.count { it.isStranded } else 0
 }
 
 data class MigrationEntryItem(

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryMvi.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryMvi.kt
@@ -11,19 +11,43 @@ data class MigrationEntryState(
     val mangaList: List<MigrationEntryItem> = emptyList(),
     val selectedIds: Set<Long> = emptySet(),
     val searchQuery: String = "",
+    /** Narrows the list to entries whose source no longer resolves. */
+    val showOnlyStranded: Boolean = false,
     val error: String? = null
-)
+) {
+    /**
+     * Entries no loaded source can serve.
+     *
+     * Derived rather than stored so it cannot drift from [mangaList] — the count and the list it
+     * describes are always computed from the same snapshot.
+     */
+    val strandedCount: Int get() = mangaList.count { it.isStranded }
+}
 
 data class MigrationEntryItem(
     val id: Long,
     val title: String,
-    val thumbnailUrl: String?
-)
+    val thumbnailUrl: String?,
+    /**
+     * Display name of the source this manga came from, or null when no loaded source owns its key.
+     *
+     * Null carries real meaning here and is not merely "unknown": the manga row stores a `Long`
+     * key that is a one-way hash of a source's string id, so an unresolved key cannot be turned
+     * back into a name to show. It means the source is genuinely unreachable — its extension was
+     * uninstalled, or the backend that provided it is gone — and every read of this manga will
+     * fail until it is migrated to a source that exists.
+     */
+    val sourceName: String?
+) {
+    val isStranded: Boolean get() = sourceName == null
+}
 
 sealed class MigrationEntryEvent {
     data class OnSearchQueryChange(val query: String) : MigrationEntryEvent()
     data class OnMangaToggle(val mangaId: Long) : MigrationEntryEvent()
     data object SelectAll : MigrationEntryEvent()
+    data object SelectAllStranded : MigrationEntryEvent()
+    data object ToggleStrandedFilter : MigrationEntryEvent()
     data object ClearSelection : MigrationEntryEvent()
     data object OnStartMigration : MigrationEntryEvent()
     data object NavigateBack : MigrationEntryEvent()

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryScreen.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryScreen.kt
@@ -166,7 +166,12 @@ fun MigrationEntryScreen(
     viewModel: MigrationEntryViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val filtered = remember(state.mangaList, state.searchQuery) {
+        // Keyed on the whole state, not on the fields filteredList happens to read today.
+        // Mirroring individual fields here is a standing trap: it silently broke the moment
+        // showOnlyStranded was added, flipping the button's label while the list kept rendering
+        // the previous cached rows. Re-deriving is a filter over the library — cheap next to a
+        // wrong list the user then migrates from.
+    val filtered = remember(state) {
         viewModel.filteredList(state)
     }
     val snackbarHostState = remember { SnackbarHostState() }

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryScreen.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryScreen.kt
@@ -111,9 +111,12 @@ fun MigrationEntryContent(
                     )
                 }
                 else -> LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    // Only when something is actually broken. A permanent banner would train the
-                    // user to ignore it, which is exactly when it needs to be read.
-                    if (state.strandedCount > 0) {
+                    // Shown when something is broken — a permanent banner would train the user to
+                    // ignore it, which is exactly when it needs to be read — and also whenever the
+                    // filter is on, even at zero. The toggle lives here and nowhere else, so
+                    // hiding the banner the moment the last stranded entry is migrated would strand
+                    // the user in an empty filtered list with no way back out of it.
+                    if (state.strandedCount > 0 || state.showOnlyStranded) {
                         item(key = "stranded-banner") {
                             StrandedBanner(state = state, onEvent = onEvent)
                         }

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryScreen.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryScreen.kt
@@ -115,12 +115,18 @@ fun MigrationEntryContent(
                     if (filtered.isEmpty()) {
                         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                             Text(
+                                // Order matters. "Nothing is stranded" is only true when the
+                                // stranded set is genuinely empty — with the filter on and a query
+                                // typed, an empty result usually means the query matched none of
+                                // several stranded entries, and saying nothing is stranded there
+                                // contradicts the banner sitting directly above it.
                                 text = when {
-                                    state.showOnlyStranded ->
+                                    state.showOnlyStranded && state.sourcesKnown &&
+                                        state.strandedCount == 0 ->
                                         stringResource(R.string.migration_entry_no_stranded)
-                                    state.searchQuery.isBlank() ->
-                                        stringResource(R.string.migration_entry_library_empty)
-                                    else -> stringResource(R.string.migration_entry_no_results)
+                                    state.searchQuery.isNotBlank() ->
+                                        stringResource(R.string.migration_entry_no_results)
+                                    else -> stringResource(R.string.migration_entry_library_empty)
                                 },
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryScreen.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryScreen.kt
@@ -99,34 +99,44 @@ fun MigrationEntryContent(
                         }
                     }
                 }
-                filtered.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text(
-                        text = if (state.searchQuery.isBlank()) {
-                            stringResource(R.string.migration_entry_library_empty)
-                        } else {
-                            stringResource(R.string.migration_entry_no_results)
-                        },
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                else -> LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    // Shown when something is broken — a permanent banner would train the user to
-                    // ignore it, which is exactly when it needs to be read — and also whenever the
-                    // filter is on, even at zero. The toggle lives here and nowhere else, so
-                    // hiding the banner the moment the last stranded entry is migrated would strand
-                    // the user in an empty filtered list with no way back out of it.
+                else -> Column(modifier = Modifier.fillMaxSize()) {
+                    // Outside the empty-state branch on purpose. The filter's only toggle lives in
+                    // this banner, and the filter can legitimately produce no rows — the user
+                    // migrates the last stranded entry, or turns it on when none are stranded. Kept
+                    // inside the list, that empty result rendered the "your library is empty"
+                    // message with no way to switch the filter back off.
+                    //
+                    // Shown only when something is broken or the filter is on: a banner that is
+                    // always present is one the user learns to skip past.
                     if (state.strandedCount > 0 || state.showOnlyStranded) {
-                        item(key = "stranded-banner") {
-                            StrandedBanner(state = state, onEvent = onEvent)
-                        }
+                        StrandedBanner(state = state, onEvent = onEvent)
                     }
-                    items(filtered, key = { it.id }) { manga ->
-                        MigrationEntryMangaRow(
-                            manga = manga,
-                            isSelected = manga.id in state.selectedIds,
-                            onToggle = { onEvent(MigrationEntryEvent.OnMangaToggle(manga.id)) },
-                        )
+
+                    if (filtered.isEmpty()) {
+                        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            Text(
+                                text = when {
+                                    state.showOnlyStranded ->
+                                        stringResource(R.string.migration_entry_no_stranded)
+                                    state.searchQuery.isBlank() ->
+                                        stringResource(R.string.migration_entry_library_empty)
+                                    else -> stringResource(R.string.migration_entry_no_results)
+                                },
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    } else {
+                        LazyColumn(modifier = Modifier.fillMaxSize()) {
+                            items(filtered, key = { it.id }) { manga ->
+                                MigrationEntryMangaRow(
+                                    manga = manga,
+                                    isSelected = manga.id in state.selectedIds,
+                                    sourcesKnown = state.sourcesKnown,
+                                    onToggle = { onEvent(MigrationEntryEvent.OnMangaToggle(manga.id)) },
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -286,6 +296,7 @@ private fun StrandedBanner(
 private fun MigrationEntryMangaRow(
     manga: MigrationEntryItem,
     isSelected: Boolean,
+    sourcesKnown: Boolean,
     onToggle: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -321,10 +332,17 @@ private fun MigrationEntryMangaRow(
             // entry whose source cannot be resolved is unreadable, and nothing else in the app
             // says so. Rendered in the error colour rather than as a separate icon so the state
             // survives being skimmed.
+            // Blank rather than "Source not installed" while the inventory is still loading:
+            // an unresolved key means nothing yet, and saying otherwise accuses every row.
+            val unresolvedLabel = if (sourcesKnown) {
+                stringResource(R.string.migration_entry_source_missing)
+            } else {
+                ""
+            }
             Text(
-                text = manga.sourceName ?: stringResource(R.string.migration_entry_source_missing),
+                text = manga.sourceName ?: unresolvedLabel,
                 style = MaterialTheme.typography.bodySmall,
-                color = if (manga.isStranded) {
+                color = if (sourcesKnown && manga.isStranded) {
                     MaterialTheme.colorScheme.error
                 } else {
                     MaterialTheme.colorScheme.onSurfaceVariant

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryScreen.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -110,6 +111,13 @@ fun MigrationEntryContent(
                     )
                 }
                 else -> LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    // Only when something is actually broken. A permanent banner would train the
+                    // user to ignore it, which is exactly when it needs to be read.
+                    if (state.strandedCount > 0) {
+                        item(key = "stranded-banner") {
+                            StrandedBanner(state = state, onEvent = onEvent)
+                        }
+                    }
                     items(filtered, key = { it.id }) { manga ->
                         MigrationEntryMangaRow(
                             manga = manga,
@@ -220,6 +228,52 @@ fun MigrationEntryScreen(
     }
 }
 
+/**
+ * Surfaces entries no loaded source can serve, with the two actions that resolve them.
+ *
+ * Selecting is offered separately from filtering because they answer different questions — "fix
+ * these" versus "let me look at these" — and a user who only wants the first should not have to
+ * change what the list shows to get it.
+ */
+@Composable
+private fun StrandedBanner(
+    state: MigrationEntryState,
+    onEvent: (MigrationEntryEvent) -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+            Text(
+                text = androidx.compose.ui.res.pluralStringResource(
+                    R.plurals.migration_entry_stranded_banner,
+                    state.strandedCount,
+                    state.strandedCount,
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TextButton(onClick = { onEvent(MigrationEntryEvent.SelectAllStranded) }) {
+                    Text(stringResource(R.string.migration_entry_select_stranded))
+                }
+                TextButton(onClick = { onEvent(MigrationEntryEvent.ToggleStrandedFilter) }) {
+                    Text(
+                        stringResource(
+                            if (state.showOnlyStranded) {
+                                R.string.migration_entry_show_all_entries
+                            } else {
+                                R.string.migration_entry_show_stranded_only
+                            }
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
 @Composable
 private fun MigrationEntryMangaRow(
     manga: MigrationEntryItem,
@@ -248,13 +302,29 @@ private fun MigrationEntryMangaRow(
                 .aspectRatio(3f / 4f)
         )
 
-        Text(
-            text = manga.title,
-            style = MaterialTheme.typography.bodyLarge,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f)
-        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = manga.title,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            // The source line is the whole point of showing this screen before a migration: an
+            // entry whose source cannot be resolved is unreadable, and nothing else in the app
+            // says so. Rendered in the error colour rather than as a separate icon so the state
+            // survives being skimmed.
+            Text(
+                text = manga.sourceName ?: stringResource(R.string.migration_entry_source_missing),
+                style = MaterialTheme.typography.bodySmall,
+                color = if (manga.isStranded) {
+                    MaterialTheme.colorScheme.error
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
 
         Checkbox(
             checked = isSelected,

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryViewModel.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryViewModel.kt
@@ -72,8 +72,13 @@ class MigrationEntryViewModel @Inject constructor(
         // that mistake corrects itself; it does not stop it being shown.
         //
         // An empty source list is therefore treated as "not loaded yet" rather than "nothing is
-        // installed". That is sound because `refreshSources()` always publishes the built-in local
-        // source alongside whatever else it found, so a loaded list is never empty.
+        // installed" — sound because `refreshSources()` always publishes the built-in local source
+        // alongside whatever else it found, so a loaded list is never empty.
+        //
+        // That readiness is carried on the state, NOT used to withhold the library. Withholding it
+        // was the first attempt and it was worse: a genuinely empty source list left the screen on
+        // its spinner for good, and Retry re-collected the same flow to the same effect. The rows
+        // appear immediately; only the stranded verdict waits.
         loadJob = combine(getLibraryManga(), sourceRepository.getSources()) { manga, sources ->
             // The one correct key -> source bridge. `associateBySourceKey` is the same index
             // `getSourceByKey` uses, legacy-key precedence included; matching on
@@ -90,12 +95,13 @@ class MigrationEntryViewModel @Inject constructor(
             LoadedLibrary(items = items, sourcesReady = sources.isNotEmpty())
         }
             .onEach { loaded ->
-                // Hold the screen on its spinner until sources are ready. Publishing the entries
-                // early would be worse than slow: every row would read "Source not installed" and
-                // the banner would invite the user to migrate their whole library.
-                if (!loaded.sourcesReady) return@onEach
                 _state.update { state ->
-                    state.copy(isLoading = false, error = null, mangaList = loaded.items)
+                    state.copy(
+                        isLoading = false,
+                        error = null,
+                        mangaList = loaded.items,
+                        sourcesKnown = loaded.sourcesReady,
+                    )
                 }
             }
             .catch { e ->
@@ -138,6 +144,8 @@ class MigrationEntryViewModel @Inject constructor(
      */
     private fun selectAllStranded() {
         _state.update { state ->
+            // No-op until the inventory is known — selecting here would pick the entire library.
+            if (!state.sourcesKnown) return@update state
             state.copy(selectedIds = state.mangaList.filter { it.isStranded }.map { it.id }.toSet())
         }
     }
@@ -167,7 +175,11 @@ class MigrationEntryViewModel @Inject constructor(
     /** The manga list as the screen shows it: narrowed by the stranded filter, then the query. */
     fun filteredList(state: MigrationEntryState = _state.value): List<MigrationEntryItem> {
         val query = state.searchQuery.trim()
-        val bySource = if (state.showOnlyStranded) state.mangaList.filter { it.isStranded } else state.mangaList
+        val bySource = if (state.showOnlyStranded && state.sourcesKnown) {
+            state.mangaList.filter { it.isStranded }
+        } else {
+            state.mangaList
+        }
         return if (query.isBlank()) bySource
         else bySource.filter { it.title.contains(query, ignoreCase = true) }
     }

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryViewModel.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryViewModel.kt
@@ -2,6 +2,8 @@ package app.otakureader.feature.migration
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import app.otakureader.domain.repository.SourceRepository
+import app.otakureader.domain.repository.associateBySourceKey
 import app.otakureader.domain.usecase.GetLibraryMangaUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -12,6 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
@@ -20,7 +23,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MigrationEntryViewModel @Inject constructor(
-    private val getLibraryManga: GetLibraryMangaUseCase
+    private val getLibraryManga: GetLibraryMangaUseCase,
+    private val sourceRepository: SourceRepository
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(MigrationEntryState())
@@ -41,6 +45,8 @@ class MigrationEntryViewModel @Inject constructor(
             is MigrationEntryEvent.OnSearchQueryChange -> onSearchQueryChange(event.query)
             is MigrationEntryEvent.OnMangaToggle -> toggleManga(event.mangaId)
             MigrationEntryEvent.SelectAll -> selectAll()
+            MigrationEntryEvent.SelectAllStranded -> selectAllStranded()
+            MigrationEntryEvent.ToggleStrandedFilter -> toggleStrandedFilter()
             MigrationEntryEvent.ClearSelection -> clearSelection()
             MigrationEntryEvent.OnStartMigration -> startMigration()
             MigrationEntryEvent.NavigateBack -> navigateBack()
@@ -54,20 +60,27 @@ class MigrationEntryViewModel @Inject constructor(
         // concurrent collectors racing to update _state. Hold the Job and cancel before relaunch.
         loadJob?.cancel()
         _state.update { it.copy(isLoading = true, error = null) }
-        loadJob = getLibraryManga()
-            .onEach { manga ->
+        // Combined rather than read once, because both sides change while this screen is open:
+        // the library updates as entries are migrated, and the source list is populated
+        // asynchronously at startup and again after a refresh. Resolving against a snapshot taken
+        // before sources finished loading would mark the entire library as stranded.
+        loadJob = combine(getLibraryManga(), sourceRepository.getSources()) { manga, sources ->
+            // The one correct key -> source bridge. `associateBySourceKey` is the same index
+            // `getSourceByKey` uses, legacy-key precedence included; matching on
+            // `sourceId.toString()` compares a hash's decimal against a real id and never hits.
+            val byKey = sources.associateBySourceKey { it.id }
+            manga.map { m ->
+                MigrationEntryItem(
+                    id = m.id,
+                    title = m.title,
+                    thumbnailUrl = m.thumbnailUrl,
+                    sourceName = byKey[m.sourceId]?.name
+                )
+            }
+        }
+            .onEach { items ->
                 _state.update { state ->
-                    state.copy(
-                        isLoading = false,
-                        error = null,
-                        mangaList = manga.map { m ->
-                            MigrationEntryItem(
-                                id = m.id,
-                                title = m.title,
-                                thumbnailUrl = m.thumbnailUrl
-                            )
-                        }
-                    )
+                    state.copy(isLoading = false, error = null, mangaList = items)
                 }
             }
             .catch { e ->
@@ -100,6 +113,24 @@ class MigrationEntryViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Select exactly the entries no loaded source can serve.
+     *
+     * Deliberately ignores the search query and the stranded filter, unlike [selectAll]. This is
+     * the "fix what is broken" action, and its value is that the user does not have to have found
+     * the broken entries first — narrowing it by whatever happens to be typed in the search box
+     * would silently select a subset and leave the rest behind.
+     */
+    private fun selectAllStranded() {
+        _state.update { state ->
+            state.copy(selectedIds = state.mangaList.filter { it.isStranded }.map { it.id }.toSet())
+        }
+    }
+
+    private fun toggleStrandedFilter() {
+        _state.update { it.copy(showOnlyStranded = !it.showOnlyStranded) }
+    }
+
     private fun clearSelection() {
         _state.update { it.copy(selectedIds = emptySet()) }
     }
@@ -118,10 +149,11 @@ class MigrationEntryViewModel @Inject constructor(
         }
     }
 
-    /** Returns the manga list filtered by the current search query. */
+    /** The manga list as the screen shows it: narrowed by the stranded filter, then the query. */
     fun filteredList(state: MigrationEntryState = _state.value): List<MigrationEntryItem> {
         val query = state.searchQuery.trim()
-        return if (query.isBlank()) state.mangaList
-        else state.mangaList.filter { it.title.contains(query, ignoreCase = true) }
+        val bySource = if (state.showOnlyStranded) state.mangaList.filter { it.isStranded } else state.mangaList
+        return if (query.isBlank()) bySource
+        else bySource.filter { it.title.contains(query, ignoreCase = true) }
     }
 }

--- a/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryViewModel.kt
+++ b/feature/migration/src/main/java/app/otakureader/feature/migration/MigrationEntryViewModel.kt
@@ -62,14 +62,24 @@ class MigrationEntryViewModel @Inject constructor(
         _state.update { it.copy(isLoading = true, error = null) }
         // Combined rather than read once, because both sides change while this screen is open:
         // the library updates as entries are migrated, and the source list is populated
-        // asynchronously at startup and again after a refresh. Resolving against a snapshot taken
-        // before sources finished loading would mark the entire library as stranded.
+        // asynchronously at startup and again after a refresh.
+        //
+        // Combining alone is NOT enough to make the stranded status trustworthy, which an earlier
+        // version of this comment claimed. `getSources()` is backed by a StateFlow seeded with an
+        // empty list, so the first emission arrives before any source has loaded and resolves
+        // every key to nothing — the screen would show the entire library as stranded, and offer
+        // to migrate all of it, until the real list arrived a moment later. Combining only means
+        // that mistake corrects itself; it does not stop it being shown.
+        //
+        // An empty source list is therefore treated as "not loaded yet" rather than "nothing is
+        // installed". That is sound because `refreshSources()` always publishes the built-in local
+        // source alongside whatever else it found, so a loaded list is never empty.
         loadJob = combine(getLibraryManga(), sourceRepository.getSources()) { manga, sources ->
             // The one correct key -> source bridge. `associateBySourceKey` is the same index
             // `getSourceByKey` uses, legacy-key precedence included; matching on
             // `sourceId.toString()` compares a hash's decimal against a real id and never hits.
             val byKey = sources.associateBySourceKey { it.id }
-            manga.map { m ->
+            val items = manga.map { m ->
                 MigrationEntryItem(
                     id = m.id,
                     title = m.title,
@@ -77,10 +87,15 @@ class MigrationEntryViewModel @Inject constructor(
                     sourceName = byKey[m.sourceId]?.name
                 )
             }
+            LoadedLibrary(items = items, sourcesReady = sources.isNotEmpty())
         }
-            .onEach { items ->
+            .onEach { loaded ->
+                // Hold the screen on its spinner until sources are ready. Publishing the entries
+                // early would be worse than slow: every row would read "Source not installed" and
+                // the banner would invite the user to migrate their whole library.
+                if (!loaded.sourcesReady) return@onEach
                 _state.update { state ->
-                    state.copy(isLoading = false, error = null, mangaList = items)
+                    state.copy(isLoading = false, error = null, mangaList = loaded.items)
                 }
             }
             .catch { e ->
@@ -157,3 +172,15 @@ class MigrationEntryViewModel @Inject constructor(
         else bySource.filter { it.title.contains(query, ignoreCase = true) }
     }
 }
+
+/**
+ * One resolved snapshot of the library, plus whether the source list backing it had loaded.
+ *
+ * Carried rather than inferred from `mangaList.all { it.isStranded }`, because a library where
+ * every entry genuinely is stranded and one resolved before sources arrived look identical from
+ * the items alone — and they want opposite treatment.
+ */
+private data class LoadedLibrary(
+    val items: List<MigrationEntryItem>,
+    val sourcesReady: Boolean,
+)

--- a/feature/migration/src/main/res/values/strings.xml
+++ b/feature/migration/src/main/res/values/strings.xml
@@ -82,4 +82,14 @@
     <string name="migration_entry_retry">Retry</string>
     <string name="migration_entry_library_empty">Your library is empty</string>
     <string name="migration_entry_no_results">No manga match your search</string>
+    <!-- Entries whose source no longer resolves: the extension was uninstalled, or the backend
+         that provided it is gone. Every read of such a manga fails until it is migrated. -->
+    <string name="migration_entry_source_missing">Source not installed</string>
+    <string name="migration_entry_select_stranded">Select them</string>
+    <string name="migration_entry_show_stranded_only">Show only these</string>
+    <string name="migration_entry_show_all_entries">Show all</string>
+    <plurals name="migration_entry_stranded_banner">
+        <item quantity="one">%d entry has no working source</item>
+        <item quantity="other">%d entries have no working source</item>
+    </plurals>
 </resources>

--- a/feature/migration/src/main/res/values/strings.xml
+++ b/feature/migration/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="migration_entry_select_stranded">Select them</string>
     <string name="migration_entry_show_stranded_only">Show only these</string>
     <string name="migration_entry_show_all_entries">Show all</string>
+    <string name="migration_entry_no_stranded">No entries are missing a source</string>
     <plurals name="migration_entry_stranded_banner">
         <item quantity="one">%d entry has no working source</item>
         <item quantity="other">%d entries have no working source</item>

--- a/feature/migration/src/test/java/app/otakureader/feature/migration/MigrationEntryViewModelTest.kt
+++ b/feature/migration/src/test/java/app/otakureader/feature/migration/MigrationEntryViewModelTest.kt
@@ -3,7 +3,10 @@ package app.otakureader.feature.migration
 import app.cash.turbine.test
 import app.otakureader.domain.model.Manga
 import app.otakureader.domain.model.MangaStatus
+import app.otakureader.domain.repository.SourceRepository
 import app.otakureader.domain.usecase.GetLibraryMangaUseCase
+import app.otakureader.sourceapi.MangaSource
+import app.otakureader.sourceapi.toSourceId
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -27,6 +30,15 @@ class MigrationEntryViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var getLibraryManga: GetLibraryMangaUseCase
+    private lateinit var sourceRepository: SourceRepository
+
+    /** A source whose canonical key is the hash of its string id. */
+    private fun source(id: String, name: String): MangaSource {
+        val mock = mockk<MangaSource>(relaxed = true)
+        every { mock.id } returns id
+        every { mock.name } returns name
+        return mock
+    }
 
     private val sampleMangas = listOf(
         Manga(id = 1L, sourceId = 10L, url = "/m/1", title = "Naruto", favorite = true),
@@ -39,6 +51,8 @@ class MigrationEntryViewModelTest {
         Dispatchers.setMain(testDispatcher)
         getLibraryManga = mockk()
         every { getLibraryManga.invoke() } returns flowOf(emptyList<Manga>())
+        sourceRepository = mockk()
+        every { sourceRepository.getSources() } returns flowOf(emptyList())
     }
 
     @After
@@ -46,7 +60,7 @@ class MigrationEntryViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() = MigrationEntryViewModel(getLibraryManga)
+    private fun createViewModel() = MigrationEntryViewModel(getLibraryManga, sourceRepository)
 
     @Test
     fun init_loadsLibraryManga() = runTest {
@@ -210,5 +224,119 @@ class MigrationEntryViewModelTest {
 
             assertTrue(awaitItem() is MigrationEntryEffect.NavigateBack)
         }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Stranded entries — the recourse for a library row whose source no longer exists
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    fun sourceName_resolvesThroughTheHashedKey() = runTest {
+        val sourceId = "mangadex-en"
+        val manga = Manga(id = 1L, sourceId = sourceId.toSourceId(), url = "/m/1", title = "Naruto", favorite = true)
+        every { getLibraryManga() } returns flowOf(listOf(manga))
+        every { sourceRepository.getSources() } returns flowOf(listOf(source(sourceId, "MangaDex")))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // The rule that bites: the row stores id.hashCode().toLong(), so anything that compares
+        // sourceId.toString() against the source's id resolves nothing and marks a perfectly
+        // healthy entry as stranded.
+        val item = viewModel.state.value.mangaList.single()
+        assertEquals("MangaDex", item.sourceName)
+        assertFalse(item.isStranded)
+        assertEquals(0, viewModel.state.value.strandedCount)
+    }
+
+    @Test
+    fun sourceName_resolvesLegacyNumericKeys() = runTest {
+        // Rows written by an older build stored the source's raw numeric id rather than the hash.
+        // getSourceByKey still resolves those, so this screen has to as well — otherwise the same
+        // source is reachable when reading a chapter and "not installed" here.
+        val manga = Manga(id = 1L, sourceId = 10L, url = "/m/1", title = "Naruto", favorite = true)
+        every { getLibraryManga() } returns flowOf(listOf(manga))
+        every { sourceRepository.getSources() } returns flowOf(listOf(source("10", "Legacy Source")))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("Legacy Source", viewModel.state.value.mangaList.single().sourceName)
+    }
+
+    @Test
+    fun anEntryWithNoLoadedSourceIsStranded() = runTest {
+        val manga = Manga(id = 1L, sourceId = 999L, url = "/m/1", title = "Orphan", favorite = true)
+        every { getLibraryManga() } returns flowOf(listOf(manga))
+        every { sourceRepository.getSources() } returns flowOf(listOf(source("other", "Other")))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val item = viewModel.state.value.mangaList.single()
+        assertNull(item.sourceName)
+        assertTrue(item.isStranded)
+        assertEquals(1, viewModel.state.value.strandedCount)
+    }
+
+    @Test
+    fun selectAllStranded_selectsOnlyTheBrokenEntries() = runTest {
+        val healthyId = "alive"
+        every { getLibraryManga() } returns flowOf(
+            listOf(
+                Manga(id = 1L, sourceId = healthyId.toSourceId(), url = "/m/1", title = "Healthy", favorite = true),
+                Manga(id = 2L, sourceId = 424242L, url = "/m/2", title = "Broken", favorite = true),
+            )
+        )
+        every { sourceRepository.getSources() } returns flowOf(listOf(source(healthyId, "Alive")))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+        viewModel.onEvent(MigrationEntryEvent.SelectAllStranded)
+
+        assertEquals(setOf(2L), viewModel.state.value.selectedIds)
+    }
+
+    @Test
+    fun selectAllStranded_ignoresTheSearchQuery() = runTest {
+        every { getLibraryManga() } returns flowOf(
+            listOf(
+                Manga(id = 1L, sourceId = 111L, url = "/m/1", title = "Naruto", favorite = true),
+                Manga(id = 2L, sourceId = 222L, url = "/m/2", title = "Bleach", favorite = true),
+            )
+        )
+        every { sourceRepository.getSources() } returns flowOf(emptyList())
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+        viewModel.onEvent(MigrationEntryEvent.OnSearchQueryChange("Naruto"))
+        viewModel.onEvent(MigrationEntryEvent.SelectAllStranded)
+
+        // Both are stranded, and the action is "fix everything broken" — narrowing it by whatever
+        // is typed in the search box would silently leave Bleach behind with no indication.
+        assertEquals(setOf(1L, 2L), viewModel.state.value.selectedIds)
+    }
+
+    @Test
+    fun strandedFilter_narrowsTheVisibleListAndRestoresIt() = runTest {
+        val healthyId = "alive"
+        every { getLibraryManga() } returns flowOf(
+            listOf(
+                Manga(id = 1L, sourceId = healthyId.toSourceId(), url = "/m/1", title = "Healthy", favorite = true),
+                Manga(id = 2L, sourceId = 424242L, url = "/m/2", title = "Broken", favorite = true),
+            )
+        )
+        every { sourceRepository.getSources() } returns flowOf(listOf(source(healthyId, "Alive")))
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(2, viewModel.filteredList().size)
+        viewModel.onEvent(MigrationEntryEvent.ToggleStrandedFilter)
+        assertEquals(listOf(2L), viewModel.filteredList().map { it.id })
+        // Assert it toggles back too: a filter that only turns on strands the user in a view they
+        // cannot leave.
+        viewModel.onEvent(MigrationEntryEvent.ToggleStrandedFilter)
+        assertEquals(2, viewModel.filteredList().size)
     }
 }

--- a/feature/migration/src/test/java/app/otakureader/feature/migration/MigrationEntryViewModelTest.kt
+++ b/feature/migration/src/test/java/app/otakureader/feature/migration/MigrationEntryViewModelTest.kt
@@ -305,7 +305,9 @@ class MigrationEntryViewModelTest {
                 Manga(id = 2L, sourceId = 222L, url = "/m/2", title = "Bleach", favorite = true),
             )
         )
-        every { sourceRepository.getSources() } returns flowOf(emptyList())
+        // Loaded, but owning neither key: both entries are genuinely stranded. An empty list would
+        // mean "not loaded yet" instead, and nothing would be classified at all.
+        every { sourceRepository.getSources() } returns flowOf(listOf(source("other", "Other")))
 
         val viewModel = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
@@ -338,5 +340,28 @@ class MigrationEntryViewModelTest {
         // cannot leave.
         viewModel.onEvent(MigrationEntryEvent.ToggleStrandedFilter)
         assertEquals(2, viewModel.filteredList().size)
+    }
+
+    @Test
+    fun nothingIsStrandedUntilSourcesLoad() = runTest {
+        every { getLibraryManga() } returns flowOf(
+            listOf(Manga(id = 1L, sourceId = 999L, url = "/m/1", title = "Orphan", favorite = true))
+        )
+        // The repository's source list is a StateFlow seeded empty; this is that first emission.
+        every { sourceRepository.getSources() } returns flowOf(emptyList())
+
+        val viewModel = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // The row is published — withholding it hung the screen on its spinner forever — but no
+        // verdict is reached, so the banner stays away and nothing invites migrating the library.
+        assertEquals(1, viewModel.state.value.mangaList.size)
+        assertFalse(viewModel.state.value.isLoading)
+        assertFalse(viewModel.state.value.sourcesKnown)
+        assertEquals(0, viewModel.state.value.strandedCount)
+
+        // And the action is inert rather than selecting everything.
+        viewModel.onEvent(MigrationEntryEvent.SelectAllStranded)
+        assertTrue(viewModel.state.value.selectedIds.isEmpty())
     }
 }

--- a/tools/js-prelude-harness/.gitignore
+++ b/tools/js-prelude-harness/.gitignore
@@ -2,4 +2,3 @@ node_modules/
 idx.json
 tmp_*.js
 tmp_*.json
-package-lock.json

--- a/tools/js-prelude-harness/.gitignore
+++ b/tools/js-prelude-harness/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+idx.json
+tmp_*.js
+tmp_*.json
+package-lock.json

--- a/tools/js-prelude-harness/README.md
+++ b/tools/js-prelude-harness/README.md
@@ -1,0 +1,65 @@
+# JavaScript prelude harness
+
+Runs real, unmodified Mangayomi extensions against
+`core/js-runtime/src/main/resources/js/prelude.js` — outside Android, on Node.
+
+## Why this exists
+
+The prelude is the compatibility layer between the object-oriented API community JavaScript
+sources are written against (`new Client()`, `new Document(html)`, `class DefaultExtension extends
+MProvider`) and the flat, primitives-only bindings `QuickJsHost` installs.
+
+It cannot be unit-tested from the JVM: QuickJS ships as an Android artifact, so there is no engine
+to evaluate it in. `JsPreludeTest` therefore only checks that the file is packaged and still
+publishes the right globals — it cannot tell you whether a real source *works*.
+
+This harness can. `host.mjs` reimplements every `QuickJsHost` binding with the same argument
+order, the same return types, the same handle discipline and the same 32-document cap, backed by
+cheerio instead of Jsoup. `run.mjs` then reproduces `QuickJsHost.call` exactly: host globals →
+source config global → prelude → extension script → the invocation `buildInvocation()` emits.
+
+It is deliberately **not** a Gradle module and never runs in CI: it needs live network and real
+third-party sites, so it fails for reasons that have nothing to do with this repository.
+
+## Use
+
+```bash
+cd tools/js-prelude-harness
+npm install
+
+# Fetch the index once.
+curl -s -o idx.json https://kodjodevf.github.io/mangayomi-extensions/index.json
+
+# One extension, one method.
+node run.mjs <script.js> <config.json> getPopular 1
+node run.mjs <script.js> <config.json> getDetail "/manga/<id>"
+
+# Or sweep the first N JavaScript sources in the index.
+node batch.mjs 14
+```
+
+`config.json` mirrors `JsSourceConfig`:
+
+```json
+{ "id": "810342358", "name": "MangaDex", "baseUrl": "https://mangadex.org",
+  "apiUrl": "https://api.mangadex.org", "lang": "en", "isNsfw": false, "preferences": {} }
+```
+
+## Reading the output
+
+`batch.mjs` prints `peakDocs` and `leaked` per source. `leaked` must always be `0` — a non-zero
+value means a selector path returned without releasing its handle, which only becomes a visible
+failure against a page with enough rows to exhaust the 32-handle pool.
+
+**Most failures are not the prelude.** In the sweep that validated this layer, every hard failure
+traced to something external: a Cloudflare interstitial, a site that had moved domain since its
+extension was published (leaving a stale declared `overrideBaseUrl1` default), an upstream error
+from the site itself, and one host blocked by the local egress proxy. Check the site with `curl`
+before suspecting this code.
+
+Two real defects *were* found this way, which is the argument for keeping the harness:
+
+- extensions read preferences the user has never set (`new SharedPreferences().get("overrideBaseUrl1")`),
+  so the prelude has to fall back to the default the extension declares in `getSourcePreferences()`;
+- a preference with no value produced a literal `User-Agent: null` header, because the Kotlin
+  binding stringified a null rather than dropping the entry.

--- a/tools/js-prelude-harness/batch.mjs
+++ b/tools/js-prelude-harness/batch.mjs
@@ -18,11 +18,24 @@ if (!fs.existsSync(INDEX_PATH)) {
 const index = JSON.parse(fs.readFileSync(INDEX_PATH, 'utf8'));
 const candidates = index.filter((e) => e.sourceCodeLanguage === 1 && e.itemType === 0);
 
-const wanted = Number(process.argv[2] || 12);
+const wanted = Number.parseInt(process.argv[2] ?? '12', 10);
+if (!Number.isInteger(wanted) || wanted < 1) {
+    console.error(`Sample size must be a positive integer; got "${process.argv[2]}".`);
+    process.exit(2);
+}
+
+// Deduped by id, not by name. The index publishes the same display name for a source that exists
+// in several languages ("MangaDex" appears once per language), and those are genuinely different
+// entries with different base URLs — collapsing them by name silently shrinks a sweep of 12 to
+// whatever handful of distinct names happened to sort first, which reads as a smaller ecosystem
+// than there is.
 const picked = [];
+const seen = new Set();
 for (const e of candidates) {
     if (picked.length >= wanted) break;
-    if (picked.some((p) => p.name === e.name)) continue;
+    const key = String(e.id);
+    if (seen.has(key)) continue;
+    seen.add(key);
     picked.push(e);
 }
 
@@ -57,8 +70,14 @@ for (const e of picked) {
             sample: list[0]?.name?.slice(0, 34),
         });
     } catch (err) {
-        const msg = (err.stderr || err.stdout || String(err)).toString().toString().split('\n').find(l=>l.includes('FAILED'));
-        results.push({ name: e.name, status: 'FAIL', error: msg?.slice(0, 130) });
+        // run.mjs prints a line tagged FAILED for the two failures it recognises. Anything else —
+        // a timeout kill, an ENOENT, a crash before that point — has no such line, and reporting
+        // an empty error column there is how a real regression gets read as noise. Fall back to
+        // the first non-empty line of whatever the child did say.
+        const raw = (err.stderr || err.stdout || String(err)).toString();
+        const lines = raw.split('\n').map((l) => l.trim()).filter(Boolean);
+        const msg = lines.find((l) => l.includes('FAILED')) ?? lines[0] ?? String(err);
+        results.push({ name: e.name, status: 'FAIL', error: msg.slice(0, 130) });
     } finally {
         for (const f of [scriptPath, configPath]) {
             // rmSync with force ignores a missing file, so the cleanup needs no empty catch —

--- a/tools/js-prelude-harness/batch.mjs
+++ b/tools/js-prelude-harness/batch.mjs
@@ -1,8 +1,21 @@
 /* Run getPopular for many real JS extensions and report which survive the prelude. */
 import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 
-const index = JSON.parse(fs.readFileSync('../idx.json', 'utf8'));
+// Anchored to this file, so the harness works from any working directory and the path matches
+// what the README tells you to download.
+const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH = process.env.OTAKU_INDEX ?? path.join(HARNESS_DIR, 'idx.json');
+
+if (!fs.existsSync(INDEX_PATH)) {
+    console.error(`No index at ${INDEX_PATH}.\nFetch it first:\n` +
+        `  curl -s -o "${INDEX_PATH}" https://kodjodevf.github.io/mangayomi-extensions/index.json`);
+    process.exit(2);
+}
+
+const index = JSON.parse(fs.readFileSync(INDEX_PATH, 'utf8'));
 const candidates = index.filter((e) => e.sourceCodeLanguage === 1 && e.itemType === 0);
 
 const wanted = Number(process.argv[2] || 12);
@@ -16,8 +29,8 @@ for (const e of candidates) {
 const results = [];
 for (const e of picked) {
     const slug = String(e.id);
-    const scriptPath = `tmp_${slug}.js`;
-    const configPath = `tmp_${slug}.json`;
+    const scriptPath = path.join(HARNESS_DIR, `tmp_${slug}.js`);
+    const configPath = path.join(HARNESS_DIR, `tmp_${slug}.json`);
     try {
         const res = await fetch(e.sourceCodeUrl);
         if (!res.ok) { results.push({ name: e.name, status: `script ${res.status}` }); continue; }
@@ -29,7 +42,7 @@ for (const e of picked) {
             lang: e.lang, isNsfw: !!e.isNsfw, preferences: {},
         }));
 
-        const out = execFileSync('node', ['run.mjs', scriptPath, configPath, 'getPopular', '1'],
+        const out = execFileSync('node', [path.join(HARNESS_DIR, 'run.mjs'), scriptPath, configPath, 'getPopular', '1'],
             { timeout: 90000, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
         const parsed = JSON.parse(out);
         const list = parsed.result?.list ?? [];

--- a/tools/js-prelude-harness/batch.mjs
+++ b/tools/js-prelude-harness/batch.mjs
@@ -45,7 +45,11 @@ for (const e of picked) {
         const msg = (err.stderr || err.stdout || String(err)).toString().toString().split('\n').find(l=>l.includes('FAILED'));
         results.push({ name: e.name, status: 'FAIL', error: msg?.slice(0, 130) });
     } finally {
-        for (const f of [scriptPath, configPath]) { try { fs.unlinkSync(f); } catch {} }
+        for (const f of [scriptPath, configPath]) {
+            // rmSync with force ignores a missing file, so the cleanup needs no empty catch —
+            // the temp files legitimately may not exist when the download itself failed.
+            fs.rmSync(f, { force: true });
+        }
     }
 }
 

--- a/tools/js-prelude-harness/batch.mjs
+++ b/tools/js-prelude-harness/batch.mjs
@@ -1,0 +1,59 @@
+/* Run getPopular for many real JS extensions and report which survive the prelude. */
+import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const index = JSON.parse(fs.readFileSync('../idx.json', 'utf8'));
+const candidates = index.filter((e) => e.sourceCodeLanguage === 1 && e.itemType === 0);
+
+const wanted = Number(process.argv[2] || 12);
+const picked = [];
+for (const e of candidates) {
+    if (picked.length >= wanted) break;
+    if (picked.some((p) => p.name === e.name)) continue;
+    picked.push(e);
+}
+
+const results = [];
+for (const e of picked) {
+    const slug = String(e.id);
+    const scriptPath = `tmp_${slug}.js`;
+    const configPath = `tmp_${slug}.json`;
+    try {
+        const res = await fetch(e.sourceCodeUrl);
+        if (!res.ok) { results.push({ name: e.name, status: `script ${res.status}` }); continue; }
+        const body = await res.text();
+        if (body.length < 200) { results.push({ name: e.name, status: 'script too small' }); continue; }
+        fs.writeFileSync(scriptPath, body);
+        fs.writeFileSync(configPath, JSON.stringify({
+            id: slug, name: e.name, baseUrl: e.baseUrl, apiUrl: e.apiUrl || '',
+            lang: e.lang, isNsfw: !!e.isNsfw, preferences: {},
+        }));
+
+        const out = execFileSync('node', ['run.mjs', scriptPath, configPath, 'getPopular', '1'],
+            { timeout: 90000, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+        const parsed = JSON.parse(out);
+        const list = parsed.result?.list ?? [];
+        results.push({
+            name: e.name,
+            status: list.length > 0 ? 'OK' : 'empty list',
+            items: list.length,
+            peakDocs: parsed.documentStats.peakLiveDocuments,
+            liveLeaked: parsed.documentStats.liveDocuments,
+            sample: list[0]?.name?.slice(0, 34),
+        });
+    } catch (err) {
+        const msg = (err.stderr || err.stdout || String(err)).toString().toString().split('\n').find(l=>l.includes('FAILED'));
+        results.push({ name: e.name, status: 'FAIL', error: msg?.slice(0, 130) });
+    } finally {
+        for (const f of [scriptPath, configPath]) { try { fs.unlinkSync(f); } catch {} }
+    }
+}
+
+for (const r of results) {
+    const tag = r.status === 'OK' ? 'PASS' : (r.status === 'FAIL' ? 'FAIL' : 'WARN');
+    console.log(`[${tag}] ${r.name.slice(0, 26).padEnd(26)} ${String(r.status).padEnd(13)}` +
+        (r.items !== undefined ? ` items=${String(r.items).padEnd(3)} peakDocs=${r.peakDocs} leaked=${r.liveLeaked} ${r.sample ?? ''}` : ` ${r.error ?? ''}`));
+}
+const pass = results.filter((r) => r.status === 'OK').length;
+console.log(`\n${pass}/${results.length} returned a populated list; ` +
+    `${results.filter(r => r.status === 'FAIL').length} hard failures`);

--- a/tools/js-prelude-harness/batch.mjs
+++ b/tools/js-prelude-harness/batch.mjs
@@ -61,3 +61,17 @@ for (const r of results) {
 const pass = results.filter((r) => r.status === 'OK').length;
 console.log(`\n${pass}/${results.length} returned a populated list; ` +
     `${results.filter(r => r.status === 'FAIL').length} hard failures`);
+
+// A leaked document handle is the one failure this harness must never merely report.
+//
+// Most rows here go red for reasons outside the repository — a Cloudflare interstitial, a site
+// that moved domain — so a non-zero exit on those would make the harness useless. A leak is the
+// opposite: it is always ours, and it stays invisible until a page carries enough rows to exhaust
+// the 32-handle pool, which is exactly the size of input nobody tests with. Fail the run on it so
+// the invariant is asserted rather than left for a reader to notice in a column of numbers.
+const leaked = results.filter((r) => r.liveLeaked > 0);
+if (leaked.length > 0) {
+    console.error(`\nLEAKED DOCUMENT HANDLES in ${leaked.length} source(s):`);
+    for (const r of leaked) console.error(`  ${r.name}: ${r.liveLeaked} handle(s) still live`);
+    process.exit(1);
+}

--- a/tools/js-prelude-harness/batch.mjs
+++ b/tools/js-prelude-harness/batch.mjs
@@ -77,7 +77,16 @@ for (const e of picked) {
         const raw = (err.stderr || err.stdout || String(err)).toString();
         const lines = raw.split('\n').map((l) => l.trim()).filter(Boolean);
         const msg = lines.find((l) => l.includes('FAILED')) ?? lines[0] ?? String(err);
-        results.push({ name: e.name, status: 'FAIL', error: msg.slice(0, 130) });
+        // run.mjs prints its handle counts before any non-zero exit, so a source that leaks *and*
+        // throws still reaches the leak gate below. Without this the gate only ever saw sources
+        // that succeeded — and a leak severe enough to exhaust the pool always throws.
+        const stats = lines.find((l) => l.startsWith('DOCSTATS '));
+        let liveLeaked;
+        if (stats) {
+            try { liveLeaked = JSON.parse(stats.slice('DOCSTATS '.length)).liveDocuments; }
+            catch { liveLeaked = undefined; }
+        }
+        results.push({ name: e.name, status: 'FAIL', error: msg.slice(0, 130), liveLeaked });
     } finally {
         for (const f of [scriptPath, configPath]) {
             // rmSync with force ignores a missing file, so the cleanup needs no empty catch —

--- a/tools/js-prelude-harness/batch.mjs
+++ b/tools/js-prelude-harness/batch.mjs
@@ -32,7 +32,9 @@ for (const e of picked) {
     const scriptPath = path.join(HARNESS_DIR, `tmp_${slug}.js`);
     const configPath = path.join(HARNESS_DIR, `tmp_${slug}.json`);
     try {
-        const res = await fetch(e.sourceCodeUrl);
+        // Bounded: the child-process timeout does not start until the download finishes, so a
+        // server that accepts the connection and then stalls would hang the whole sweep.
+        const res = await fetch(e.sourceCodeUrl, { signal: AbortSignal.timeout(60_000) });
         if (!res.ok) { results.push({ name: e.name, status: `script ${res.status}` }); continue; }
         const body = await res.text();
         if (body.length < 200) { results.push({ name: e.name, status: 'script too small' }); continue; }

--- a/tools/js-prelude-harness/host.mjs
+++ b/tools/js-prelude-harness/host.mjs
@@ -1,0 +1,89 @@
+/*
+ * A faithful stand-in for QuickJsHost's bindings, so prelude.js can be exercised outside Android.
+ *
+ * Every function here mirrors the Kotlin binding it is named after: same argument order, same
+ * return type, same handle discipline, same cap. Where Kotlin uses Jsoup, this uses cheerio.
+ * If the prelude works against this, the only thing left to differ is Jsoup vs cheerio selector
+ * behaviour — not the shape of the API.
+ */
+import * as cheerio from 'cheerio';
+
+const MAX_LIVE_DOCUMENTS = 32;
+
+export function installHost(global, { baseUrl, preferences = {}, onRequest }) {
+    const documents = new Map();
+    let nextHandle = 1;
+    let peakLiveDocuments = 0;
+    const prefs = { ...preferences };
+
+    // --- Client: engine.define("Client") { asyncFunction("get"/"post") } ---
+    global.Client = {
+        async get(url, headers) {
+            return JSON.stringify(await onRequest({ url, method: 'GET', headers: headers || {}, body: null }));
+        },
+        async post(url, headers, body) {
+            return JSON.stringify(await onRequest({ url, method: 'POST', headers: headers || {}, body }));
+        },
+    };
+
+    // --- Document: handle-based, returns outerHtml strings ---
+    const absUrl = (value) => {
+        if (!value) return '';
+        try { return new URL(value, baseUrl).toString(); } catch { return value; }
+    };
+
+    global.Document = {
+        parse(html) {
+            if (documents.size >= MAX_LIVE_DOCUMENTS) {
+                throw new Error(`Source holds more than ${MAX_LIVE_DOCUMENTS} parsed documents; release them`);
+            }
+            const handle = nextHandle++;
+            documents.set(handle, cheerio.load(html ?? ''));
+            peakLiveDocuments = Math.max(peakLiveDocuments, documents.size);
+            return handle;
+        },
+        select(handle, selector) {
+            const $ = documents.get(handle);
+            if (!$) return [];
+            return $(selector).toArray().map((el) => $.html(el));
+        },
+        selectFirst(handle, selector) {
+            const $ = documents.get(handle);
+            if (!$) return null;
+            const found = $(selector).first();
+            return found.length ? $.html(found) : null;
+        },
+        text(html) {
+            return cheerio.load(html ?? '').root().text();
+        },
+        attr(html, name) {
+            const $ = cheerio.load(html ?? '');
+            const el = $('body').children().first();
+            if (!el.length) return '';
+            const raw = el.attr(name);
+            if (raw === undefined) return '';
+            // Kotlin prefers absUrl and falls back to the raw attribute.
+            return (name === 'href' || name === 'src') ? absUrl(raw) : raw;
+        },
+        release(handle) {
+            documents.delete(handle);
+            return null;
+        },
+    };
+
+    // --- SharedPreferences ---
+    global.SharedPreferences = {
+        get(key) {
+            return Object.prototype.hasOwnProperty.call(prefs, key) ? prefs[key] : null;
+        },
+        set(key, value) {
+            prefs[key] = String(value);
+            return null;
+        },
+    };
+
+    return {
+        stats: () => ({ liveDocuments: documents.size, peakLiveDocuments }),
+        preferences: () => ({ ...prefs }),
+    };
+}

--- a/tools/js-prelude-harness/host.mjs
+++ b/tools/js-prelude-harness/host.mjs
@@ -16,13 +16,31 @@ export function installHost(global, { baseUrl, preferences = {}, onRequest }) {
     let peakLiveDocuments = 0;
     const prefs = { ...preferences };
 
+    /**
+     * Mirror QuickJsHost's header handling: drop null/undefined entries, stringify the rest.
+     *
+     * Not cosmetic. Sources build header maps from preferences that are frequently unset —
+     * `{"user-agent": this.getPreference("custom_user_agent")}` is the common shape — and passing
+     * the null through would send a literal `User-Agent: null` here while Android sends no header
+     * at all. The entire value of this harness is that a source behaves the same in both, so any
+     * divergence makes a green run meaningless.
+     */
+    const normalizeHeaders = (headers) => {
+        const out = {};
+        for (const [k, v] of Object.entries(headers || {})) {
+            if (v === null || v === undefined) continue;
+            out[k] = String(v);
+        }
+        return out;
+    };
+
     // --- Client: engine.define("Client") { asyncFunction("get"/"post") } ---
     global.Client = {
         async get(url, headers) {
-            return JSON.stringify(await onRequest({ url, method: 'GET', headers: headers || {}, body: null }));
+            return JSON.stringify(await onRequest({ url, method: 'GET', headers: normalizeHeaders(headers), body: null }));
         },
         async post(url, headers, body) {
-            return JSON.stringify(await onRequest({ url, method: 'POST', headers: headers || {}, body }));
+            return JSON.stringify(await onRequest({ url, method: 'POST', headers: normalizeHeaders(headers), body }));
         },
     };
 
@@ -54,16 +72,36 @@ export function installHost(global, { baseUrl, preferences = {}, onRequest }) {
             return found.length ? $.html(found) : null;
         },
         text(html) {
-            return cheerio.load(html ?? '').root().text();
+            // Jsoup's Element.text() collapses whitespace runs, trims, and puts a boundary between
+            // block-level elements; cheerio's .text() concatenates raw text nodes, so
+            // `<p>a</p><p>b</p>` yields "ab" there and "a b" on Android. Insert a separator at
+            // block boundaries and collapse, which covers the cases sources actually depend on
+            // (multi-line titles, chapter names split across tags).
+            //
+            // This is an approximation of Jsoup, not a reimplementation — exotic inline/block
+            // nesting can still differ. It is close enough that a source parsing correctly here is
+            // strong evidence, and the Android run remains the authority.
+            const $ = cheerio.load(html ?? '');
+            $('br').replaceWith(' ');
+            $('p,div,li,tr,h1,h2,h3,h4,h5,h6,section,article,blockquote').each((_, el) => {
+                $(el).after(' ');
+            });
+            return $.root().text().replace(/\s+/g, ' ').trim();
         },
         attr(html, name) {
             const $ = cheerio.load(html ?? '');
             const el = $('body').children().first();
             if (!el.length) return '';
+            // Raw, matching the Kotlin `attr` binding. Resolution lives in absAttr.
+            return el.attr(name) ?? '';
+        },
+        absAttr(html, name) {
+            const $ = cheerio.load(html ?? '');
+            const el = $('body').children().first();
+            if (!el.length) return '';
             const raw = el.attr(name);
             if (raw === undefined) return '';
-            // Kotlin prefers absUrl and falls back to the raw attribute.
-            return (name === 'href' || name === 'src') ? absUrl(raw) : raw;
+            return absUrl(raw) || raw;
         },
         release(handle) {
             documents.delete(handle);
@@ -77,7 +115,9 @@ export function installHost(global, { baseUrl, preferences = {}, onRequest }) {
             return Object.prototype.hasOwnProperty.call(prefs, key) ? prefs[key] : null;
         },
         set(key, value) {
-            prefs[key] = String(value);
+            // Mirrors the Kotlin binding's `?.toString().orEmpty()`: a nullish write stores an
+            // empty string, not the literal "null".
+            prefs[key] = value === null || value === undefined ? '' : String(value);
             return null;
         },
     };

--- a/tools/js-prelude-harness/host.mjs
+++ b/tools/js-prelude-harness/host.mjs
@@ -10,6 +10,14 @@ import * as cheerio from 'cheerio';
 
 const MAX_LIVE_DOCUMENTS = 32;
 
+// Jsoup's block set, used to reproduce the whitespace boundary its Element.text() inserts.
+const BLOCK_TAGS = [
+    'address', 'article', 'aside', 'blockquote', 'dd', 'div', 'dl', 'dt', 'fieldset',
+    'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header',
+    'hr', 'li', 'main', 'nav', 'ol', 'p', 'pre', 'section', 'table', 'tbody', 'td', 'tfoot',
+    'th', 'thead', 'tr', 'ul',
+].join(',');
+
 export function installHost(global, { baseUrl, preferences = {}, onRequest }) {
     const documents = new Map();
     let nextHandle = 1;
@@ -83,7 +91,11 @@ export function installHost(global, { baseUrl, preferences = {}, onRequest }) {
             // strong evidence, and the Android run remains the authority.
             const $ = cheerio.load(html ?? '');
             $('br').replaceWith(' ');
-            $('p,div,li,tr,td,th,h1,h2,h3,h4,h5,h6,section,article,blockquote').each((_, el) => {
+            // Jsoup decides a boundary from the tag's own block/inline classification, so this
+            // list tracks its block set rather than the handful of tags that happened to come up.
+            // `br` is not in it — it is replaced above, and replacing then also appending would
+            // double the space.
+            $(BLOCK_TAGS).each((_, el) => {
                 $(el).after(' ');
             });
             return $.root().text().replace(/\s+/g, ' ').trim();

--- a/tools/js-prelude-harness/host.mjs
+++ b/tools/js-prelude-harness/host.mjs
@@ -83,7 +83,7 @@ export function installHost(global, { baseUrl, preferences = {}, onRequest }) {
             // strong evidence, and the Android run remains the authority.
             const $ = cheerio.load(html ?? '');
             $('br').replaceWith(' ');
-            $('p,div,li,tr,h1,h2,h3,h4,h5,h6,section,article,blockquote').each((_, el) => {
+            $('p,div,li,tr,td,th,h1,h2,h3,h4,h5,h6,section,article,blockquote').each((_, el) => {
                 $(el).after(' ');
             });
             return $.root().text().replace(/\s+/g, ' ').trim();
@@ -117,6 +117,11 @@ export function installHost(global, { baseUrl, preferences = {}, onRequest }) {
         set(key, value) {
             // Mirrors the Kotlin binding's `?.toString().orEmpty()`: a nullish write stores an
             // empty string, not the literal "null".
+            //
+            // The prelude never sends one — it drops nullish writes before they reach here, and
+            // says why. This stays as the binding's own floor, and keeping it identical to the
+            // Kotlin is the point of the file: the harness must not be the reason a behaviour
+            // looks correct.
             prefs[key] = value === null || value === undefined ? '' : String(value);
             return null;
         },

--- a/tools/js-prelude-harness/package-lock.json
+++ b/tools/js-prelude-harness/package-lock.json
@@ -1,0 +1,313 @@
+{
+  "name": "js-prelude-harness",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "js-prelude-harness",
+      "dependencies": {
+        "cheerio": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tools/js-prelude-harness/package-lock.json
+++ b/tools/js-prelude-harness/package-lock.json
@@ -9,7 +9,7 @@
         "cheerio": "^1.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/boolbase": {

--- a/tools/js-prelude-harness/package.json
+++ b/tools/js-prelude-harness/package.json
@@ -2,6 +2,9 @@
   "name": "js-prelude-harness",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "cheerio": "^1.0.0"
   }

--- a/tools/js-prelude-harness/package.json
+++ b/tools/js-prelude-harness/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "js-prelude-harness",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "cheerio": "^1.0.0"
+  }
+}

--- a/tools/js-prelude-harness/package.json
+++ b/tools/js-prelude-harness/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.18.1"
   },
   "dependencies": {
     "cheerio": "^1.0.0"

--- a/tools/js-prelude-harness/run.mjs
+++ b/tools/js-prelude-harness/run.mjs
@@ -1,0 +1,90 @@
+/*
+ * The kill-criterion check: does a real, unmodified Mangayomi extension run against prelude.js?
+ *
+ * Mirrors QuickJsHost.call end to end — install host globals, evaluate the source config global,
+ * evaluate the prelude, evaluate the extension script, then run the same invocation
+ * buildInvocation() produces.
+ */
+import fs from 'node:fs';
+import vm from 'node:vm';
+import { installHost } from './host.mjs';
+
+const PRELUDE = '/home/user/Otaku-Reader/core/js-runtime/src/main/resources/js/prelude.js';
+
+const [, , scriptPath, configPath, method, argRaw] = process.argv;
+const script = fs.readFileSync(scriptPath, 'utf8');
+const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+
+let requestCount = 0;
+async function onRequest({ url, method: verb, headers, body }) {
+    requestCount++;
+    try {
+        const res = await fetch(url, {
+            method: verb,
+            headers,
+            body: body ?? undefined,
+            redirect: 'follow',
+        });
+        const text = await res.text();
+        return {
+            ok: res.ok,
+            code: res.status,
+            headers: Object.fromEntries(res.headers.entries()),
+            body: text,
+        };
+    } catch (e) {
+        return { ok: false, code: 0, headers: {}, body: '', error: String(e) };
+    }
+}
+
+const sandbox = { console, URL, TextEncoder, TextDecoder, setTimeout, clearTimeout, fetch };
+sandbox.globalThis = sandbox;
+const context = vm.createContext(sandbox);
+
+const probe = installHost(sandbox, { baseUrl: config.baseUrl, preferences: config.preferences || {}, onRequest });
+
+// Same order as QuickJsHost.call: host globals, then config, then prelude, then the script.
+vm.runInContext(`globalThis.__otakuSourceConfig = ${JSON.stringify(JSON.stringify(config))};`, context);
+vm.runInContext(fs.readFileSync(PRELUDE, 'utf8'), context, { filename: 'prelude.js' });
+
+try {
+    vm.runInContext(script, context, { filename: scriptPath });
+} catch (e) {
+    console.error(`SCRIPT EVALUATION FAILED: ${e}`);
+    process.exit(2);
+}
+
+// The invocation buildInvocation() emits.
+const call = {
+    getPopular: `getPopular(${argRaw || 1})`,
+    getLatestUpdates: `getLatestUpdates(${argRaw || 1})`,
+    getDetail: `getDetail(${JSON.stringify(argRaw || '')})`,
+    getPageList: `getPageList(${JSON.stringify(argRaw || '')})`,
+    getFilterList: `getFilterList()`,
+}[method];
+
+const invocation = `
+    (async () => {
+        const provider = new DefaultExtension();
+        const result = await provider.${call};
+        __otakuEmitResult(JSON.stringify(result === undefined ? null : result));
+    })()
+`;
+
+let captured = null;
+sandbox.__otakuEmitResult = (json) => { captured = json; };
+
+try {
+    await vm.runInContext(invocation, context, { filename: 'invocation' });
+} catch (e) {
+    console.error(`INVOCATION FAILED: ${e && e.stack ? e.stack : e}`);
+    process.exit(3);
+}
+
+console.log(JSON.stringify({
+    method,
+    requests: requestCount,
+    documentStats: probe.stats(),
+    preferencesAfter: probe.preferences(),
+    result: captured ? JSON.parse(captured) : null,
+}, null, 1));

--- a/tools/js-prelude-harness/run.mjs
+++ b/tools/js-prelude-harness/run.mjs
@@ -22,6 +22,14 @@ const [, , scriptPath, configPath, method, argRaw] = process.argv;
 const script = fs.readFileSync(scriptPath, 'utf8');
 const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
 
+// Bounds on a single source request. Neither exists to be tuned — they exist so that one
+// misbehaving site cannot stall or exhaust a sweep of dozens of sources. A server that accepts the
+// connection and then dribbles bytes forever would otherwise hang the run with no output at all,
+// and a source pointed at a video or a multi-gigabyte file would be read entirely into a string
+// before anything noticed.
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_RESPONSE_BYTES = 32 * 1024 * 1024;
+
 let requestCount = 0;
 async function onRequest({ url, method: verb, headers, body }) {
     requestCount++;
@@ -31,23 +39,43 @@ async function onRequest({ url, method: verb, headers, body }) {
             headers,
             body: body ?? undefined,
             redirect: 'follow',
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
         });
-        const text = await res.text();
+        // Read incrementally rather than via res.text(): the cap has to be enforced while the body
+        // is arriving, since by the time text() resolves the whole thing is already in memory.
+        const chunks = [];
+        let total = 0;
+        for await (const chunk of res.body ?? []) {
+            total += chunk.length;
+            if (total > MAX_RESPONSE_BYTES) {
+                return {
+                    ok: false,
+                    code: res.status,
+                    headers: Object.fromEntries(res.headers.entries()),
+                    body: '',
+                    error: `response exceeded ${MAX_RESPONSE_BYTES} bytes`,
+                };
+            }
+            chunks.push(chunk);
+        }
         return {
             ok: res.ok,
             code: res.status,
             headers: Object.fromEntries(res.headers.entries()),
-            body: text,
+            body: Buffer.concat(chunks).toString('utf8'),
         };
     } catch (e) {
         return { ok: false, code: 0, headers: {}, body: '', error: String(e) };
     }
 }
 
-// No `fetch` in the sandbox. The Android QuickJS context provides none, so a source reaching for
-// it must fail here too — otherwise the harness reports an extension as compatible that cannot run
-// on the device, which is the one verdict it must never give.
-const sandbox = { console, URL, TextEncoder, TextDecoder, setTimeout, clearTimeout };
+// Deliberately spare. QuickJsHost's own header states that "capability arrives solely through the
+// globals installed below", and it installs exactly three: Client, Document, SharedPreferences.
+// Anything handed out here that Android does not have — `fetch`, and timers, which a source would
+// reach for to throttle or retry — makes the harness report an extension as compatible when it
+// cannot run on the device, and that is the one verdict this tool must never give. Being stricter
+// than the device is the safe direction: it costs a false failure, which a human then checks.
+const sandbox = { console, URL, TextEncoder, TextDecoder };
 sandbox.globalThis = sandbox;
 const context = vm.createContext(sandbox);
 

--- a/tools/js-prelude-harness/run.mjs
+++ b/tools/js-prelude-harness/run.mjs
@@ -6,10 +6,17 @@
  * buildInvocation() produces.
  */
 import fs from 'node:fs';
+import path from 'node:path';
 import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
 import { installHost } from './host.mjs';
 
-const PRELUDE = '/home/user/Otaku-Reader/core/js-runtime/src/main/resources/js/prelude.js';
+// Resolved from this file's own location, never from the working directory or an absolute path.
+// The harness is checked in for other people to run, so anything anchored to one machine's
+// checkout fails with ENOENT before a single extension is exercised.
+const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const PRELUDE = process.env.OTAKU_PRELUDE ??
+    path.resolve(HARNESS_DIR, '../../core/js-runtime/src/main/resources/js/prelude.js');
 
 const [, , scriptPath, configPath, method, argRaw] = process.argv;
 const script = fs.readFileSync(scriptPath, 'utf8');

--- a/tools/js-prelude-harness/run.mjs
+++ b/tools/js-prelude-harness/run.mjs
@@ -44,7 +44,10 @@ async function onRequest({ url, method: verb, headers, body }) {
     }
 }
 
-const sandbox = { console, URL, TextEncoder, TextDecoder, setTimeout, clearTimeout, fetch };
+// No `fetch` in the sandbox. The Android QuickJS context provides none, so a source reaching for
+// it must fail here too — otherwise the harness reports an extension as compatible that cannot run
+// on the device, which is the one verdict it must never give.
+const sandbox = { console, URL, TextEncoder, TextDecoder, setTimeout, clearTimeout };
 sandbox.globalThis = sandbox;
 const context = vm.createContext(sandbox);
 
@@ -62,13 +65,23 @@ try {
 }
 
 // The invocation buildInvocation() emits.
+// Mirrors QuickJsHost.buildInvocation exactly — every method it dispatches, with the same
+// argument order. An entry missing here silently invokes `provider.undefined`.
 const call = {
-    getPopular: `getPopular(${argRaw || 1})`,
-    getLatestUpdates: `getLatestUpdates(${argRaw || 1})`,
+    getPopular: `getPopular(${Number(argRaw) || 1})`,
+    getLatestUpdates: `getLatestUpdates(${Number(argRaw) || 1})`,
+    search: `search(${JSON.stringify(argRaw || '')}, 1, [])`,
     getDetail: `getDetail(${JSON.stringify(argRaw || '')})`,
     getPageList: `getPageList(${JSON.stringify(argRaw || '')})`,
+    getHtmlContent: `getHtmlContent(${JSON.stringify(argRaw || '')})`,
     getFilterList: `getFilterList()`,
 }[method];
+
+if (!call) {
+    console.error(`Unknown method "${method}". Supported: getPopular, getLatestUpdates, search, ` +
+        `getDetail, getPageList, getHtmlContent, getFilterList`);
+    process.exit(4);
+}
 
 const invocation = `
     (async () => {

--- a/tools/js-prelude-harness/run.mjs
+++ b/tools/js-prelude-harness/run.mjs
@@ -34,13 +34,25 @@ let requestCount = 0;
 async function onRequest({ url, method: verb, headers, body }) {
     requestCount++;
     try {
-        const res = await fetch(url, {
+        // `fetch` throws "Request with GET/HEAD method cannot have body" for a GET carrying a
+        // real body; `body: undefined` on a GET is accepted, which is why the previous uniform
+        // `body: body ?? undefined` never actually misfired — MClient.get passes null.
+        //
+        // Structuring it this way anyway, because the alternative rests on a promise made
+        // somewhere else: the day a source builds a GET with a payload, or the prelude's request()
+        // helper routes a verb differently, the throw lands in the catch below and is reported as
+        // an unreachable site. That is the most misleading verdict this harness can give — it
+        // blames the source's server for the harness's own malformed request.
+        const init = {
             method: verb,
             headers,
-            body: body ?? undefined,
             redirect: 'follow',
             signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-        });
+        };
+        if (body !== null && body !== undefined && verb !== 'GET' && verb !== 'HEAD') {
+            init.body = body;
+        }
+        const res = await fetch(url, init);
         // Read incrementally rather than via res.text(): the cap has to be enforced while the body
         // is arriving, since by the time text() resolves the whole thing is already in memory.
         const chunks = [];

--- a/tools/js-prelude-harness/run.mjs
+++ b/tools/js-prelude-harness/run.mjs
@@ -97,11 +97,20 @@ const probe = installHost(sandbox, { baseUrl: config.baseUrl, preferences: confi
 vm.runInContext(`globalThis.__otakuSourceConfig = ${JSON.stringify(JSON.stringify(config))};`, context);
 vm.runInContext(fs.readFileSync(PRELUDE, 'utf8'), context, { filename: 'prelude.js' });
 
+// A leak in a source that *also* throws was invisible: both exits below fired before the stats
+// were printed, so batch.mjs recorded a plain FAIL with no handle count and its leak gate — which
+// exists precisely to fail the run on a leak — never saw one. Exhausting the 32-handle pool is
+// itself a throwing failure, so that was the single case the gate most needed to catch.
+function bail(message, code) {
+    console.error(message);
+    console.error(`DOCSTATS ${JSON.stringify(probe.stats())}`);
+    process.exit(code);
+}
+
 try {
     vm.runInContext(script, context, { filename: scriptPath });
 } catch (e) {
-    console.error(`SCRIPT EVALUATION FAILED: ${e}`);
-    process.exit(2);
+    bail(`SCRIPT EVALUATION FAILED: ${e}`, 2);
 }
 
 // The invocation buildInvocation() emits.
@@ -137,8 +146,7 @@ sandbox.__otakuEmitResult = (json) => { captured = json; };
 try {
     await vm.runInContext(invocation, context, { filename: 'invocation' });
 } catch (e) {
-    console.error(`INVOCATION FAILED: ${e && e.stack ? e.stack : e}`);
-    process.exit(3);
+    bail(`INVOCATION FAILED: ${e && e.stack ? e.stack : e}`, 3);
 }
 
 console.log(JSON.stringify({


### PR DESCRIPTION
## **User description**
## 📋 Description

Makes the JavaScript backend actually run published Mangayomi extensions. It was written to that contract but never met it.

**`MProvider` did not exist.** `buildInvocation` emits `new DefaultExtension()` and its comment names `class DefaultExtension extends MProvider` — but `MProvider` appears nowhere outside that comment. Every published extension failed at *script evaluation* with a `ReferenceError`, before any method ran.

**The script-facing API was a different shape.** `QuickJsHost` installs flat namespaces (`Client.get`, `Document.parse` → integer handle) because keeping host objects out of JavaScript is a deliberate isolation property. Extensions are written against an object API — `new Client()`, `new Document(html)`, `doc.selectFirst(s)?.text`.

The fix is a **JavaScript prelude**, evaluated between the host bindings and the extension, rebuilding the object API on top of the flat primitives. Doing it in JS rather than Kotlin means the boundary still passes only strings and integers, so the isolation property is untouched.

**The index reader also claimed more than it did.** Its comment said Mangayomi sources "work here unmodified"; against the live index:

| Field | Index publishes | DTO expected | Effect |
|---|---|---|---|
| `id` | number | `String` | decode threw |
| `itemType` | number `0` | `"manga"` | every entry filtered out |
| `sourceCodeLanguage` | `0` Dart / `1` JS | *unread* | 249 Dart files handed to a JS engine |
| index path | `/index.json` | `/js/index.json` | 404 → "no sources" |

Two further defects, both found by running real extensions:

- Sources read preferences the user has never set — a mirror or base-URL override is near-universal — and ship the working value as that preference's *declared default*. Nothing seeded those, so such a source built every request against `null/...`. The prelude now falls back to the extension's own `getSourcePreferences()`; a stored value still wins, so an updated default reaches users who never touched the setting.
- An unset preference in a header map became a literal `User-Agent: null`, because the binding stringified a null instead of dropping the entry.

Verified against the artifacts rather than the docs: the contributing guide documents `getLatest`, but all 18 sampled sources define `getLatestUpdates` — which is what this code already called.

## 🔄 Type of Change
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📖 Documentation
- [x] 🧪 Tests

## 🧪 Testing

**All required `ci.yml` gates are green** — Unit Tests, Detekt, Ktlint, Assemble, Security Check, Coverage Gate, Screenshot Tests and Dependency License Report, across all three commits.

*(An earlier version of this description said nothing had been compiled or tested. That was true when the PR was opened — it was authored in an environment with no Android SDK — and CI has since run everything. Corrected so it doesn't hold up review.)*

Beyond CI, the part the JVM **cannot** cover was verified against the live network. QuickJS ships as an Android artifact, so the prelude has no engine to run in from a unit test; `JsPreludeTest` can only guard packaging and the published global names.

`tools/js-prelude-harness/` (new) closes that gap. It reproduces `QuickJsHost.call` on Node — same binding signatures, same handle discipline, same 32-document cap, cheerio in place of Jsoup — and runs **real, unmodified extensions** fetched from the live index:

```
[PASS] 漫画柜         items=42  peakDocs=1 leaked=0   鬼灭之刃
[PASS] Webtoons      items=150 peakDocs=1 leaked=0   Situationship
[PASS] MangaDex      items=20  peakDocs=0 leaked=0   Solo Leveling
[PASS] TeamX         items=10  peakDocs=1 leaked=0   fast break
[PASS] MangaWorld    items=16  peakDocs=0 leaked=0   One Piece
[PASS] Oduto         items=1   peakDocs=0 leaked=0   BORUTO: Two Blue Vortex
```

`leaked=0` everywhere is the load-bearing number — the handle pool is capped and the host refuses rather than evicts, so a selector that returned without releasing would only fail against a page with enough rows to exhaust 32 handles.

No remaining failure in the sweep is attributable to this layer; each was checked with `curl`:

| Source | Cause |
|---|---|
| Mangafire | Cloudflare `Just a moment...` 403 |
| Asura Scans | site moved `asuracomic.net` → `asurascans.com`; its declared default is stale |
| 动漫之家 | site returns `upstream connect error` |
| Comick | blocked by the authoring environment's egress proxy (502) |

Kotlin-side tests cover what the JVM *can* reach: decoding the real index shape, Dart entries being dropped, `apiUrl` surviving onto the source, version ordering (`1.0.0` > `0.9.9` — the case that distinguishes packing from summing), and an APK-only repository staying silent.

Two **existing** tests were corrected: the new fallback request made `one unreachable repository does not suppress another` pass for the wrong reason, silently feeding the first repository's index to the second.

**CodeFactor is red and is not a gate.** It reported `2 issues found.` on two commits with almost disjoint content, completing in ~1 second each, and now reports `Something went wrong.` in 0 seconds. Its findings are not retrievable — empty check output, client-rendered detail page, API behind auth. See the comment below.

## ✅ Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated — `CLAUDE.md` and `.claude/skills/extension-system`, see below
- [x] No new warnings — Detekt and Ktlint green
- [x] Tests pass — Unit Tests green

## 📖 Documentation

`CLAUDE.md` and `.claude/skills/extension-system` are updated in this PR, since both stated that Tachiyomi APK compatibility "must never be broken" and would have got this work reverted. The reversal is written as an explicit, dated decision rather than a silent deletion.

Also corrected while there: the schema version was recorded as v42 in one place and v44 in another (it is **v45**); a `server/` module was documented that does not exist; `core/js-runtime`, `core/webview`, `feature/webview` and `tools/` were missing from the layout; and the skill documented a `Source` interface that has never existed in this repository.

**One correction is worth calling out**, because it changes the plan: a first pass at these docs claimed `core/tachiyomi-compat` was used by nothing but the APK path. That is wrong. It also holds **`LocalSource`** — local manga folders, a shipped feature wired into settings, navigation and preferences — and **`SourceHealthMonitor`**, which `SourceRepositoryImpl` routes *every* source call through, JavaScript included. Deleting on the original premise would have removed a working feature. Both modules are now documented as *partly* retiring, with the survivors listed and the sequence stated as extract-then-delete.

## 📌 Follow-ups

- **Retiring the APK backend is not just a deletion.** Mangayomi source ids are not Tachiyomi ids and `Manga.sourceId` is a one-way hash, so removing the loader repoints every library row at a source that no longer exists. A guided migration (reusing `feature/migration/`) and a resolution for orphaned downloads (#1256) have to ship with it.
- **Source coverage is the open question.** Keiyoushi lists 2,128 sources across 1,390 distinct sites; the Mangayomi JavaScript catalogue is 114 sources across 18 sites, overlapping on 10. The overlap is weighted toward the large aggregators (MangaDex, Webtoons, Weeb Central, Mangapill), but it is a small fraction of the sites by count.
- Preference defaults are resolved at read time in the prelude. Seeding them at install time (a new `SOURCE_PREFERENCES` protocol method) would also let the source-settings UI show and edit them.

## Summary by Sourcery

Enable unmodified Mangayomi JavaScript extensions and improve recovery for library entries whose sources are unavailable.

New Features:
- Add a JavaScript compatibility prelude that lets published Mangayomi extensions run without source modifications.
- Add migration UI support for identifying, filtering, and selecting library entries whose sources are no longer available.

Bug Fixes:
- Correct Mangayomi index discovery and decoding so JavaScript manga sources are loaded while Dart, non-manga, malformed, and APK-only entries are handled appropriately.
- Preserve source API URLs and derive usable version codes when index build numbers are absent.
- Use declared extension preference defaults for unset values and omit null-valued request headers.
- Fix document attribute handling and ensure parsed document handles are released on all paths.
- Resolve migration source names using hashed and legacy source keys.

Enhancements:
- Introduce a Node-based harness that exercises the compatibility layer with real, unmodified Mangayomi extensions and checks document-handle usage.
- Update project guidance to document the JavaScript backend direction, source identity risks, migration requirements, and the partial retirement plan for APK compatibility modules.

Documentation:
- Update CLAUDE.md and the extension-system skill documentation to reflect the JavaScript source backend and current repository structure.

Tests:
- Expand remote source tests for real Mangayomi index formats, repository fallback behavior, language filtering, API URLs, version ordering, and APK-only repositories.
- Add prelude packaging and global-contract tests.
- Add migration tests for stranded-source detection, filtering, and selection behavior.


___

## **CodeAnt-AI Description**
Run Mangayomi JavaScript sources and identify library entries with missing sources

### What Changed
- Published Mangayomi JavaScript extensions can now run without modification through a compatibility layer that provides their expected client, document, preferences, and provider APIs.
- Source indexes accept Mangayomi’s numeric fields, load the correct combined index, exclude Dart and non-manga entries, preserve API URLs, and derive update versions when build numbers are absent.
- Unset preferences use the defaults declared by each extension, while headers with missing values are omitted instead of sending the text `"null"`.
- Migration entries now show their source, identify manga whose source is unavailable, and provide actions to select or filter stranded entries for migration.
- Added tests and a Node-based harness covering real index formats, extension compatibility, document-handle cleanup, and stranded-entry selection.

### Impact
`✅ Mangayomi JavaScript extensions install and run`
`✅ JavaScript repositories show usable sources instead of empty results`
`✅ Clearer recovery for library manga with missing sources`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
